### PR TITLE
Update plugin_transmission.py

### DIFF
--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -434,8 +434,8 @@ class PluginTransmissionClean(TransmissionBase):
             downloaded, dummy = self.torrent_info(torrent)
             seed_ratio_ok, idle_limit_ok = self.check_seed_limits(torrent, session)
             if (downloaded and ((nrat is None and nfor is None and transmission_checks is None) or
-                                (transmission_checks and (seed_ratio_ok is None and idle_limit_ok is None) or
-                                                         (seed_ratio_ok is True or idle_limit_ok is True)) or
+                                (transmission_checks and ((seed_ratio_ok is None and idle_limit_ok is None) or
+                                                         (seed_ratio_ok is True or idle_limit_ok is True))) or
                                 (nrat and (nrat <= torrent.ratio)) or
                                 (nfor and ((torrent.date_done + nfor) <= datetime.now())))):
                 if task.options.test:


### PR DESCRIPTION
clean transmission plug-in was always removing torrents if the internal transmission limits were met independent of the settings supplied. Added a missing bracket to fix the logic. Couldn't find any tests to update, if there are point me to it and I will apply it.
