### PR TITLE
Main file ratio

### DIFF
--- a/flexget/plugins/plugin_deluge.py
+++ b/flexget/plugins/plugin_deluge.py
@@ -640,10 +640,10 @@ class OutputDeluge(DelugePlugin):
                                                      [(file['index'], new_name)]))
                         log.debug('File %s in %s renamed to %s' % (file['path'], entry['title'], new_name))
 
-                    # find a file that makes up more than 90% of the total size
+                    # find a file that makes up more than main_file_ratio (default: 90%) of the total size
                     main_file = None
                     for file in status['files']:
-                        if file['size'] > (status['total_size'] * 0.9):
+                        if file['size'] > (status['total_size'] * opts.get('main_file_ratio')):
                             main_file = file
                             break
 
@@ -690,7 +690,7 @@ class OutputDeluge(DelugePlugin):
                                 rename_pairs = [(f['index'], other_files_dir + f['path']) for f in other_files]
                                 main_file_dlist.append(client.core.rename_files(torrent_id, rename_pairs))
                     else:
-                        log.warning('No files in %s are > 90%% of content size, no files renamed.' % entry['title'])
+                        log.warning('No files in %s are > %d%% of content size, no files renamed.' % (entry['title'], opts.get('main_file_ratio') * 100))
 
                 return defer.DeferredList(main_file_dlist)
 

--- a/flexget/plugins/plugin_deluge.py
+++ b/flexget/plugins/plugin_deluge.py
@@ -690,7 +690,7 @@ class OutputDeluge(DelugePlugin):
                                 rename_pairs = [(f['index'], other_files_dir + f['path']) for f in other_files]
                                 main_file_dlist.append(client.core.rename_files(torrent_id, rename_pairs))
                     else:
-                        log.warning('No files in %s are > %d%% of content size, no files renamed.' % (entry['title'], opts.get('main_file_ratio') * 100))
+                        log.warning('No files in "%s" are > %d%% of content size, no files renamed.' % (entry['title'], opts.get('main_file_ratio') * 100))
 
                 return defer.DeferredList(main_file_dlist)
 

--- a/flexget/plugins/plugin_deluge.py
+++ b/flexget/plugins/plugin_deluge.py
@@ -343,6 +343,7 @@ class OutputDeluge(DelugePlugin):
                     'compact': {'type': 'boolean'},
                     'content_filename': {'type': 'string'},
                     'main_file_only': {'type': 'boolean'},
+                    'main_file_ratio': {'type': 'number'},
                     'keep_subs': {'type': 'boolean'},
                     'hide_sparse_files': {'type': 'boolean'},
                     'enabled': {'type': 'boolean'},
@@ -360,6 +361,7 @@ class OutputDeluge(DelugePlugin):
         config.setdefault('path', '')
         config.setdefault('movedone', '')
         config.setdefault('label', '')
+        config.setdefault('main_file_ratio', 0.90)
         config.setdefault('keep_subs', True)  # does nothing without 'content_filename' or 'main_file_only' enabled
         config.setdefault('hide_sparse_files', False)  # does nothing without 'main_file_only' enabled
         return config

--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -93,7 +93,7 @@ class TransmissionBase(object):
                 raise plugin.PluginError("Error connecting to transmission: %s" % e.message)
         return cli
 
-    def torrent_info(self, torrent):
+    def torrent_info(self, torrent, config):
         done = torrent.totalSize > 0
         vloc = None
         best = None
@@ -105,7 +105,7 @@ class TransmissionBase(object):
                     break
                 if not best or tf['size'] > best[1]:
                     best = (tf['name'], tf['size'])
-        if done and best and (100 * float(best[1]) / float(torrent.totalSize)) >= 90:
+        if done and best and (100 * float(best[1]) / float(torrent.totalSize)) >= (config['main_file_ratio'] * 100):
             vloc = ('%s/%s' % (torrent.downloadDir, best[0])).replace('/', os.sep)
         return done, vloc
 
@@ -186,7 +186,7 @@ class PluginTransmissionInput(TransmissionBase):
         session = self.client.get_session()
 
         for torrent in self.client.get_torrents():
