### PR TITLE
Update urlrewrite_redirect.py

### DIFF
--- a/flexget/plugins/urlrewrite_redirect.py
+++ b/flexget/plugins/urlrewrite_redirect.py
@@ -25,7 +25,11 @@ class UrlRewriteRedirect(object):
             # Don't accidentally go online in unit tests
             if task.manager.unit_test:
                 return
-            r = task.requests.head(entry['url'])
+            auth = None
+            if 'download_auth' in entry:
+                auth = entry['download_auth']
+                log.debug('Custom auth enabled for %s url_redirect: %s' % (entry['title'], entry['download_auth']))
+            r = task.requests.head(entry['url'], auth=auth)
             if 300 <= r.status_code < 400 and 'location' in r.headers:
                 entry['url'] = r.headers['location']
         except Exception:


### PR DESCRIPTION
not log in = redirect
logged in = not redirect
we need to check the headers once we are logged into to the web site. 

EDIT: it was creating a redirect bug, when no auth was used, because if no auth used there is a redirect. If auth is used no redirect and everything works as it should! Thanks! 
