### PR TITLE
Get emit_series into shape

### DIFF
--- a/docs/develop/index.rst
+++ b/docs/develop/index.rst
@@ -20,6 +20,7 @@ Core
 * PyNBZ
 * Jinja2
 * PyYaml
+* jsonschema
 * Some smaller misc libraries
 
 WebUI


### PR DESCRIPTION
- [ ] We need to have a concept in the database of which series are still configured, along with which tasks they are in
- [x] Deal with season jumping. Probably emit SxEy+1 as well as Sx+1E1

This could be problematic due to episode advancement. If it gets next season too early, it won't fill in the rest of the previous season.
- [ ] An est_released plugin that estimates an episode's next release date based on the history of last found episode times.
- [ ] Deal with possible different form of episode ids (S01E01 vs 1x01)
- [ ] sequence or date based show support? sequence should at least be doable, not sure how well it would come out.
