### PR TITLE
Abstract out torrent file renaming

### DIFF
--- a/flexget/plugins/modify/torrent_renamefiles.py
+++ b/flexget/plugins/modify/torrent_renamefiles.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals, division, absolute_import
 import logging
 import posixpath
 import os
+import re
 
 from flexget import plugin
 from flexget.event import event
@@ -22,6 +23,7 @@ class TorrentRenameFiles(object):
                 'properties': {
                     'keep_container': {'type': 'boolean'},
                     'container_directory': {'type': 'string'},
+                    'container_multiple': {'type': 'boolean'},
                     'rename_main_file_only': {'type': 'boolean'},
                     'fix_year': {'type': 'boolean'},
                 },
@@ -33,6 +35,7 @@ class TorrentRenameFiles(object):
     def prepare_config(self, config):
         config.setdefault('keep_container', True)
         config.setdefault('container_directory', '')
+        config.setdefault('container_multiple', '')
         config.setdefault('fix_year', False)
         config.setdefault('rename_main_file_only', False)
         return config
@@ -42,6 +45,11 @@ class TorrentRenameFiles(object):
         file_ratio = status['total_size'] * config.get('main_file_ratio')
         log.debug('File ratio: %s' % file_ratio)
         log.debug('Torrent size: %s' % status['total_size'])
+
+        if not entry['main_fileid']:
+            entry['main_fileid'] = None
+        if not entry['sub_fileid']:
+            entry['sub_fileid'] = None
 
         series_tokens = False
         if config.get('content_filename'):
@@ -70,34 +78,25 @@ class TorrentRenameFiles(object):
                         if ext in sub_exts:
                             entry['sub_fileid'] = sub_file['index']
                             break
+        top_level = False
         if len(set(top_levels)) == 1:
             # the top level of every item's path is the same, therefore there's a container directory
             top_level = True
-        else:
-            top_level = False
         if entry['main_fileid'] is None:
             # if main_fileid wasn't set in the prior loop, no file is greater than
             # main_file_ratio% of the total size, therefore this is likely a season pack
-            entry['main_fileid'] = -1
             if config.get('rename_main_file_only'):
                 log.warning('No files in %s are > 90%% of content size, no files renamed.' % entry['title'])
-        if entry['sub_fileid'] is None:
-            entry['sub_fileid'] = -1
 
         log.debug('main_fileid: %s' % entry['main_fileid'])
 
         new_filenames = []
         files = {}
         os_sep = os.sep
+        do_container = False
+        if (config.get('container_multiple') and entry['main_fileid'] == None) or not config.get('container_multiple'):
+            do_container = True
         for file in status['files']:
-            try:
-                entry.pop('series_id')
-                entry.pop('season')
-                entry.pop('series_name')
-            except:
-                pass
-
-
             original_pathfile = file['path']
             cur_path = os.path.split(file['path'])[0]
             original_path = cur_path
@@ -106,12 +105,37 @@ class TorrentRenameFiles(object):
             original_filename = cur_filename
             log.debug('Current filename: %s', cur_filename)
 
+            try:
+                entry.pop('series_id')
+                entry.pop('season')
+                entry.pop('series_name')
+            except:
+                pass
+
+            if series_tokens:
+                parser = get_plugin_by_name('parsing').instance.parse_series(data=cur_filename)
+                if parser and parser.valid:
+                    entry['series_name'] = parser.name
+                if re.search(r'\d{4}', entry['series_name'][-4:]) is not None and config['fix_year']:
+                    entry['series_name'] = ''.join([entry['series_name'][0:-4], '(',
+                                                   entry['series_name'][-4:], ')'])
+                log.verbose(entry['series_name'])
+                log.debug('ID type: ' + parser.id_type)
+                if parser.id_type == 'ep':
+                    entry['season'] = parser.season
+                    entry['series_id'] = 'S' + str(parser.season).rjust(2, str('0')) + 'E'
+                    entry['series_id'] += str(parser.episode).rjust(2, str('0'))
+                elif parser.id_type == 'sequence':
+                    entry['series_id'] = parser.episode
+                elif parser.id_type and parser.id:
+                    entry['series_id'] = parser.id
+
             if not config.get('keep_container') and top_level:# and len(cur_path) > 1:
                 cur_path = os_sep.join(cur_path.split(os.sep)[1:])
                 log.debug('Removed container directory. New path: %s', cur_path)
                 removed_container = True
 
