### PR TITLE
regexp queue

### DIFF
--- a/docs/api/flexget.rst
+++ b/docs/api/flexget.rst
@@ -65,16 +65,27 @@ flexget Package
     :undoc-members:
     :show-inheritance:
 
-:mod:`schema` Module
+:mod:`db_schema` Module
 --------------------
 
-.. automodule:: flexget.schema
+.. automodule:: flexget.db_schema
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+:mod:`config_schema` Module
+--------------------
+
+.. automodule:: flexget.config_schema
     :members:
     :undoc-members:
     :show-inheritance:
 
 :mod:`validator` Module
 -----------------------
+
+.. deprecated:: 1.1
+    Use :mod:`config_schema` instead
 
 .. automodule:: flexget.validator
     :members:

--- a/docs/plugins/flexget.plugins.filter.rst
+++ b/docs/plugins/flexget.plugins.filter.rst
@@ -177,6 +177,14 @@ filter Package
     :undoc-members:
     :show-inheritance:
 
+:mod:`regexp` Module
+--------------------
+
+.. automodule:: flexget.plugins.filter.regexp_queue
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 :mod:`retry_failed` Module
 ---------------------------
 

--- a/flexget/plugins/cli/regexp_queue.py
+++ b/flexget/plugins/cli/regexp_queue.py
@@ -1,0 +1,163 @@
+from __future__ import unicode_literals, division, absolute_import
+from datetime import datetime, timedelta
+from string import capwords
+from flexget.event import event
+
+from flexget.manager import Session
+from flexget.plugin import register_plugin, register_parser_option, DependencyError
+from flexget.utils import qualities
+from flexget.utils.tools import console
+
+try:
+    from flexget.plugins.filter.regexp_queue import (QueuedRegexp, queue_add,
+            queue_del, queue_edit, queue_get, QueueError)
+except ImportError:
+    raise DependencyError(issued_by='cli_regexp_queue', missing='regexp_queue', message='RegexpQueue commandline interface not loaded')
+
+
+def cmdline_option(name, *args, **kwargs):
+    f = event('manager.startup')
+    register_parser_option(name, *args, **kwargs)
+    argument_name = name
+    if argument_name.startswith('--'):
+        argument_name = name[2:]
+    argument_name = argument_name.replace('-','_')
+    def wrapper(fn):
+        def func(manager):
+            arg = getattr(manager.options, argument_name, False)
+            if arg:
+                manager.disable_tasks()
+                return fn(manager, arg)
+        return f(func)
+    return wrapper
+
+
+class CLIException(Exception):
+    pass
+
+
+class BaseCLI(object):
+    @classmethod
+    def handle(cls, manager, args):
+        if len(args) == 0:
+            args = [cls.DEFAULT_ACTION]
+
+        action = args[0]
+        args = args[1:]
+        try:
+            return cls._run(action, manager, args)
+        except CLIException as e:
+            console('Error: %s' % e.message)
+            console('Usage: '+ cls.USAGE)
+
+    @classmethod
+    def _run(cls, action, manager, args):
+        func = getattr(cls, 'do_%s' % action, None)
+        if func:
+            return func(manager, args)
+        else:
+            raise CLIException('Invalid action %s' % action)
+
+    @classmethod
+    def register(cls):
+        cmdline_option(cls.OPTION, nargs=cls.NARGS, metavar=cls.METAVAR,
+                help=cls.USAGE)(cls.handle)
+
+class RegexpQueueCLI(BaseCLI):
+    OPTION = '--regexp-queue'
+    NARGS = '*'
+    METAVAR = ('ACTION', 'REGEXP')
+    DEFAULT_ACTION = 'list'
+    ACTIONS = ['add', 'del', 'forget', 'list', 'downloaded', 'clear']
+    USAGE = '(%s) [REGEXP] [QUALITY]' % '|'.join(ACTIONS)
+    ITEM_FORMAT = staticmethod(lambda item: '%-20s %-15s' % (item.regexp, item.quality))
+
+    @staticmethod
+    def do_add(manager, args):
+        if len(args) < 1:
+            raise CLIException('Missing regexp and/or quality parameter')
+        regexp, quality = None, None
+        if len(args) > 1:
+            regexp, quality = args[:2]
+        else:
+            regexp = args[0]
+
+        if not isinstance(regexp, unicode):
+            console('Unknown regexp %s' % regexp)
+            return
+
+        # convert quality
+        if not isinstance(quality, unicode):
+            quality = qualities.Requirements('any')
+        else:
+            quality = qualities.Requirements(quality)
+
+        try:
+            item = queue_add(regexp, quality)
+        except QueueError as e:
+            console('ERROR: %s' % e.message)
+        else:
+            console('Added %s to queue.' % regexp)
+
+
+    @classmethod
+    def do_downloaded(cls, manager, args):
+        return cls.do_list(manager, args, downloaded=True)
+
+    @classmethod
+    def do_list(cls, manager, args, downloaded=False):
+        items = queue_get(downloaded=downloaded)
+        line = lambda: console('-' * 79)
+        line()
+        if len(items) > 0:
+            map(console, map(cls.ITEM_FORMAT, items))
+        else:
+            console('No results')
+
+        line()
+
+
+    @staticmethod
+    def do_del(manager, args):
+        if len(args) == 0:
+            raise CLIException('Missing regexp')
+
+        regexp = args[0]
+
+        try:
+            item = queue_del(regexp=regexp)
+        except QueueError as e:
+            raise CLIException(e.message)
+
+        console('Deleted %s' % regexp)
+
+    @classmethod
+    def do_clear(manager, args):
+        items = queue_get()
+        console('Deleting the following expressions:')
+        line = lambda: console('-' * 79)
+        line()
+        if len(items) > 0:
+            for item in items:
+                console(cls.ITEM_FORMAT(item))
+                queue_del(item.regexp)
+        else:
+            console('No results')
+
+        line()
+
+    @classmethod
+    def do_forget(cls, manager, args):
+        if len(args) < 1:
+            raise CLIException('Missing regexp to delete')
+
+        regexp = args[0]
+        item = queue_get(regexp=regexp)
+        if not item:
+            raise CLIException('Unknown regexp %s' % regexp)
+        console('Deleteing:')
+        console(cls.FORMAT_ITEM(item))
+        queue_del(item.regexp)
+
+RegexpQueueCLI.register()
+

