### PR TITLE
Expose full torrent directory structure in content_files

### DIFF
--- a/flexget/plugins/plugin_deluge.py
+++ b/flexget/plugins/plugin_deluge.py
@@ -239,7 +239,7 @@ class InputDeluge(DelugePlugin):
         'save_path': 'deluge_path',
         'label': 'deluge_label',
         'total_size': ('content_size', lambda size: size / 1024 / 1024),
-        'files': ('content_files', lambda file_dicts: [os.path.basename(f['path']) for f in file_dicts])}
+        'files': ('content_files', lambda file_dicts: [f['path'] for f in file_dicts])}
 
     def __init__(self):
         self.entries = []


### PR DESCRIPTION
Currently the directory structure inside the torrent (if any) is removed prior to adding to entry['content_files']. This makes the structure opaque to any other plugin that may need it (such as a downloading plugin). This change passes the full directory structure along with the filename.

As discussed in IRC the only affected plugin is content_filter and this actually should make the behavior consistent with torrent.py (which reads a torrent file and, amongst other things provides the full directory structure in content_files).
