### PR TITLE
Allow history to be filtered by task

### DIFF
--- a/flexget/plugins/output/history.py
+++ b/flexget/plugins/output/history.py
@@ -62,6 +62,8 @@ def do_cli(manager, options):
         if options.search:
             search_term = options.search.replace(' ', '%').replace('.', '%')
             query = query.filter(History.title.like('%' + search_term + '%'))
+        if options.task:
+            query = query.filter(History.task.like('%' + options.task + '%'))
         query = query.order_by(desc(History.time)).limit(options.limit)
         for item in reversed(query.all()):
             console(' Task    : %s' % item.task)
@@ -82,7 +84,7 @@ def register_parser_arguments():
     parser.add_argument('--limit', action='store', type=int, metavar='NUM', default=50,
                         help='limit to %(metavar)s results')
     parser.add_argument('--search', action='store', metavar='TERM', help='limit to results that contain %(metavar)s')
-
+    parser.add_argument('--task', action='store', metavar='TASK', help='limit to results in specified %(metavar)s')
 
 @event('plugin.register')
 def register_plugin():


### PR DESCRIPTION
I'd love for history to get a few more options, maybe also a date-range instead of a count-based limit. Ideally, --search should check all (or most) fields and every field should be searchable on its own via dedicated parameter. What do you think?