### PR TITLE
sftp_list: Fix inaccurate docstring

### DIFF
--- a/flexget/plugins/plugin_sftp.py
+++ b/flexget/plugins/plugin_sftp.py
@@ -93,15 +93,15 @@ class SftpList(object):
     Example:
 
       sftp_list:
-          config:
-              host: example.com
-              username: Username
-              private_key: /Users/username/.ssh/id_rsa
-              recursive: False
-              get_size: True
-              files_only: False
+          host: example.com
+          username: Username
+          private_key: /Users/username/.ssh/id_rsa
+          recursive: False
+          get_size: True
+          files_only: False
           dirs: 
               - '/path/to/list/'
+              - '/another/path/'
     """
 
     schema = {


### PR DESCRIPTION
Previous docstring was full of lies, mistruths and falsehoods.