-            downloaded, bigfella = self.torrent_info(torrent)
+            downloaded, bigfella = self.torrent_info(torrent, config)
             seed_ratio_ok, idle_limit_ok = self.check_seed_limits(torrent, session)
             if not config['onlycomplete'] or (downloaded and torrent.status == 'stopped' and
                                               (seed_ratio_ok is None and idle_limit_ok is None) or

--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -244,6 +244,7 @@ class PluginTransmission(TransmissionBase):
                     'addpaused': {'type': 'boolean'},
                     'content_filename': {'type': 'string'},
                     'main_file_only': {'type': 'boolean'},
+                    'main_file_ratio': {'type': 'number'},
                     'enabled': {'type': 'boolean'},
                     'include_subs': {'type': 'boolean'},
                     'bandwidthpriority': {'type': 'number'},
@@ -261,6 +262,7 @@ class PluginTransmission(TransmissionBase):
         config = TransmissionBase.prepare_config(self, config)
         config.setdefault('path', '')
         config.setdefault('main_file_only', False)
+        config.setdefault('main_file_ratio', 0.90)
         config.setdefault('include_subs', False)
         config.setdefault('rename_like_files', False)
         config.setdefault('include_files', [])

--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -310,7 +310,7 @@ class PluginTransmission(TransmissionBase):
         opt_dic = {}
 
         for opt_key in ('path', 'addpaused', 'honourlimits', 'bandwidthpriority',
-                        'maxconnections', 'maxupspeed', 'maxdownspeed', 'ratio', 'main_file_only',
+                        'maxconnections', 'maxupspeed', 'maxdownspeed', 'ratio', 'main_file_only', 'main_file_ratio',
                         'include_subs', 'content_filename', 'include_files', 'skip_files', 'rename_like_files'):
             # Values do not merge config with task
             # Task takes priority then config is used
@@ -362,6 +362,8 @@ class PluginTransmission(TransmissionBase):
             post['paused'] = opt_dic['addpaused']
         if 'main_file_only' in opt_dic:
             post['main_file_only'] = opt_dic['main_file_only']
+        if 'main_file_ratio' in opt_dic:
+            post['main_file_ratio'] = opt_dic['main_file_ratio']
         if 'include_subs' in opt_dic:
             post['include_subs'] = opt_dic['include_subs']
         if 'content_filename' in opt_dic:
@@ -445,6 +447,10 @@ class PluginTransmission(TransmissionBase):
                         main_list = []
                         full_list = []
                         ext_list = ['*.srt', '*.sub', '*.idx', '*.ssa', '*.ass']
+                        
+                        main_ratio = config['main_file_ratio']
+                        if 'main_file_ratio' in options['post']:
+                            main_ratio = options['post']['main_file_ratio']
                                               
                         if 'include_files' in options['post']:                
                             include_files = True

--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -458,7 +458,7 @@ class PluginTransmission(TransmissionBase):
 
                         for f in fl[r.id]:
                             full_list.append(f)
-                            if fl[r.id][f]['size'] > total_size * 0.90:
+                            if fl[r.id][f]['size'] > total_size * main_ratio:
                                 main_id = f
 
                             if 'include_files' in options['post']:

--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -486,6 +486,8 @@ class PluginTransmission(TransmissionBase):
          
                             if main_id not in dl_list:
                                 dl_list.append(main_id)
+                        else:
+                            log.warning('No files in %s are > %d%% of content size, no files renamed.' % (entry['title'], main_ratio * 100))
 
                         # If we have a main file and want to rename it and associated files
                         if 'content_filename' in options['post'] and main_id is not None:

--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -487,7 +487,7 @@ class PluginTransmission(TransmissionBase):
                             if main_id not in dl_list:
                                 dl_list.append(main_id)
                         else:
-                            log.warning('No files in %s are > %d%% of content size, no files renamed.' % (entry['title'], main_ratio * 100))
+                            log.warning('No files in "%s" are > %d%% of content size, no files renamed.' % (entry['title'], main_ratio * 100))
 
                         # If we have a main file and want to rename it and associated files
                         if 'content_filename' in options['post'] and main_id is not None:


### PR DESCRIPTION
adding a new config key (`main_file_ratio`) to deluge and transmisson plugins so that when using the `main_file_only` config item, you are not forced to assume that the main file must be > 90% of the total torrent size, this ratio is now configurable. This helps a lot with shows that sometimes include samples which are potentially 10-15% of the total size.

I'm getting this PR started early as I want to start the review process right away (since I'm not super familiar with flexget plugins to begin with). I believe I got things right, or close to right at least, but I'm happy to fix style/consistency issues if there are any. I tried to add as little code as possible and keep existing code as unchanged as possible, as a result I may not be doing things the best way possible, but it will be as consistent as possible with the existing code base.

I'm testing this out on my server right now but won't really be able to see it's effectiveness for a few days. 