### PR TITLE
Add's a advanced Matching System to crossmatch

### DIFF
--- a/flexget/plugins/filter/crossmatch.py
+++ b/flexget/plugins/filter/crossmatch.py
@@ -101,12 +101,12 @@ class CrossMatch(object):
                 v1Re = v1.lower()
                 v1Re = unicodedata.normalize('NFKD', v1Re).encode('ASCII', 'ignore')
                 v1Re = re.sub("[^a-zA-Z0-9 ]", " ", v1Re)
-                v1Re = v1Re.replace(' ','.*')
+                v1Re = v1Re.replace(' ','.?')
                 v1Re = '.*' + v1Re + '.*'
                 v2Re = v2.lower()
                 v2Re = unicodedata.normalize('NFKD', v2Re).encode('ASCII', 'ignore')
                 v2Re = re.sub("[^a-zA-Z0-9 ]", " ", v2Re)
-                v2Re = v2Re.replace(' ','.*')
+                v2Re = v2Re.replace(' ','.?')
                 v2Re = '.*' + v2Re + '.*'
                 
                 log.debug('Performing flexible Regex search %s and %s' % (v1Re, v2Re))

--- a/flexget/plugins/filter/crossmatch.py
+++ b/flexget/plugins/filter/crossmatch.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
 import re
-
+import unicodedata
 from flexget import plugin
 from flexget.event import event
 
@@ -100,10 +100,14 @@ class CrossMatch(object):
             log.trace('v2: %r' % v2)
 
             if advanced == True:
-                v1Re = v1
+                v1Re = v1.lower()
+                v1Re = unicodedata.normalize('NFKD', v1Re).encode('ASCII', 'ignore')
+                v1Re = re.sub("[^a-zA-Z0-9 ]", " ", v1Re)
                 v1Re = v1Re.replace(' ','.*')
                 v1Re = '.*' + v1Re + '.*'
-                v2Re = v2
+                v2Re = v2.lower()
+                v2Re = unicodedata.normalize('NFKD', v2Re).encode('ASCII', 'ignore')
+                v2Re = re.sub("[^a-zA-Z0-9 ]", " ", v2Re)
                 v2Re = v2Re.replace(' ','.*')
                 v2Re = '.*' + v2Re + '.*'
                 


### PR DESCRIPTION
This add's a advanced mode to crossmatch that will make a Regex Search to match strings.

This can be very useful in for example downloading Ebooks or content that can have mixed names, example:
```
  Ebooks:
    rss:
      url: 'http://my_rff_feed
    crossmatch:
      from:
        - listdir:
          - /mnt/Downloads/Ebooks
      fields:
        - title
      action: accept
      advanced: yes
    transmission:
      host: 'localhost'
      path: '/mnt/Downloads/Ebooks/{{ match }}'
```
On my folder I can use:
-- Downloads
------ Ebooks
---------- Python
---------- PHP
---------- Spider Man

This will match on the feed for example:
- Advanced Python programming
- Python_Article_May15
- PHP form Dummies
- The Spider-Man Adventures
- The Amazing spiderMan

A match property is added to the entry to use for example in download path