### PR TITLE
enhance url composition in sonarr couchpotato and sickbeard plugins

### DIFF
--- a/flexget/plugins/input/couchpotato.py
+++ b/flexget/plugins/input/couchpotato.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals, division, absolute_import
+from urlparse import urlparse
 import logging
 import requests
 
@@ -34,9 +35,10 @@ class CouchPotato(object):
 
         Options base_url, port and api_key are required.
         """
-
-        url = '%s:%s/api/%s/movie.list?status=active' \
-              % (config['base_url'], config['port'], config['api_key'])
+        parsedurl = urlparse(config.get('base_url'))
+        url = '%s://%s:%s%s/api/%s/movie.list?status=active' \
+              % (parsedurl.scheme, parsedurl.netloc,
+                 config.get('port'), parsedurl.path, config.get('api_key'))
         json = task.requests.get(url).json()
         entries = []
         for movie in json['movies']:

--- a/flexget/plugins/input/couchpotato.py
+++ b/flexget/plugins/input/couchpotato.py
@@ -16,10 +16,10 @@ class CouchPotato(object):
         'type': 'object',
         'properties': {
             'base_url': {'type': 'string'},
-            'port': {'type': 'number'},
+            'port': {'type': 'number', 'default': 80},
             'api_key': {'type': 'string'}
         },
-        'required': ['api_key', 'base_url', 'port'],
+        'required': ['api_key', 'base_url'],
         'additionalProperties': False
     }
 
@@ -33,7 +33,7 @@ class CouchPotato(object):
           port: <value>
           api_key: <value>
 
-        Options base_url, port and api_key are required.
+        Options base_url and api_key are required.
         """
         parsedurl = urlparse(config.get('base_url'))
         url = '%s://%s:%s%s/api/%s/movie.list?status=active' \

--- a/flexget/plugins/input/sickbeard.py
+++ b/flexget/plugins/input/sickbeard.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals, division, absolute_import
+from urlparse import urlparse
 import logging
 import requests
 
@@ -61,7 +62,9 @@ class Sickbeard(object):
         remove it in flexget as well,which good be positive or negative,
         depending on your usage.
         '''
-        url = '%s:%s/api/%s/?cmd=shows' % (config['base_url'], config['port'], config['api_key'])
+        parsedurl = urlparse(config.get('base_url'))
+        url = '%s://%s:%s%s/api/%s/?cmd=shows' % (parsedurl.scheme, parsedurl.netloc,
+                                                  config.get('port'), parsedurl.path, config.get('api_key'))
         json = task.requests.get(url).json()
         entries = []
         for id, show in json['data'].items():

--- a/flexget/plugins/input/sickbeard.py
+++ b/flexget/plugins/input/sickbeard.py
@@ -16,12 +16,12 @@ class Sickbeard(object):
         'type': 'object',
         'properties': {
             'base_url': {'type': 'string'},
-            'port': {'type': 'number'},
+            'port': {'type': 'number', 'default': 80},
             'api_key': {'type': 'string'},
             'include_ended': {'type': 'boolean', 'default': True},
             'only_monitored': {'type': 'boolean', 'default': False}
         },
-        'required': ['api_key', 'base_url', 'port'],
+        'required': ['api_key', 'base_url'],
         'additionalProperties': False
     }
 
@@ -35,6 +35,8 @@ class Sickbeard(object):
           base_url=<value>
           port=<value>
           api_key=<value>
+
+        Options base_url and api_key are required.
 
         Use with input plugin like discover and/or cofnigure_series.
         Example:

--- a/flexget/plugins/input/sonarr.py
+++ b/flexget/plugins/input/sonarr.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals, division, absolute_import
+from urlparse import urlparse
 import logging
 import requests
 
@@ -65,7 +66,8 @@ class Sonarr(object):
         remove it in flexget as well,which good be positive or negative,
         depending on your usage.
         '''
-        url = '%s:%s/api/series' % (config['base_url'], config['port'])
+        parsedurl = urlparse(config.get('base_url'))
+        url = '%s://%s:%s%s/api/series' % (parsedurl.scheme, parsedurl.netloc, config.get('port'), parsedurl.path)
         headers = {'X-Api-Key': config['api_key']}
         json = task.requests.get(url, headers=headers).json()
         entries = []

--- a/flexget/plugins/input/sonarr.py
+++ b/flexget/plugins/input/sonarr.py
@@ -16,12 +16,12 @@ class Sonarr(object):
         'type': 'object',
         'properties': {
             'base_url': {'type': 'string'},
-            'port': {'type': 'number'},
+            'port': {'type': 'number', 'default': 80},
             'api_key': {'type': 'string'},
             'include_ended': {'type': 'boolean', 'default': True},
             'only_monitored': {'type': 'boolean', 'default': False}
         },
-        'required': ['api_key', 'base_url', 'port'],
+        'required': ['api_key', 'base_url'],
         'additionalProperties': False
     }
 
@@ -38,7 +38,7 @@ class Sonarr(object):
           include_ended=<yes|no>
           only_monitored=<yes|no>
 
-        Options base_url, port and api_key are required.
+        Options base_url and api_key are required.
 
         Use with input plugin like discover and/or cofnigure_series.
         Example:


### PR DESCRIPTION
should fix the use case where these plugins are not located at the server root path or behind a http proxy