### PR TITLE
Refactor set plugin to render templates lazily.

### DIFF
--- a/flexget/entry.py
+++ b/flexget/entry.py
@@ -218,7 +218,7 @@ class Entry(dict):
 
         # url and original_url handling
         if key == 'url':
-            if not isinstance(value, basestring):
+            if not isinstance(value, (basestring, LazyField)):
                 raise PluginError('Tried to set %r url to %r' % (self.get('title'), value))
             self.setdefault('original_url', value)
 

--- a/flexget/plugins/modify/set_field.py
+++ b/flexget/plugins/modify/set_field.py
@@ -1,14 +1,13 @@
 from __future__ import unicode_literals, division, absolute_import
-from copy import copy
+
 import logging
+from functools import partial
 
 from flexget import plugin
 from flexget.event import event
 from flexget.utils.template import RenderError
 
 log = logging.getLogger('set')
-
-PRIORITY_LAST = -255
 
 
 class ModifySet(object):
@@ -26,44 +25,33 @@ class ModifySet(object):
         "minProperties": 1
     }
 
-    # Filter priority is -255 so we run after all filters are finished
-    @plugin.priority(PRIORITY_LAST)
-    def on_task_filter(self, task, config):
+    def on_task_metainfo(self, task, config):
         """Adds the set dict to all accepted entries."""
-        # TODO: This is ugly, maybe we should only run on accepted entries all the time, or have an option to run on all
-        if plugin.get_plugin_by_name('set').phase_handlers['filter'].priority == PRIORITY_LAST:
-            # If priority is last only run on accepted entries to prevent unneeded lazy lookups
-            log.debug('Set plugin at default priority, only running on accepted entries.')
-            entries = task.accepted
-        else:
-        # If the priority has been modified to run before last, run on all entries
-            log.debug('Set plugin\'s priority has been altered, running on all entries.')
-            entries = task.entries
-
-        for entry in entries:
+        for entry in task.all_entries:
             self.modify(entry, config)
 
     def modify(self, entry, config, errors=True):
         """This can be called from a plugin to add set values to an entry"""
+        orig_field_values = {}
+        for field in config:
+            # If we aren't setting to a string, it can't be a template, so just set it now.
+            if not isinstance(config[field], basestring):
+                entry[field] = config[field]
+            # Ntore original values before overwriting with a lazy field, so that set directives can reference
+            # themselves.
+            elif field in entry:
+                orig_field_values[field] = entry.pop(field)
+        entry.register_lazy_fields(config, partial(self.lazy_set, config, orig_field_values, errors=errors))
 
-        # Create a new dict so we don't overwrite the set config with string replaced values.
-        conf = copy(config)
-
-        # Do jinja2 rendering/string replacement
-        for field, value in conf.items():
-            if isinstance(value, basestring):
-                logger = log.error if errors else log.debug
-                try:
-                    conf[field] = entry.render(value)
-                except RenderError as e:
-                    logger('Could not set %s for %s: %s' % (field, entry['title'], e))
-                    # If the replacement failed, remove this key from the update dict
-                    del conf[field]
-
-        # If there are valid items in the config, apply to entry.
-        if conf:
-            log.debug('adding set: info to entry:\'%s\' %s' % (entry['title'], conf))
-            entry.update(conf)
+    def lazy_set(self, config, orig_field_values, entry, field, errors=True):
+        logger = log.error if errors else log.debug
+        if field in orig_field_values:
+            entry[field] = orig_field_values[field]
+        try:
+            entry[field] = entry.render(config[field])
+        except RenderError as e:
+            logger('Could not set %s for %s: %s' % (field, entry['title'], e))
+        return entry.get(field, eval_lazy=False)
 
 @event('plugin.register')
 def register_plugin():

--- a/flexget/plugins/modify/set_field.py
+++ b/flexget/plugins/modify/set_field.py
@@ -34,8 +34,8 @@ class ModifySet(object):
         """This can be called from a plugin to add set values to an entry"""
         orig_field_values = {}
         for field in config:
-            # If we aren't setting to a string, it can't be a template, so just set it now.
-            if not isinstance(config[field], basestring):
+            # If this doesn't appear to be a jinja template, just set it right away.
+            if not isinstance(config[field], basestring) or '{' not in config[field]:
                 entry[field] = config[field]
             # Store original values before overwriting with a lazy field, so that set directives can reference
             # themselves.

--- a/flexget/plugins/modify/set_field.py
+++ b/flexget/plugins/modify/set_field.py
@@ -37,7 +37,7 @@ class ModifySet(object):
             # If we aren't setting to a string, it can't be a template, so just set it now.
             if not isinstance(config[field], basestring):
                 entry[field] = config[field]
-            # Ntore original values before overwriting with a lazy field, so that set directives can reference
+            # Store original values before overwriting with a lazy field, so that set directives can reference
             # themselves.
             elif field in entry:
                 orig_field_values[field] = entry.pop(field)


### PR DESCRIPTION
This changes the set plugin to render entries lazily. This has several advantages:
- We can do the set earlier, so that its fields can be used throughout the filter phase. (also less chance of people needing to use plugin_priority for advanced setups)
- Fields get set on all entries, instead of just accepted ones, so they can be used for filtering (or other plugins that act on non-accepted entries) if desired.
- Less chance of causing lookups that aren't needed, if the fields never get accessed.
- We can now reference other fields set by the set plugin, no matter the order.

@paranoidi Thoughts on this? I think the outcome is awesome, perhaps there are better ways to implement though, or unintended consequences.