### PR TITLE
Update EZTV URL from .IT to .CH

### DIFF
--- a/flexget/plugins/urlrewrite_eztv.py
+++ b/flexget/plugins/urlrewrite_eztv.py
@@ -13,7 +13,7 @@ from flexget.utils.soup import get_soup
 log = logging.getLogger('eztv')
 
 EZTV_MIRRORS = [
-    ('http', 'eztv.it'),
+    ('http', 'eztv.ch'),
     ('https', 'eztv-proxy.net'),
     ('http', 'eztv.come.in')]
 
@@ -22,7 +22,7 @@ class UrlRewriteEztv(object):
     """Eztv url rewriter."""
 
     def url_rewritable(self, task, entry):
-        return urlparse(entry['url']).netloc == 'eztv.it'
+        return urlparse(entry['url']).netloc == 'eztv.ch'
 
     def url_rewrite(self, task, entry):
         url = entry['url']


### PR DESCRIPTION
Since EZTV has moved away from the .IT domain, its URL has to be updated.