### PR TITLE
 path_select plugin allows setting a field to a folder based on it's spa...

### DIFF
--- a/flexget/plugins/modify/path_select.py
+++ b/flexget/plugins/modify/path_select.py
@@ -6,53 +6,10 @@ from collections import namedtuple
 
 from flexget import plugin
 from flexget.event import event
+from flexget.config_schema import parse_size, parse_percent
 from flexget.config_schema import one_or_more
 
 log = logging.getLogger('path_select')
-
-SYMBOLS = {
-    'customary': ('B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'),
-    'customary_ext': ('byte', 'kilo', 'mega', 'giga', 'tera', 'peta', 'exa', 'zetta', 'iotta'),
-    'iec': ('Bi', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi', 'Yi'),
-    'iec_ext': ('byte', 'kibi', 'mebi', 'gibi', 'tebi', 'pebi', 'exbi', 'zebi', 'yobi'),
-}
-
-
-def human2bytes(s):
-    """
-    Attempts to guess the string format based on default symbols
-    set and return the corresponding bytes as an integer.
-    When unable to recognize the format ValueError is raised.
-    """
-
-    init = s
-    num = ""
-    while s and s[0:1].isdigit() or s[0:1] == '.':
-        num += s[0]
-        s = s[1:]
-    num = float(num)
-    letter = s.strip()
-    for name, sset in SYMBOLS.items():
-        if letter in sset:
-            break
-    else:
-        if letter == 'k':
-            # treat 'k' as an alias for 'K' as per: http://goo.gl/kTQMs
-            sset = SYMBOLS['customary']
-            letter = letter.upper()
-        else:
-            raise ValueError("can't interpret %r" % init)
-    prefix = {sset[0]: 1}
-    for i, s in enumerate(sset[1:]):
-        prefix[s] = 1 << (i+1)*10
-    return int(num * prefix[letter])
-
-
-def percentage(part, whole):
-    try:
-        return 100 * part/whole
-    except ZeroDivisionError:
-        return 0.0
 
 
 disk_stats_tuple = namedtuple(
@@ -62,8 +19,8 @@ disk_stats_tuple = namedtuple(
 )
 
 
-def get_disk_stats(folder):
-    """ Return folder/drive stats in megabytes (free, used, total) """
+def os_disk_stats(folder):
+    """ Return drive free, used and total bytes """
     if os.name == 'nt':
         import ctypes
         free_bytes = ctypes.c_ulonglong(0)
@@ -75,25 +32,24 @@ def get_disk_stats(folder):
             ctypes.pointer(free_bytes)
         )
 
-        free_bytes = free_bytes.value
-        total_bytes = total_bytes.value
+        return free_bytes.value, total_bytes.value
     else:
         stats = os.statvfs(folder)
-        free_bytes = stats.f_bavail * stats.f_frsize
-        total_bytes = stats.f_blocks * stats.f_frsize
+        return stats.f_bavail * stats.f_frsize, stats.f_blocks * stats.f_frsize
 
-    free_bytes = int(free_bytes)
-    total_bytes = int(total_bytes)
+
+def disk_stats(folder):
+
+    free_bytes, total_bytes = os_disk_stats(folder)
     used_bytes = total_bytes - free_bytes
-
-    free_percent = 0.0 if total_bytes == 0 else percentage(free_bytes, total_bytes)
-    used_percent = 0.0 if total_bytes == 0 else percentage(used_bytes, total_bytes)
+    free_percent = 0.0 if total_bytes == 0 else 100 * free_bytes / total_bytes
+    used_percent = 0.0 if total_bytes == 0 else 100 * used_bytes / total_bytes
 
     return disk_stats_tuple(folder, free_bytes, used_bytes, total_bytes, free_percent, used_percent)
 
 
-def path_selector(paths, threshold, stat_attr, reverse=True):
-    paths_stats = [get_disk_stats(path) for path in paths]
+def _path_selector(paths, threshold, stat_attr, reverse=True):
+    paths_stats = [disk_stats(path) for path in paths]
 
     # Sort paths by key
     paths_stats.sort(key=lambda p: getattr(p, stat_attr), reverse=reverse)
@@ -118,39 +74,38 @@ def path_selector(paths, threshold, stat_attr, reverse=True):
 
 
 def select_most_free(paths, threshold):
-    return path_selector(paths, threshold, "free_bytes", reverse=True)
+    return _path_selector(paths, threshold, 'free_bytes', reverse=True)
 
 
 def select_most_used(paths, threshold):
-    return path_selector(paths, threshold, "used_bytes", reverse=True)
+    return _path_selector(paths, threshold, 'used_bytes', reverse=True)
 
 
 def select_most_free_percent(paths, threshold):
-    return path_selector(paths, threshold, "free_percent", reverse=True)
+    return _path_selector(paths, threshold, 'free_percent', reverse=True)
 
 
 def select_most_used_percent(paths, threshold):
-    return path_selector(paths, threshold, "used_percent", reverse=True)
+    return _path_selector(paths, threshold, 'used_percent', reverse=True)
 
 
 def select_has_free(paths, threshold):
-    paths_stats = [get_disk_stats(path) for path in paths]
+    paths_stats = [disk_stats(path) for path in paths]
 
     valid_paths = [
         path_stat.path for path_stat in paths_stats
         if path_stat.free_bytes >= threshold
     ]
-
     if valid_paths:
         return random.choice(valid_paths)
 
 
 selector_map = {
-    "most_free": select_most_free,
-    "most_used": select_most_used,
-    "most_free_percent": select_most_free_percent,
-    "most_used_percent": select_most_used_percent,
-    "has_free": select_has_free,
+    'most_free': select_most_free,
+    'most_used': select_most_used,
+    'most_free_percent': select_most_free_percent,
+    'most_used_percent': select_most_used_percent,
+    'has_free': select_has_free,
 }
 
 
@@ -174,9 +129,14 @@ class PluginPathSelect(object):
         'type': 'object',
         'properties': {
             'select': {'type': 'string', 'enum': selector_map.keys()},
-            'threshold': {'type': 'string', 'default': "0%", 'pattern': '^\d+\s?(%|[BKMGT]?)$'},
             'to_field': {'type': 'string', 'default': 'path'},
-            'paths': one_or_more({'type': 'string', 'format': 'path'})
+            'paths': one_or_more({'type': 'string', 'format': 'path'}),
+            'threshold': {
+                'oneOf': [
+                    {'type': 'string', 'format': 'size'},
+                    {'type': 'string', 'format': 'percent'},
+                ]
+            },
         },
         'required': ['paths', 'select'],
         'additionalProperties': False,
@@ -188,26 +148,21 @@ class PluginPathSelect(object):
         selector = selector_map[config['select']]
 
         # Convert threshold to bytes (int) or percent (float)
-        if '%' in config['threshold']:
-            try:
-                threshold = float(config['threshold'].strip('%'))
-            except ValueError:
-                raise plugin.PluginError("%s is not a valid percentage" % config['threshold'])
+        threshold = config.get('threshold')
+        if isinstance(threshold, basestring) and '%' in threshold:
+            threshold = parse_percent(threshold)
         else:
-            try:
-                threshold = human2bytes(config['threshold'])
-            except ValueError as e:
-                raise plugin.PluginError("%s is not a valid size" % config['threshold'])
+            threshold = parse_size(threshold)
 
         path = selector(config['paths'], threshold=threshold)
 
         if path:
-            log.debug("Path %s selected due to (%s)" % (path, config['select']))
+            log.debug('Path %s selected due to (%s)' % (path, config['select']))
 
             for entry in task.all_entries:
                 entry[config['to_field']] = path
         else:
-            log.warning("Unable to select a path based on %s" % config['select'])
+            log.warning('Unable to select a path based on %s' % config['select'])
             return
 
 

--- a/flexget/plugins/modify/path_select.py
+++ b/flexget/plugins/modify/path_select.py
@@ -1,0 +1,136 @@
+from __future__ import unicode_literals, division, absolute_import
+import logging
+import os
+
+from flexget import plugin
+from flexget.event import event
+from flexget.config_schema import one_or_more
+
+log = logging.getLogger('path_select')
+
+
+def percentage(part, whole):
+    try:
+        return 100 * float(part)/float(whole)
+    except ZeroDivisionError:
+        return float(0.0)
+
+
+def get_disk_stats(folder):
+    """ Return folder/drive stats in megabytes (free, used, total) """
+    if os.name == 'nt':
+        import ctypes
+        free_bytes = ctypes.c_ulonglong(0)
+        total_bytes = ctypes.c_ulonglong(0)
+        ctypes.windll.kernel32.GetDiskFreeSpaceExW(
+            ctypes.c_wchar_p(folder),
+            None,
+            ctypes.pointer(total_bytes),
+            ctypes.pointer(free_bytes)
+        )
+
+        free_bytes = free_bytes.value
+        total_bytes = total_bytes.value
+    else:
+        stats = os.statvfs(folder)
+        free_bytes = stats.f_bavail * stats.f_frsize
+        total_bytes = stats.f_blocks * stats.f_frsize
+
+    free_bytes_mb = int(free_bytes / 1024 / 1024)
+    total_bytes_mb = int(total_bytes / 1024 / 1024)
+    used_bytes_mb = total_bytes_mb - free_bytes_mb
+
+    return free_bytes_mb, used_bytes_mb, total_bytes_mb
+
+
+def get_free_space(folder):
+    return get_disk_stats(folder)[0]
+
+
+def get_used_space(folder):
+    return get_disk_stats(folder)[1]
+
+
+def get_free_space_percent(folder):
+    free_bytes_mb, __, total_bytes_mb = get_disk_stats(folder)
+    return percentage(free_bytes_mb, total_bytes_mb)
+
+
+def get_used_space_percent(folder):
+    __, used_bytes_mb, total_bytes_mb = get_disk_stats(folder)
+    return percentage(used_bytes_mb, total_bytes_mb)
+
+
+def select_most_free(paths, reverse=False):
+    return sorted(paths, key=get_free_space, reverse=not reverse)[0]
+
+
+def select_most_free_percent(paths, reverse=False):
+    return sorted(paths, key=get_free_space_percent, reverse=not reverse)[0]
+
+
+def select_most_used(paths, reverse=True):
+    return sorted(paths, key=get_used_space, reverse=not reverse)[0]
+
+
+def select_most_used_percent(paths, reverse=True):
+    return sorted(paths, key=get_used_space_percent, reverse=not reverse)[0]
+
+
+selector_map = {
+    "most_free": select_most_free,
+    "most_used": select_most_used,
+    "most_free_percent": select_most_free_percent,
+    "most_used_percent": select_most_used_percent,
+}
+
+
+class PluginPathSelect(object):
+    """Allows setting a field to a folder based on it's space
+
+    Example:
+
+    path_select:
+      select: most_free_percent # or most_free, most_used, most_used_percent
+      reverse: False # reverse the select, default is False
+      paths:
+        - /drive1/
+        - /drive2/
+        - /drive3/
+    """
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'select': {'type': 'string', 'enum': selector_map.keys()},
+            'reverse': {'type': 'boolean'},
+            'to_field': {'type': 'string'},
+            'paths': one_or_more({'type': 'string'})
+        },
+        'required': ['paths', 'select'],
+        'additionalProperties': False,
+    }
+
+    def prepare_config(self, config):
+        config.setdefault('to_field', "path")
+        config.setdefault('reverse', False)
+        return config
+
+    @plugin.priority(250)  # run before other plugins
+    def on_task_metainfo(self, task, config):
+        config = self.prepare_config(config)
+
+        if not config.get('paths'):
+            return
+
+        selector = selector_map[config['select']]
+        path = selector(config['paths'], reverse=config['reverse'])
+        log.debug("path %s selected due to (%s)" % (path, config['select']))
+
+        for entry in task.all_entries:
+            entry[config['to_field']] = path
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(PluginPathSelect, 'path_select', api_ver=2)

