### PR TITLE
Fix RottenTomatoes filter

### DIFF
--- a/flexget/plugins/filter/rottentomatoes.py
+++ b/flexget/plugins/filter/rottentomatoes.py
@@ -86,14 +86,10 @@ class FilterRottenTomatoes(object):
     # Run later to avoid unnecessary lookups
     @plugin.priority(115)
     def on_task_filter(self, task, config):
-
         lookup = plugin.get_plugin_by_name('rottentomatoes_lookup').instance.lookup
 
         # since the plugin does not reject anything, no sense going trough accepted
         for entry in task.undecided:
-
-            force_accept = False
-
             try:
                 lookup(entry)
             except plugin.PluginError as e:
@@ -107,87 +103,92 @@ class FilterRottenTomatoes(object):
             #    log.debug('%s = %s (type: %s)' % (key, value, type(value)))
 
             # Check defined conditions, TODO: rewrite into functions?
-            reasons = []
+            reject_reasons = []
+            accept_reasons = []
+            
             if 'min_critics_score' in config:
                 if entry.get('rt_critics_score', 0) < config['min_critics_score']:
-                    reasons.append('min_critics_score (%s < %s)' % (entry.get('rt_critics_score'),
+                    reject_reasons.append('min_critics_score (%s < %s)' % (entry.get('rt_critics_score'),
                         config['min_critics_score']))
+            
             if 'min_audience_score' in config:
                 if entry.get('rt_audience_score', 0) < config['min_audience_score']:
-                    reasons.append('min_audience_score (%s < %s)' % (entry.get('rt_audience_score'),
+                    reject_reasons.append('min_audience_score (%s < %s)' % (entry.get('rt_audience_score'),
                         config['min_audience_score']))
+            
             if 'min_average_score' in config:
                 if entry.get('rt_average_score', 0) < config['min_average_score']:
-                    reasons.append('min_average_score (%s < %s)' % (entry.get('rt_average_score'),
+                    reject_reasons.append('min_average_score (%s < %s)' % (entry.get('rt_average_score'),
                         config['min_average_score']))
+            
             if 'min_critics_rating' in config:
                 if not entry.get('rt_critics_rating'):
-                    reasons.append('min_critics_rating (no rt_critics_rating)')
+                    reject_reasons.append('min_critics_rating (no rt_critics_rating)')
                 elif self.critics_ratings.get(entry.get('rt_critics_rating').lower(), 0) < self.critics_ratings[config['min_critics_rating']]:
-                    reasons.append('min_critics_rating (%s < %s)' % (entry.get('rt_critics_rating').lower(), config['min_critics_rating']))
+                    reject_reasons.append('min_critics_rating (%s < %s)' % (entry.get('rt_critics_rating').lower(), config['min_critics_rating']))
+            
             if 'min_audience_rating' in config:
                 if not entry.get('rt_audience_rating'):
-                    reasons.append('min_audience_rating (no rt_audience_rating)')
+                    reject_reasons.append('min_audience_rating (no rt_audience_rating)')
                 elif self.audience_ratings.get(entry.get('rt_audience_rating').lower(), 0) < self.audience_ratings[config['min_audience_rating']]:
-                    reasons.append('min_audience_rating (%s < %s)' % (entry.get('rt_audience_rating').lower(), config['min_audience_rating']))
+                    reject_reasons.append('min_audience_rating (%s < %s)' % (entry.get('rt_audience_rating').lower(), config['min_audience_rating']))
+            
             if 'min_year' in config:
                 if entry.get('rt_year', 0) < config['min_year']:
-                    reasons.append('min_year (%s < %s)' % (entry.get('rt_year'), config['min_year']))
+                    reject_reasons.append('min_year (%s < %s)' % (entry.get('rt_year'), config['min_year']))
+            
             if 'max_year' in config:
                 if entry.get('rt_year', 0) > config['max_year']:
-                    reasons.append('max_year (%s > %s)' % (entry.get('rt_year'), config['max_year']))
+                    reject_reasons.append('max_year (%s > %s)' % (entry.get('rt_year'), config['max_year']))
+            
             if 'reject_genres' in config:
                 rejected = config['reject_genres']
                 for genre in entry.get('rt_genres', []):
                     if genre in rejected:
-                        reasons.append('reject_genres')
+                        reject_reasons.append('reject_genres')
                         break
 
             if 'reject_actors' in config:
                 rejected = config['reject_actors']
                 for actor_name in entry.get('rt_actors', []):
                     if actor_name in rejected:
-                        reasons.append('reject_actors %s' % actor_name)
+                        reject_reasons.append('reject_actors %s' % actor_name)
                         break
 
-            # Accept if actors contains an accepted actor, but don't reject otherwise
-            if 'accept_actors' in config:
+            if not reject_reasons and 'accept_actors' in config:
                 accepted = config['accept_actors']
                 for actor_name in entry.get('rt_actors', []):
                     if actor_name in accepted:
-                        log.debug('Accepting because of accept_actors %s' % actor_name)
-                        force_accept = True
+                        accept_reasons.append('accept_actors %s' % actor_name)
                         break
 
             if 'reject_directors' in config:
                 rejected = config['reject_directors']
                 for director_name in entry.get('rt_directors', []):
                     if director_name in rejected:
-                        reasons.append('reject_directors %s' % director_name)
+                        reject_reasons.append('reject_directors %s' % director_name)
                         break
 
-            # Accept if the director is in the accept list, but do not reject if the director is unknown
-            if 'accept_directors' in config:
+            if not reject_reasons and 'accept_directors' in config:
                 accepted = config['accept_directors']
                 for director_name in entry.get('rt_directors', []):
                     if director_name in accepted:
-                        log.debug('Accepting because of accept_directors %s' % director_name)
-                        force_accept = True
+                        accept_reasons.append('accept_directors %s' % director_name)
                         break
 
             if 'reject_mpaa_ratings' in config:
                 rejected = config['reject_mpaa_ratings']
                 if entry.get('rt_mpaa_rating') in rejected:
-                    reasons.append('reject_mpaa_ratings %s' % entry['rt_mpaa_rating'])
+                    reject_reasons.append('reject_mpaa_ratings %s' % entry['rt_mpaa_rating'])
 
-            if 'accept_mpaa_ratings' in config:
+            if not reject_reasons and 'accept_mpaa_ratings' in config:
                 accepted = config['accept_mpaa_ratings']
                 if entry.get('rt_mpaa_rating') not in accepted:
-                    reasons.append('accept_mpaa_ratings %s' % entry.get('rt_mpaa_rating'))
+                    accept_reasons.append('accept_mpaa_ratings %s' % entry.get('rt_mpaa_rating'))
 
-            if reasons and not force_accept:
+            if reject_reasons:
                 msg = 'Didn\'t accept `%s` because of rule(s) %s' % \
-                    (entry.get('rt_name', None) or entry['title'], ', '.join(reasons))
+                    (entry.get('rt_name', None) or entry['title'], ', '.join(reject_reasons))
                 if task.options.debug:
                     log.debug(msg)
                 else:
@@ -195,9 +196,10 @@ class FilterRottenTomatoes(object):
                         log_once(msg, log)
                     else:
                         log.info(msg)
+            elif accept_reasons:
+                entry.accept(', '.join(accept_reasons))
             else:
-                log.debug('Accepting %s' % (entry['title']))
-                entry.accept()
+                log.debug('Found no reason to accept or reject %s' % entry['title'])
 
 
 @event('plugin.register')


### PR DESCRIPTION
As discussed in http://flexget.com/ticket/2574, looks like if there are no reject options in the config then the filter accepts all the movies it should ignore.

There's a test in my last comment in the ticket. The results after this fix:
```
pydev debugger: starting
2014-04-29 16:39 VERBOSE  details       rtf             Produced 3 entries.
2014-04-29 16:39 VERBOSE  task          rtf             ACCEPTED: `inception.1080p.lol` by rottentomatoes plugin because accept_actors Leonardo DiCaprio
2014-04-29 16:39 VERBOSE  task          rtf             ACCEPTED: `inglorious.bastards.720p.lol` by rottentomatoes plugin because accept_actors Christoph Waltz
2014-04-29 16:39 VERBOSE  details       rtf             Summary - Accepted: 2 (Rejected: 0 Undecided: 1 Failed: 0)
2014-04-29 16:39 WARNING  task          rtf             Task doesn't have any output plugins, you should add (at least) one!
```