### PR TITLE
Subliminal plugin added.

### DIFF
--- a/flexget/plugins/output/subtitles_periscope.py
+++ b/flexget/plugins/output/subtitles_periscope.py
@@ -2,7 +2,8 @@ import logging
 import os
 import tempfile
 
-from flexget.plugin import register_plugin, DependencyError
+from flexget import plugin
+from flexget.event import event
 
 log = logging.getLogger('subtitles')
 
@@ -45,7 +46,7 @@ class PluginPeriscope(object):
             import periscope
         except ImportError as e:
             log.debug('Error importing Periscope: %s' % e)
-            raise DependencyError('periscope', 'periscope', 
+            raise plugin.DependencyError('periscope', 'periscope', 
                                   'Periscope module required. ImportError: %s' % e)
     
     def subbed(self, filename):
@@ -94,6 +95,8 @@ class PluginPeriscope(object):
                     # don't want to abort the entire task for errors in a  
                     # single video file or for occasional network timeouts
                     entry.fail(err.message)
-    
 
-register_plugin(PluginPeriscope, 'periscope', api_ver=2)
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(PluginPeriscope, 'periscope', api_ver=2)

--- a/flexget/plugins/output/subtitles_subliminal.py
+++ b/flexget/plugins/output/subtitles_subliminal.py
@@ -2,7 +2,8 @@ import logging
 import os
 import tempfile
 
-from flexget.plugin import register_plugin, DependencyError
+from flexget import plugin
+from flexget.event import event
 
 log = logging.getLogger('subtitles')
 
@@ -44,13 +45,13 @@ class PluginSubliminal(object):
             import babelfish
         except ImportError as e:
             log.debug('Error importing Babelfish: %s' % e)
-            raise DependencyError('subliminal', 'babelfish', 
+            raise plugin.DependencyError('subliminal', 'babelfish', 
                                   'Babelfish module required. ImportError: %s' % e)
         try:
             import subliminal
         except ImportError as e:
             log.debug('Error importing Subliminal: %s' % e)
-            raise DependencyError('subliminal', 'subliminal', 
+            raise plugin.DependencyError('subliminal', 'subliminal', 
                                   'Subliminal module required. ImportError: %s' % e)
     
     def on_task_output(self, task, config):
@@ -97,4 +98,6 @@ class PluginSubliminal(object):
                     entry.fail(err.message)
 
 
-register_plugin(PluginSubliminal, 'subliminal', api_ver=2)
+@event('plugin.register')
+def register_plugin():
+    plugin.register(PluginSubliminal, 'subliminal', api_ver=2)


### PR DESCRIPTION
Subliminal itself check for existing subtitles (even inside mkv videos), so there's no need for a 'overwrite' control in the plugin schema as for Periscope. Language codes instead must be 3-letter ISO-639-3 code. The accept/reject criteria is the same. Subs will have the language code in extension (i.e. "title.it.srt", "title.en.srt" ecc).
