### PR TITLE
fix pyLoads multiple hoster option

### DIFF
--- a/flexget/plugins/output/pyload.py
+++ b/flexget/plugins/output/pyload.py
@@ -114,7 +114,7 @@ class PluginPyLoad(object):
             for name in hoster:
                 if name in parsed:
                     urls.extend(parsed[name])
-                    if not config.get('multihoster', self.DEFAULT_MULTIPLE_HOSTER):
+                    if not config.get('multiple_hoster', self.DEFAULT_MULTIPLE_HOSTER):
                         break
 
             # no preferred hoster, add all recognized plugins


### PR DESCRIPTION
this fixes the multiple_hoster option in the pyLoad plugin