-            if config.get('container_directory'):
+            if config.get('container_directory') and do_container:
                 try:
                     container_directory = pathscrub(entry.render(config.get('container_directory')))
                     cur_path = os.path.join(container_directory, cur_path)
@@ -123,33 +147,17 @@ class TorrentRenameFiles(object):
                 (config.get('rename_main_file_only') and file['index'] == entry['main_fileid']) or
                 (config.get('keep_subs') and file['index'] == entry['sub_fileid'])):
 
-                if series_tokens:
-                    parser = get_plugin_by_name('parsing').instance.parse_series(data=cur_filename)
-                    if parser and parser.valid:
-                        entry['series_name'] = parser.name
-                    if re.search(r'\d{4}', entry['series_name'][-4:]) is not None and config['fix_year']:
-                        entry['series_name'] = ''.join([entry['series_name'][0:-4], '(',
-                                                       entry['series_name'][-4:], ')'])
-                        log.verbose(entry['series_name'])
-                        log.debug('ID type: ' + parser.id_type)
-                        if parser.id_type == 'ep':
-                            entry['season'] = parser.season
-                            entry['series_id'] = 'S' + str(parser.season).rjust(2, str('0')) + 'E'
-                            entry['series_id'] += str(parser.episode).rjust(2, str('0'))
-                        elif parser.id_type == 'sequence':
-                            entry['series_id'] = parser.episode
-                        elif parser.id_type and parser.id:
-                            entry['series_id'] = parser.id
                 try:
                     cur_filename = pathscrub(entry.render(config.get('content_filename')))
-                    # keep track of this filename being used
-                    cur_withext = cur_filename + os.path.splitext(original_filename)[1]
-                    if cur_withext in new_filenames:
-                        # if this exact filename has been used before, append -# to it
-                        cur_filename = ''.join(cur_filename, '-', str(new_filenames.count(cur_filename)), os.path.splitext(original_filename)[1])
-                    log.debug('Rendered filename: %s', cur_filename)
+                    log.debug('Rendered filename: %s', cur_filename + os.path.splitext(original_filename)[1])
                 except RenderError as e:
-                    log.error('Error rendering content_filename for %s: %s' % (cur_filename, e))
+                    log.error('Error rendering content_filename for %s: %s' % (original_filename, e))
+                cur_withext = cur_filename + os.path.splitext(original_filename)[1]
+                if cur_withext in new_filenames:
+                    # if this exact filename has been used before, append -# to it
+                    cur_filename = ''.join(cur_filename, '-', str(new_filenames.count(cur_filename)), os.path.splitext(original_filename)[1])
+                else:
+                    cur_filename = cur_withext
 
             # hide sparse files
             if config.get('main_file_only') and file['index'] != entry['main_fileid'] and config.get('hide_sparse_files'):

