### PR TITLE
support tracker filtering in clean_transmission

### DIFF
--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -5,6 +5,8 @@ from datetime import timedelta
 from netrc import netrc, NetrcParseError
 import logging
 import base64
+import re
+from urlparse import urlparse
 
 from flexget import plugin, validator
 from flexget.entry import Entry
@@ -644,6 +646,7 @@ class PluginTransmissionClean(TransmissionBase):
         advanced.accept('interval', key='finished_for')
         advanced.accept('boolean', key='transmission_seed_limits')
         advanced.accept('boolean', key='delete_files')
+        advanced.accept('regexp', key='tracker')
         return root
     
     def on_task_exit(self, task, config):
@@ -656,6 +659,7 @@ class PluginTransmissionClean(TransmissionBase):
         nfor = parse_timedelta(config['finished_for']) if 'finished_for' in config else None
         delete_files = bool(config['delete_files']) if 'delete_files' in config else False
         trans_checks = bool(config['transmission_seed_limits']) if 'transmission_seed_limits' in config else False
+        tracker_re = re.compile(config['tracker'], re.IGNORECASE) if 'tracker' in config else None
         
         session = self.client.get_session()
 
@@ -665,6 +669,7 @@ class PluginTransmissionClean(TransmissionBase):
                         (torrent.name, torrent.status, torrent.ratio, torrent.date_added, torrent.date_done))
             downloaded, dummy = self.torrent_info(torrent, config)
             seed_ratio_ok, idle_limit_ok = self.check_seed_limits(torrent, session)
+            tracker_hosts = (urlparse(tracker['announce']).hostname for tracker in torrent.trackers)
             is_clean_all = nrat is None and nfor is None and trans_checks is None
             is_minratio_reached = nrat and (nrat <= torrent.ratio)
             is_transmission_seedlimit_unset = trans_checks and seed_ratio_ok is None and idle_limit_ok is None
@@ -673,13 +678,15 @@ class PluginTransmissionClean(TransmissionBase):
             is_torrent_seed_only = torrent.date_done <= torrent.date_added
             is_torrent_idlelimit_since_added_reached = nfor and (torrent.date_added + nfor) <= datetime.now()
             is_torrent_idlelimit_since_finished_reached = nfor and (torrent.date_done + nfor) <= datetime.now()
+            is_tracker_matching = not tracker_re or any(tracker_re.search(host) for host in tracker_hosts)
             if (downloaded and (is_clean_all or
                                 is_transmission_seedlimit_unset or
                                 is_transmission_seedlimit_reached or
                                 is_transmission_idlelimit_reached or
                                 is_minratio_reached or
                                 (is_torrent_seed_only and is_torrent_idlelimit_since_added_reached) or
-                                (not is_torrent_seed_only and is_torrent_idlelimit_since_finished_reached))):
+                                (not is_torrent_seed_only and is_torrent_idlelimit_since_finished_reached))
+                           and is_tracker_matching):
                 if task.options.test:
                     log.info('Would remove finished torrent `%s` from transmission' % torrent.name)
                     continue


### PR DESCRIPTION
This PR implements the ability to restrict the cleaning of torrents to specific trackers using a regular expression provided to the plugin, like so:

    clean_transmission:
        tracker: nyaa|animebytes
        finished_for: 4 weeks

as to not interfere with non-Flexget managed torrents.