### PR TITLE
[WIP] Allow default settings for series.

### DIFF
--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -814,6 +814,8 @@ class FilterSeriesBase(object):
         for group_name in config:
             if group_name == 'settings':
                 continue
+            if group_name == "default":
+                continue
             group_series = []
             if isinstance(group_name, basestring):
                 # if group name is known quality, convenience create settings with that quality
@@ -826,6 +828,7 @@ class FilterSeriesBase(object):
             for series in config[group_name]:
                 # convert into dict-form if necessary
                 series_settings = {}
+                default_settings = config['settings'].get('default', {})
                 group_settings = config['settings'].get(group_name, {})
                 if isinstance(series, dict):
                     series, series_settings = series.items()[0]
@@ -842,6 +845,7 @@ class FilterSeriesBase(object):
                 if isinstance(series_settings, basestring):
                     series_settings = {'path': series_settings}
                 # merge group settings into this series settings
+                merge_dict_from_to(default_settings, series_settings)
                 merge_dict_from_to(group_settings, series_settings)
                 # Convert to dict if watched is in SXXEXX format
                 if isinstance(series_settings.get('watched'), basestring):


### PR DESCRIPTION
Uses the special group_name `default` to set settings for every series,
including the ones generated from `configure_series`.

Would allow configs as followed to work:

```yaml
series:
  settings:
    default:
      identified_by: ep
    group1:
      identified_by: seq
    group2:
      quality: 720p

configure_series:
  from:
    [...]
  settings:
    quality: 1080p
```

All series will inherit the settings from group `default` and be identified by `ep`, except `group1` which overrides the default settings. `configure_series` inherits the default settings as well and would be able to override them if necessary.