--- a/flexget/plugins/modify/torrent_renamefiles.py
+++ b/flexget/plugins/modify/torrent_renamefiles.py
@@ -1,0 +1,181 @@
+from __future__ import unicode_literals, division, absolute_import
+import logging
+import posixpath
+import os
+
+from flexget import plugin
+from flexget.event import event
+
+from flexget.utils.template import RenderError
+from flexget.plugin import get_plugin_by_name
+from flexget.utils.pathscrub import pathscrub
+
+
+log = logging.getLogger('torrent_frename')
+
+class TorrentRenameFiles(object):
+    """Performs renaming operations on the content_files field"""
+    schema = {
+        'anyOf': [
+            {
+                'type': 'object',
+                'properties': {
+                    'keep_container': {'oneOf': [{'type': 'string', 'enum': ['yes', 'no', 'episode', 'other']}, {'type': 'boolean'}]},
+                    'container_directory': {'type': 'string'},
+                    'rename_main_file_only': {'type': 'boolean'},
+                    'fix_year': {'type': 'boolean'},
+                },
+                'additionalProperties': False
+            }
+        ]
+    }
+
+    def prepare_config(self, config):
+        #if isinstance(config, bool):
+        #    config = {'enabled': config}
+        config.setdefault('keep_container', True) # can only work if there's only one file in the torrent...maybe?
+        config.setdefault('container_directory', '')
+        config.setdefault('fix_year', False)
+        config.setdefault('rename_main_file_only', False)
+        return config
+
+    #@plugin.priority(-255)
+    #def on_task_output(self, entry, config):
+    #    return False
+
+    def on_task_rename(self, entry, status, config):
+        # get total torrent size
+        file_ratio = status['total_size'] * config.get('main_file_ratio')
+        log.debug('File ratio: %s' % file_ratio)
+        log.debug('Torrent size: %s' % status['total_size'])
+
+        series_tokens = False
+        if config.get('content_filename'):
+            cf = config.get('content_filename')
+            if cf.find('series_id') > -1 or cf.find('season') > -1 or cf.find('series_name') > -1:
+                series_tokens = True
+
+        top_levels = []
+        # loop through to determine main_fileid and if there is a top-level folder
+        for file in status['files']:
+            # split path into directory structure
+            structure = file['path'].split(os.sep)
+            # if there is more than 1 directory, there is a top-level; if so, add it to the list
+            if len(structure) > 1:
+                top_levels.extend([structure[0]])
+            # if this file is greater than main_file_ratio% of the total torrent size, it is the "main" file
+            log.debug('File size: %s' % file['size'])
+            if file['size'] > file_ratio:
+                log.debug('Greater than file_ratio: %s' % file['index'])
+                entry['main_fileid'] = file['index']
+                if config['keep_subs']:
+                    sub_file = None
+                    sub_exts = [".srt", ".sub"]
+                    for sub_file in status['files']:
+                        ext = os.path.splitext(sub_file['path'])[1]
+                        if ext in sub_exts:
+                            entry['sub_fileid'] = sub_file['index']
+                            break
+        if len(set(top_levels)) == 1:
+            # the top level of every item's path is the same, therefore there's a container directory
+            top_level = True
+        else:
+            top_level = False
+        if entry['main_fileid'] is None:
+            # if main_fileid wasn't set in the prior loop, no file is greater than
+            # main_file_ratio% of the total size, therefore this is likely a season pack
+            entry['main_fileid'] = -1
+            if config.get('rename_main_file_only'):
+                log.warning('No files in %s are > 90%% of content size, no files renamed.' % entry['title'])
+        if entry['sub_fileid'] is None:
+            entry['sub_fileid'] = -1
+
+        log.debug('main_fileid: %s' % entry['main_fileid'])
+
+        new_filenames = []
+        files = {}
+        os_sep = os.sep
+        for file in status['files']:
+            try:
+                entry.pop('series_id')
+                entry.pop('season')
+                entry.pop('series_name')
+            except:
+                pass
+
+
+            original_pathfile = file['path']
+            cur_path = os.path.split(file['path'])[0]
+            original_path = cur_path
+            log.debug('Current path: %s', cur_path)
+            cur_filename = os.path.split(file['path'])[1]
+            original_filename = cur_filename
+            log.debug('Current filename: %s', cur_filename)
+
+            if not config.get('keep_container') and top_level:# and len(cur_path) > 1:
+                cur_path = os_sep.join(cur_path.split(os.sep)[1:])
+                log.debug('Removed container directory. New path: %s', cur_path)
+                removed_container = True
+
+            if config.get('container_directory'):
+                try:
+                    container_directory = pathscrub(entry.render(config.get('container_directory')))
+                    cur_path = os.path.join(container_directory, cur_path)
+                    log.debug('Added container directory. New path: %s', cur_path)
+                except RenderError as e:
+                    log.error('Error rendering container_directory for %s: %s' % (cur_file, e))
+
+            if config.get('content_filename') and (not config.get('rename_main_file_only') or
+                (config.get('rename_main_file_only') and file['index'] == entry['main_fileid']) or
+                (config.get('keep_subs') and file['index'] == entry['sub_fileid'])):
+
+                if series_tokens:
+                    parser = get_plugin_by_name('parsing').instance.parse_series(data=cur_filename)
+                    if parser and parser.valid:
+                        entry['series_name'] = parser.name
+                    if re.search(r'\d{4}', entry['series_name'][-4:]) is not None and config['fix_year']:
+                        entry['series_name'] = ''.join([entry['series_name'][0:-4], '(',
+                                                       entry['series_name'][-4:], ')'])
+                        log.verbose(entry['series_name'])
+                        log.debug('ID type: ' + parser.id_type)
+                        if parser.id_type == 'ep':
+                            entry['season'] = parser.season
+                            entry['series_id'] = 'S' + str(parser.season).rjust(2, str('0')) + 'E'
+                            entry['series_id'] += str(parser.episode).rjust(2, str('0'))
+                        elif parser.id_type == 'sequence':
+                            entry['series_id'] = parser.episode
+                        elif parser.id_type and parser.id:
+                            entry['series_id'] = parser.id
+                try:
+                    cur_filename = pathscrub(entry.render(config.get('content_filename')))
+                    # keep track of this filename being used
+                    cur_withext = cur_filename + os.path.splitext(original_filename)[1]
+                    if cur_withext in new_filenames:
+                        # if this exact filename has been used before, append -# to it
+                        cur_filename = ''.join(cur_filename, '-', str(new_filenames.count(cur_filename)), os.path.splitext(original_filename)[1])
+                    log.debug('Rendered filename: %s', cur_filename)
+                except RenderError as e:
+                    log.error('Error rendering content_filename for %s: %s' % (cur_filename, e))
+
+            # hide sparse files
+            if config.get('main_file_only') and file['index'] != entry['main_fileid'] and config.get('hide_sparse_files'):
+                if not config.get('keep_subs') or (config.get('keep_subs') and entry['sub_fileid'] != file['index']):
+                    if cur_filename:
+                        add_path = cur_filename
+                    elif container_directory:
+                        add_path = container_directory
+                    else:
+                        add_path = ''
+                    cur_path = os.path.join('._' + add_path, cur_path)
+
+            if original_pathfile != os.path.join(cur_path, cur_filename):
+                files[file['index']] = os.path.join(cur_path, cur_filename)
+            if cur_filename != original_filename:
+                new_filenames.append(cur_filename)
+
+        return files
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(TorrentRenameFiles, 'torrent_frename', api_ver=2)

