### PR TITLE
Fix deluge sparse files/movedone functionality

### DIFF
--- a/flexget/plugins/plugin_deluge.py
+++ b/flexget/plugins/plugin_deluge.py
@@ -663,13 +663,15 @@ class OutputDeluge(DelugePlugin):
 
                         if opts.get('content_filename'):
                             # rename the main file
-                            big_file_name = opts['content_filename'] + os.path.splitext(main_file['path'])[1]
+                            big_file_name = os.path.dirname(main_file['path']) + "/"\
+                                            + opts['content_filename'] \
+                                            + os.path.splitext(main_file['path'])[1]
                             big_file_name = unused_name(big_file_name)
                             rename(main_file, big_file_name)
 
                             # rename subs along with the main file
                             if sub_file is not None and keep_subs:
-                                sub_file_name = os.path.splitext(big_file_name   )[0] \
+                                sub_file_name = os.path.splitext(big_file_name)[0] \
                                               + os.path.splitext(sub_file['path'])[1]
                                 rename(sub_file, sub_file_name)
 
@@ -683,11 +685,11 @@ class OutputDeluge(DelugePlugin):
                             if opts.get('hide_sparse_files'):
                                 # hide the other sparse files that are not supposed to download but are created anyway
                                 # http://dev.deluge-torrent.org/ticket/1827
-                                other_files = [f for f in status['files']
+                                # Made sparse files behave better with deluge http://flexget.com/ticket/2881
+                                sparse_files = [f for f in status['files']
                                                if f != main_file and (f != sub_file or (not keep_subs))]
-                                other_files_dir = "._" + (opts['content_filename'] + "/"
-                                                          if opts.get('content_filename') else "")
-                                rename_pairs = [(f['index'], other_files_dir + f['path']) for f in other_files]
+                                top_files_dir = os.path.dirname(main_file['path']) + "/" 
+                                rename_pairs = [(f['index'], top_files_dir + ".sparse_files/" + os.path.basename(f['path']) ) for f in sparse_files]
                                 main_file_dlist.append(client.core.rename_files(torrent_id, rename_pairs))
                     else:
                         log.warning('No files in "%s" are > %d%% of content size, no files renamed.' % (entry['title'], opts.get('main_file_ratio') * 100))

--- a/flexget/plugins/plugin_deluge.py
+++ b/flexget/plugins/plugin_deluge.py
@@ -664,10 +664,10 @@ class OutputDeluge(DelugePlugin):
                         # check for single file torrents so we dont add unnecessary folders
                         if (os.path.dirname(main_file['path']) is not ("" or "/")):
                             # check for top folder in user config
-                            if (os.path.dirname(opts['content_filename']) is ""):
-                                top_files_dir = os.path.dirname(main_file['path']) + "/"
-                            else:
+                            if (opts.get('content_filename') and os.path.dirname(opts['content_filename']) is not ""):
                                 top_files_dir = os.path.dirname(opts['content_filename']) + "/"
+                            else:
+                                top_files_dir = os.path.dirname(main_file['path']) + "/"
                         else:
                             top_files_dir = "/"
 

--- a/flexget/plugins/plugin_deluge.py
+++ b/flexget/plugins/plugin_deluge.py
@@ -663,16 +663,16 @@ class OutputDeluge(DelugePlugin):
 
                         if opts.get('content_filename'):
                             # rename the main file
-                            big_file_name = os.path.dirname(main_file['path']) + "/"\
-                                            + opts['content_filename'] \
-                                            + os.path.splitext(main_file['path'])[1]
+                            big_file_name = (os.path.dirname(main_file['path']) + "/" +
+                                            opts['content_filename'] +
+                                            os.path.splitext(main_file['path'])[1])
                             big_file_name = unused_name(big_file_name)
                             rename(main_file, big_file_name)
 
                             # rename subs along with the main file
                             if sub_file is not None and keep_subs:
-                                sub_file_name = os.path.splitext(big_file_name)[0] \
-                                              + os.path.splitext(sub_file['path'])[1]
+                                sub_file_name = (os.path.splitext(big_file_name)[0] +
+                                                os.path.splitext(sub_file['path'])[1])
                                 rename(sub_file, sub_file_name)
 
                         if opts.get('main_file_only'):
@@ -689,7 +689,9 @@ class OutputDeluge(DelugePlugin):
                                 sparse_files = [f for f in status['files']
                                                if f != main_file and (f != sub_file or (not keep_subs))]
                                 top_files_dir = os.path.dirname(main_file['path']) + "/" 
-                                rename_pairs = [(f['index'], top_files_dir + ".sparse_files/" + os.path.basename(f['path']) ) for f in sparse_files]
+                                rename_pairs = [(f['index'],
+                                               top_files_dir + ".sparse_files/" + os.path.basename(f['path']))
+                                               for f in sparse_files]
                                 main_file_dlist.append(client.core.rename_files(torrent_id, rename_pairs))
                     else:
                         log.warning('No files in "%s" are > %d%% of content size, no files renamed.' % (entry['title'], opts.get('main_file_ratio') * 100))

--- a/flexget/plugins/plugin_deluge.py
+++ b/flexget/plugins/plugin_deluge.py
@@ -661,10 +661,20 @@ class OutputDeluge(DelugePlugin):
                                     sub_file = file
                                     break
 
+                        # check for single file torrents so we dont add unnecessary folders
+                        if (os.path.dirname(main_file['path']) is not ("" or "/")):
+                            # check for top folder in user config
+                            if (os.path.dirname(opts['content_filename']) is ""):
+                                top_files_dir = os.path.dirname(main_file['path']) + "/"
+                            else:
+                                top_files_dir = os.path.dirname(opts['content_filename']) + "/"
+                        else:
+                            top_files_dir = "/"
+
                         if opts.get('content_filename'):
                             # rename the main file
-                            big_file_name = (os.path.dirname(main_file['path']) + "/" +
-                                            opts['content_filename'] +
+                            big_file_name = (top_files_dir +
+                                            os.path.basename(opts['content_filename']) +
                                             os.path.splitext(main_file['path'])[1])
                             big_file_name = unused_name(big_file_name)
                             rename(main_file, big_file_name)
@@ -688,7 +698,6 @@ class OutputDeluge(DelugePlugin):
                                 # Made sparse files behave better with deluge http://flexget.com/ticket/2881
                                 sparse_files = [f for f in status['files']
                                                if f != main_file and (f != sub_file or (not keep_subs))]
-                                top_files_dir = os.path.dirname(main_file['path']) + "/" 
                                 rename_pairs = [(f['index'],
                                                top_files_dir + ".sparse_files/" + os.path.basename(f['path']))
                                                for f in sparse_files]


### PR DESCRIPTION
Fixed http://flexget.com/ticket/2881

Makes sure there is only one top level directory, enabling correct movedone functionality in deluge.

This is accomplished by ensuring the content_filename option doesn't pop the main file / sub file out of folder and also by changing the location of the sparse files (top_torrent_folder/.sparse_files)
