### PR TITLE
Require at least 1 item in the path list of the find plugin

### DIFF
--- a/flexget/plugins/input/find.py
+++ b/flexget/plugins/input/find.py
@@ -37,7 +37,7 @@ class InputFind(object):
         from flexget import validator
         root = validator.factory('dict')
         root.accept('path', key='path', required=True)
-        root.accept('list', key='path').accept('path')
+        root.accept('list', key='path', minItems=1).accept('path')
         root.accept('text', key='mask')
         root.accept('regexp', key='regexp')
         root.accept('boolean', key='recursive')

--- a/flexget/validator.py
+++ b/flexget/validator.py
@@ -366,13 +366,17 @@ class UrlValidator(TextValidator):
 class ListValidator(Validator):
     name = 'list'
 
+    def __init__(self, *args, **kwargs):
+        self.minItems = kwargs.pop('minItems', 0)
+        Validator.__init__(self, *args, **kwargs)
+
     def accept(self, value, **kwargs):
         v = self.get_validator(value, **kwargs)
         self.valid.append(v)
         return v
 
     def _schema(self):
-        return {'type': 'array', 'items': any_schema([v.schema() for v in self.valid])}
+        return {'type': 'array', 'minItems': self.minItems, 'items': any_schema([v.schema() for v in self.valid])}
 
 
 class DictValidator(Validator):


### PR DESCRIPTION
This requires at least 1 item in the path list. Additionally it allows other plugins to specify the  'minItems' argument from jsonschema on 'list'-validators.
