### PR TITLE
Add additional Torrentz domains to url rewrite_torrentz

### DIFF
--- a/flexget/plugins/urlrewrite_torrentz.py
+++ b/flexget/plugins/urlrewrite_torrentz.py
@@ -12,7 +12,7 @@ from flexget.utils.search import torrent_availability, normalize_unicode
 
 log = logging.getLogger('torrentz')
 
-REGEXP = re.compile(r'http://torrentz\.(eu|me)/(?P<hash>[a-f0-9]{40})')
+REGEXP = re.compile(r'https?://torrentz\.(eu|me|ch|in)/(?P<hash>[a-f0-9]{40})')
 REPUTATIONS = {  # Maps reputation name to feed address
     'any': 'feed_any',
     'low': 'feed_low',
@@ -61,7 +61,7 @@ class UrlRewriteTorrentz(object):
         entries = set()
         for search_string in entry.get('search_strings', [entry['title']]):
             query = normalize_unicode(search_string+config.get('extra_terms', ''))
-            for domain in ['eu', 'me']:
+            for domain in ['eu', 'me', 'ch', 'in']:
                 # urllib.quote will crash if the unicode string has non ascii characters, so encode in utf-8 beforehand
                 url = 'http://torrentz.%s/%s?q=%s' % (domain, feed, urllib.quote(query.encode('utf-8')))
                 log.debug('requesting: %s' % url)


### PR DESCRIPTION
.eu/.me are blocked in the UK, this is a small change to search on .ch/.in if the other two fail to connect, also this updates the regex matching to support https urls as well.
