### PR TITLE
Torrentz rewriter fixed for ticket

### DIFF
--- a/flexget/plugins/urlrewrite_torrentz.py
+++ b/flexget/plugins/urlrewrite_torrentz.py
@@ -32,9 +32,9 @@ class UrlRewriteTorrentz(object):
 
     def url_rewrite(self, task, entry):
         hash = REGEXP.match(entry['url']).group(1)
-        #entry['url'] = 'http://zoink.it/torrent/%s.torrent' % hash.upper()
         # Would be cool if we can have a list that automatically switches when a server is down
-        entry['url'] = 'http://torcache.net/torrent/%s.torrent' % hash.upper()
+        #entry['url'] = 'http://zoink.it/torrent/%s.torrent' % hash.upper()
+        entry['url'] = 'https://torcache.net/torrent/%s.torrent' % hash.upper()
         entry['torrent_info_hash'] = hash
 
     def search(self, query, comparator=StringComparator(), config=None):


### PR DESCRIPTION
Torrentz rewriter rewrites to zoink.it which has been down for a while.

Fixed. I submitted a ticket earlier but it is not in the tracker(?) so I cannot provide the ticket number.
