### PR TITLE
Change PluginDetails to output warning event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ setuptools-*.tar.gz
 pip-*.tar.gz
 .DS_Store
 /lib64
+*.noseids

--- a/flexget/plugins/plugin_verbose_details.py
+++ b/flexget/plugins/plugin_verbose_details.py
@@ -17,7 +17,7 @@ class PluginDetails(object):
             if task.no_entries_ok:
                 log.verbose('Task didn\'t produce any entries.')
             else:
-                log.verbose('Task didn\'t produce any entries. This is likely due to a mis-configured or non-functional input.')
+                log.warning('Task didn\'t produce any entries. This is likely due to a mis-configured or non-functional input.')
         else:
             log.verbose('Produced %s entries.' % (len(task.entries)))
 


### PR DESCRIPTION
Changes PluginDetails to output a warning log event rather than
verbose when a task with no_entries_ok == false produces no entries.
Brings it more in line with similar errors (no input plugins, etc) and
makes problem more obvious in logs.
