### PR TITLE
adding \n support for prowl description

### DIFF
--- a/flexget/plugins/output/prowl.py
+++ b/flexget/plugins/output/prowl.py
@@ -65,7 +65,7 @@ class OutputProwl(object):
 
             url = 'https://api.prowlapp.com/publicapi/add'
             data = {'priority': priority, 'application': application, 'apikey': apikey,
-                    'event': event, 'description': description}
+                    'event': event, 'description': description.replace('\n','%0A'}
 
             if task.options.test:
                 log.info('Would send prowl message about: %s', entry['title'])


### PR DESCRIPTION
I wanted to be able to add new lines in my description like the following example:

https://api.prowlapp.com/publicapi/add?apikey=API_KEY_HERE&application=myapp&event=myevent&description=hello%0Aworld'
