### PR TITLE
Improvements to transmission plugin

### DIFF
--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -410,7 +410,7 @@ class PluginTransmissionClean(TransmissionBase):
         self._validator(advanced)
         advanced.accept('number', key='min_ratio')
         advanced.accept('interval', key='finished_for')
-        advanced.accept('boolean', key='transmission_seeds_limits')
+        advanced.accept('boolean', key='transmission_seed_limits')
         advanced.accept('boolean', key='delete_files')
         return root
 


### PR DESCRIPTION
I've added some extra code to transmission plugin so it can verify transmission's builtin seed limits ( if set )
by default it automatically checks them as "completion" condition for input plugin, while for the cleanup plugin they are optional and enabled with a config flag
