### PR TITLE
Configurable temp download directory

### DIFF
--- a/flexget/plugins/output/download.py
+++ b/flexget/plugins/output/download.py
@@ -58,7 +58,8 @@ class PluginDownload(object):
                 'properties': {
                     'path': {'type': 'string', 'format': 'path'},
                     'fail_html': {'type': 'boolean', 'default': True},
-                    'overwrite': {'type': 'boolean', 'default': False}
+                    'overwrite': {'type': 'boolean', 'default': False},
+                    'temp': {'type': 'string', 'format': 'path'}
                 },
                 'additionalProperties': False
             },
@@ -76,6 +77,7 @@ class PluginDownload(object):
         if not config.get('path'):
             config['require_path'] = True
         config.setdefault('fail_html', True)
+        config.setdefault('temp', '')
         return config
 
     def on_task_download(self, task, config):
@@ -245,8 +247,13 @@ class PluginDownload(object):
             return
 
         # download and write data into a temp file
-        # generate temp file using stdlib
-        tmp_path = os.path.join(task.manager.config_base, 'temp')
+        # generate temp file using stdlib based on user's config setting
+        temp = task.config['download'].get('temp', False)
+        if temp:
+            tmp_path = temp
+        else:
+            tmp_path = os.path.join(task.manager.config_base, 'temp')
+
         if not os.path.isdir(tmp_path):
             log.debug('creating tmp_path %s' % tmp_path)
             os.mkdir(tmp_path)


### PR DESCRIPTION
I've been using this myself because Flexget is on my SSD and I wanted to avoid unnecessary write cycles.
Turns out, it's also a [3-year old ticket on Trac](http://flexget.com/ticket/452) :)
Although my commit only allows for a change of the temp directory, not disable it altogether. IMO that would require a bigger rewrite of the download plugin with the only benefit being the ability maybe to watch a movie while it downloads - which would break again once multithreaded downloads are allowed.
