### PR TITLE
fix aria2 plugin

### DIFF
--- a/flexget/plugins/plugin_aria2.py
+++ b/flexget/plugins/plugin_aria2.py
@@ -235,7 +235,7 @@ class OutputAria2(object):
                     if cur_filename.lower().find('sample') > -1:
                         continue
 
-                if file_ext in config['file_exts']:
+                if file_ext not in config['file_exts']:
                     if config['exclude_non_content'] == True:
                         # don't download non-content files, like nfos - definable in file_exts
                         continue
@@ -302,7 +302,7 @@ class OutputAria2(object):
                             log.error('Could not rename file %s: %s. Try enabling imdb_lookup in this task'
                                       ' to assist.' % (cur_filename, e))
                             continue
-                else:
+                elif not 'torrent_info_hash' in entry: 
                     config['aria_config']['out'] = cur_filename
 
                 if config['do'] == 'add-new':
@@ -311,7 +311,7 @@ class OutputAria2(object):
                     if 'gid' in config['aria_config']:
                         try:
                             r = s.aria2.tellStatus(config['aria_config']['gid'], ['gid', 'status'])
-                            log.info('Download status for %s (gid %s): %s' % (config['aria_config']['out'], r['gid'],
+                            log.info('Download status for %s (gid %s): %s' % (config['aria_config'].get('out', config['uri']), r['gid'],
                                      r['status']))
                             if r['status'] == 'paused':
                                 try:
@@ -356,7 +356,7 @@ class OutputAria2(object):
                                     r = '1234567890123456'
                                 else:
                                     r = config['aria_config']['gid']
-                            log.info('%s successfully added to aria2 with gid %s.' % (config['aria_config']['out'], r))
+                            log.info('%s successfully added to aria2 with gid %s.' % (config['aria_config'].get('out', config['uri']), r))
                         except xmlrpclib.Fault as err:
                             raise plugin.PluginError('aria2 response to add URI request: %s' % err.faultString, log)
                         except socket_error as (error, msg):


### PR DESCRIPTION
Small fixex:
1- out option should not be used for torrent files: as per http://aria2.sourceforge.net/manual/en/html/aria2c.html#cmdoption-
Using it causes problems to follow torrent files: the torrent file is downloaded and saved with an extension different from ".torrent", which makes aria2 unable to follow the torrent. This small fix correct the behavior.
2- exclude_non_content should exclude file extenstions that are not in the list, not file extentions that are in the list as per the doc. "Whether to exclude "non-content" files; that is, anything that does not have an extension listed in file_exts". This small fix correct the behavior.