### PR TITLE
AssumeQuality plugin - default quality for tasks

### DIFF
--- a/flexget/plugins/metainfo/assume_quality.py
+++ b/flexget/plugins/metainfo/assume_quality.py
@@ -29,10 +29,9 @@ class AssumeQuality(object):
     schema = {
         'oneOf': [
             {'title':'simple config', 'type': 'string', 'format': 'quality'},
-            {'title':'advanced config', 'type': 'object', 'properties': {
-                           'target': {'type': 'string', 'format': 'quality'},
-                           'quality': {'type': 'string', 'format': 'quality'}
-                           }
+            {'title':'advanced config', 'type': 'object',
+                   #Can't validate dict keys, so allow any
+                   'additionalProperties': {'type': 'string', 'format': 'quality'}
             }
         ]
     }


### PR DESCRIPTION
Update of https://github.com/Flexget/Flexget/pull/111

Many releases no longer explicitly flag 720p, breaking quality filters or requiring complex manipulate setups. This allows default quality components to be applied to entries when missing from the release.

For example: "assumequality: 1080p webdl 10bit truehd" and a release flagged 720p h264 is output with "720p webdl h264 truehd"

http://flexget.com/ticket/1498
