### PR TITLE
Prevent some episode numbers from being treated as quality

### DIFF
--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -214,7 +214,7 @@ class Quality(object):
         """
         self.text = text
         self.clean_text = text
-        self.resolution = self._find_best(_resolutions, _UNKNOWNS['resolution'])
+        self.resolution = self._find_best(_resolutions, _UNKNOWNS['resolution'], False)
         self.source = self._find_best(_sources, _UNKNOWNS['source'])
         self.codec = self._find_best(_codecs, _UNKNOWNS['codec'])
         self.audio = self._find_best(_audios, _UNKNOWNS['audio'])
@@ -225,14 +225,19 @@ class Quality(object):
                 if not getattr(self, default.type):
                     setattr(self, default.type, default)
 
-    def _find_best(self, qlist, default=None):
+    def _find_best(self, qlist, default=None, strip_all=True):
         """Finds the highest matching quality component from `qlist`"""
         result = None
+        search_in = self.clean_text
         for item in qlist:
-            match = item.matches(self.clean_text)
+            match = item.matches(search_in)
             if match[0]:
                 result = item
                 self.clean_text = match[1]
+                if strip_all:
+                    # In some cases we want to strip all found quality components,
+                    # even though we're going to return only the last of them.
+                    search_in = self.clean_text
                 if item.modifier is not None:
                     # If this item has a modifier, do not proceed to check higher qualities in the list
                     break


### PR DESCRIPTION
Flexget apparently doesn't correctly handle episode numbers that look like a quality. For instance when presented "[HorribleSubs] Naruto Shippuuden - 368 [720p].mkv", it strips BOTH 368 and 720p from the string, which leads to "cannot find a(n) `sequence` style identifier" later.

This patch tries to work around that by preventing stripping of all matched resolution-like strings, and instead stripping only the resolution that is returned as a result from _find_best(). This can be deemed a non-invasive change, b/c it's unlikely that there will be several resolutions mentioned in entry at once (e.g. 720p 480p). This is not so e.g. for codecs, where there can be e.g. h264 hi10p, but this patch doesn't alter the parsing of that.
