### PR TITLE
Fixed some issues with torrent_alive related to invalid ports.

### DIFF
--- a/flexget/plugins/filter/torrent_alive.py
+++ b/flexget/plugins/filter/torrent_alive.py
@@ -61,16 +61,31 @@ def get_scrape_url(tracker_url, info_hash):
 
 def get_udp_seeds(url, info_hash):
     parsed_url = urlparse(url)
+    port = None
+    try:
+        port = parsed_url.port
+    except ValueError, ve:
+        log.error('UDP Port Error, url was %s' % url)
+        return 0
+
     log.debug('Checking for seeds from %s' % url)
 
     connection_id = 0x41727101980  # connection id is always this
     transaction_id = randrange(1, 65535)  # Random Transaction ID creation
 
+    if port is None:
+        log.error('UDP Port Error, port was None')
+        return 0
+
+    if port < 0 or port > 65535:
+        log.error('UDP Port Error, port was %s' % port)
+        return 0
+
     # Create the socket
     try:
         clisocket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         clisocket.settimeout(5.0)
-        clisocket.connect((parsed_url.hostname, parsed_url.port))
+        clisocket.connect((parsed_url.hostname, port))
 
         # build packet with connection_ID, using 0 value for action, giving our transaction ID for this packet
         packet = struct.pack(b">QLL", connection_id, 0, transaction_id)

--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -289,6 +289,16 @@ class TestTorrentAlive(FlexGetBase):
         assert self.task.accepted
         assert self.task._rerun_count == 0, 'Torrent should have been accepted without rerun.'
 
+    @attr(online=True)
+    def test_torrent_alive_udp_invalid_port(self):
+        from flexget.plugins.filter.torrent_alive import get_udp_seeds
+        assert get_udp_seeds('udp://[2001::1]/announce','HASH') == 0
+        assert get_udp_seeds('udp://[::1]/announce','HASH') == 0
+        assert get_udp_seeds('udp://["2100::1"]:-1/announce', 'HASH') == 0
+        assert get_udp_seeds('udp://127.0.0.1/announce','HASH') == 0
+        assert get_udp_seeds('udp://127.0.0.1:-1/announce','HASH') == 0
+        assert get_udp_seeds('udp://127.0.0.1:PORT/announce','HASH') == 0
+        assert get_udp_seeds('udp://127.0.0.1:65536/announce','HASH') == 0
 
 class TestRtorrentMagnet(FlexGetBase):
     __tmp__ = True


### PR DESCRIPTION
Should catch all the cases where the port might cause torrent_alive to fail.

Since it's not (easily) possible to catch the real exceptions with the task based approach, get_udp_seeds has been used directly.
