### PR TITLE
hmac only works with `str` type in Python 2

### DIFF
--- a/flexget/plugins/output/send_email.py
+++ b/flexget/plugins/output/send_email.py
@@ -107,7 +107,8 @@ def send_email(subject, content, config):
         try:
 
             if config.get('smtp_username') and config.get('smtp_password'):
-                mailServer.login(config['smtp_username'], config['smtp_password'])
+                # Forcing to use `str` type
+                mailServer.login(str(config['smtp_username']), str(config['smtp_password']))
             mailServer.sendmail(message['From'], config['to'], message.as_string())
         except IOError as e:
             # Ticket #686


### PR DESCRIPTION
If you provide unicode type variables, it throws a `TypeError`.

Full trace back:

```
2014-12-29 03:06 ERROR    task          test BUG: Unhandled error in plugin em
ail: character mapping must return integer, None or unicode
Traceback (most recent call last):
  File "/opt/flexget/local/lib/python2.7/site-packages/flexget/task.py", line 439, in __run_plugin
    return method(*args, **kwargs)
  File "/opt/flexget/local/lib/python2.7/site-packages/flexget/event.py", line 22, in __call__
    return self.func(*args, **kwargs)
  File "/opt/flexget/local/lib/python2.7/site-packages/flexget/plugins/output/send_email.py", line 274, in on_task_abort
    self.on_task_output(task, config)
  File "/opt/flexget/local/lib/python2.7/site-packages/flexget/plugins/output/send_email.py", line 270, in on_task_output
    send_email(subject, content, config)
  File "/opt/flexget/local/lib/python2.7/site-packages/flexget/plugins/output/send_email.py", line 110, in send_email
    mailServer.login(config['smtp_username'], config['smtp_password'])
  File "/usr/lib/python2.7/smtplib.py", line 600, in login
    (code, resp) = self.docmd(encode_cram_md5(resp, user, password))
  File "/usr/lib/python2.7/smtplib.py", line 564, in encode_cram_md5
    response = user + " " + hmac.HMAC(password, challenge).hexdigest()
  File "/usr/lib/python2.7/hmac.py", line 75, in __init__
    self.outer.update(key.translate(trans_5C))
TypeError: character mapping must return integer, None or unicode
```

See also http://bugs.python.org/issue5285.
