### PR TITLE
fixed attribute error when downloading subtitles for movies

### DIFF
--- a/flexget/plugins/output/subtitles_subliminal.py
+++ b/flexget/plugins/output/subtitles_subliminal.py
@@ -105,7 +105,11 @@ class PluginSubliminal(object):
             elif not '$RECYCLE.BIN' in entry['location']:  # ignore deleted files in Windows shares
                 try:
                     video = subliminal.scan_video(entry['location'])
-                    log.info('Series name computed for %s was %s' % (entry['location'], video.series))
+                    if isinstance(video, subliminal.Episode):
+                        title = video.series
+                    else:
+                        title = video.title
+                    log.info('Name computed for %s was %s' % (entry['location'], title))
                     msc = video.scores['hash'] if config['exact_match'] else 0
                     if langs & video.subtitle_languages:
                         continue  # subs for preferred lang(s) already exists


### PR DESCRIPTION
Subliminal plugin would throw an exception when trying to download subtitles for movies as the movie object does not have the `series` attribute.