### PR TITLE
[download] improve error message

### DIFF
--- a/flexget/plugins/output/download.py
+++ b/flexget/plugins/output/download.py
@@ -195,8 +195,7 @@ class PluginDownload(object):
                     log.info('Downloading: %s' % entry['title'])
                 self.download_entry(task, entry, url, tmp_path)
         except RequestException as e:
-            # TODO: Improve this error message?
-            log.warning('RequestException %s' % e)
+            log.warning('RequestException %s, while downloading %s' % (e, url))
             return 'Network error during request: %s' % e
         except BadStatusLine as e:
             log.warning('Failed to reach server. Reason: %s' % getattr(e, 'message', 'N/A'))


### PR DESCRIPTION
will give

```
2014-08-30 12:24 INFO     download      bt-chat.com     Downloading: Bering.Sea.Gold.Under.the.Ice.S03E02.480p.HDTV.x264-mSD
2014-08-30 12:24 WARNING  download      bt-chat.com     RequestException [Errno 1] _ssl.c:504: error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed, while downloading https://torcache.net/torrent/C28D6A86369E095B7D3509D4C86C0BC09286995B.torrent
```

 instead of

```
 2014-08-30 12:30 INFO     download      bt-chat.com     Downloading: Bering.Sea.Gold.Under.the.Ice.S03E02.480p.HDTV.x264-mSD
2014-08-30 12:30 WARNING  download      bt-chat.com     RequestException [Errno 1] _ssl.c:504: error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed
```
