### PR TITLE
Disabled SSL certificate validation to avoid SSLErrors in TPB

### DIFF
--- a/flexget/plugins/urlrewrite_piratebay.py
+++ b/flexget/plugins/urlrewrite_piratebay.py
@@ -88,7 +88,7 @@ class UrlRewritePirateBay(object):
 
     @plugin.internet(log)
     def parse_download_page(self, url):
-        page = requests.get(url).content
+        page = requests.get(url,verify=False).content
         try:
             soup = get_soup(page)
             tag_div = soup.find('div', attrs={'class': 'download'})
@@ -127,7 +127,7 @@ class UrlRewritePirateBay(object):
             # urllib.quote will crash if the unicode string has non ascii characters, so encode in utf-8 beforehand
             url = 'http://thepiratebay.%s/search/%s%s' % (CUR_TLD, urllib.quote(query.encode('utf-8')), filter_url)
             log.debug('Using %s as piratebay search url' % url)
-            page = requests.get(url).content
+            page = requests.get(url,verify=False).content
             soup = get_soup(page)
             for link in soup.find_all('a', attrs={'class': 'detLink'}):
                 entry = Entry()


### PR DESCRIPTION
Pirate bay discover plugin was failing with the following error:

    Error searching with piratebay: RequestException: hostname 'thepiratebay.se' doesn't match either of 'ssl2000.cloudflare.com', 'cloudflare.com', '*.cloudflare.com'

It seems that TPB's HTTPS certificate is not well configured. I just disabled host certificate validation, now it works.