### PR TITLE
[FIX] netrc is a valid key for plugin transmission

### DIFF
--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -228,6 +228,7 @@ class PluginTransmission(TransmissionBase):
                 'properties': {
                     'host': {'type': 'string'},
                     'port': {'type': 'integer'},
+                    'netrc': {'type': 'string'},
                     'username': {'type': 'string'},
                     'password': {'type': 'string'},
                     'path': {'type': 'string'},   


### PR DESCRIPTION
This fix the netrc key not being recognized after the ec1c113d commit.
