### PR TITLE
Update plugin_transmission.py (base64encode & cli.add_torrent & cli.change_torrent)

### DIFF
--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -336,7 +336,7 @@ class PluginTransmission(TransmissionBase):
                     torrent = r
                 log.info('"%s" torrent added to transmission' % (entry['title']))
                 if options['change'].keys():
-                    cli.change_torrent(id, 30, **options['change'])
+                    cli.change_torrent(r.id, 30, **options['change'])
             except TransmissionError as e:
                 log.debug('TransmissionError', exc_info=True)
                 log.debug('Failed options dict: %s' % options)


### PR DESCRIPTION
Finished verification of pull request #173

Updated the base encoding to use same behavior as transmissionrpc https://bitbucket.org/blueluna/transmissionrpc/src/c5237f6ed9e2c9ad5dccf7387bf0b6cc95785152/transmissionrpc/client.py?at=default#cl-704

Updated to use cli.change_torrent and cli.add_torrent instead of deprecated functions.