--- a/flexget/plugins/modify/torrent_renamefiles.py
+++ b/flexget/plugins/modify/torrent_renamefiles.py
@@ -15,7 +15,7 @@ from flexget.utils.pathscrub import pathscrub
 log = logging.getLogger('torrent_frename')
 
 class TorrentRenameFiles(object):
-    """Performs renaming operations on the content_files field"""
+    """Performs renaming operations on files passed via status parameter. Expects Deluge status dict."""
     schema = {
         'anyOf': [
             {
@@ -26,25 +26,41 @@ class TorrentRenameFiles(object):
                     'container_multiple': {'type': 'boolean'},
                     'rename_main_file_only': {'type': 'boolean'},
                     'fix_year': {'type': 'boolean'},
+                    'unlisted_filetype_default': {'type': 'boolean'},
+                    'filetypes': {
+                        'type': 'object',
+                        'additionalProperties': {
+                            'oneOf': [
+                                {'type': 'string'},
+                                {'type': 'boolean'},
+                            ]
+                        }
+                    }
                 },
                 'additionalProperties': False
             }
         ]
     }
 
+    # Hierarchy:
+    #   keep_subs overrides rename_main_file_only
+    #   rename_main_file_only overrides filetypes
+    #   filetypes overrides unlisted_filetype_default
     def prepare_config(self, config):
         config.setdefault('keep_container', True)
         config.setdefault('container_directory', '')
         config.setdefault('container_multiple', '')
         config.setdefault('fix_year', False)
         config.setdefault('rename_main_file_only', False)
+        config.setdefault('unlisted_filetype_default', True)
+        config.setdefault('filetypes', {})
         return config
 
-    def on_task_rename(self, entry, status, config):
+    def rename_files(self, entry, status, config):
         # get total torrent size
         file_ratio = status['total_size'] * config.get('main_file_ratio')
-        log.debug('File ratio: %s' % file_ratio)
         log.debug('Torrent size: %s' % status['total_size'])
+        log.debug('Main file ratio size: %s' % file_ratio)
 
         entry['main_fileid'] = -1
         entry['sub_fileid'] = -1
@@ -64,7 +80,7 @@ class TorrentRenameFiles(object):
             if len(structure) > 1:
                 top_levels.extend([structure[0]])
             # if this file is greater than main_file_ratio% of the total torrent size, it is the "main" file
