### PR TITLE
Decompress: Close file handles after file is extracted

### DIFF
--- a/flexget/plugins/plugin_decompress.py
+++ b/flexget/plugins/plugin_decompress.py
@@ -216,6 +216,7 @@ class Decompress(object):
             if not os.path.exists(destination):
                 success = False
                 error_message = ''
+                source = None
 
                 log.debug('Attempting to extract: %s to %s' % (path, destination))
                 try:
@@ -223,7 +224,6 @@ class Decompress(object):
                     source = archive.open(path)
                     with open(destination, 'wb') as target:
                         shutil.copyfileobj(source, target)
-                    source.close()
 
                     log.verbose('Extracted: %s' % path )
                     success = True
@@ -236,6 +236,9 @@ class Decompress(object):
                 except Exception as e:
                     error_message = 'Unexpected error while extracting %s from %s (%s)' % \
                                     (path, archive_path, e)
+                finally:
+                    if source and not source.closed:
+                        source.close()
 
                 if not success:
                     log.error(error_message)

--- a/flexget/plugins/plugin_decompress.py
+++ b/flexget/plugins/plugin_decompress.py
@@ -4,6 +4,7 @@ import os
 import re
 import shutil
 import zipfile
+import contextlib
 
 from flexget import plugin
 from flexget.entry import Entry
@@ -219,9 +220,8 @@ class Decompress(object):
 
                 log.debug('Attempting to extract: %s to %s' % (path, destination))
                 try:
-                    with archive.open(path) as source:
-                        with open(destination, 'wb') as target:
-                            shutil.copyfileobj(source, target)
+                    with contextlib.nested(archive.open(path), open(destination, 'wb')) as (source, target):
+                        shutil.copyfileobj(source, target)
                     log.verbose('Extracted: %s' % path )
                     success = True
                 except (IOError, os.error) as e:

--- a/flexget/plugins/plugin_decompress.py
+++ b/flexget/plugins/plugin_decompress.py
@@ -123,6 +123,8 @@ class Decompress(object):
         """
         Prepare config for processing
         """
+        from fnmatch import translate
+        
         if not isinstance(config, dict):
             config = {}
 

--- a/flexget/plugins/plugin_decompress.py
+++ b/flexget/plugins/plugin_decompress.py
@@ -233,9 +233,6 @@ class Decompress(object):
                 except (zipfile.BadZipfile, rarfile.Error) as e:
                     error_message = 'Failed to extract file: %s in %s (%s)' % \
                                     (path, archive_path, e)
-                except Exception as e:
-                    error_message = 'Unexpected error while extracting %s from %s (%s)' % \
-                                    (path, archive_path, e)
                 finally:
                     if source and not source.closed:
                         source.close()

--- a/flexget/plugins/plugin_decompress.py
+++ b/flexget/plugins/plugin_decompress.py
@@ -225,15 +225,11 @@ class Decompress(object):
                     log.verbose('Extracted: %s' % path )
                     success = True
                 except (IOError, os.error) as e:
-                    error_message = 'OS error while creting file: %s (%s)' % \
+                    error_message = 'OS error while creating file: %s (%s)' % \
                                     (destination, e)
                 except (zipfile.BadZipfile, rarfile.Error) as e:
                     error_message = 'Failed to extract file: %s in %s (%s)' % \
                                     (path, archive_path, e)
-
-                    if os.path.exists(destination):
-                        error_message = log.debug('Cleaning up partially extracted file: %s' % destination) % \
-                                        (path, archive_path, e)
                 except Exception as e:
                     error_message = 'Unexpected error while extracting %s from %s (%s)' % \
                                     (path, archive_path, e)
@@ -241,6 +237,10 @@ class Decompress(object):
                 if not success:
                     log.error(error_message)
                     entry.fail(error_message)
+
+                    if os.path.exists(destination):
+                        error_message = log.debug('Cleaning up partially extracted file: %s' % destination) % \
+                                        (path, archive_path, e)
                     return
             else:
                 log.verbose('File already exists: %s' % destination)

--- a/flexget/plugins/plugin_decompress.py
+++ b/flexget/plugins/plugin_decompress.py
@@ -218,6 +218,8 @@ class Decompress(object):
                     target = file(destination, "wb")
                     shutil.copyfileobj(source, target)
                     log.verbose('Extracted: %s' % path )
+                    source.close()
+                    target.close()
                 except Exception as e:
                     error_message = 'Failed to extract file: %s in %s (%s)' % \
                                     (path, archive_path, e)

--- a/flexget/plugins/plugin_decompress.py
+++ b/flexget/plugins/plugin_decompress.py
@@ -4,7 +4,6 @@ import os
 import re
 import shutil
 import zipfile
-import contextlib
 
 from flexget import plugin
 from flexget.entry import Entry
@@ -220,8 +219,12 @@ class Decompress(object):
 
                 log.debug('Attempting to extract: %s to %s' % (path, destination))
                 try:
-                    with contextlib.nested(archive.open(path), open(destination, 'wb')) as (source, target):
+                    # python 2.6 doesn't seem to like "with" in conjuntion with ZipFile.open
+                    source = archive.open(path)
+                    with open(destination, 'wb') as target:
                         shutil.copyfileobj(source, target)
+                    source.close()
+
                     log.verbose('Extracted: %s' % path )
                     success = True
                 except (IOError, os.error) as e:

--- a/flexget/plugins/plugin_decompress.py
+++ b/flexget/plugins/plugin_decompress.py
@@ -216,12 +216,9 @@ class Decompress(object):
             if not os.path.exists(destination):
                 log.debug('Attempting to extract: %s to %s' % (path, destination))
                 try:
-                    source = archive.open(path)
-                    target = file(destination, "wb")
-                    shutil.copyfileobj(source, target)
+                    with archive.open(path) as source, open(destination, 'wb') as target:
+                        shutil.copyfileobj(source, target)
                     log.verbose('Extracted: %s' % path )
-                    source.close()
-                    target.close()
                 except Exception as e:
                     error_message = 'Failed to extract file: %s in %s (%s)' % \
                                     (path, archive_path, e)


### PR DESCRIPTION
Dangling file handles were causing tests to fail under Windows. This is a fix for: http://flexget.com/ticket/3003