### PR TITLE
Update parser_guessit.py

### DIFF
--- a/flexget/plugins/parsers/parser_guessit.py
+++ b/flexget/plugins/parsers/parser_guessit.py
@@ -44,7 +44,9 @@ class GuessRegexpId(Transformer):
 
 
 add_transformer('guess_regexp_id = flexget.plugins.parsers.parser_guessit:GuessRegexpId')
-guessit.default_options = {'name_only': True, 'clean_function': clean_value, 'allowed_languages': ['en', 'fr'], 'allowed_countries': ['us', 'uk', 'gb']}
+#this was affecting subliminal, causing it to fail download subtitles for some providers (e.g. addic7ed)
+#because of name_only was set to True (changing to False doesn't seem to have any negative side-effect)
+guessit.default_options = {'name_only': False, 'clean_function': clean_value, 'allowed_languages': ['en', 'fr'], 'allowed_countries': ['us', 'uk', 'gb']}
 
 
 class GuessitParsedEntry(ParsedEntry):


### PR DESCRIPTION
changed 'name_only' to False in the assignment to guessit.default_options, this variable is set globally to guessit and using 'name_only' as True causes problems on subliminal,
preventing it from downloading subtitles for some providers (e.g. addic7ed)

more detailed info on
http://discuss.flexget.com/t/flexget-subliminal-guessit/622/12
