### PR TITLE
-Changed config threshold to within as it makes more sens.

### DIFF
--- a/tests/test_path_select.py
+++ b/tests/test_path_select.py
@@ -25,18 +25,18 @@ class TestPathSelect(FlexGetBase):
               - {title: 'Existence.2012'}
             path_select:
               to_field: path
-              threshold: 0
+              within: 0
               select: most_free
               paths:
                 - /data/1.5G,100G
                 - /data/50G,100G
                 - /data/1G,100G
-          test_most_free_threshold:
+          test_most_free_within:
             mock:
               - {title: 'Existence.2012'}
             path_select:
               to_field: path
-              threshold: 1G
+              within: 1G
               select: most_free
               paths:
                 - /data/49.5G,100G
@@ -49,7 +49,7 @@ class TestPathSelect(FlexGetBase):
               - {title: 'Existence.2012'}
             path_select:
               to_field: path
-              threshold: 1G
+              within: 1G
               select: most_used
               paths:
                 - /data/90G,100G
@@ -61,39 +61,38 @@ class TestPathSelect(FlexGetBase):
               - {title: 'Existence.2012'}
             path_select:
               to_field: path
-              threshold: 2%
+              within: 2%
               select: most_free_percent
               paths:
                 - /data/50G,100G
                 - /data/40G,50G
                 - /data/65G,80G
                 - /data/50.5G,100G
+          test_most_free_percent_within:
+            mock:
+              - {title: 'Existence.2012'}
+            path_select:
+              to_field: path
+              within: 2%
+              select: most_free_percent
+              paths:
+                - /data/50G,100G
+                - /data/50.5G,100G
+                - /data/52G,100G
+                - /data/57G,100G
+                - /data/80G,100G
           test_most_used_percent:
             mock:
               - {title: 'Existence.2012'}
             path_select:
               to_field: path
-              threshold: 2%
+              within: 2%
               select: most_used_percent
               paths:
                 - /data/99G,100G
                 - /data/49G,50G
                 - /data/40.5G,50G
                 - /data/90.5G,100G
-          test_has_free:
-            mock:
-              - {title: 'Existence.2012'}
-            path_select:
-              to_field: path
-              threshold: 50G
-              select: has_free
-              paths:
-                - /data/65G,100G
-                - /data/50.2G,100G
-                - /data/45G,100G
-                - /data/20G,100G
-                - /data/30G,100G
-                - /data/90G,100G
     """
 
     @mock.patch('flexget.plugins.modify.path_select.os_disk_stats', side_effect=mock_os_disk_stats)
@@ -102,22 +101,13 @@ class TestPathSelect(FlexGetBase):
         assert self.task.entries[0].get('path') == "/data/1G,100G"
 
     @mock.patch('flexget.plugins.modify.path_select.os_disk_stats', side_effect=mock_os_disk_stats)
-    def test_most_free_threshold(self, disk_static_func):
+    def test_most_free_within(self, disk_static_func):
         for i in range(0, 3):
-            self.execute_task('test_most_free_threshold')
+            self.execute_task('test_most_free_within')
             assert self.task.entries[0].get('path') in [
                 "/data/49.5G,100G",
                 "/data/50.5G,100G",
                 "/data/50G,100G",
-            ], "path %s not in list" % self.task.entries[0].get('path')
-
-    @mock.patch('flexget.plugins.modify.path_select.os_disk_stats', side_effect=mock_os_disk_stats)
-    def test_most_used(self, disk_static_func):
-        for i in range(0, 2):
-            self.execute_task('test_most_used')
-            assert self.task.entries[0].get('path') in [
-                '/data/90G,100G',
-                '/data/90.5G,100G',
             ], "path %s not in list" % self.task.entries[0].get('path')
 
     @mock.patch('flexget.plugins.modify.path_select.os_disk_stats', side_effect=mock_os_disk_stats)
@@ -130,6 +120,16 @@ class TestPathSelect(FlexGetBase):
             ], "path %s not in list" % self.task.entries[0].get('path')
 
     @mock.patch('flexget.plugins.modify.path_select.os_disk_stats', side_effect=mock_os_disk_stats)
+    def test_most_free_percent_within(self, disk_static_func):
+        for i in range(0, 2):
+            self.execute_task('test_most_free_percent_within')
+            assert self.task.entries[0].get('path') in [
+                '/data/50G,100G',
+                '/data/50.5G,100G',
+                '/data/52G,100G',
+            ], "path %s not in list" % self.task.entries[0].get('path')
+
+    @mock.patch('flexget.plugins.modify.path_select.os_disk_stats', side_effect=mock_os_disk_stats)
     def test_most_used_percent(self, disk_static_func):
         for i in range(0, 2):
             self.execute_task('test_most_used_percent')
@@ -139,11 +139,11 @@ class TestPathSelect(FlexGetBase):
             ], "path %s not in list" % self.task.entries[0].get('path')
 
     @mock.patch('flexget.plugins.modify.path_select.os_disk_stats', side_effect=mock_os_disk_stats)
-    def test_has_free(self, disk_static_func):
-        for i in range(0, 3):
-            self.execute_task('test_has_free')
+    def test_most_used(self, disk_static_func):
+        for i in range(0, 2):
+            self.execute_task('test_most_used')
             assert self.task.entries[0].get('path') in [
-                '/data/45G,100G',
-                '/data/20G,100G',
-                '/data/30G,100G',
+                '/data/90G,100G',
+                '/data/90.5G,100G',
             ], "path %s not in list" % self.task.entries[0].get('path')
+


### PR DESCRIPTION
 @gazpachoking I've changed path_select to make it simpler to understand..

-Removed has_free selector as i don't think it's required.
-Added extra test for within

So the config looks like

The follow task will find the path with the most free space by percentage. It will also include other paths within 2% diffeerence of that drive..

So below it will choose both drive1 and drive2 randomly.
```
        tasks:
          some-task:
            path_select:
              select: most_free_percent
              within: 2%
              paths:
                - /some/drive1  # 50% free
                - /some/drive2  # 51% free
                - /some/drive3  # 10% free
```

Same thing goes by size..

The below config will choose paths drive1 and drive2

```
        tasks:
          some-task:
            path_select:
              select: most_free
              within: 2G
              paths:
                - /some/drive1  # 50G free
                - /some/drive2  # 51G free
                - /some/drive3  # 10G Free free
```
