### PR TITLE
fixing deluge plugin crash due to main_file_ratio config value not being present

### DIFF
--- a/flexget/plugins/plugin_deluge.py
+++ b/flexget/plugins/plugin_deluge.py
@@ -802,6 +802,7 @@ class OutputDeluge(DelugePlugin):
                 modify_opts = {'label': format_label(entry.get('label', config['label'])),
                                'queuetotop': entry.get('queuetotop', config.get('queuetotop')),
                                'main_file_only': entry.get('main_file_only', config.get('main_file_only', False)),
+                               'main_file_ratio': entry.get('main_file_ratio', config.get('main_file_ratio')),
                                'hide_sparse_files': entry.get('hide_sparse_files', config.get('hide_sparse_files', True)),
                                'keep_subs': entry.get('keep_subs', config.get('keep_subs', True))
                 }


### PR DESCRIPTION
this should fix the deluge plugin bug present in the latest 1.2.292 master branch. I don't have a test environment to confirm validity, but I'm fairly certain this was the missing code.

see https://github.com/Flexget/Flexget/pull/460#issuecomment-84051984