### PR TITLE
Transmission plugin magnetization waiting

### DIFF
--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -413,6 +413,8 @@ class PluginTransmission(TransmissionBase):
                         filedump = base64.b64encode(f.read()).encode('utf-8')
                     r = cli.add_torrent(filedump, 30, **options['add'])
                 else:
+                    # we need to set paused to false so the magnetization begins immediately
+                    options['add']['paused'] = False
                     r = cli.add_torrent(entry['url'], timeout=30, **options['add'])
                 if r:
                     torrent = r

--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -456,6 +456,14 @@ class PluginTransmission(TransmissionBase):
                    'content_filename' in options['post'] or skip_files):
                         fl = cli.get_files(r.id)
                 
+                        if 'magnetization_timeout' in options['post'] and options['post']['magnetization_timeout'] > 0 and not downloaded and len(fl[r.id]) == 0:
+                            log.debug('Waiting %d seconds for "%s" to magnetize' % (options['post']['magnetization_timeout'], entry['title']))
+                            fl = _wait_for_files(cli, r, options['post']['magnetization_timeout'])
+                            if len(fl[r.id]) == 0:
+                                log.warning('"%s" did not magnetize before the timeout elapsed, file list unavailable for processing.' % entry['title'])
+                            else:
+                                total_size = cli.get_torrent(r.id, ['id', 'totalSize']).totalSize
+                
                         # Find files based on config
                         dl_list = []
                         skip_list = []

--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -427,6 +427,17 @@ class PluginTransmission(TransmissionBase):
                         if fnmatch(name, mask):
                             return True
                     return False
+                
+                def _wait_for_files(cli, r, timeout):
+                    from time import sleep
+                    while timeout > 0:
+                        sleep(1)
+                        fl = cli.get_files(r.id)
+                        if len(fl[r.id]) > 0:
+                            return fl
+                        else:
+                            timeout -= 1
+                    return fl
 
                 skip_files = False
                 # Filter list because "set" plugin doesn't validate based on schema

--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -246,6 +246,7 @@ class PluginTransmission(TransmissionBase):
                     'content_filename': {'type': 'string'},
                     'main_file_only': {'type': 'boolean'},
                     'main_file_ratio': {'type': 'number'},
+                    'magnetization_timeout' : {'type': 'integer'},
                     'enabled': {'type': 'boolean'},
                     'include_subs': {'type': 'boolean'},
                     'bandwidthpriority': {'type': 'number'},
@@ -263,6 +264,7 @@ class PluginTransmission(TransmissionBase):
         config = TransmissionBase.prepare_config(self, config)
         config.setdefault('path', '')
         config.setdefault('main_file_only', False)
+        config.setdefault('magnetization_timeout', 0)
         config.setdefault('include_subs', False)
         config.setdefault('rename_like_files', False)
         config.setdefault('include_files', [])
@@ -309,8 +311,8 @@ class PluginTransmission(TransmissionBase):
 
         opt_dic = {}
 
-        for opt_key in ('path', 'addpaused', 'honourlimits', 'bandwidthpriority',
-                        'maxconnections', 'maxupspeed', 'maxdownspeed', 'ratio', 'main_file_only', 'main_file_ratio',
+        for opt_key in ('path', 'addpaused', 'honourlimits', 'bandwidthpriority', 'maxconnections', 'maxupspeed', 
+                        'maxdownspeed', 'ratio', 'main_file_only', 'main_file_ratio', 'magnetization_timeout',
                         'include_subs', 'content_filename', 'include_files', 'skip_files', 'rename_like_files'):
             # Values do not merge config with task
             # Task takes priority then config is used
@@ -364,6 +366,8 @@ class PluginTransmission(TransmissionBase):
             post['main_file_only'] = opt_dic['main_file_only']
         if 'main_file_ratio' in opt_dic:
             post['main_file_ratio'] = opt_dic['main_file_ratio']
+        if 'magnetization_timeout' in opt_dic:
+            post['magnetization_timeout'] = opt_dic['magnetization_timeout']
         if 'include_subs' in opt_dic:
             post['include_subs'] = opt_dic['include_subs']
         if 'content_filename' in opt_dic:


### PR DESCRIPTION
This patch addresses [this issue (#2911)](http://flexget.com/ticket/2911) that was posted not too long ago, but was closed prematurely (due to a misunderstanding of the issue I assume).

I have only patched the transmission plugin, I'm unsure if the deluge plugin requires patching but I have no test environment to do any proper QA for a deluge patch. I have just deployed the patched file to my own environment, I should get confirmation if it is working over the next few days.

This patch simply checks for a (_new_) `magnetization_timeout` configuration value (in seconds, defaults to 0, i.e., disabled). If this timeout is set to any number > 0 then the add will poll the transmission RPC client every second (until the timeout elapses) to see if the torrent has been magnetized. Once magnetized, the file list will be populated and the `totalSize` will be re-fetched. This will allow proper pre-processing of the `main_file_only`, `content_filename`, `skip_files`, etc... when a torrent is added to transmission via a magnet URI.

Because the default value for `magnetization_timeout` is zero, the default behaviour for this feature is disabled entirely.

**NOTE**
I'm not a python programmer professionally (mostly C# these days), so my programming style may not be ideal. There may be some more optimal ways of accomplishing the tasks I have added in this patch. I'm open to constructive comments to improve the coding style and efficiency of the patch additions.