### PR TITLE
Fix for errors caused when searching tvrage for release estimations

### DIFF
--- a/flexget/plugins/api_tvrage.py
+++ b/flexget/plugins/api_tvrage.py
@@ -189,6 +189,11 @@ def lookup_series(name=None, session=None):
     except (timeout, AttributeError):
         # AttributeError is due to a bug in tvrage package trying to access URLError.code
         raise LookupError('Timed out while connecting to tvrage')
+    except TypeError:
+        # TODO: There should be option to pass tvrage id directly from within series plugin via "set:" (like tvdb_id)
+        # and search directly for tvrage id. This is problematic, because 3rd party TVRage API does not support this.
+        raise LookupError('Returned invalid data for "%s". This is often caused when TVRage is missing episode info'
+                          % name)
     # Make sure the result is close enough to the search
     if difflib.SequenceMatcher(a=name, b=fetched.name).ratio() < 0.7:
         log.debug('Show result `%s` was not a close enough match for `%s`' % (fetched.name, name))


### PR DESCRIPTION
Just a quick fix, so that Flexget won't just close when it happens. 

This is a fix for tickets #2276 and #2222 (there could be more, though)

It can  be fixed better, for example by adjusting the series name in user's configurations to match that of TVrage's. However if users makes series filter from trakt_list for example, it's not possible to change series' name.

I tried to experimentally add a way of directly telling ragetv ID for complicated shows (for example trakt_list could pass this on too so it would be handy to have), but problems I faced were:
- Lot of spaghetti-passing of task instances through lot of methods from discover.py up until flexget's api_tvrage.py
- 3rd party python-tvrage does not support looking up show by telling it tvrage ID directly - this could be solved by either overriding their method, or merging their API to flexget's directly (could be beneficial, because there hasn't been an update for python-tvrage in a while, so it could be abandoned)