-            log.debug('File size: %s' % file['size'])
+            log.debug('File size is %s for file %d: %s' % (file['size'], file['index'], file['path']))
             if file['size'] > file_ratio:
                 log.debug('Greater than file_ratio: %s' % file['index'])
                 entry['main_fileid'] = file['index']
@@ -80,13 +96,17 @@ class TorrentRenameFiles(object):
         if len(set(top_levels)) == 1:
             # the top level of every item's path is the same, therefore there's a container directory
             top_level = True
+            log.debug('Common top level folder detected.')
         if entry['main_fileid'] < 0:
             # if main_fileid wasn't set in the prior loop, no file is greater than
             # main_file_ratio% of the total size, therefore this is likely a season pack
             if config.get('rename_main_file_only'):
-                log.warning('No files in %s are > 90%% of content size, no files renamed.' % entry['title'])
+                log.warning('No files in %s are > %s%% of content size, no files renamed.' % entry['title'], config.get('main_file_ratio')*100)
 
         log.debug('main_fileid: %s' % entry['main_fileid'])
+
+        if series_tokens:
+            tokens_title_parser = get_plugin_by_name('parsing').instance.parse_series(data=entry['title'])
 
         new_filenames = []
         files = {}
@@ -96,39 +116,79 @@ class TorrentRenameFiles(object):
             do_container = True
         for file in status['files']:
             original_pathfile = file['path']
+            log.debug('Current file: %s', original_pathfile)
+
             cur_path = os.path.split(file['path'])[0]
             original_path = cur_path
-            log.debug('Current path: %s', cur_path)
+
             cur_filename = os.path.split(file['path'])[1]
             original_filename = cur_filename
-            log.debug('Current filename: %s', cur_filename)
 
-            try:
-                entry.pop('series_id')
-                entry.pop('season')
-                entry.pop('series_name')
-            except:
-                pass
+            original_ext = os.path.splitext(original_filename)[1][1:]
 
-            if series_tokens:
+            subs_file = False
+            main_file = False
+            rename_file = False
+            content_filename = ''
+            if config.get('keep_subs') and file['index'] == entry['sub_fileid']:
+                log.debug('This is subs file, renaming it.')
+                subs_file = True
+                rename_file = True
+            if config.get('rename_main_file_only') and file['index'] == entry['main_fileid']:
+                log.debug('This is main file, renaming it.')
+                main_file = True
+                rename_file = True
+            if original_ext in config.get('filetypes'):
+                if isinstance(config.get('filetypes')[original_ext], basestring):
+                    log.debug('Custom template present for this filetype.')
+                    content_filename = config.get('filetypes')[original_ext]
+                    rename_file = True
+                elif config.get('filetypes')[original_ext]:
+                    log.debug('Using content_filename to rename this filetype.')
+                    rename_file = True
+            elif config.get('unlisted_filetype_default'):
+                log.debug('Filetype is unlisted, but default is to rename all files.')
+                rename_file = True
+            if rename_file and not content_filename:
+                if config.get('content_filename'):
+                    log.debug('Using content_filename for renaming template.')
+                    content_filename = config.get('content_filename')
+                else:
+                    rename_file = False
+                    log.error('Settings indicate to rename file, but content_filename template was not provided.')
+
+            removed_container = ''
+
+            if series_tokens and (config.get('container_directory') or content_filename):
                 parser = get_plugin_by_name('parsing').instance.parse_series(data=cur_filename)
+                if not parser or not parser.valid:
+                    parser = tokens_title_parser
                 if parser and parser.valid:
-                    entry['series_name'] = parser.name
-                if re.search(r'\d{4}', entry['series_name'][-4:]) is not None and config['fix_year']:
-                    entry['series_name'] = ''.join([entry['series_name'][0:-4], '(',
-                                                   entry['series_name'][-4:], ')'])
-                log.verbose(entry['series_name'])
-                log.debug('ID type: ' + parser.id_type)
-                if parser.id_type == 'ep':
-                    entry['season'] = parser.season
-                    entry['series_id'] = 'S' + str(parser.season).rjust(2, str('0')) + 'E'
-                    entry['series_id'] += str(parser.episode).rjust(2, str('0'))
-                elif parser.id_type == 'sequence':
-                    entry['series_id'] = parser.episode
-                elif parser.id_type and parser.id:
-                    entry['series_id'] = parser.id
+                    try:
+                        entry.pop('series_id')
+                        entry.pop('season')
+                        entry.pop('series_name')
+                    except:
+                        pass
 
