### PR TITLE
Fixed folder setting with PyLoad

### DIFF
--- a/flexget/plugins/output/pyload.py
+++ b/flexget/plugins/output/pyload.py
@@ -164,6 +164,7 @@ class PluginPyLoad(object):
 
                 # Set Folder
                 folder = config.get('folder', self.DEFAULT_FOLDER)
+                folder = entry.get('path', folder)
                 if folder:
                     # If folder has jinja template, render it
                     try:


### PR DESCRIPTION
This fixes #2451 http://flexget.com/ticket/2451
(Pyload raises Internal API Error when adding Links with folder set)

Also added possibility to change pyload folder dynamicly with jinja support and set path plugin
