### PR TITLE
Switch simple persistence to load/flush from/to db outside task runs fix #2820, #2672, #2835

### DIFF
--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -846,7 +846,7 @@ class Manager(object):
             log.info('Running database cleanup.')
             session = Session()
             try:
-                fire_event('manager.db_cleanup', session)
+                fire_event('manager.db_cleanup', self, session)
                 session.commit()
             finally:
                 session.close()

--- a/flexget/plugins/api_tvrage.py
+++ b/flexget/plugins/api_tvrage.py
@@ -28,7 +28,7 @@ tvrage.feeds.BASE_URL = 'http://services.tvrage.com/feeds/%s.php?%s=%s'
 
 
 @event('manager.db_cleanup')
-def db_cleanup(session):
+def db_cleanup(manager, session):
     value = datetime.datetime.now() - parse_timedelta('30 days')
     for de in session.query(TVRageSeries).filter(TVRageSeries.last_update <= value).all():
         log.debug('deleting %s' % de)

--- a/flexget/plugins/filter/remember_rejected.py
+++ b/flexget/plugins/filter/remember_rejected.py
@@ -183,7 +183,7 @@ def clear_rejected(manager):
 
 
 @event('manager.db_cleanup')
-def db_cleanup(session):
+def db_cleanup(manager, session):
     # Remove entries older than 30 days
     result = session.query(RememberEntry).filter(RememberEntry.added < datetime.now() - timedelta(days=30)).delete()
     if result:

--- a/flexget/plugins/filter/seen.py
+++ b/flexget/plugins/filter/seen.py
@@ -232,7 +232,7 @@ class FilterSeen(object):
 
 
 @event('manager.db_cleanup')
-def db_cleanup(session):
+def db_cleanup(manager, session):
     log.debug('TODO: Disabled because of ticket #1321')
     return
 

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -151,7 +151,7 @@ def upgrade(ver, session):
 
 
 @event('manager.db_cleanup')
-def db_cleanup(session):
+def db_cleanup(manager, session):
     # Clean up old undownloaded releases
     result = session.query(Release).\
         filter(Release.downloaded == False).\

--- a/flexget/plugins/input/discover.py
+++ b/flexget/plugins/input/discover.py
@@ -36,7 +36,7 @@ Index('ix_discover_entry_title_task', DiscoverEntry.title, DiscoverEntry.task)
 
 
 @event('manager.db_cleanup')
-def db_cleanup(session):
+def db_cleanup(manager, session):
     value = datetime.datetime.now() - parse_timedelta('7 days')
     for de in session.query(DiscoverEntry).filter(DiscoverEntry.last_execution <= value).all():
         log.debug('deleting %s' % de)

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -174,6 +174,10 @@ class Task(object):
 
       ``parameters: task, keyword``
 
+    * task.execute.started
+
+      Before a task starts execution
+
     * task.execute.completed
 
       After task execution has been completed
@@ -555,7 +559,6 @@ class Task(object):
         else:
             for entry in self.all_entries:
                 entry.complete()
-            fire_event('task.execute.completed', self)
 
     @use_task_logging
     def execute(self):
@@ -574,6 +577,7 @@ class Task(object):
         try:
             if self.options.cron:
                 self.manager.db_cleanup()
+            fire_event('task.execute.started', self)
             while True:
                 self._execute()
                 # rerun task
@@ -588,6 +592,7 @@ class Task(object):
                 elif self._rerun:
                     log.info('Task has been re-run %s times already, stopping for now' % self._rerun_count)
                 break
+            fire_event('task.execute.completed', self)
         finally:
             self.finished_event.set()
 

--- a/flexget/utils/cached_input.py
+++ b/flexget/utils/cached_input.py
@@ -43,7 +43,7 @@ class InputCacheEntry(Base):
 
 
 @event('manager.db_cleanup')
-def db_cleanup(session):
+def db_cleanup(manager, session):
     """Removes old input caches from plugins that are no longer configured."""
     result = session.query(InputCache).filter(InputCache.added < datetime.now() - timedelta(days=7)).delete()
     if result:

--- a/flexget/utils/log.py
+++ b/flexget/utils/log.py
@@ -44,7 +44,7 @@ class LogMessage(Base):
 
 
 @event('manager.db_cleanup')
-def purge(session):
+def purge(manager, session):
     """Purge old messages from database"""
     old = datetime.now() - timedelta(days=365)
 

