### PR TITLE
Adding language to qualitities

### DIFF
--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -139,7 +139,7 @@ _sources = [
     QualityComponent('source', 130, 'dvdscr', '(?:(?:dvd|web)[\W_]?)?scr(?:eener)?', modifier=0),
     QualityComponent('source', 140, 'bdscr', 'bdscr(?:eener)?'),
     QualityComponent('source', 150, 'hdtv', 'a?hdtv(?:[\W_]?rip)?'),
-    QualityComponent('source', 160, 'webdl', 'web(?:[\W_]?(dl|hd))'),
+    QualityComponent('source', 160, 'webdl', '(web|iTunes|Netflix)(?:[\W_]?(dl|hd))'),
     QualityComponent('source', 170, 'dvdrip', 'dvd(?:[\W_]?rip)?'),
     QualityComponent('source', 175, 'remux'),
     QualityComponent('source', 180, 'bluray', '(?:b[dr][\W_]?rip|blu[\W_]?ray(?:[\W_]?rip)?)')
@@ -176,6 +176,8 @@ _languages = [
     QualityComponent('language', 7, 'japanese', 'jap(anese)?'),
     QualityComponent('language', 8, 'dutch', 'dutch|netherlandi(sh|c)'),
     QualityComponent('language', 9, 'korean', 'korean'),
+    # Dual Language
+    QualityComponent('language', 10, 'dl', 'DL')
 ]
 
 _UNKNOWNS = {


### PR DESCRIPTION
I know there may be other/better ways, but could you take a look in this issue?

This would easily make it possible to define the language you want to download, without changing anything when no language is set. 
My problem is, that when i download an original episode and later on the synchronized one, it will be not accepted because they have the same quality, but different languages...