### PR TITLE
Fix authentication.py typo for webui username.

### DIFF
--- a/flexget/ui/plugins/authentication/authentication.py
+++ b/flexget/ui/plugins/authentication/authentication.py
@@ -50,7 +50,7 @@ def enable_authentication():
         db_session.add(credentials)
 
     if manager.options.webui.username:
-        credentials.username = manager.options.username
+        credentials.username = manager.options.webui.username
     if manager.options.webui.password:
         credentials.password = manager.options.webui.password
     db_session.commit()


### PR DESCRIPTION
Seems like a simple typo. Tested locally. Fixes an issue where using the --username flag with flexget webui would throw an AttributeError.