### PR TITLE
Several fixes to ftp_list plugin

### DIFF
--- a/flexget/plugins/input/ftp_list.py
+++ b/flexget/plugins/input/ftp_list.py
@@ -146,6 +146,7 @@ class InputFtpList(object):
 
             if not files_only or mlst.get('type') == 'file':
                 url = baseurl + path + '/' + p
+		url = url.replace(' ', '%20')
                 title = os.path.basename(p)
                 log.info('Accepting entry "%s" [%s]' % (path + '/' + p, mlst.get('type') or "unknown",))
                 entry = Entry(title, url)


### PR DESCRIPTION
Fixes to ftp_list plugin especially related to :
- size computation and folder detection when MLST is not supported by the ftp server
- file path definition when a path with multiple subdirectories is used in the plugin configuration
- management of options "recursive" and "files-only" (some cases were ignored)
- handling of spaces in directories names

Please note that I was not able to test the modifications on a FTP server that supports MLST but everything should work correctly.
