### PR TITLE
Allow all_series to parse only

### DIFF
--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -913,6 +913,10 @@ class FilterSeries(FilterSeriesBase):
             if entry.get('series_name') and entry.get('series_id') is not None and entry.get('series_parser'):
                 found_series.setdefault(entry['series_name'], []).append(entry)
 
+        if task.config.get('all_series', {}).get('parse_only'):
+            log.debug('Skipping filtering of any series because of parse_only')
+            return
+
         for series_item in config:
             series_name, series_config = series_item.items()[0]
             if series_config.get('parse_only'):


### PR DESCRIPTION
all_series and parse_only previously didn't play well together. This allows them to work as expected.
