### PR TITLE
removing redundant config default setter for main_file_ratio

### DIFF
--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -263,7 +263,6 @@ class PluginTransmission(TransmissionBase):
         config = TransmissionBase.prepare_config(self, config)
         config.setdefault('path', '')
         config.setdefault('main_file_only', False)
-        config.setdefault('main_file_ratio', 0.90)
         config.setdefault('include_subs', False)
         config.setdefault('rename_like_files', False)
         config.setdefault('include_files', [])


### PR DESCRIPTION
due to the change made in 5a4d092, the change originally made in 089f576 is no longer necessary as the `TransmissionBase.prepare_config` performs an identical `setdefault` call.