--- a/flexget/utils/simple_persistence.py
+++ b/flexget/utils/simple_persistence.py
@@ -76,6 +76,12 @@ Index('ix_simple_persistence_feed_plugin_key', SimpleKeyValue.task, SimpleKeyVal
 
 
 class SimplePersistence(MutableMapping):
+    """
+    Store simple values that need to be persisted between FlexGet runs. Interface is like a `dict`.
+
+    This should only be used if a plugin needs to store a few values, otherwise it should create a full table in
+    the database.
+    """
     # Stores values in store[taskname][pluginname][key] format
     class_store = defaultdict(lambda: defaultdict(dict))
 
@@ -135,7 +141,9 @@ class SimplePersistence(MutableMapping):
                         if value == DELETE:
                             query.delete()
                         else:
-                            query.update({'value': value}, synchronize_session=False)
+                            updated = query.update({'value': value}, synchronize_session=False)
+                            if not updated:
+                                session.add(SimpleKeyValue(taskname, pluginname, key, value))
 
 
 class SimpleTaskPersistence(SimplePersistence):

--- a/flexget/utils/simple_persistence.py
+++ b/flexget/utils/simple_persistence.py
@@ -160,15 +160,20 @@ def load_taskless(manager):
     SimplePersistence.load()
 
 
+@event('manager.shutdown')
+def flush_taskless(manager):
+    SimplePersistence.flush()
+
+
 @event('task.execute.started')
 def load_task(task):
     """Loads all key/value pairs into memory before a task starts."""
-    if not SimplePersistence.class_store[task]:
+    if not SimplePersistence.class_store[task.name]:
         SimplePersistence.load(task.name)
 
 
 @event('task.execute.completed')
-def flush_to_db(task):
+def flush_task(task):
     """Stores all in memory key/value pairs to database when a task has completed."""
     SimplePersistence.flush(task.name)
     # Also flush items not associated with any specific task

--- a/flexget/utils/simple_persistence.py
+++ b/flexget/utils/simple_persistence.py
@@ -163,7 +163,8 @@ def load_taskless(manager):
 @event('task.execute.started')
 def load_task(task):
     """Loads all key/value pairs into memory before a task starts."""
-    SimplePersistence.load(task.name)
+    if not SimplePersistence.class_store[task]:
+        SimplePersistence.load(task.name)
 
 
 @event('task.execute.completed')

--- a/flexget/utils/simple_persistence.py
+++ b/flexget/utils/simple_persistence.py
@@ -8,7 +8,7 @@ can replace underlying mechanism in single point (and provide transparent switch
 """
 
 from __future__ import unicode_literals, division, absolute_import
-from collections import MutableMapping
+from collections import MutableMapping, defaultdict
 from datetime import datetime
 import logging
 import pickle
@@ -22,6 +22,9 @@ from flexget.utils.sqlalchemy_utils import table_schema, create_index
 
 log = logging.getLogger('util.simple_persistence')
 Base = db_schema.versioned_base('simple_persistence', 2)
+
+# Used to signify that a given key should be deleted from simple persistence on flush
+DELETE = object()
 
 
 @db_schema.upgrade('simple_persistence')
@@ -72,53 +75,49 @@ Index('ix_simple_persistence_feed_plugin_key', SimpleKeyValue.task, SimpleKeyVal
 
 
 class SimplePersistence(MutableMapping):
+    # Stores values in store[taskname][pluginname][key] format
+    class_store = defaultdict(defaultdict(dict))
 
     def __init__(self, plugin=None):
         self.taskname = None
         self.plugin = plugin
 
+    @property
+    def store(self):
+        return self.class_store[self.taskname][self.plugin]
+
     def __setitem__(self, key, value):
-        with Session() as session:
-            skv = session.query(SimpleKeyValue).filter(SimpleKeyValue.task == self.taskname).\
-                filter(SimpleKeyValue.plugin == self.plugin).filter(SimpleKeyValue.key == key).first()
-            if skv:
-                # update existing
-                log.debug('updating key %s value %s' % (key, repr(value)))
-                skv.value = value
-            else:
-                # add new key
-                skv = SimpleKeyValue(self.taskname, self.plugin, key, value)
-                log.debug('adding key %s value %s' % (key, repr(value)))
-                session.add(skv)
+        log.debug('setting key %s value %s' % (key, repr(value)))
+        self.store[key] = value
 
     def __getitem__(self, key):
+        if 'key' in self.store:
+            if self.store[key] == DELETE:
+                raise KeyError('%s is not contained in the simple_persistence table.' % key)
+            return self.store[key]
+
         with Session() as session:
             skv = session.query(SimpleKeyValue).filter(SimpleKeyValue.task == self.taskname).\
                 filter(SimpleKeyValue.plugin == self.plugin).filter(SimpleKeyValue.key == key).first()
             if not skv:
                 raise KeyError('%s is not contained in the simple_persistence table.' % key)
             else:
+                self.store[key] = skv.value
                 return skv.value
 
     def __delitem__(self, key):
-        with Session() as session:
-            session.query(SimpleKeyValue).filter(SimpleKeyValue.task == self.taskname).\
-                filter(SimpleKeyValue.plugin == self.plugin).filter(SimpleKeyValue.key == key).delete()
+        self.store[key] = DELETE
 
     def __iter__(self):
-        with Session() as session:
-            query = session.query(SimpleKeyValue.key).filter(SimpleKeyValue.task == self.taskname).\
-                filter(SimpleKeyValue.plugin == self.plugin).all()
-            if query:
-                return [item.key for item in query]
-            else:
-                return []
+        raise NotImplementedError('simple persistence does not support iteration')
 
     def __len__(self):
-        with Session() as session:
-            return session.query(SimpleKeyValue.key).filter(SimpleKeyValue.task == self.taskname).\
-                filter(SimpleKeyValue.plugin == self.plugin).count()
+        raise NotImplementedError('simple persistence does not support `len`')
 
+    def flush(self):
+        """Flush all in memory key/values to database."""
+        log.debug('Flushing simple persistence updates to db.')
+        # TODO: the stuff
 
 class SimpleTaskPersistence(SimplePersistence):
 


### PR DESCRIPTION
Simple persistence had an issue causing db locks when plugins were calling it while doing their own database read/writes. This branch changes the behavior so that the data is read from the database before a task is run, and written after.

http://flexget.com/ticket/2762
http://flexget.com/ticket/2820