### PR TITLE
Subtasks, take 2

### DIFF
--- a/flexget/options.py
+++ b/flexget/options.py
@@ -389,7 +389,10 @@ class CoreArgumentParser(ArgumentParser):
                                       'maintenance to run, disables stdout and stderr output, reduces logging level')
         exec_parser.add_argument('--profile', action='store_true', default=False, help=SUPPRESS)
         exec_parser.add_argument('--disable-phases', nargs='*', help=SUPPRESS)
+        exec_parser.add_argument('--auto-accept', action='store_true', help=SUPPRESS)
         exec_parser.add_argument('--inject', nargs='+', action=InjectAction, help=SUPPRESS)
+        exec_parser.add_argument('--disable-builtins', dest='builtins', action='store_false', default=True,
+                                 help=SUPPRESS)
         # Plugins should respect these flags where appropriate
         exec_parser.add_argument('--retry', action='store_true', dest='retry', default=False, help=SUPPRESS)
         exec_parser.add_argument('--no-cache', action='store_true', dest='nocache', default=False,

--- a/flexget/plugins/filter/accept_all.py
+++ b/flexget/plugins/filter/accept_all.py
@@ -18,6 +18,10 @@ class FilterAcceptAll(object):
 
     schema = {'type': 'boolean'}
 
+    def on_task_start(self, task, config):
+        # Can also be used to turn off the task auto_accept option from the config
+        task.options.auto_accept = config
+
     def on_task_filter(self, task, config):
         if config:
             for entry in task.entries:

--- a/flexget/plugins/filter/crossmatch.py
+++ b/flexget/plugins/filter/crossmatch.py
@@ -3,6 +3,7 @@ import logging
 
 from flexget import plugin
 from flexget.event import event
+from flexget.task import Task
 
 log = logging.getLogger('crossmatch')
 
@@ -26,7 +27,7 @@ class CrossMatch(object):
         'properties': {
             'fields': {'type': 'array', 'items': {'type': 'string'}},
             'action': {'enum': ['accept', 'reject']},
-            'from': {'type': 'array', 'items': {'$ref': '/schema/plugins?phase=input'}}
+            'from': {'$ref': '/schema/plugins'}
         },
         'required': ['fields', 'action', 'from'],
         'additionalProperties': False
@@ -37,28 +38,9 @@ class CrossMatch(object):
         fields = config['fields']
         action = config['action']
 
-        match_entries = []
-
-        # TODO: xxx
-        # we probably want to have common "run and combine inputs" function sometime soon .. this code is in
-        # few places already (discover, inputs, ...)
-        # code written so that this can be done easily ...
-        for item in config['from']:
-            for input_name, input_config in item.iteritems():
-                input = plugin.get_plugin_by_name(input_name)
-                if input.api_ver == 1:
-                    raise plugin.PluginError('Plugin %s does not support API v2' % input_name)
-                method = input.phase_handlers['input']
-                try:
-                    result = method(task, input_config)
-                except plugin.PluginError as e:
-                    log.warning('Error during input plugin %s: %s' % (input_name, e))
-                    continue
-                if result:
-                    match_entries.extend(result)
-                else:
-                    log.warning('Input %s did not return anything' % input_name)
-                    continue
+        subtask = task.make_subtask(name_ext='/crossmatch/from', config=config['from'])
+        subtask.execute()
+        match_entries = list(subtask.accepted)
 
         # perform action on intersecting entries
         for entry in task.entries:

--- a/flexget/plugins/input/discover.py
+++ b/flexget/plugins/input/discover.py
@@ -6,9 +6,10 @@ import random
 from sqlalchemy import Column, Integer, DateTime, Unicode, Index
 
 from flexget import options, plugin
+from flexget import db_schema
 from flexget.event import event
 from flexget.plugin import get_plugin_by_name, PluginError, PluginWarning
-from flexget import db_schema
+from flexget.task import Task
 from flexget.utils.tools import parse_timedelta, multiply_timedelta
 
 log = logging.getLogger('discover')
@@ -50,7 +51,7 @@ class Discover(object):
 
       discover:
         what:
-          - emit_series: yes
+          emit_series: yes
         from:
           - piratebay
         interval: [1 hours|days|weeks]
@@ -60,9 +61,7 @@ class Discover(object):
     schema = {
         'type': 'object',
         'properties': {
-            'what': {'type': 'array', 'items': {
-                'allOf': [{'$ref': '/schema/plugins?phase=input'}, {'maxProperties': 1, 'minProperties': 1}]
-            }},
+            'what': {'$ref': '/schema/plugins'},
             'from': {'type': 'array', 'items': {
                 'allOf': [{'$ref': '/schema/plugins?group=search'}, {'maxProperties': 1, 'minProperties': 1}]
             }},
@@ -78,41 +77,11 @@ class Discover(object):
         """
         :param config: Discover config
         :param task: Current task
-        :return: List of pseudo entries created by inputs under `what` configuration
+        :return: List of pseudo entries created by task under `what` configuration
         """
-        entries = []
-        entry_titles = set()
-        entry_urls = set()
-        # run inputs
-        for item in config['what']:
-            for input_name, input_config in item.iteritems():
-                input = get_plugin_by_name(input_name)
-                if input.api_ver == 1:
-                    raise PluginError('Plugin %s does not support API v2' % input_name)
-                method = input.phase_handlers['input']
-                try:
-                    result = method(task, input_config)
-                except PluginError as e:
-                    log.warning('Error during input plugin %s: %s' % (input_name, e))
-                    continue
-                if not result:
-                    log.warning('Input %s did not return anything' % input_name)
-                    continue
-
-                for entry in result:
-                    urls = ([entry['url']] if entry.get('url') else []) + entry.get('urls', [])
-                    if any(url in entry_urls for url in urls):
-                        log.debug('URL for `%s` already in entry list, skipping.' % entry['title'])
-                        continue
-
-                    if entry['title'] in entry_titles:
-                        log.verbose('Ignored duplicate title `%s`' % entry['title'])    # TODO: should combine?
-                        continue
-
-                    entries.append(entry)
-                    entry_titles.add(entry['title'])
-                    entry_urls.update(urls)
-        return entries
+        subtask = task.make_subtask('/discover/what', config['what'])
+        subtask.execute()
+        return list(subtask.accepted)
 
     def execute_searches(self, config, entries):
         """

--- a/flexget/plugins/input/emit_series.py
+++ b/flexget/plugins/input/emit_series.py
@@ -72,12 +72,10 @@ class EmitSeries(object):
         entries = []
         # Determine series we should be emitting
         seriestasks = task.session.query(SeriesTask)
-        if 'series' in task.config:
+        if task.parent:
+            seriestasks = seriestasks.filter((SeriesTask.name == task.name) | (SeriesTask.name == task.parent.name))
+        else:
             seriestasks = seriestasks.filter(SeriesTask.name == task.name)
-        # If this task doesn't have series plugin, check if parent does
-        elif task.parent and 'series' in task.parent.config:
-            seriestasks = seriestasks.filter(SeriesTask.name == task.parent.name)
-        # If no series plugin is found in this or parent task, we'll just emit every configured series
 
         for seriestask in seriestasks.all():
             series = seriestask.series

--- a/flexget/plugins/input/emit_series.py
+++ b/flexget/plugins/input/emit_series.py
@@ -69,7 +69,16 @@ class EmitSeries(object):
         if not task.is_rerun:
             self.try_next_season = {}
         entries = []
-        for seriestask in task.session.query(SeriesTask).filter(SeriesTask.name == task.name).all():
+        # Determine series we should be emitting
+        seriestasks = task.session.query(SeriesTask)
+        if 'series' in task.config:
+            seriestasks = seriestasks.filter(SeriesTask.name == task.name)
+        # If this task doesn't have series plugin, check if parent does
+        elif task.parent and 'series' in task.parent.config:
+            seriestasks = seriestasks.filter(SeriesTask.name == task.parent.name)
+        # If no series plugin is found in this or parent task, we'll just emit every configured series
+
+        for seriestask in seriestasks.all():
             series = seriestask.series
             if not series:
                 # TODO: How can this happen?

--- a/flexget/plugins/input/inputs.py
+++ b/flexget/plugins/input/inputs.py
@@ -3,6 +3,7 @@ import logging
 
 from flexget import plugin
 from flexget.event import event
+from flexget.task import TaskAbort
 
 log = logging.getLogger('inputs')
 
@@ -20,43 +21,42 @@ class PluginInputs(object):
 
     schema = {
         'type': 'array',
-        'items': {'allOf': [{'$ref': '/schema/plugins?phase=input'}, {'maxProperties': 1, 'minProperties': 1}]}
+        'items': {'allOf': [{'$ref': '/schema/plugins'}, {'minProperties': 1}]}
     }
 
     def on_task_input(self, task, config):
         entries = []
         entry_titles = set()
         entry_urls = set()
-        for item in config:
-            for input_name, input_config in item.iteritems():
-                input = plugin.get_plugin_by_name(input_name)
-                if input.api_ver == 1:
-                    raise plugin.PluginError('Plugin %s does not support API v2' % input_name)
+        for index, item in enumerate(config):
+            # This turns off auto_accept so that entries can be transferred directly to main task
+            # Perhaps it should keep it on, then reset and inject only accepted entries
+            subtask = task.make_subtask('/inputs/%s' % index, item, options={'auto_accept': False})
+            try:
+                subtask.execute()
+            except TaskAbort as e:
+                log.warning('Error during input number %s: %s' % (index, e))
+                continue
 
-                method = input.phase_handlers['input']
-                try:
-                    result = method(task, input_config)
-                except plugin.PluginError as e:
-                    log.warning('Error during input plugin %s: %s' % (input_name, e))
+            result = subtask.all_entries
+            if not result:
+                msg = 'Input %s did not return anything' % index
+                if getattr(subtask, 'no_entries_ok', False):
+                    log.verbose(msg)
+                else:
+                    log.warning(msg)
+                continue
+            for entry in result:
+                if entry['title'] in entry_titles:
+                    log.debug('Title `%s` already in entry list, skipping.' % entry['title'])
                     continue
-                if not result:
-                    msg = 'Input %s did not return anything' % input_name
-                    if getattr(task, 'no_entries_ok', False):
-                        log.verbose(msg)
-                    else:
-                        log.warning(msg)
+                urls = ([entry['url']] if entry.get('url') else []) + entry.get('urls', [])
+                if any(url in entry_urls for url in urls):
+                    log.debug('URL for `%s` already in entry list, skipping.' % entry['title'])
                     continue
-                for entry in result:
-                    if entry['title'] in entry_titles:
-                        log.debug('Title `%s` already in entry list, skipping.' % entry['title'])
-                        continue
-                    urls = ([entry['url']] if entry.get('url') else []) + entry.get('urls', [])
-                    if any(url in entry_urls for url in urls):
-                        log.debug('URL for `%s` already in entry list, skipping.' % entry['title'])
-                        continue
-                    entries.append(entry)
-                    entry_titles.add(entry['title'])
-                    entry_urls.update(urls)
+                entries.append(entry)
+                entry_titles.add(entry['title'])
+                entry_urls.update(urls)
         return entries
 
 

--- a/flexget/plugins/plugin_configure_series.py
+++ b/flexget/plugins/plugin_configure_series.py
@@ -8,7 +8,6 @@ from flexget import db_schema, plugin
 from flexget.event import event
 from flexget.config_schema import process_config
 from flexget.plugins.filter.series import FilterSeriesBase
-from flexget.task import Task
 
 log = logging.getLogger('configure_series')
 Base = db_schema.versioned_base('import_series', 0)

--- a/flexget/plugins/plugin_configure_series.py
+++ b/flexget/plugins/plugin_configure_series.py
@@ -8,6 +8,7 @@ from flexget import db_schema, plugin
 from flexget.event import event
 from flexget.config_schema import process_config
 from flexget.plugins.filter.series import FilterSeriesBase
+from flexget.task import Task
 
 log = logging.getLogger('configure_series')
 Base = db_schema.versioned_base('import_series', 0)
@@ -49,38 +50,31 @@ class ConfigureSeries(FilterSeriesBase):
             'type': 'object',
             'properties': {
                 'settings': self.settings_schema,
-                'from': {'$ref': '/schema/plugins?phase=input'}
+                'from': {'$ref': '/schema/plugins'}
             },
+            'required': ['from'],
             'additionalProperties': False
         }
 
     def on_task_start(self, task, config):
+        subtask = task.make_subtask('/configure_series/from', config=config['from'])
+        subtask.execute()
+        result = subtask.accepted
 
         series = {}
-        for input_name, input_config in config.get('from', {}).iteritems():
-            input = plugin.get_plugin_by_name(input_name)
-            if input.api_ver == 1:
-                raise plugin.PluginError('Plugin %s does not support API v2' % input_name)
+        for entry in result:
+            s = series.setdefault(entry['title'], {})
+            if entry.get('tvdb_id'):
+                s['set'] = {'tvdb_id': entry['tvdb_id']}
 
-            method = input.phase_handlers['input']
-            result = method(task, input_config)
-            if not result:
-                log.warning('Input %s did not return anything' % input_name)
-                continue
-
-            for entry in result:
-                s = series.setdefault(entry['title'], {})
-                if entry.get('tvdb_id'):
-                    s['set'] = {'tvdb_id': entry['tvdb_id']}
-
-                # Allow configure_series to set anything available to series
-                for key, schema in self.settings_schema['properties'].iteritems():
-                    if 'configure_series_' + key in entry:
-                        errors = process_config(entry['configure_series_' + key], schema, set_defaults=False)
-                        if errors:
-                            log.debug('not setting series option %s for %s. errors: %s' % (key, entry['title'], errors))
-                        else:
-                            s[key] = entry['configure_series_' + key]
+            # Allow configure_series to set anything available to series
+            for key, schema in self.settings_schema['properties'].iteritems():
+                if 'configure_series_' + key in entry:
+                    errors = process_config(entry['configure_series_' + key], schema, set_defaults=False)
+                    if errors:
+                        log.debug('not setting series option %s for %s. errors: %s' % (key, entry['title'], errors))
+                    else:
+                        s[key] = entry['configure_series_' + key]
 
         # Set the config_modified flag if the list of shows changed since last time
         new_hash = hashlib.md5(unicode(sorted(series))).hexdigest().decode('ascii')

--- a/flexget/plugins/plugin_entry_trace.py
+++ b/flexget/plugins/plugin_entry_trace.py
@@ -14,6 +14,14 @@ def on_entry_action(entry, act=None, task=None, reason=None, **kwargs):
         entry['reason'] = reason
 
 
+def on_entry_reset(entry):
+    """Remove the metainfo we added to the entry."""
+    entry.pop('accepted_by', None)
+    entry.pop('rejected_by', None)
+    entry.pop('failed_by', None)
+    entry.pop('reason', None)
+
+
 class EntryOperations(object):
     """
     Records accept, reject and fail metainfo into entries.
@@ -33,6 +41,7 @@ class EntryOperations(object):
             entry.on_accept(on_entry_action, act='accepted', task=task)
             entry.on_reject(on_entry_action, act='rejected', task=task)
             entry.on_fail(on_entry_action, act='failed', task=task)
+            entry.on_reset(on_entry_reset)
 
 
 @event('plugin.register')

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -179,6 +179,7 @@ class Task(object):
         """
         self.name = unicode(name)
         self.manager = manager
+        self.parent = None
         # raw_config should remain the untouched input config
         if config is None:
             config = manager.config['tasks'].get(name, {})
@@ -234,8 +235,10 @@ class Task(object):
         opts = {'builtins': False, 'auto_accept': True}
         if options:
             opts.update(options)
-        return type(self)(self.manager, self.name + name_ext, config, session=self.session, req_sess=self.requests,
-                          options=opts)
+        subtask = type(self)(self.manager, self.name + name_ext, config, session=self.session, req_sess=self.requests,
+                             options=opts)
+        subtask.parent = self
+        return subtask
 
     @property
     def undecided(self):

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -168,11 +168,14 @@ class Task(object):
 
     max_reruns = 5
 
-    def __init__(self, manager, name, config=None, options=None):
+    def __init__(self, manager, name, config=None, options=None, session=None, req_sess=None):
         """
         :param Manager manager: Manager instance.
         :param string name: Name of the task.
         :param dict config: Task configuration.
+        :param options: dict or argparse namespace object with task options
+        :param session: If provided, database changes will be done in given sqlalchemy session
+        :param req_sess: If provided, task requests will be sent using given requests session.
         """
         self.name = unicode(name)
         self.manager = manager
@@ -197,8 +200,42 @@ class Task(object):
 
         self.config_modified = None
 
-        # use reset to init variables when creating
-        self._reset()
+        self.enabled = not self.name.startswith('_')
+        self.session = session
+        # We keep track of this, since outer scope will be responsible for comitting/closing if provided
+        self._session_provided = session is not None
+        self.priority = 65535
+
+        self.requests = req_sess or requests.Session()
+
+        # List of all entries in the task
+        self._all_entries = EntryContainer()
+
+        self.disabled_phases = []
+
+        # These are just to query what happened in task. Call task.abort to set.
+        self.aborted = False
+        self.abort_reason = None
+        self.silent_abort = False
+
+        self._rerun = False
+
+        # current state
+        self.current_phase = None
+        self.current_plugin = None
+
+    def make_subtask(self, name_ext, config, options=None):
+        """
+        Creates a new task initialized appropriately for running as a subtask within this task.
+
+        :param name_ext: This will be appended to the name of the parent task to create subtask name
+        :param dict config: Configuration for the subtask
+        """
+        opts = {'builtins': False, 'auto_accept': True}
+        if options:
+            opts.update(options)
+        return type(self)(self.manager, self.name + name_ext, config, session=self.session, req_sess=self.requests,
+                          options=opts)
 
     @property
     def undecided(self):
@@ -245,32 +282,6 @@ class Task(object):
     @property
     def is_rerun(self):
         return self._rerun_count
-
-    # TODO: can we get rid of this now that Tasks are instantiated on demand?
-    def _reset(self):
-        """Reset task state"""
-        log.debug('resetting %s' % self.name)
-        self.enabled = not self.name.startswith('_')
-        self.session = None
-        self.priority = 65535
-
-        self.requests = requests.Session()
-
-        # List of all entries in the task
-        self._all_entries = EntryContainer()
-
-        self.disabled_phases = []
-
-        # These are just to query what happened in task. Call task.abort to set.
-        self.aborted = False
-        self.abort_reason = None
-        self.silent_abort = False
-
-        self._rerun = False
-
-        # current state
-        self.current_phase = None
-        self.current_plugin = None
 
     def __cmp__(self, other):
         return cmp(self.priority, other.priority)
@@ -335,7 +346,7 @@ class Task(object):
             plugins = sorted(get_plugins(phase=phase), key=lambda p: p.phase_handlers[phase], reverse=True)
         else:
             plugins = all_plugins.itervalues()
-        return (p for p in plugins if p.name in self.config or p.builtin)
+        return (p for p in plugins if p.name in self.config or self.options.builtins and p.builtin)
 
     def __run_task_phase(self, phase):
         """Executes task phase, ie. call all enabled plugins on the task.
@@ -382,6 +393,8 @@ class Task(object):
                     # add entries returned by input to self.all_entries
                     for e in response:
                         e.task = self
+                        if self.options.auto_accept:
+                            e.accept('task auto-accepted')
                     self.all_entries.extend(response)
             finally:
                 fire_event('task.execute.after_plugin', self, plugin.name)
@@ -477,11 +490,10 @@ class Task(object):
         if self.options.cron:
             self.manager.db_cleanup()
 
-        self._reset()
         log.debug('executing %s' % self.name)
-        if not self.enabled:
-            log.debug('task %s disabled during preparation, not running' % self.name)
-            return
+        # Reset a couple things before execution
+        self._all_entries = EntryContainer()
+        self._rerun = False
 
         # Handle keyword args
         if self.options.learn:
@@ -491,12 +503,16 @@ class Task(object):
         if self.options.disable_phases:
             map(self.disable_phase, self.options.disable_phases)
         if self.options.inject:
-            # If entries are passed for this execution (eg. rerun), disable the input phase
+            # If entries are passed for this execution (eg. inject), disable the input phase
             self.disable_phase('input')
             self.all_entries.extend(self.options.inject)
+            if self.options.auto_accept:
+                for entry in self.all_entries:
+                    entry.accept('task auto-accepted')
 
-        log.debug('starting session')
-        self.session = Session()
+        if not self._session_provided:
+            log.debug('starting session')
+            self.session = Session()
 
         # Save current config hash and set config_modidied flag
         config_hash = hashlib.md5(str(sorted(self.config.items()))).hexdigest()
@@ -551,19 +567,19 @@ class Task(object):
         else:
             for entry in self.all_entries:
                 entry.complete()
-            log.debug('committing session')
-            self.session.commit()
+            if not self._session_provided:
+                log.debug('committing session')
+                self.session.commit()
             fire_event('task.execute.completed', self)
         finally:
             # this will cause database rollback on exception
-            self.session.close()
+            if not self._session_provided:
+                self.session.close()
 
         # rerun task
         if self._rerun:
             log.info('Rerunning the task in case better resolution can be achieved.')
             self._rerun_count += 1
-            # TODO: Potential optimization is to take snapshots (maybe make the ones backlog uses built in instead of
-            # taking another one) after input and just inject the same entries for the rerun
             self.execute()
 
     def __eq__(self, other):

--- a/tests/test_crossmatch.py
+++ b/tests/test_crossmatch.py
@@ -10,7 +10,7 @@ class TestCrossmatch(FlexGetBase):
             - title: entry 2
             crossmatch:
               from:
-              - mock:
+                mock:
                 - title: entry 2
               action: reject
               fields: [title]

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -141,7 +141,7 @@ class TestEmitSeriesInDiscover(FlexGetBase):
             discover:
               ignore_estimations: yes
               what:
-              - emit_series:
+                emit_series:
                   backfill: yes
               from:
               - test_search: yes

--- a/tests/test_only_new.py
+++ b/tests/test_only_new.py
@@ -12,22 +12,31 @@ class TestOnlyNew(FlexGetBase):
             only_new: yes
             disable_builtins: [seen] # Disable the seen plugin to make sure only_new does the filtering.
             accept_all: yes
+            mock_output: yes
     """
 
     def test_only_new(self):
         self.execute_task('test')
+        entry = self.task.find_entry('rejected', title='title 1')
+        assert entry, 'Test entry missing'
         # only_new will reject the entry on task_exit, make sure accept_all accepted it during filter event though
-        assert self.task.find_entry('rejected', title='title 1', accepted_by='accept_all'), 'Test entry missing'
+        assert entry in self.task.mock_output
         # run again, should filter
         self.execute_task('test')
-        assert self.task.find_entry('rejected', title='title 1', rejected_by='remember_rejected'), 'Seen test entry remains'
+        entry = self.task.find_entry('rejected', title='title 1', rejected_by='remember_rejected')
+        assert entry
+        assert entry not in self.task.mock_output
 
         # add another entry to the task
         self.manager.config['tasks']['test']['mock'].append({'title': 'title 2', 'url': 'http://localhost/title2'})
         # execute again
         self.execute_task('test')
         # both entries should be present as config has changed
-        assert self.task.find_entry('rejected', title='title 1', accepted_by='accept_all'), 'title 1 was not found'
-        assert self.task.find_entry('rejected', title='title 2', accepted_by='accept_all'), 'title 2 was not found'
+        entry = self.task.find_entry('rejected', title='title 1')
+        assert entry, 'title 1 was not found'
+        assert entry in self.task.mock_output
+        assert self.task.find_entry('rejected', title='title 2')
+        assert entry, 'title 2 was not found'
+        assert entry in self.task.mock_output
 
         # TODO: Test that new entries are accepted. Tough to do since we can't change the task name or config..


### PR DESCRIPTION
The idea here is to let any plugin that allows entry generation via input subplugins, (discover and configure_series,) have a more general way to get their input, that works like a full task (with manipulation and filtering.)

Description of current implementation:
- Added 2 options for tasks `auto_accept` and `disable_builtins`
- Subtasks are just regular `Task`s initialized with different defaults:
  - They inherit db and requests session from their parent task
  - Both disable_builtins and auto_accept options are on by default
- To create them, call `parent_task.make_subtask`
- Name given to subtask will be appended to name of parent to create the full task name
- Plugins switched to use them:
  - crossmatch
  - discover
  - configure_series
  - if
  - inputs


The first try left several problems:
- [ ] Subtask names ended up really long and crappy in logs
- [ ] Warnings in subtasks about lack of filter and output plugins is not desired
- [x] emit_series totally went to shit

Possible TODOs/concerns:
- [x] ~~Make a new option for tasks, where every entry starts already accepted, rather than hacking in accept_all~~
Task now has auto_accept option, which subtasks turn on
- [x] ~~Right now, it makes and commits a new sqlalchemy session. Should it?~~
Added option to pass in sqlalchemy session to a task, task does not commit or close session when passed in
- [x] ~~requests session should maybe be transferred from main task?~~
Added option to init new Task with existing requests session
- [x] ~~discover plugin currently takes a list, rather than a plain dict. Change that, and just require use of `inputs` plugin for repeated input plugins? (we could even support backwards compatible configs if desired via inputs plugin)~~
Changed both discover and crossmatch to take a dict config that runs as a task.
- [x] ~~hrmmm... template/include plugin will not work in a subtask right now.~~ And.. I'm silly. They work fine.