### PR TITLE
imdb_list import from HTML  page instead RSS feed

### DIFF
--- a/flexget/plugins/input/imdb_list.py
+++ b/flexget/plugins/input/imdb_list.py
@@ -74,7 +74,7 @@ class ImdbList(object):
                 year = tr.find('td', class_='year').string
                 entry = Entry()
                 entry['title'] = a.string + ' (' + year + ')'
-                entry['imdb_year'] = year
+                entry['imdb_year'] = int(year)
                 entry['url'] = link
                 entry['imdb_id'] = extract_id(link)
                 entry['imdb_name'] = entry['title']


### PR DESCRIPTION
imdb watchlist rss feed is broken right now and can't be sure when and
if it will be back up. this will now parse the html page for movies and
create entries.
