### PR TITLE
update urwlrewrite_divxatope link handling

### DIFF
--- a/flexget/plugins/urlrewrite_divxatope.py
+++ b/flexget/plugins/urlrewrite_divxatope.py
@@ -31,9 +31,12 @@ class UrlRewriteDivxATope(object):
         try:
             page = requests.get(url).content
             soup = get_soup(page, 'html.parser')
-            download_link = soup.findAll(href=re.compile('redirect.php'))
+            download_link = soup.findAll(href=re.compile('redirect.php|redirectlink'))
             download_href = download_link[0]['href']
-            return download_href[download_href.index('url=') + 4:]
+            if "url" in download_href:
+                return download_href[download_href.index('url=') + 4:]
+            else:
+                return download_href
         except Exception:
             raise UrlRewritingError(
                 'Unable to locate torrent from url %s' % url


### PR DESCRIPTION
Update to reflect the new format for the links: "redirectlink" to identify the link and url without the "url" keyword. Backwards compatibility is maintained.
