### PR TITLE
Many fixes and feature additions

### DIFF
--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -532,7 +532,7 @@ class PluginTransmission(TransmissionBase):
                 # prevents downloading data before we set what files we want
                 if ('paused' in options['post'] and options['post']['paused'] == False or
                    'paused' not in options['post'] and cli.get_session().start_added_torrents == True):
-                        cli.get_torrent(r.id).start()
+                        cli.start_torrent(r.id)
 
             except TransmissionError as e:
                 log.debug('TransmissionError', exc_info=True)


### PR DESCRIPTION
Tested it fairly comprehensively with various combinations.. the feature that adds the most time is renaming the files as each file needs one RPC query due to the way TransmissionRPC is setup.

Overall summary:

Fixes error with content_filename if "path" was not set in task.
Improves overall RPC communication to not duplicate.
Adds schema validation.
Fixes existing PEP8 issues.
Adds features:
`include_files` - similar format to "content_filter" plugin, will include the files matching the mask if "main_file_only" is configured AND the main file is found
`skip_files` - similar format to "content_filter" plugin, will exclude files matching masks if "main_file_only" mode returns no main file OR is not enabled
`rename_like_files` - if true will rename files matching the base name of the main file (if found) to the pattern in "content_filename." Helpful for subs and whatnot.
