### PR TITLE
Force tvrage lookups when no upcoming shows

### DIFF
--- a/flexget/plugins/api_tvrage.py
+++ b/flexget/plugins/api_tvrage.py
@@ -4,7 +4,7 @@ import datetime
 import difflib
 from socket import timeout
 
-from sqlalchemy import Column, Integer, DateTime, String, Unicode, ForeignKey, select, update
+from sqlalchemy import Column, Integer, DateTime, String, Unicode, ForeignKey, select, update, func
 from sqlalchemy.orm import relation
 import tvrage.api
 
@@ -153,6 +153,31 @@ class TVRageEpisodes(Base):
             filter(TVRageEpisodes.episode == 1).first()
 
 
+def closest_airdate(series_id, session):
+    """Returns the next upcoming show's airdate or last airdate."""
+    sq = session.query(TVRageEpisodes).\
+         filter(TVRageEpisodes.tvrage_series_id == series_id).\
+         filter(TVRageEpisodes.airdate > datetime.datetime.now()).subquery()
+
+    upcoming_episode = session.query(sq).\
+                       filter(sq.c.airdate == func.min(sq.c.airdate).select()).first()
+
+    if upcoming_episode is not None:
+        return upcoming_episode.airdate
+
+    sq = session.query(TVRageEpisodes).\
+         filter(TVRageEpisodes.tvrage_series_id == series_id).\
+         filter(TVRageEpisodes.airdate < datetime.datetime.now()).subquery()
+
+    past_episode = session.query(sq).\
+                   filter(sq.c.airdate == func.max(sq.c.airdate).select()).first()
+
+    if past_episode is not None:
+        return past_episode.airdate
+
+    return datetime.datetime.max
+
+
 @with_session
 def lookup_series(name=None, session=None):
     series = None
@@ -165,9 +190,20 @@ def lookup_series(name=None, session=None):
             raise LookupError('Could not find show %s' % name)
     elif res:
         series = res.series
-        # if too old result, clean the db and refresh it
+
+        airdate = closest_airdate(series.id, session)
+        now = datetime.datetime.now()
         interval = parse_timedelta(UPDATE_INTERVAL)
-        if datetime.datetime.now() > series.last_update + interval:
+
+        # if too old result or no upcoming result, clean the db and refresh it
+        if (series.last_update - datetime.timedelta(days=1)) < airdate < now and \
+           now > series.last_update + datetime.timedelta(hours=4):
+            # no upcoming episode and last check done before one day after last airdate; adding timedelta
+            # because last_update has no time information. Left-hand and statement is here to ensure there is
+            # 4 hours between two tvrage lookups
+            log.debug('No next episode information for %s; refreshing now', name)
+        elif now > series.last_update + interval:
+            # too old result, refreshing
             log.debug('Refreshing tvrage info for %s', name)
         else:
             return series


### PR DESCRIPTION
Allow `tvrage_api` to do a lookup when there is no upcoming episode and last lookup was done before last episode.

It is useful because it doesn't wait a whole week before trying to fetch information that is likely to be available...
