### PR TITLE
handle disappearing folders (eg. samba shares) in listdir

### DIFF
--- a/flexget/plugins/input/listdir.py
+++ b/flexget/plugins/input/listdir.py
@@ -31,7 +31,12 @@ class Listdir(object):
         entries = []
         for folder in config:
             folder = path(folder).expanduser()
-            for filepath in folder.listdir():
+            try:
+                dir_files = folder.listdir()
+            except OSError as e:
+                log.error('error accessing folder: %s' % e.strerror)
+                continue
+            for filepath in dir_files:
                 try:
                     filepath.exists()
                 except UnicodeError:

--- a/flexget/plugins/input/listdir.py
+++ b/flexget/plugins/input/listdir.py
@@ -34,7 +34,7 @@ class Listdir(object):
             try:
                 dir_files = folder.listdir()
             except OSError as e:
-                log.error('error accessing folder: %s' % e.strerror)
+                log.error('Path %s could not be accessed: %s' % (folder, e.strerror))
                 continue
             for filepath in dir_files:
                 try:


### PR DESCRIPTION
Last pull request had some garbage commits I thought I had removed. Let's try again.

The daemon will check for the existence of folders listed in `listdir`, but if they disappear after the config validation, then the `listdir` plugin will throw an OSError and abort the task (same for non-daemon runs). I haven't really tested my changes but it should work.

Log:

```
2015-01-12 12:00 ERROR    task          Move tvshows    BUG: Unhandled error in plugin configure_series: [Errno 112] Host is down: '/media/network/seagate/staging/tv'
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/flexget/task.py", line 444, in __run_plugin
    return method(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/flexget/event.py", line 22, in __call__
    return self.func(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/flexget/plugins/plugin_configure_series.py", line 69, in on_task_start
    result = method(task, input_config)
  File "/usr/local/lib/python2.7/dist-packages/flexget/event.py", line 22, in __call__
    return self.func(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/flexget/plugins/input/listdir.py", line 34, in on_task_input
    for filepath in folder.listdir():
  File "/usr/local/lib/python2.7/dist-packages/path.py", line 506, in listdir
    for child in map(self._always_unicode, os.listdir(self))
OSError: [Errno 112] Host is down: '/media/network/seagate/staging/tv'
2015-01-12 12:00 WARNING  task          Move tvshows    Aborting task (plugin: configure_series)
```