### PR TITLE
New regex input plugin 

### DIFF
--- a/flexget/plugins/input/regexp_parse.py
+++ b/flexget/plugins/input/regexp_parse.py
@@ -39,7 +39,7 @@ class RegexpParse(object):
     regexp_parse:
       source: http://username:password@ezrss.it/feed/
       sections:
-        - {regexp: "(?<=<item>).*?(?=</item>)", flags: "DOTALL"}
+        - {regexp: "(?<=<item>).*?(?=</item>)", flags: "DOTALL,IGNORECASE"}
 
       keys:
         title:
@@ -50,7 +50,7 @@ class RegexpParse(object):
             - {regexp: "magnet:.*?(?=])"}
         custom_field:
           regexps:
-            - {regexp: "custom regexps", flags: "flags for python regexps see python regexps docs"}
+            - {regexp: "custom regexps", flags: "comma seperated list of flags (see python regex docs)"}
           required: False
         custom_field2:
           regexps:


### PR DESCRIPTION
added regex input plugin. A more complete offering of what the text plugin currently does. Specifically support for files, flags, regexs with newlines, and detailed support for custom fields. 0 errors with <code>pep8 --max-line-length=100 --first regex_input.py</code>. I didn't want to send a request to replace the text plugin as my code uses a different config format and would break anyone's setup that uses it.

Example config parse ezrss.it rss feed:

``` yml
regexp_parse:
  source: http://username:password@ezrss.it/feed/
  sections:
    - {regexp: "(?<=<item>).*?(?=</item>)", flags: "DOTALL"}

  keys:
    title:
      regexps:
        - {regexp: '(?<=<title><!\[CDATA\[).*?(?=\]\]></title>)'} #comment
    url:
      regexps:
        - {regexp: "magnet:.*?(?=])"}
    custom_field:
      regexps:
        - {regexp: "custom regexps", flags: "comma separated list of flags (see python regexps docs)"}
      required: False
    custom_field2:
      regexps:
          - {regexp: 'first custom regexps'}
          - {regexp: 'can't find first regexp so try this one'}
```
