### PR TITLE
Fixed encoding problem in listdir plugin.

### DIFF
--- a/flexget/plugins/input/listdir.py
+++ b/flexget/plugins/input/listdir.py
@@ -36,8 +36,9 @@ class Listdir(object):
             path = os.path.expanduser(path)
             for name in os.listdir(unicode(path)):
                 e = Entry()
+                name = name.decode('utf-8')
                 filepath = os.path.join(path, name)
-                if os.path.isfile(filepath):
+                if os.path.isfile(filepath.encode('utf-8')):
                     e['title'] = os.path.splitext(name)[0]
                 else:
                     e['title'] = name


### PR DESCRIPTION
This pull request is related to the issue #273.
It fix encoding errors in the listdir plugin when directories have non-ascii characters.