-            if not config.get('keep_container') and top_level:# and len(cur_path) > 1:
+                    entry['series_name'] = parser.name
+                    if re.search(r'\d{4}', entry['series_name'][-4:]) is not None and config['fix_year']:
+                        entry['series_name'] = ''.join([entry['series_name'][0:-4], '(',
+                                                       entry['series_name'][-4:], ')'])
+                    log.verbose('Series: ' + entry['series_name'])
+                    log.debug('ID type: ' + parser.id_type)
+                    entry['season'] = ''
+                    if parser.id_type == 'ep':
+                        entry['season'] = parser.season
+                        entry['series_id'] = 'S' + str(parser.season).rjust(2, str('0')) + 'E'
+                        entry['series_id'] += str(parser.episode).rjust(2, str('0'))
+                    elif parser.id_type == 'sequence':
+                        entry['series_id'] = parser.episode
+                    elif parser.id_type and parser.id:
+                        entry['series_id'] = parser.id
+
+            if not config.get('keep_container') and top_level:
+                removed_container = cur_path.split(os.sep)[0]
                 cur_path = os_sep.join(cur_path.split(os.sep)[1:])
                 log.debug('Removed container directory. New path: %s', cur_path)
                 removed_container = True
@@ -139,39 +199,40 @@ class TorrentRenameFiles(object):
                     cur_path = os.path.join(container_directory, cur_path)
                     log.debug('Added container directory. New path: %s', cur_path)
                 except RenderError as e:
-                    log.error('Error rendering container_directory for %s: %s' % (cur_file, e))
+                    log.error('Error rendering container_directory for %s: %s' % (cur_filename, e))
+                    if removed_container:
+                        container_directory = removed_container
+                        cur_path = os.path.join(container_directory, cur_path)
+                        log.debug('Due to failure to add container, readding removed container to path. New path: %s', cur_path)
 
-            if config.get('content_filename') and (not config.get('rename_main_file_only') or
-                (config.get('rename_main_file_only') and file['index'] == entry['main_fileid']) or
-                (config.get('keep_subs') and file['index'] == entry['sub_fileid'])):
-
+            if content_filename and rename_file:
                 try:
-                    cur_filename = pathscrub(entry.render(config.get('content_filename')))
+                    cur_filename = pathscrub(entry.render(content_filename))
                     log.debug('Rendered filename: %s', cur_filename + os.path.splitext(original_filename)[1])
                 except RenderError as e:
                     log.error('Error rendering content_filename for %s: %s' % (original_filename, e))
                 cur_withext = cur_filename + os.path.splitext(original_filename)[1]
-                if cur_withext in new_filenames:
-                    # if this exact filename has been used before, append -# to it
-                    cur_filename = ''.join(cur_filename, '-', str(new_filenames.count(cur_filename)), os.path.splitext(original_filename)[1])
-                else:
+                if cur_filename != original_filename:
+                    new_filenames.append(os.path.join(cur_path, cur_withext))
+                if new_filenames.count(os.path.join(cur_path, cur_withext)) > 1:
+                    # if this exact path & filename has been used before, append -# to it
+                    cur_filename = ''.join([cur_filename, '-', str(new_filenames.count(cur_withext)), os.path.splitext(original_filename)[1]])
+                elif cur_filename[-len(original_ext):] != original_ext:
                     cur_filename = cur_withext
 
             # hide sparse files
-            if config.get('main_file_only') and file['index'] != entry['main_fileid'] and config.get('hide_sparse_files'):
-                if not config.get('keep_subs') or (config.get('keep_subs') and entry['sub_fileid'] != file['index']):
-                    if cur_filename:
-                        add_path = cur_filename
-                    elif container_directory:
+            if config.get('main_file_only') and not main_file and config.get('hide_sparse_files'):
+                if not config.get('keep_subs') or not subs_file:
+                    if container_directory:
                         add_path = container_directory
+                    elif cur_filename:
+                        add_path = cur_filename
                     else:
                         add_path = ''
