### PR TITLE
Enhance title parsing of entries

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -23,7 +23,7 @@ install_requires = ['FeedParser>=5.1.3', 'SQLAlchemy >=0.7, <0.7.99', 'PyYAML', 
                     # There is a bug in beautifulsoup 4.2.0 that breaks imdb parsing, see http://flexget.com/ticket/2091
                     'beautifulsoup4>=4.1, !=4.2.0, <4.4', 'html5lib>=0.11', 'PyRSS2Gen', 'pynzb', 'progressbar',
                     'jinja2', 'flask', 'cherrypy', 'requests>=1.0, <2.99', 'python-dateutil!=2.0, !=2.2', 'jsonschema>=2.0',
-                    'python-tvrage', 'tmdb3']
+                    'python-tvrage', 'tmdb3', 'guessit']
 if sys.version_info < (2, 7):
     # argparse is part of the standard library in python 2.7+
     install_requires.append('argparse')


### PR DESCRIPTION
Title parsing fails to often. Here is some tweaks to make it more efficient.

Tasks:
- [ ] Remove language tags in movie parser (FRENCH, GERMAN, TRUEFRENCH, etc ...)
- [ ] Remove file extensions in movie parser (iso, rar, zip, ...)
- [ ] Add more qualities (dvix, ...)
- [ ] Make a Unit Test with various entry titles (scene tagging, dirty tagging, no tagging at all, ...)
- [ ] Support custom configuration through a "titleparser" plugin

If you have other ideas, we can talk about it here ...