--- a/flexget/plugins/modify/path_select.py
+++ b/flexget/plugins/modify/path_select.py
@@ -174,7 +174,7 @@ class PluginPathSelect(object):
         'type': 'object',
         'properties': {
             'select': {'type': 'string', 'enum': selector_map.keys()},
-            'threshold': {'type': 'string', 'default': "0%", 'pattern': '^\d+\s?(%|[KMGT]?B)$'},
+            'threshold': {'type': 'string', 'default': "0%", 'pattern': '^\d+\s?(%|[BKMGT]?)$'},
             'to_field': {'type': 'string', 'default': 'path'},
             'paths': one_or_more({'type': 'string', 'format': 'path'})
         },

--- a/tests/test_path_select.py
+++ b/tests/test_path_select.py
@@ -4,6 +4,7 @@ import os
 import mock
 from flexget.config_schema import parse_size
 
+
 def mock_os_disk_stats(folder):
 
     used, total = os.path.basename(folder).split(',')
@@ -97,54 +98,48 @@ class TestPathSelect(FlexGetBase):
 
     @mock.patch('flexget.plugins.modify.path_select.os_disk_stats', side_effect=mock_os_disk_stats)
     def test_most_free(self, disk_static_func):
-        """exists_movie plugin: existing"""
         self.execute_task('test_most_free')
         assert self.task.entries[0].get('path') == "/data/1G,100G"
 
     @mock.patch('flexget.plugins.modify.path_select.os_disk_stats', side_effect=mock_os_disk_stats)
     def test_most_free_threshold(self, disk_static_func):
