### PR TITLE
Adding support for Jinja2 enabled specification of package names

### DIFF
--- a/flexget/plugins/output/pyload.py
+++ b/flexget/plugins/output/pyload.py
@@ -25,6 +25,7 @@ class PluginPyLoad(object):
         username: my_username
         password: my_password
         folder: desired_folder
+        package: desired_package_name (jinja2 supported)
         hoster:
           - YoutubeCom
         parse_url: no
@@ -63,6 +64,7 @@ class PluginPyLoad(object):
         advanced.accept('text', key='username')
         advanced.accept('text', key='password')
         advanced.accept('text', key='folder')
+        advanced.accept('text', key='package')
         advanced.accept('boolean', key='queue')
         advanced.accept('boolean', key='parse_url')
         advanced.accept('boolean', key='multiple_hoster')
@@ -140,7 +142,17 @@ class PluginPyLoad(object):
 
             try:
                 dest = 1 if config.get('queue', self.DEFAULT_QUEUE) else 0  # Destination.Queue = 1
-                name = entry['pyload_package'] if 'pyload_package' in entry else entry['title']
+
+                # Use the title of the enty, if no naming schema for the package is defined.
+                name = config.get('package', entry['title'])
+
+                # If name has jinja template, render it
+                try:
+                    name = entry.render(name)
+                except RenderError as e:
+                    name = entry['title']
+                    log.error('Error rendering jinja event: %s' % e)
+
                 post = {'name': "'%s'" % name.encode("ascii", "ignore"),
                         'links': str(urls),
                         'dest': dest,


### PR DESCRIPTION
This allows for a Jinja2 enabled specification of package names.

Usage:

```
pyload:
  api: xxx
  username: xxx
  password: xxx
  parse_url: yes
  queue: no
  hoster:
    - xxx
  multiple_hoster: no

set:
  pyload_package: 'Series - {{series_name}} - {{series_id}}'
```
