### PR TITLE
Heroku compatability.

### DIFF
--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -104,7 +104,7 @@ class Manager(object):
         self.db_filename = None
         self.engine = None
         self.lockfile = None
-        self.database_uri = None
+        self.database_uri = os.environ.get('DATABASE_URL')
         self.db_upgraded = False
 
         self.config = {}


### PR DESCRIPTION
This project is great, but I wanted to run it on Heroku. Since Heroku uses an ephemeral filesystem, sqlite3 doesn't work. This change will allow FlexGet to be deployed to Heroku, and use postgres.