--- a/flexget/plugins/filter/movie_queue.py
+++ b/flexget/plugins/filter/movie_queue.py
@@ -15,6 +15,7 @@ from flexget.event import event
 
 try:
     from flexget.plugins.filter import queue_base
+    from flexget.plugins.filter.queue_base import QueueError
 except ImportError:
     raise DependencyError(issued_by='movie_queue', missing='queue_base',
                           message='movie_queue requires the queue_base plugin')
@@ -109,16 +110,6 @@ class FilterMovieQueue(queue_base.FilterQueueBase):
         if movie and movie.quality_req.allows(quality):
             return movie
 
-
-class QueueError(Exception):
-    """Exception raised if there is an error with a queue operation"""
-
-    # TODO: I think message was removed from exception baseclass and is now masked
-    # some other custom exception (DependencyError) had to make so tweaks to make it work ..
-
-    def __init__(self, message, errno=0):
-        self.message = message
-        self.errno = errno
 
 
 @with_session

--- a/flexget/plugins/filter/queue_base.py
+++ b/flexget/plugins/filter/queue_base.py
@@ -49,7 +49,7 @@ class QueueError(Exception):
     # some other custom exception (DependencyError) had to make so tweaks to make it work ..
 
     def __init__(self, message, errno=0):
-        self.message = message
+        super(QueueError, self).__init__(message)
         self.errno = errno
 
 

--- a/flexget/plugins/filter/queue_base.py
+++ b/flexget/plugins/filter/queue_base.py
@@ -42,6 +42,16 @@ class QueuedItem(Base):
         super(QueuedItem, self).__init__(**kwargs)
         self.added = datetime.now()
 
+class QueueError(Exception):
+    """Exception raised if there is an error with a queue operation"""
+
+    # TODO: I think message was removed from exception baseclass and is now masked
+    # some other custom exception (DependencyError) had to make so tweaks to make it work ..
+
+    def __init__(self, message, errno=0):
+        self.message = message
+        self.errno = errno
+
 
 class FilterQueueBase(object):
     """Base class to handle general tasks of keeping a queue of wanted items."""