-                    cur_path = os.path.join('._' + add_path, cur_path)
+                    cur_path = os.path.join(['._' + add_path, cur_path])
 
             if original_pathfile != os.path.join(cur_path, cur_filename):
                 files[file['index']] = os.path.join(cur_path, cur_filename)
-            if cur_filename != original_filename:
-                new_filenames.append(cur_filename)
 
         return files
 

--- a/flexget/plugins/modify/torrent_renamefiles.py
+++ b/flexget/plugins/modify/torrent_renamefiles.py
@@ -20,7 +20,7 @@ class TorrentRenameFiles(object):
             {
                 'type': 'object',
                 'properties': {
-                    'keep_container': {'oneOf': [{'type': 'string', 'enum': ['yes', 'no', 'episode', 'other']}, {'type': 'boolean'}]},
+                    'keep_container': {'type': 'boolean'},
                     'container_directory': {'type': 'string'},
                     'rename_main_file_only': {'type': 'boolean'},
                     'fix_year': {'type': 'boolean'},
@@ -31,17 +31,11 @@ class TorrentRenameFiles(object):
     }
 
     def prepare_config(self, config):
-        #if isinstance(config, bool):
-        #    config = {'enabled': config}
-        config.setdefault('keep_container', True) # can only work if there's only one file in the torrent...maybe?
+        config.setdefault('keep_container', True)
         config.setdefault('container_directory', '')
         config.setdefault('fix_year', False)
         config.setdefault('rename_main_file_only', False)
         return config
-
-    #@plugin.priority(-255)
-    #def on_task_output(self, entry, config):
-    #    return False
 
     def on_task_rename(self, entry, status, config):
         # get total torrent size

--- a/flexget/plugins/modify/torrent_renamefiles.py
+++ b/flexget/plugins/modify/torrent_renamefiles.py
@@ -46,10 +46,8 @@ class TorrentRenameFiles(object):
         log.debug('File ratio: %s' % file_ratio)
         log.debug('Torrent size: %s' % status['total_size'])
 
-        if not entry['main_fileid']:
-            entry['main_fileid'] = None
-        if not entry['sub_fileid']:
-            entry['sub_fileid'] = None
+        entry['main_fileid'] = -1
+        entry['sub_fileid'] = -1
 
         series_tokens = False
         if config.get('content_filename'):
@@ -82,7 +80,7 @@ class TorrentRenameFiles(object):
         if len(set(top_levels)) == 1:
             # the top level of every item's path is the same, therefore there's a container directory
             top_level = True
-        if entry['main_fileid'] is None:
+        if entry['main_fileid'] < 0:
             # if main_fileid wasn't set in the prior loop, no file is greater than
             # main_file_ratio% of the total size, therefore this is likely a season pack
             if config.get('rename_main_file_only'):
@@ -94,7 +92,7 @@ class TorrentRenameFiles(object):
         files = {}
         os_sep = os.sep
         do_container = False
-        if (config.get('container_multiple') and entry['main_fileid'] == None) or not config.get('container_multiple'):
+        if (config.get('container_multiple') and len(status['files']) > 1) or not config.get('container_multiple'):
             do_container = True
         for file in status['files']:
             original_pathfile = file['path']

--- a/flexget/plugins/plugin_deluge.py
+++ b/flexget/plugins/plugin_deluge.py
@@ -15,6 +15,8 @@ from flexget.event import event
 from flexget.utils.template import RenderError
 from flexget.utils.pathscrub import pathscrub
 
+from flexget.plugin import get_plugin_by_name
+
 log = logging.getLogger('deluge')
 
 
@@ -349,6 +351,7 @@ class OutputDeluge(DelugePlugin):
                     'enabled': {'type': 'boolean'},
                     'keep_container': {'type': 'boolean'},
                     'container_directory': {'type': 'string'},
+                    'container_multiple': {'type': 'boolean'},
                     'rename_main_file_only': {'type': 'boolean'},
                     'fix_year': {'type': 'boolean'},
                 },
@@ -370,6 +373,7 @@ class OutputDeluge(DelugePlugin):
         config.setdefault('hide_sparse_files', False)  # does nothing without 'main_file_only' enabled
         config.setdefault('content_filename', '')
         config.setdefault('keep_container', True)
+        config.setdefault('container_multiple', True)
         config.setdefault('container_directory', '')
         config.setdefault('fix_year', False)
         return config

