### PR TITLE
Update plugin_transmission.py (base64encode & cli.add_torrent)

### DIFF
--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -336,8 +336,7 @@ class PluginTransmission(TransmissionBase):
                     torrent = r
                 log.info('"%s" torrent added to transmission' % (entry['title']))
                 if options['change'].keys():
-                    for id in r.keys():
-                        cli.change(id, 30, **options['change'])
+                    cli.change_torrent(id, 30, **options['change'])
             except TransmissionError as e:
                 log.debug('TransmissionError', exc_info=True)
                 log.debug('Failed options dict: %s' % options)


### PR DESCRIPTION
As of transmissionrpc-0.11-py2.7.egg/client.py
add() & add_uri() are deprecated.

Althought, I was getting transmissionError (Query failed with result:...) when trying to launch a new torrent. So I went in the rpc/client code and used the same syntax they use to base64 the data and everything'sback to normal working order ^^

Althought I suspect that line 339 (for id in r.keys(): ) won't work with the return from cli.add_torrent(), I'm not equipped to deal with that (don't know when it occurs)