-        """exists_movie plugin: existing"""
         self.execute_task('test_most_free_threshold')
         assert self.task.entries[0].get('path') in [
             "/data/49.5G,100G",
             "/data/50.5G,100G",
             "/data/50G,100G",
-        ]
+        ], "path %s not in list" % self.task.entries[0].get('path')
 
     @mock.patch('flexget.plugins.modify.path_select.os_disk_stats', side_effect=mock_os_disk_stats)
     def test_most_used(self, disk_static_func):
-        """exists_movie plugin: existing"""
         self.execute_task('test_most_used')
         assert self.task.entries[0].get('path') in [
             '/data/90G,100G',
             '/data/90.5G,100G',
-        ]
+        ], "path %s not in list" % self.task.entries[0].get('path')
 
     @mock.patch('flexget.plugins.modify.path_select.os_disk_stats', side_effect=mock_os_disk_stats)
     def test_most_free_percent(self, disk_static_func):
-        """exists_movie plugin: existing"""
         self.execute_task('test_most_free_percent')
         assert self.task.entries[0].get('path') in [
             '/data/50.5G,100G',
             '/data/50G,100G',
-        ]
+        ], "path %s not in list" % self.task.entries[0].get('path')
 
     @mock.patch('flexget.plugins.modify.path_select.os_disk_stats', side_effect=mock_os_disk_stats)
     def most_used_percent(self, disk_static_func):
