### PR TITLE
Add old TLDs for the pirate bay url rewriter

### DIFF
--- a/flexget/plugins/urlrewrite_piratebay.py
+++ b/flexget/plugins/urlrewrite_piratebay.py
@@ -12,6 +12,12 @@ from flexget import validator
 
 log = logging.getLogger('piratebay')
 
+TLDS = "com|org|sx|se"
+CUR_TLD = "sx"
+
+URL_MATCH = re.compile("^http://(?:torrent\.)?thepiratebay\.(?:%s)/.*$" % TLDS)
+URL_SEARCH = re.compile("^http://thepiratebay\.(?:%s)/search/.*$" % TLDS)
+
 CATEGORIES = {
     'all': 0,
     'audio': 100,
@@ -50,12 +56,7 @@ class UrlRewritePirateBay(object):
         url = entry['url']
         if url.endswith('.torrent'):
             return False
-        url = url.replace('thepiratebay.org', 'thepiratebay.sx')
-        if url.startswith('http://thepiratebay.sx/'):
-            return True
-        if url.startswith('http://torrents.thepiratebay.sx/'):
-            return True
-        return False
+        return bool(URL_MATCH.match(url))
 
     # urlrewriter API
     def url_rewrite(self, task, entry):
@@ -63,7 +64,7 @@ class UrlRewritePirateBay(object):
             log.error("Didn't actually get a URL...")
         else:
             log.debug("Got the URL: %s" % entry['url'])
-        if entry['url'].startswith(('http://thepiratebay.sx/search/', 'http://thepiratebay.org/search/')):
+        if URL_SEARCH.match(entry['url']):
             # use search
             results = self.search(entry)
             if not results:
@@ -113,14 +114,14 @@ class UrlRewritePirateBay(object):
             # TPB search doesn't like dashes
             query = query.replace('-', ' ')
             # urllib.quote will crash if the unicode string has non ascii characters, so encode in utf-8 beforehand
-            url = 'http://thepiratebay.sx/search/' + urllib.quote(query.encode('utf-8')) + filter_url
+            url = 'http://thepiratebay.%s/search/%s%s' % (CUR_TLD, urllib.quote(query.encode('utf-8')), filter_url)
             log.debug('Using %s as piratebay search url' % url)
             page = requests.get(url).content
             soup = get_soup(page)
             for link in soup.find_all('a', attrs={'class': 'detLink'}):
                 entry = Entry()
                 entry['title'] = link.contents[0]
-                entry['url'] = 'http://thepiratebay.sx' + link.get('href')
+                entry['url'] = 'http://thepiratebay.%s%s' % (CUR_TLD, link.get('href'))
                 tds = link.parent.parent.parent.find_all('td')
                 entry['torrent_seeds'] = int(tds[-2].contents[0])
                 entry['torrent_leeches'] = int(tds[-1].contents[0])


### PR DESCRIPTION
The old Pirate Bay URL rewriter has the domains hardcoded in multiple places. This patch switches to using regular expressions and allows for matching any number of the old TPB domain names, as well as specifying the current correct TLD.

Since TPB domain changes so often, it makes sense to go this route.
