### PR TITLE
use only ascii letters for IPC password generation

### DIFF
--- a/flexget/ipc.py
+++ b/flexget/ipc.py
@@ -106,7 +106,7 @@ class IPCServer(threading.Thread):
         self.manager = manager
         self.host = '127.0.0.1'
         self.port = port or 0
-        self.password = ''.join(random.choice(string.letters + string.digits) for x in range(15))
+        self.password = ''.join(random.choice(string.ascii_letters + string.digits) for x in range(15))
         self.server = None
 
     def authenticator(self, sock):


### PR DESCRIPTION
This PR fixes an issue I had with getting Flexget to start on a host running Omnios (Solaris).
***
Starting Flexget with a minimal configuration (or even empty config) resulted in the following error appearing:
```
(flexget-dev)aidan@pez:/export/home/aidan/flexget-dev$ ~/flexget-dev/bin/flexget execute
Could not start manager: 'ascii' codec can't decode byte 0xe5 in position 0: ordinal not in range(128)
```
The debug output showed that the `sys.defaultencoding` and `sys.getfilesystemencoding` values matched that of a Linux host that was able to start Flexget successfully.
```
2015-02-14 02:15 DEBUG    manager                       sys.defaultencoding: ascii
2015-02-14 02:15 DEBUG    manager                       sys.getfilesystemencoding: UTF-8
2015-02-14 02:15 DEBUG    manager                       os.path.supports_unicode_filenames: False
``` 
It turns out that on this particular host, `string.letters` is returning more than just the full ascii set and is including a bunch of unicode characters which is causing the exception to be thrown.  The `string` doco says that the output of `string.letters` is dependent on the systems locale whilst `ascii_letters` is not ([letters](https://docs.python.org/2/library/string.html#string.letters), [ascii_letters](https://docs.python.org/2/library/string.html#string.ascii_letters)).  

After applying this diff (and installing some other dependencies), I am now able to run Flexget on my host.

Here is a replication of the 'issue', incase anyone is interested:
```
(flexget-dev)aidan@pez:/export/home/aidan/flexget-dev$ python
Python 2.7.6 (default, Feb 19 2014, 13:37:36) 
[GCC 4.7.3] on sunos5
Type "help", "copyright", "credits" or "license" for more information.
>>> import string
>>> string.letters
'abcdefghijklmnopqrstuvwxyz\xaa\xb5\xba\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xffABCDEFGHIJKLMNOPQRSTUVWXYZ\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd8\xd9\xda\xdb\xdc\xdd\xde'
>>> 
>>> import random
>>> password = ''.join(random.choice(string.letters + string.digits) for x in range(15))
>>> print password
??k?v?i??H??c?H
```