### PR TITLE
Fix for torrent_completed condition check.  

### DIFF
--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -150,7 +150,7 @@ class PluginTransmissionInput(TransmissionBase):
     def _torrent_completed(self, torrent):
         result = True
         for tf in torrent.files().iteritems():
-            result &= (tf[1]['completed'] != tf[1]['size'])
+            result &= (tf[1]['completed'] == tf[1]['size'])
         return result
 
 


### PR DESCRIPTION
'completed' and 'size' values are number of bytes, downloaded and total. Checking inequality there produces result opposite to expected from method named torrent_completed. I learned this hard way trying to build configuration with from_transmission plugin.
