### PR TITLE
Make auto_escape also work with spaces and single quotes

### DIFF
--- a/flexget/plugins/output/exec.py
+++ b/flexget/plugins/output/exec.py
@@ -27,8 +27,12 @@ class EscapingDict(MutableMapping):
     def __getitem__(self, key):
         value = self._data[key]
         if isinstance(value, basestring):
-            # TODO: May need to be different depending on OS
-            value = value.replace('"', '\\"')
+            if sys.platform.startswith('win'):
+                value = value.replace('"', '\\"')
+            else:
+                value = value.replace('"', '\\"')
+                value = value.replace('\'', '\\\'')
+                value = value.replace(' ', '\\ ')
         return value
 
     def __setitem__(self, key, value):


### PR DESCRIPTION
I'm not sure if it might have already worked for Windows, so I didn't change the current behavior for that platform, but in Unix-based systems the option didn't work at all. Spaces were not escaped and single quotes were not escaped. There might be even more things that need escaping, but so far I've only ever come across spaces and single quotes. So far I've fixed it myself by jinja-replacing them ( ```{{ location|replace("'", "\\'")|replace(" ", "\\ ") }}``` ), and now that I haven't encountered any troubles with that in a while I figured it should be a worthwhile fix in the actual codebase.