### PR TITLE
Protect imdb_id field from rottentomatoes_lookup

### DIFF
--- a/flexget/plugins/metainfo/rottentomatoes_lookup.py
+++ b/flexget/plugins/metainfo/rottentomatoes_lookup.py
@@ -14,12 +14,6 @@ except ImportError:
 log = logging.getLogger('rottentomatoes_lookup')
 
 
-def get_imdb_id(movie):
-    for alt_id in movie.alternate_ids:
-        if alt_id.name == 'imdb':
-            return 'tt' + alt_id.id
-
-
 def get_rt_url(movie):
     for link in movie.links:
         if link.name == 'alternate':
@@ -37,7 +31,6 @@ class PluginRottenTomatoesLookup(object):
     field_map = {
         'rt_name': 'title',
         'rt_id': 'id',
-        'imdb_id': get_imdb_id,
         'rt_year': 'year',
         'rt_genres': lambda movie: [genre.name for genre in movie.genres],
         'rt_mpaa_rating': 'mpaa_rating',
@@ -101,6 +94,12 @@ class PluginRottenTomatoesLookup(object):
                              )
         log.debug(u'Got movie: %s' % movie)
         entry.update_using_map(self.field_map, movie)
+        
+        if not entry.get('imdb_id', eval_lazy=False):
+            for alt_id in movie.alternate_ids:
+                if alt_id.name == 'imdb':
+                    entry['imdb_id'] = 'tt' + alt_id.id
+                    break
 
     def on_task_metainfo(self, task, config):
         if not config:


### PR DESCRIPTION
If the alternate_ids list in rottentomatoes_lookup's movie object does not contains a valid imdb_id, the plugin **might** assign it to None on target entry, eventually clearing a real value **or** preventing any other metainfo plugin to assign it (since the field it's not lazy anymore).

Example 1 (imdb_id is _None_):

```
  rtl:
    mock:
      - { title: '12 Years a Slave' }
    imdb_lookup: yes
    rottentomatoes_lookup: yes
    if:
      - imdb_languages: accept
      - rt_critics_score: reject
```

Example 2 (changing the conditions order the imdb_id is good):

```
  rtl:
    mock:
      - { title: '12 Years a Slave' }
    imdb_lookup: yes
    rottentomatoes_lookup: yes
    if:
      - rt_critics_score: reject
      - imdb_languages: accept
```
