### PR TITLE
Fix bug in movie lookup code

### DIFF
--- a/flexget/plugins/filter/movie_queue.py
+++ b/flexget/plugins/filter/movie_queue.py
@@ -152,7 +152,7 @@ def parse_what(what, lookup=True, session=None):
 
     search_entry = Entry(title=result['title'] or '')
     for field in ['imdb_id', 'tmdb_id']:
-        if result.get('field'):
+        if result.get(field):
             search_entry[field] = result[field]
     # Put lazy lookup fields on the search entry
     get_plugin_by_name('imdb_lookup').instance.register_lazy_fields(search_entry)


### PR DESCRIPTION
When adding a movie to the movie queue, the `parse_what` function that
interprets the search term will currently never perform a search using the
imdb_id or tmdb_id.

Currently, when populating the `search_entry` `Entry` dict, the code uses the
string `'field'` instead of the value of the variable `field` to check for id
attributes of the result, causing the `search_entry` dict to only use the
title of the movie and disregard the imdb/tvdb id.

This patch fixes the issue by replacing the string `'field'` with the variable
`field`.
