### PR TITLE
Allow list of exec commands

### DIFF
--- a/flexget/plugins/output/exec.py
+++ b/flexget/plugins/output/exec.py
@@ -6,6 +6,7 @@ import subprocess
 
 from flexget import plugin
 from flexget.event import event
+from flexget.config_schema import one_or_more
 from flexget.utils.template import render_from_entry, render_from_task, RenderError
 from flexget.utils.tools import io_encoding
 
@@ -67,7 +68,7 @@ class PluginExec(object):
 
     schema = {
         'oneOf': [
-            {'type': 'string'},
+            one_or_more({'type': 'string'}),
             {
                 'type': 'object',
                 'properties': {
@@ -88,11 +89,11 @@ class PluginExec(object):
             'phaseSettings': {
                 'type': 'object',
                 'properties': {
-                    'phase': {'type': 'string'},
-                    'for_entries': {'type': 'string'},
-                    'for_accepted': {'type': 'string'},
-                    'for_rejected': {'type': 'string'},
-                    'for_failed': {'type': 'string'}
+                    'phase': one_or_more({'type': 'string'}),
+                    'for_entries': one_or_more({'type': 'string'}),
+                    'for_accepted': one_or_more({'type': 'string'}),
+                    'for_rejected': one_or_more({'type': 'string'}),
+                    'for_failed': one_or_more({'type': 'string'})
                 },
                 'additionalProperties': False
             }
@@ -104,6 +105,12 @@ class PluginExec(object):
             config = {'on_output': {'for_accepted': config}}
         if not config.get('encoding'):
             config['encoding'] = io_encoding
+        for phase_name in config:
+            if phase_name.startswith('on_'):
+                for items_name in config[phase_name]:
+                    if isinstance(config[phase_name][items_name], basestring):
+                        config[phase_name][items_name] = [config[phase_name][items_name]]
+
         return config
 
     def execute_cmd(self, cmd, allow_background, encoding):
@@ -136,48 +143,48 @@ class PluginExec(object):
             log.debug('running phase_name: %s operation: %s entries: %s' % (phase_name, operation, len(entries)))
 
             for entry in entries:
-                cmd = config[phase_name][operation]
-                entrydict = EscapingDict(entry) if config.get('auto_escape') else entry
-                # Do string replacement from entry, but make sure quotes get escaped
-                try:
-                    cmd = render_from_entry(cmd, entrydict)
-                except RenderError as e:
-                    log.error('Could not set exec command for %s: %s' % (entry['title'], e))
-                    # fail the entry if configured to do so
-                    if config.get('fail_entries'):
-                        entry.fail('Entry `%s` does not have required fields for string replacement.' % entry['title'])
-                    continue
-
-                log.debug('phase_name: %s operation: %s cmd: %s' % (phase_name, operation, cmd))
-                if task.options.test:
-                    log.info('Would execute: %s' % cmd)
-                else:
-                    # Make sure the command can be encoded into appropriate encoding, don't actually encode yet,
-                    # so logging continues to work.
+                for cmd in config[phase_name][operation]:
+                    entrydict = EscapingDict(entry) if config.get('auto_escape') else entry
+                    # Do string replacement from entry, but make sure quotes get escaped
                     try:
-                        cmd.encode(config['encoding'])
-                    except UnicodeEncodeError:
-                        log.error('Unable to encode cmd `%s` to %s' % (cmd, config['encoding']))
+                        cmd = render_from_entry(cmd, entrydict)
+                    except RenderError as e:
+                        log.error('Could not set exec command for %s: %s' % (entry['title'], e))
+                        # fail the entry if configured to do so
                         if config.get('fail_entries'):
-                            entry.fail('cmd `%s` could not be encoded to %s.' % (cmd, config['encoding']))
+                            entry.fail('Entry `%s` does not have required fields for string replacement.' % entry['title'])
                         continue
-                    # Run the command, fail entries with non-zero return code if configured to
-                    if self.execute_cmd(cmd, allow_background, config['encoding']) != 0 and config.get('fail_entries'):
-                        entry.fail('exec return code was non-zero')
+
+                    log.debug('phase_name: %s operation: %s cmd: %s' % (phase_name, operation, cmd))
+                    if task.options.test:
+                        log.info('Would execute: %s' % cmd)
+                    else:
+                        # Make sure the command can be encoded into appropriate encoding, don't actually encode yet,
+                        # so logging continues to work.
+                        try:
+                            cmd.encode(config['encoding'])
+                        except UnicodeEncodeError:
+                            log.error('Unable to encode cmd `%s` to %s' % (cmd, config['encoding']))
+                            if config.get('fail_entries'):
+                                entry.fail('cmd `%s` could not be encoded to %s.' % (cmd, config['encoding']))
+                            continue
+                        # Run the command, fail entries with non-zero return code if configured to
+                        if self.execute_cmd(cmd, allow_background, config['encoding']) != 0 and config.get('fail_entries'):
+                            entry.fail('exec return code was non-zero')
 
         # phase keyword in this
         if 'phase' in config[phase_name]:
-            cmd = config[phase_name]['phase']
-            try:
-                cmd = render_from_task(cmd, task)
-            except RenderError as e:
-                log.error('Error rendering `%s`: %s' % (cmd, e))
-            else:
-                log.debug('phase cmd: %s' % cmd)
-                if task.options.test:
-                    log.info('Would execute: %s' % cmd)
+            for cmd in config[phase_name]['phase']:
+                try:
+                    cmd = render_from_task(cmd, task)
+                except RenderError as e:
+                    log.error('Error rendering `%s`: %s' % (cmd, e))
                 else:
-                    self.execute_cmd(cmd, allow_background, config['encoding'])
+                    log.debug('phase cmd: %s' % cmd)
+                    if task.options.test:
+                        log.info('Would execute: %s' % cmd)
+                    else:
+                        self.execute_cmd(cmd, allow_background, config['encoding'])
 
     def __getattr__(self, item):
         """Creates methods to handle task phases."""


### PR DESCRIPTION
Not sure if this is the best approach. Maybe add a new `outputs` plugin similar to `inputs`?

The diff is a bit misleading as I had to indent large blocks, here it is again with `-w`

```diff
diff --git a/flexget/plugins/output/exec.py b/flexget/plugins/output/exec.py
index 7efeda0..b9d04f9 100644
--- a/flexget/plugins/output/exec.py
+++ b/flexget/plugins/output/exec.py
@@ -6,6 +6,7 @@ import subprocess
 
 from flexget import plugin
 from flexget.event import event
+from flexget.config_schema import one_or_more
 from flexget.utils.template import render_from_entry, render_from_task, RenderError
 from flexget.utils.tools import io_encoding
 
@@ -67,7 +68,7 @@ class PluginExec(object):
 
     schema = {
         'oneOf': [
-            {'type': 'string'},
+            one_or_more({'type': 'string'}),
             {
                 'type': 'object',
                 'properties': {
@@ -88,11 +89,11 @@ class PluginExec(object):
             'phaseSettings': {
                 'type': 'object',
                 'properties': {
-                    'phase': {'type': 'string'},
-                    'for_entries': {'type': 'string'},
-                    'for_accepted': {'type': 'string'},
-                    'for_rejected': {'type': 'string'},
-                    'for_failed': {'type': 'string'}
+                    'phase': one_or_more({'type': 'string'}),
+                    'for_entries': one_or_more({'type': 'string'}),
+                    'for_accepted': one_or_more({'type': 'string'}),
+                    'for_rejected': one_or_more({'type': 'string'}),
+                    'for_failed': one_or_more({'type': 'string'})
                 },
                 'additionalProperties': False
             }
@@ -104,6 +105,12 @@ class PluginExec(object):
             config = {'on_output': {'for_accepted': config}}
         if not config.get('encoding'):
             config['encoding'] = io_encoding
+        for phase_name in config:
+            if phase_name.startswith('on_'):
+                for items_name in config[phase_name]:
+                    if isinstance(config[phase_name][items_name], basestring):
+                        config[phase_name][items_name] = [config[phase_name][items_name]]
+
         return config
 
     def execute_cmd(self, cmd, allow_background, encoding):
@@ -136,7 +143,7 @@ class PluginExec(object):
             log.debug('running phase_name: %s operation: %s entries: %s' % (phase_name, operation, len(entries)))
 
             for entry in entries:
-                cmd = config[phase_name][operation]
+                for cmd in config[phase_name][operation]:
                     entrydict = EscapingDict(entry) if config.get('auto_escape') else entry
                     # Do string replacement from entry, but make sure quotes get escaped
                     try:
@@ -167,7 +174,7 @@ class PluginExec(object):
 
         # phase keyword in this
         if 'phase' in config[phase_name]:
-            cmd = config[phase_name]['phase']
+            for cmd in config[phase_name]['phase']:
                 try:
                     cmd = render_from_task(cmd, task)
                 except RenderError as e:
```