### PR TITLE
fix broken clean_transmission plugin for seeding only torrent see #2803

### DIFF
--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -618,14 +618,21 @@ class PluginTransmissionClean(TransmissionBase):
                         (torrent.name, torrent.status, torrent.ratio, torrent.date_added, torrent.date_done))
             downloaded, dummy = self.torrent_info(torrent)
             seed_ratio_ok, idle_limit_ok = self.check_seed_limits(torrent, session)
-            if (downloaded and ((nrat is None and nfor is None and trans_checks is None) or
-                                (trans_checks and ((seed_ratio_ok is None and idle_limit_ok is None) or
-                                 (seed_ratio_ok is True or idle_limit_ok is True))) or
-                                (nrat and (nrat <= torrent.ratio)) or
-                                (nfor and ((torrent.date_done + nfor) <= datetime.now()) and
-                                ((torrent.date_added + nfor) <= datetime.now())) or
-                                (nfor and (torrent.date_done <= torrent.date_added) and
-                                ((torrent.date_added + nfor) <= datetime.now())))):
+            is_clean_all= nrat is None and nfor is None and trans_checks is None
+            is_minratio_reached= nrat and (nrat <= torrent.ratio)
+            is_transmission_seedlimit_unset = trans_checks and seed_ratio_ok is None and idle_limit_ok is None
+            is_transmission_seedlimit_reached = trans_checks and seed_ratio_ok is True
+            is_transmission_idlelimit_reached = trans_checks and idle_limit_ok is True
+            is_torrent_seed_only = torrent.date_done <= torrent.date_added
+            is_torrent_idlelimit_since_added_reached = nfor and (torrent.date_added + nfor)  <= datetime.now()
+            is_torrent_idlelimit_since_finished_reached = nfor and (torrent.date_done + nfor)  <= datetime.now()
+            if (downloaded and (is_clean_all or
+                                is_transmission_seedlimit_unset or
+                                is_transmission_seedlimit_reached or
+                                is_transmission_idlelimit_reached or
+                                is_minratio_reached or
+                                     (is_torrent_seed_only and is_torrent_idlelimit_since_added_reached) or
+                                     (not is_torrent_seed_only and is_torrent_idlelimit_since_finished_reached))):
                 if task.options.test:
                     log.info('Would remove finished torrent `%s` from transmission' % torrent.name)
                     continue


### PR DESCRIPTION
by looking at the date_added time of the torrent. 
Date added should usually be less than date completed, but if one adds a torrent only for seeding (so all files are completed before adding the torrent) the date_finisehd field is not written.

This PR could be altered by someone more experienced to also remove seeding torrents after given timeframe.
Currently seeding only torrents are not deleted.