--- a/flexget/plugins/plugin_deluge.py
+++ b/flexget/plugins/plugin_deluge.py
@@ -666,7 +666,7 @@ class OutputDeluge(DelugePlugin):
                             main_file_dlist.append(
                                 client.core.set_torrent_file_priorities(torrent_id, file_priorities))
 
-                        if renamed[file['index']]:
+                        if renamed.get(file['index'], None):
                             filename = unused_name(renamed[file['index']])
 
                             log.debug('File %s in %s renamed to %s' % (file['path'], entry['title'], filename))

--- a/flexget/plugins/plugin_deluge.py
+++ b/flexget/plugins/plugin_deluge.py
@@ -354,6 +354,16 @@ class OutputDeluge(DelugePlugin):
                     'container_multiple': {'type': 'boolean'},
                     'rename_main_file_only': {'type': 'boolean'},
                     'fix_year': {'type': 'boolean'},
+                    'unlisted_filetype_default': {'type': 'boolean'},
+                    'filetypes': {
+                        'type': 'object',
+                        'additionalProperties': {
+                            'oneOf': [
+                                {'type': 'string'},
+                                {'type': 'boolean'},
+                            ]
+                        }
+                    }
                 },
                 'additionalProperties': False
             }
@@ -375,7 +385,10 @@ class OutputDeluge(DelugePlugin):
         config.setdefault('keep_container', True)
         config.setdefault('container_multiple', True)
         config.setdefault('container_directory', '')
+        config.setdefault('rename_main_file_only', False)
         config.setdefault('fix_year', False)
+        config.setdefault('unlisted_filetype_default', True)
+        config.setdefault('filetypes', {})
         return config
 
     def __init__(self):
@@ -657,7 +670,7 @@ class OutputDeluge(DelugePlugin):
                                                      [(file['index'], new_name)]))
                         log.debug('File %s in %s renamed to %s' % (file['path'], entry['title'], new_name))
 
-                    renamed = get_plugin_by_name('torrent_frename').instance.on_task_rename(entry, status, config)
+                    renamed = get_plugin_by_name('torrent_frename').instance.rename_files(entry, status, config)
  
                     for file in status['files']:
 


### PR DESCRIPTION
Create new plugin to handle renaming of files within torrents.
Currently only works with Deluge. Also render label before applying it.

New options (set under Deluge plugin config):
`keep_container` Default: True. Keeps existing container folder in torrent, if any. (If a multi-file torrent is added to Deluge, Deluge automatically creates a container folder using info.name from the torrent metadata. Setting this to false causes that part of the path to be removed. Similarly, if the torrent file structure itself had a top-level folder that contained all files in the torrent, setting this to False would cause it to be removed from the path.)
`container_directory` Default: blank. Create new container directory around all files within the torrent. Rendered before being applied.
`fix_year` Default: False. When this is enabled and a TV show is being processed, and the last four characters of the series name are a number (almost certainly a year), add parentheses around the year.
`rename_main_file_only` Default: False. Only rename the main file within the torrent. Note that `keep_container` and `container_directory` settings still apply even when this is set to True. In that case, the only filename changed will be the largest file (as determined using `main_file_ratio`), but the paths for the other files will still be changed.
`container_multiple` Default: True. Only applies the `container_directory` setting if there are multiple files within the torrent that will be downloaded. Useful if you have a task that processes both season packs and individual episodes.
`unlisted_filetype_default` Default: True. Whether to rename files whose extensions are not explicitly named in `filetypes` setting (see below). By default, renaming affects all files.
`filetypes` Default: Empty dict. Allows specifying yes/no (yes = rename, no = do not rename) or a different naming template on a per-file extension basis. Example: You want to rename all files except .nfo and .ogg files, and you want to change the template set in `content_filename`, but only for .avi files. Since `unlisted_filetype_default` defaults to True, all other files will be renamed using `content_filename` as a template.
```
deluge:
  filetypes:
    nfo: no
    ogg: no
    avi: '{{series_name}} (AVI)'
```

`content_filename` template from the existing Deluge config is used to change filenames (and paths, if `content_filename` contains directory separators), unless overridden on a per-file extension basis.
All options respect `hide_sparse_files` and `keep_subs` as provided by existing Deluge config.