--- a/flexget/plugins/filter/regexp_queue.py
+++ b/flexget/plugins/filter/regexp_queue.py
@@ -20,6 +20,7 @@ except ImportError:
     raise DependencyError(issued_by='regexp_queue', missing='queue_base',
                           message='movie_queue requires the queue_base plugin')
 
+
 log = logging.getLogger('regexp_queue')
 Base = db_schema.versioned_base('regexp_queue', 0)
 
@@ -32,6 +33,7 @@ class QueuedRegexp(queue_base.QueuedItem, Base):
     ignorecase = Column(Boolean)
     quality = Column('quality', String)
     quality_req = quality_requirement_property('quality')
+
 
 class FilterRegexpQueue(queue_base.FilterQueueBase):
     def matches(self, task, config, entry):
@@ -72,7 +74,7 @@ def queue_add(regexp=None, quality=None, session=None):
         item = QueuedRegexp(regexp=regexp, quality=quality.text)
         session.add(item)
         log.info('Adding %s to regexp queue with quality=%s.' % (regexp, quality))
-        return {'regexp': regexp, 'quality': quality}
+        return item # {'regexp': regexp, 'quality': quality}
     else:
         if item.downloaded:
             raise QueueError('ERROR: %s has already been queued and downloaded' % regexp)
@@ -97,6 +99,7 @@ def queue_del(regexp=None, session=None):
     except NoResultFound as e:
         raise QueueError('regexp=%s' % (regexp))
 
+
 @with_session
 def queue_edit(regexp, quality, session=None):
     """
@@ -112,6 +115,7 @@ def queue_edit(regexp, quality, session=None):
     except NoResultFound as e:
         raise QueueError('regexp=%s not found from queue' % (regexp))
 
+
 @with_session
 def queue_get(session, downloaded=False):
     """
@@ -125,5 +129,6 @@ def queue_get(session, downloaded=False):
         return session.query(QueuedRegexp).filter(QueueRegexp.downloaded == None).all()
     else:
         return session.query(QueuedRegexp).filter(QueueRegexp.downloaded != None).all()
+
 
 register_plugin(FilterRegexpQueue, 'regexp_queue', api_ver=2)

--- a/flexget/plugins/filter/regexp_queue.py
+++ b/flexget/plugins/filter/regexp_queue.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
 
+import re
+
 from sqlalchemy import Column, Boolean, String, ForeignKey, Integer, and_
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -47,8 +49,8 @@ class FilterRegexpQueue(queue_base.FilterQueueBase):
         expressions = filter(lambda exp: exp.quality_req.allows(quality), expressions)
 
         # compile all the expressions and check if they match
-        compile = lambda exp: re.compile(exp.regexp, re.IGNORECASE | rc.UNICODE)
-        expressions = filter(lambda exp: compile(exp).matches(title), expressions)
+        compile = lambda exp: re.compile(exp.regexp, re.IGNORECASE | re.UNICODE)
+        expressions = filter(lambda exp: compile(exp).search(title), expressions)
 
         # all left over expressions fit the quality and match
         if len(expressions) > 0:
@@ -126,9 +128,9 @@ def queue_get(session, downloaded=False):
     :return: List of QueuedRegexp (deatched from session)
     """
     if not downloaded:
-        return session.query(QueuedRegexp).filter(QueueRegexp.downloaded == None).all()
+        return session.query(QueuedRegexp).filter(QueuedRegexp.downloaded == None).all()
     else:
-        return session.query(QueuedRegexp).filter(QueueRegexp.downloaded != None).all()
+        return session.query(QueuedRegexp).filter(QueuedRegexp.downloaded != None).all()
 
 
 register_plugin(FilterRegexpQueue, 'regexp_queue', api_ver=2)

--- a/flexget/plugins/filter/regexp_queue.py
+++ b/flexget/plugins/filter/regexp_queue.py
@@ -1,0 +1,81 @@
+from __future__ import unicode_literals, division, absolute_import
+import logging
+
+from sqlalchemy import Column, Boolean, String, ForeignKey, Integer, and_
+from sqlalchemy.orm.exc import NoResultFound
+
+from flexget import db_schema
+from flexget.manager import Session
+from flexget.utils import qualities
+from flexget.utils.imdb import extract_id
+from flexget.utils.database import quality_requirement_property, with_session
+from flexget.utils.sqlalchemy_utils import table_exists, table_schema
+from flexget.plugin import DependencyError, get_plugin_by_name, register_plugin
+from flexget.event import event
+
+try:
+    from flexget.plugins.filter import queue_base
+    from flexget.plugins.filter.queue_base import QueueError
+except ImportError:
+    raise DependencyError(issued_by='regexp_queue', missing='queue_base',
+                          message='movie_queue requires the queue_base plugin')
+
+log = logging.getLogger('regexp_queue')
+Base = db_schema.versioned_base('regexp_queue', 0)
+
+
+class QueuedRegexp(queue_base.QueuedItem, Base):
+    __tablename__ = 'regexp_queue'
+    __mapper_args__ = {'polymorphic_identity': 'regexp'}
+    id = Column(Integer, ForeignKey('queue.id'), primary_key=True)
+    regexp = Column(String)
+    ignorecase = Column(Boolean)
+    quality = Column('quality', String)
+    quality_req = quality_requirement_property('quality')
+
+class FilterRegexpQueue(queue_base.FilterQueueBase):
+    def matches(self, task, config, entry):
+        title = entry['title']
+
+        # get all regexp that haven't been loaded yet
+        expressions = task.session.query(QueuedRegexp).filter(QueuedRegexp.downloaded == None)
+
+        # filter unwanted qualities
+        quality = entry.get('quality', qualities.Quality())
+        expressions = filter(lambda exp: exp.quality_req.allows(quality), expressions)
+
+        # compile all the expressions and check if they match
+        compile = lambda exp: re.compile(exp.regexp, re.IGNORECASE | rc.UNICODE)
+        expressions = filter(lambda exp: compile(exp).matches(title), expressions)
+
+        # all left over expressions fit the quality and match
+        if len(expressions) > 0:
+            return expressions[0]
+
+
+@with_session
+def queue_add(regexp=None, quality=None, session=None):
+    """
+    Add an item to the queue
+
+    :param regexp: Regexp that should match to accept an entry
+    :param quality: A QualityRequirements object defining acceptable qualities.
+    :param session: Optional session to use for database updates
+    """
+
+    # check if that regexp is already known
+    item = session.query(QueuedRegexp).filter(QueuedRegexp.regexp == regexp).first()
+
+    if not item:
+        item = QueuedRegexp(regexp=regexp, quality=quality.text)
+        session.add(item)
+        log.info('Adding %s to regexp queue with quality=%s.' % (regexp, quality))
+        return {'regexp': regexp, 'quality': quality}
+    else:
+        if item.downloaded:
+            raise QueueError('ERROR: %s has already been queued and downloaded' % regexp)
+        else:
+            raise QueueError('ERROR: %s is already in the queue' % regexp)
+
+
+register_plugin(FilterRegexpQueue, 'regexp_queue', api_ver=2)

--- a/flexget/ui/plugins/execute/execute.py
+++ b/flexget/ui/plugins/execute/execute.py
@@ -2,8 +2,7 @@ from __future__ import unicode_literals, division, absolute_import
 import logging
 from Queue import Empty
 from flask import render_template, request, flash
-from flask import Module, escape
-from flask.helpers import jsonify
+from flask import Module, escape, jsonify
 from flexget.ui.webui import register_plugin, manager, executor
 from flexget.ui.executor import BufferQueue
 

--- a/flexget/utils/sqlalchemy_utils.py
+++ b/flexget/utils/sqlalchemy_utils.py
@@ -125,3 +125,13 @@ def create_index(table_name, session, *column_names):
         Index(index_name, *columns).create(bind=session.bind)
     except OperationalError:
         log.debug('Error creating index.', exc_info=True)
+
+
+def row_to_dict(row):
+    """
+    Converts the specified sqlalchemy `row` into a dictionary.
+
+    :param row: SQLAlchemy row
+    :return: dict object
+    """
+    return {column.name: getattr(row, column.name) for column in row.__table__.columns}

--- a/tests/test_regexp_queue.py
+++ b/tests/test_regexp_queue.py
@@ -1,0 +1,36 @@
+from __future__ import unicode_literals, division, absolute_import
+
+from flexget.plugins.filter.regexp_queue import queue_add, queue_del, queue_edit, QueuedRegexp
+from flexget.utils.qualities import Requirements as QRequirements, Quality
+from flexget.manager import Session
+from tests import FlexGetBase
+
+
+class TestRegexpQueue(FlexGetBase):
+    def test_add_item(self):
+        regexp = 'Text.*Text'
+        assert queue_add(regexp=regexp).get('regexp') == regexp, "Regexp wasn't the same"
+
+    def test_add_item_with_quality(self):
+        regexp = "Test.*Test"
+
+        quality = Quality('flac')
+        assert queue_add(regexp=regexp, quality=quality).get('quality') == quality.text, "Quality wasn't the same"
+
+    def test_del_item(self):
+        regexp = 'Text.*Text'
+        obj_dict = queue_add(regexp=regexp)
+        assert queue_del(regexp=regexp) == obj_dict['regexp'], 'Didn\'t delete the right item.'
+
+    def test_edit_item(self):
+        regexp = 'Text.*Text'
+        obj_dict = queue_add(regexp=regexp)
+        new_quality = QRequirements('flac')
+        assert queue_edit(regexp=regexp, quality=new_quality.text) == regexp, 'Didn\'t edit the right item.'
+        session = Session()
+        item = session.query(QueuedRegexp).filter(QueuedRegexp.regexp == regexp).first()
+
+        # TODO: quality_req doesn't implement __eq__ which would just compare self.text == b.text
+        assert item.quality == new_quality.text, 'Quality text should be the same.'
+        assert str(item.quality_req) == str(new_quality), 'str.-repr. of qualties should be same'
+

--- a/tests/test_regexp_queue.py
+++ b/tests/test_regexp_queue.py
@@ -9,22 +9,23 @@ from tests import FlexGetBase
 class TestRegexpQueue(FlexGetBase):
     def test_add_item(self):
         regexp = 'Text.*Text'
-        assert queue_add(regexp=regexp).get('regexp') == regexp, "Regexp wasn't the same"
+        assert queue_add(regexp=regexp).regexp == regexp, "Regexp wasn't the same"
 
     def test_add_item_with_quality(self):
         regexp = "Test.*Test"
-
-        quality = Quality('flac')
-        assert queue_add(regexp=regexp, quality=quality).get('quality') == quality.text, "Quality wasn't the same"
+        quality_req = QRequirements('flac')
+        item = queue_add(regexp=regexp, quality=quality_req)
+        assert not item is None
+        assert item.quality_req.text == quality_req.text, "Quality wasn't the same"
 
     def test_del_item(self):
         regexp = 'Text.*Text'
-        obj_dict = queue_add(regexp=regexp)
-        assert queue_del(regexp=regexp) == obj_dict['regexp'], 'Didn\'t delete the right item.'
+        item = queue_add(regexp=regexp)
+        assert queue_del(regexp=regexp) == item.regexp, 'Didn\'t delete the right item.'
 
     def test_edit_item(self):
         regexp = 'Text.*Text'
-        obj_dict = queue_add(regexp=regexp)
+        item = queue_add(regexp=regexp)
         new_quality = QRequirements('flac')
         assert queue_edit(regexp=regexp, quality=new_quality.text) == regexp, 'Didn\'t edit the right item.'
         session = Session()

--- a/tests/test_regexp_queue.py
+++ b/tests/test_regexp_queue.py
@@ -1,37 +1,111 @@
 from __future__ import unicode_literals, division, absolute_import
 
-from flexget.plugins.filter.regexp_queue import queue_add, queue_del, queue_edit, QueuedRegexp
+from flexget.plugins.filter.regexp_queue import (queue_add, queue_del, queue_edit,
+                                        queue_get, QueuedRegexp, FilterRegexpQueue,
+                                        QueueError)
 from flexget.utils.qualities import Requirements as QRequirements, Quality
 from flexget.manager import Session
 from tests import FlexGetBase
 
 
 class TestRegexpQueue(FlexGetBase):
+
+    __yaml__ = """
+        tasks:
+          test_matches:
+            mock:
+              - {title: "Text Hello Text"}
+          test_task:
+            mock:
+              - {title: "Text Hello Text"}
+              - {title: "Text Hello Text2"}
+            regexp_queue: True
+    """
+
     def test_add_item(self):
         regexp = 'Text.*Text'
+
         assert queue_add(regexp=regexp).regexp == regexp, "Regexp wasn't the same"
+
+    def test_add_duplicate_item(self):
+        regexp = 'Text.*Text'
+
+        assert queue_add(regexp=regexp).regexp == regexp, "Regexp wasn't the same"
+        try:
+            queue_add(regexp=regexp)
+        except QueueError:
+            pass
+        else:
+            assert False, 'Exception wasn\' thrown'
+
 
     def test_add_item_with_quality(self):
         regexp = "Test.*Test"
         quality_req = QRequirements('flac')
         item = queue_add(regexp=regexp, quality=quality_req)
+
         assert not item is None
         assert item.quality_req.text == quality_req.text, "Quality wasn't the same"
 
     def test_del_item(self):
         regexp = 'Text.*Text'
         item = queue_add(regexp=regexp)
+
         assert queue_del(regexp=regexp) == item.regexp, 'Didn\'t delete the right item.'
 
     def test_edit_item(self):
+        session = Session()
         regexp = 'Text.*Text'
         item = queue_add(regexp=regexp)
         new_quality = QRequirements('flac')
+
         assert queue_edit(regexp=regexp, quality=new_quality.text) == regexp, 'Didn\'t edit the right item.'
-        session = Session()
+
         item = session.query(QueuedRegexp).filter(QueuedRegexp.regexp == regexp).first()
 
         # TODO: quality_req doesn't implement __eq__ which would just compare self.text == b.text
         assert item.quality == new_quality.text, 'Quality text should be the same.'
         assert str(item.quality_req) == str(new_quality), 'str.-repr. of qualties should be same'
 
+    def test_get_item(self):
+        regexp = 'Text.*Text'
+        item = queue_add(regexp=regexp)
+        queue_entries = queue_get()
+
+        assert len(queue_entries) == 1
+        assert queue_entries[0].regexp == item.regexp
+
+    def test_matches(self):
+        self.execute_task('test_matches')
+        entry = self.task.entries[0]
+        queue_add(regexp=entry['title'])
+
+        regexp_filter = FilterRegexpQueue()
+        assert not regexp_filter.matches(task=self.task, config=None, entry=entry) is None
+
+    def test_matches_fail(self):
+        self.execute_task('test_matches')
+        entry = self.task.entries[0]
+        queue_add(regexp='XXXX')
+
+        regexp_filter = FilterRegexpQueue()
+        assert regexp_filter.matches(task=self.task, config=None, entry=entry) is None
+
+    def test_task(self):
+        queue_add(regexp='2$')
+        self.execute_task('test_task')
+
+        assert self.task.find_entry('accepted', title='Text Hello Text2')
+        assert len(self.task.accepted) == 1
+
+    def test_task_fail(self):
+        queue_add(regexp='XXXXXXXX')
+        self.execute_task('test_task')
+
+        assert self.task.find_entry('accepted', title='Text Hello Text') is None
+        assert len(self.task.accepted) == 0
+
+# TODO
+#class TestRegexpQueueCLI(FlexGetBase):
+#    def test_add_regexp(self):
+#        pass


### PR DESCRIPTION
Adds a queue plugin similar to movie_queue for generic regex matches.

Still todo:
- [x] Cli interface for adding stuff, similar to `--movie-queue`
- [ ] Check if the CLI stuff might need to be rewritten to fit the existing code base
- [ ] Something like `queue_movies` to add to the regex queue from a task

Other stuff?

Maybe some more stuff can be put into queue_base for both plugins to use to implement above.