-        """exists_movie plugin: existing"""
         self.execute_task('most_used_percent')
         assert self.task.entries[0].get('path') in [
             '/data/40G,50G',
             '/data/40.5G,50G',
-        ]
+        ], "path %s not in list" % self.task.entries[0].get('path')
 
     @mock.patch('flexget.plugins.modify.path_select.os_disk_stats', side_effect=mock_os_disk_stats)
     def test_has_free(self, disk_static_func):
-        """exists_movie plugin: existing"""
         self.execute_task('test_has_free')
         assert self.task.entries[0].get('path') in [
             '/data/45G,100G',
             '/data/20G,100G',
             '/data/30G,100G',
-        ]
+        ], "path %s not in list" % self.task.entries[0].get('path')
 

--- a/tests/test_path_select.py
+++ b/tests/test_path_select.py
@@ -57,7 +57,6 @@ class BaseExistsMovie(FlexGetBase):
               select: most_used
               paths:
                 - /data/90G,100G
-                - /data/90.5G,100G
                 - /data/80G,100G
                 - /data/90.5G,100G
                 - /data/88G,100G
@@ -123,7 +122,7 @@ class BaseExistsMovie(FlexGetBase):
         self.execute_task('test_most_used')
         assert self.task.entries[0].get('path') in [
             '/data/90G,100G',
-            '/data/90.5,100G',
+            '/data/90.5G,100G',
         ]
 
     @mock.patch('flexget.plugins.modify.path_select.get_disk_stats', side_effect=mock_disk_stats)

