### PR TITLE
Torrentz improvements

### DIFF
--- a/flexget/plugins/urlrewrite_torrentz.py
+++ b/flexget/plugins/urlrewrite_torrentz.py
@@ -40,7 +40,7 @@ class UrlRewriteTorrentz(object):
     }
 
     def process_config(self, config):
-        """Return plugin configuration in advonced form"""
+        """Return plugin configuration in advanced form"""
         if isinstance(config, basestring):
             config = {'reputation': config}
         if config.get('extra_terms'):


### PR DESCRIPTION
Allow users to specify "extra_terms" to be added to their searches. This is extremely handy for keeping movies out of a series task and vice versa, therefore reducing the number of lookups required for any given task.
