### PR TITLE
Enable sqlite WAL to try to solve database locked problems.

### DIFF
--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta
 import pkg_resources
 import sqlalchemy
 import yaml
+from sqlalchemy.engine import Engine
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
@@ -43,6 +44,14 @@ DB_CLEANUP_INTERVAL = timedelta(days=7)
 def before_commit(session):
     if not manager.has_lock and session.dirty:
         log.debug('BUG?: Database writes should not be tried when there is no database lock.')
+
+
+# WAL hopefully helps when we have multiple threads accessing the database
+@sqlalchemy.event.listens_for(Engine, 'connect')
+def set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute('PRAGMA journal_mode=WAL')
+    cursor.close()
 
 
 class Manager(object):


### PR DESCRIPTION
There are several tickets involving crashes due to the database being locked. My theory is that it's when multiple threads are accessing the database at once. Hopefully enabling write ahead logging on the sqlite database will solve this. I'd like a little bit of testing for this change to see if it actually helps or causes any problems before I merge it in though. If anyone is getting errors like this:

`OperationalError: (OperationalError) database is locked`

If a few people could test this branch and give feedback it would be much appreciated.
