### PR TITLE
remove useless extra TLDs

### DIFF
--- a/flexget/plugins/urlrewrite_torrentz.py
+++ b/flexget/plugins/urlrewrite_torrentz.py
@@ -61,7 +61,7 @@ class UrlRewriteTorrentz(object):
         entries = set()
         for search_string in entry.get('search_strings', [entry['title']]):
             query = normalize_unicode(search_string+config.get('extra_terms', ''))
-            for domain in ['eu', 'me', 'ch', 'in']:
+            for domain in ['eu']:  # , 'me', 'ch', 'in' point to the same two addresses!
                 # urllib.quote will crash if the unicode string has non ascii characters, so encode in utf-8 beforehand
                 url = 'http://torrentz.%s/%s?q=%s' % (domain, feed, urllib.quote(query.encode('utf-8')))
                 log.debug('requesting: %s' % url)


### PR DESCRIPTION
DNS requests for torrentz.eu lead to the same two IP-Adresses as those for .ch, .in, .me and those extra requests make it hard to figure out working domain_delay, limit and interval settings for torrentz.eu (receiving a timeout from torrentz.eu and then hammering on the other domains might add penalty to an existing ban).

(I intend to file a separate issue/PR for "uncivilised behaviour" of the torrentz plugin, possibly resulting in bans. I need to investigate with this branch first, though.)