### PR TITLE
Catch socket errors

### DIFF
--- a/flexget/plugins/plugin_aria2.py
+++ b/flexget/plugins/plugin_aria2.py
@@ -8,6 +8,7 @@ import xmlrpclib
 from flexget import plugin
 from flexget.event import event
 from flexget.entry import Entry
+from flexget.utils.template import RenderError
 from socket import error as socket_error
 
 log = logging.getLogger('aria2')


### PR DESCRIPTION
Catch socket errors where they occur (during use of the XML-RPC connection, not when the connection is initiated).
