### PR TITLE
trakt_emit: fixed parsing error for getting show data

### DIFF
--- a/flexget/plugins/input/trakt_emit.py
+++ b/flexget/plugins/input/trakt_emit.py
@@ -61,7 +61,7 @@ class TraktEmit(object):
                 log.warning('The list "%s" is empty.' % config['list'])
                 return
             for item in data:
-                if item['type'] == 'show':
+                if item['show'] is not None:
                     if not item['show']['title']:
                         # Seems we can get entries with a blank show title sometimes
                         log.warning('Found trakt list show with no series name.')


### PR DESCRIPTION
See example of Trakt.tv json response data from
http://docs.trakt.apiary.io/#reference/users/watched/get-watched

Previous Flexget code was looking for a "type"-attribute that is no longer available in the response.