### PR TITLE
qualities: rank aac lower than ac3

### DIFF
--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -154,8 +154,8 @@ channels = '(?:(?:[\W_]?5[\W_]?1)|(?:[\W_]?2[\W_]?(?:0|ch)))'
 _audios = [
     QualityComponent('audio', 10, 'mp3'),
     # TODO: No idea what order these should go in or if we need different regexps
-    QualityComponent('audio', 20, 'dd5.1', 'dd%s' % channels),
-    QualityComponent('audio', 30, 'aac', 'aac%s?' % channels),
+    QualityComponent('audio', 20, 'aac', 'aac%s?' % channels),
+    QualityComponent('audio', 30, 'dd5.1', 'dd%s' % channels),
     QualityComponent('audio', 40, 'ac3', 'ac3%s?' % channels),
     QualityComponent('audio', 50, 'flac', 'flac%s?' % channels),
     # The DTSs are a bit backwards, but the more specific one needs to be parsed first


### PR DESCRIPTION
When the audio track is encoded with AAC, it is not uncommon for it to
be stereo only. On the other hand, the DD5.1 tag usually translates to
an AC3 audio track.

Therefore, rank an AAC encoded audio track below a DD5.1 audio track.

This is related to this ticket: http://flexget.com/ticket/2791#ticket
