### PR TITLE
Update parser_guessit.py

### DIFF
--- a/flexget/plugins/parsers/parser_guessit.py
+++ b/flexget/plugins/parsers/parser_guessit.py
@@ -44,7 +44,9 @@ class GuessRegexpId(Transformer):
 
 
 add_transformer('guess_regexp_id = flexget.plugins.parsers.parser_guessit:GuessRegexpId')
-guessit.default_options = {'name_only': True, 'clean_function': clean_value, 'allowed_languages': ['en', 'fr'], 'allowed_countries': ['us', 'uk', 'gb']}
+#this was affecting subliminal, causing it to fail download subtitles for some providers (e.g. addic7ed)
+#commented out (commenting this doesn't seem to have any negative side-effect)
+#guessit.default_options = {'name_only': True, 'clean_function': clean_value, 'allowed_languages': ['en', 'fr'], 'allowed_countries': ['us', 'uk', 'gb']}
 
 
 class GuessitParsedEntry(ParsedEntry):


### PR DESCRIPTION
commented out the assignment to guessit.default_options, this variable is set globally to guessit and causes problems on subliminal,
preventing it from downloading subtitles for some providers (e.g. addic7ed)

more detailed info on
http://discuss.flexget.com/t/flexget-subliminal-guessit/622/12
