### PR TITLE
Force no_entries_ok if rss is run with all_entries=False

### DIFF
--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -195,6 +195,7 @@ class InputRSS(object):
                        task.options.nocache or task.options.retry)
         headers = {}
         if not all_entries:
+            task.no_entries_ok = True
             etag = task.simple_persistence.get('%s_etag' % url_hash, None)
             if etag:
                 log.debug('Sending etag %s for task %s', etag, task.name)


### PR DESCRIPTION
RSS can end up producing no entries if all_entries == False. Though
usually handled as-is, if it does not encounter a HTTP 304 response
no_entries_ok is never set.

Fixes #143
