### PR TITLE
Updated notifymyandroid api url

### DIFF
--- a/flexget/plugins/output/notifymyandroid.py
+++ b/flexget/plugins/output/notifymyandroid.py
@@ -7,7 +7,7 @@ from flexget.utils.template import RenderError
 
 log = logging.getLogger('notifymyandroid')
 
-url = 'https://nma.usk.bz/publicapi/notify'
+url = 'https://www.notifymyandroid.com/publicapi/notify'
 
 
 class OutputNotifyMyAndroid(object):


### PR DESCRIPTION
The old notifymyandroid url no longer has a valid ssl certificate and
also all notifymyandroid documentation no longer refer to the old url.

> Traceback (most recent call last):
>  File "/usr/lib64/python2.7/site-packages/flexget/task.py", line 440, in **run_plugin
>    return method(_args, *_kwargs)
>  File "/usr/lib64/python2.7/site-packages/flexget/event.py", line 22, in __call**
>    return self.func(_args, *_kwargs)
>  File "/usr/lib64/python2.7/site-packages/flexget/plugins/output/notifymyandroid.py", line 69, in on_task_output
>    response = task.requests.post(url, data=data, raise_status=False)
>  File "/usr/lib64/python2.7/site-packages/requests/sessions.py", line 500, in post
>    return self.request('POST', url, data=data, json=json, *_kwargs)
>  File "/usr/lib64/python2.7/site-packages/flexget/utils/requests.py", line 140, in request
>    result = requests.Session.request(self, method, url, *args, *_kwargs)
>  File "/usr/lib64/python2.7/site-packages/requests/sessions.py", line 457, in request
>    resp = self.send(prep, *_send_kwargs)
>  File "/usr/lib64/python2.7/site-packages/requests/sessions.py", line 569, in send
>    r = adapter.send(request, *_kwargs)
>  File "/usr/lib64/python2.7/site-packages/requests/adapters.py", line 420, in send
>    raise SSLError(e, request=request)
> SSLError: [Errno bad handshake] [('SSL routines', 'SSL3_GET_SERVER_CERTIFICATE', 'certificate verify failed')]
