### PR TITLE
Changed clean_symbols method to match on all non-word, non-digit symbols

### DIFF
--- a/flexget/plugins/search_publichd.py
+++ b/flexget/plugins/search_publichd.py
@@ -9,7 +9,7 @@ from flexget.event import event
 from flexget.config_schema import one_or_more
 from flexget.utils import requests
 from flexget.utils.soup import get_soup
-from flexget.utils.search import torrent_availability, normalize_unicode
+from flexget.utils.search import torrent_availability, normalize_unicode, clean_title
 
 log = logging.getLogger('publichd')
 
@@ -80,7 +80,7 @@ class SearchPublicHD(object):
 
         entries = set()
         for search_string in entry.get('search_strings', [entry['title']]):
-            query = normalize_unicode(search_string)
+            query = normalize_unicode(clean_title(search_string))
             query_url_fragment = '&search=' + urllib.quote(query.encode('utf8'))
 
             # http://publichd.se/index.php?page=torrents&active=0&category=5;15&search=QUERY

--- a/flexget/utils/search.py
+++ b/flexget/utils/search.py
@@ -11,7 +11,7 @@ def clean_symbols(text):
     result = text
     if isinstance(result, unicode):
         result = normalize('NFKD', result)
-    return re.sub('[ \(\)\-_\[\]\.]+', ' ', result).lower()
+    return re.sub(r'[^\w\d]+', ' ', result).lower()
 
 
 def clean_title(title):


### PR DESCRIPTION
- publichd search plugin will use clean_title to remove non-word non-digit symbols from search queries 

Before this fix, release "Enders.Game.2013.etc.etc" wouldn't be found because search plugins will search for "Ender's Game" instead. (this should possibly do other plugins as well?)