--- a/tests/test_path_select.py
+++ b/tests/test_path_select.py
@@ -1,0 +1,156 @@
+from __future__ import unicode_literals, division, absolute_import
+from tests import FlexGetBase
+import os
+import mock
+from flexget.plugins.modify.path_select import disk_stats_tuple, percentage, human2bytes
+
+
+def mock_disk_stats(folder):
+
+    used, total = os.path.basename(folder).split(',')
+
+    # Convert GB to bytes
+    used_bytes = human2bytes(used)
+    total_bytes = human2bytes(total)
+
+    free_bytes = total_bytes - used_bytes
+    free_percent = 0.0 if total_bytes == 0 else percentage(free_bytes, total_bytes)
+    used_percent = 0.0 if total_bytes == 0 else percentage(used_bytes, total_bytes)
+
+    return disk_stats_tuple(folder, free_bytes, used_bytes, total_bytes, free_percent, used_percent)
+
+
+class BaseExistsMovie(FlexGetBase):
+
+    __yaml__ = """
+        tasks:
+          test_most_free:
+            mock:
+              - {title: 'Existence.2012'}
+            path_select:
+              to_field: path
+              threshold: 0B
+              select: most_free
+              paths:
+                - /data/1.5G,100G
+                - /data/50G,100G
+                - /data/1G,100G
+          test_most_free_threshold:
+            mock:
+              - {title: 'Existence.2012'}
+            path_select:
+              to_field: path
+              threshold: 1G
+              select: most_free
+              paths:
+                - /data/49.5G,100G
+                - /data/60G,100G
+                - /data/50G,100G
+                - /data/50.5G,100G
+                - /data/80G,100G
+          test_most_used:
+            mock:
+              - {title: 'Existence.2012'}
+            path_select:
+              to_field: path
+              threshold: 1G
+              select: most_used
+              paths:
+                - /data/90G,100G
+                - /data/90.5G,100G
+                - /data/80G,100G
+                - /data/90.5G,100G
+                - /data/88G,100G
+          test_most_free_percent:
+            mock:
+              - {title: 'Existence.2012'}
+            path_select:
+              to_field: path
+              threshold: 2%
+              select: most_free_percent
+              paths:
+                - /data/50G,100G
+                - /data/40G,50G
+                - /data/65G,80G
+                - /data/50.5G,100G
+          test_most_used_percent:
+            mock:
+              - {title: 'Existence.2012'}
+            path_select:
+              to_field: path
+              threshold: 2%
+              select: most_free_percent
+              paths:
+                - /data/90G,100G
+                - /data/40G,50G
+                - /data/40.5G,50G
+                - /data/90.5G,100G
+          test_has_free:
+            mock:
+              - {title: 'Existence.2012'}
+            path_select:
+              to_field: path
+              threshold: 50G
+              select: most_free_percent
+              paths:
+                - /data/65G,100G
+                - /data/50.2G,100G
+                - /data/45G,100G
+                - /data/20G,100G
+                - /data/30G,100G
+                - /data/90G,100G
+    """
+
+    @mock.patch('flexget.plugins.modify.path_select.get_disk_stats', side_effect=mock_disk_stats)
+    def test_most_free(self, disk_static_func):
+        """exists_movie plugin: existing"""
+        self.execute_task('test_most_free')
+        assert self.task.entries[0].get('path') == "/data/1G,100G"
+
+    @mock.patch('flexget.plugins.modify.path_select.get_disk_stats', side_effect=mock_disk_stats)
+    def test_most_free_threshold(self, disk_static_func):
+        """exists_movie plugin: existing"""
+        self.execute_task('test_most_free_threshold')
+        assert self.task.entries[0].get('path') in [
+            "/data/49.5G,100G",
+            "/data/50.5G,100G",
+            "/data/50G,100G",
+        ]
+
+    @mock.patch('flexget.plugins.modify.path_select.get_disk_stats', side_effect=mock_disk_stats)
+    def test_most_used(self, disk_static_func):
+        """exists_movie plugin: existing"""
+        self.execute_task('test_most_used')
+        assert self.task.entries[0].get('path') in [
+            '/data/90G,100G',
+            '/data/90.5,100G',
+        ]
+
+    @mock.patch('flexget.plugins.modify.path_select.get_disk_stats', side_effect=mock_disk_stats)
+    def test_most_free_percent(self, disk_static_func):
+        """exists_movie plugin: existing"""
+        self.execute_task('test_most_free_percent')
+        assert self.task.entries[0].get('path') in [
+            '/data/50.5G,100G',
+            '/data/50G,100G',
+        ]
+
+    @mock.patch('flexget.plugins.modify.path_select.get_disk_stats', side_effect=mock_disk_stats)
+    def most_used_percent(self, disk_static_func):
+        """exists_movie plugin: existing"""
+        self.execute_task('most_used_percent')
+        assert self.task.entries[0].get('path') in [
+            '/data/40G,50G',
+            '/data/40.5G,50G',
+        ]
+
+    @mock.patch('flexget.plugins.modify.path_select.get_disk_stats', side_effect=mock_disk_stats)
+    def test_has_free(self, disk_static_func):
+        """exists_movie plugin: existing"""
+        self.execute_task('test_has_free')
+        assert self.task.entries[0].get('path') in [
+            '/data/45G,100G',
+            '/data/20G,100G',
+            '/data/30G,100G',
+        ]
+


### PR DESCRIPTION
Allows setting a field to a folder based on it's space. Plugin will randomly select a drive If one or more drive meets the criteria.

Example:
Find path with highest percent free space and set path to <path>/TVHD

```
  path_select:
    select: most_free_percent # or most_free, most_used, most_used_percent
    threshold: 2 # Include any drives that are within 2% difference of the most free drive
    to_field: path # default
    paths:
      - /drive1/
      - /drive2/
      - /drive3/
    set:
      path: '{{ path }}/TVHD'
```
