### PR TITLE
Fix incorrectly named global in extratorrent url rewrite plugin

### DIFF
--- a/flexget/plugins/urlrewrite_extratorrent.py
+++ b/flexget/plugins/urlrewrite_extratorrent.py
@@ -60,7 +60,7 @@ class UrlRewriteExtraTorrent(object):
         if not isinstance(config, dict):
             config = {}
 
-        category = CATEGORY.get(config.get('category', 'all'), None)
+        category = CATEGORIES.get(config.get('category', 'all'), None)
         category_query = '&cid=%d' % category if category else ''
 
         entries = set()


### PR DESCRIPTION
I am getting errors whilst trying to use the plugin, this should fix it, but I was not able to test further at the moment.