### PR TITLE
remove extra urllib3 INFO logging

### DIFF
--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -15,7 +15,7 @@ from flexget.utils.tools import parse_timedelta, TimedDict
 log = logging.getLogger('requests')
 
 # Don't emit info level urllib3 log messages or below
-logging.getLogger('requests.packages.urllib3').setLevel(logging.WARNING)
+logging.getLogger('urllib3').setLevel(logging.WARNING)
 
 # Time to wait before trying an unresponsive site again
 WAIT_TIME = timedelta(seconds=60)

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -15,6 +15,8 @@ from flexget.utils.tools import parse_timedelta, TimedDict
 log = logging.getLogger('requests')
 
 # Don't emit info level urllib3 log messages or below
+logging.getLogger('requests.packages.urllib3').setLevel(logging.WARNING)
+# same as above, but for systems where urllib3 isn't part of the requests pacakge (i.e., Ubuntu)
 logging.getLogger('urllib3').setLevel(logging.WARNING)
 
 # Time to wait before trying an unresponsive site again


### PR DESCRIPTION
It was clear in the code that the intent was to remove these annoying INFO log messages
> Starting new HTTP connection (1): ...

by setting the log level to WARN `logging.getLogger('requests.packages.urllib3').setLevel(logging.WARNING)`
But it isn't taking any effect in the current release.

I changed the logger name to just `urllib3`, which seems to have corrected the problem. I'm not sure if there are any implications for the change I have made, so any input is welcome in that department.

Sourced my patch from these two StackOverflow questions:
* http://stackoverflow.com/questions/21944445
* https://stackoverflow.com/questions/11029717