### PR TITLE
Test if using a NullPool for db connections helps db issues.

### DIFF
--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -19,7 +19,6 @@ import yaml
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import SingletonThreadPool
 
 # These need to be declared before we start importing from other flexget modules, since they might import them
 from flexget.utils.sqlalchemy_utils import ContextSession
@@ -675,7 +674,6 @@ class Manager(object):
         try:
             self.engine = sqlalchemy.create_engine(self.database_uri,
                                                    echo=self.options.debug_sql,
-                                                   poolclass=SingletonThreadPool,
                                                    connect_args={'check_same_thread': False, 'timeout': 10})
         except ImportError:
             print('FATAL: Unable to use SQLite. Are you running Python 2.5 - 2.7 ?\n'


### PR DESCRIPTION
During cursory testing, using a NullPool seems to resolve some issues when multiple commands are sent to a daemon in quick succession. Specifically `(ProgrammingError) Cannot operate on a closed database.` I'm not sure if this will cause side effects though, if people could do some tests on this branch with their setups it would be much appreciated.

There is a possibility that this will also help with `database is locked` errors, but I have difficulty reproducing those to test.
