### PR TITLE
Input plugin for Letterboxd lists

### DIFF
--- a/flexget/plugins/input/letterboxd.py
+++ b/flexget/plugins/input/letterboxd.py
@@ -7,10 +7,13 @@ from flexget.entry import Entry
 from flexget.event import event
 from flexget.utils.cached_input import cached
 from flexget.utils.imdb import extract_id
-from flexget.utils.requests import RequestException
+from flexget.utils.requests import RequestException, Session
 from flexget.utils.soup import get_soup
 
 log = logging.getLogger('letterboxd')
+
+requests = Session()
+requests.set_domain_delay('letterboxd.com', '2 seconds')
 base_url = 'http://letterboxd.com'
 
 P_SLUGS = {
@@ -92,7 +95,7 @@ class Letterboxd(object):
 
         while next_page is not None and pagecount < max_pages:
             try:
-                page = task.requests.get(url).content
+                page = requests.get(url).content
             except RequestException as e:
                 raise plugin.PluginError('Can\'t retrieve Letterboxd list from %s. Make sure it\'s not set to private, and check your config.' % url)
             soup = get_soup(page)
@@ -100,7 +103,7 @@ class Letterboxd(object):
             for movie in soup.find_all(attrs={m_slug: True}):
                 m_url = base_url + movie.get(m_slug)
                 try:
-                    m_page = task.requests.get(m_url).content
+                    m_page = requests.get(m_url).content
                 except RequestException:
                     continue
                 m_soup = get_soup(m_page)                

--- a/flexget/plugins/input/letterboxd.py
+++ b/flexget/plugins/input/letterboxd.py
@@ -134,4 +134,4 @@ class Letterboxd(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(LetterboxdList, 'letterboxd', api_ver=2)
+    plugin.register(Letterboxd, 'letterboxd', api_ver=2)

--- a/flexget/plugins/input/letterboxd.py
+++ b/flexget/plugins/input/letterboxd.py
@@ -10,7 +10,7 @@ from flexget.utils.imdb import extract_id
 from flexget.utils.requests import RequestException
 from flexget.utils.soup import get_soup
 
-log = logging.getLogger('letterboxd_list')
+log = logging.getLogger('letterboxd')
 base_url = 'http://letterboxd.com'
 
 P_SLUGS = {
@@ -52,7 +52,8 @@ SORT_BY = {
     'release-descending': 'by/release/'
 }
 
-class LetterboxdList(object):
+
+class Letterboxd(object):
 
     schema = {
         'type': 'object',
@@ -66,8 +67,7 @@ class LetterboxdList(object):
         'addditionalProperties': False
     }
 
-    @cached('letterboxd_list', persist='2 hours')
-
+    @cached('letterboxd', persist='2 hours')
     def on_task_input(self, task, config):        
         m_list = config['list'].lower().replace(' ', '-')
         max_pages = config.get('max_pages', 1)
@@ -91,7 +91,6 @@ class LetterboxdList(object):
         entries = []
 
         while next_page is not None and pagecount < max_pages:
-
             try:
                 page = task.requests.get(url).content
             except RequestException as e:
@@ -135,4 +134,4 @@ class LetterboxdList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(LetterboxdList, 'letterboxd_list', api_ver=2)
+    plugin.register(LetterboxdList, 'letterboxd', api_ver=2)

--- a/flexget/plugins/input/letterboxd.py
+++ b/flexget/plugins/input/letterboxd.py
@@ -34,15 +34,6 @@ M_SLUGS = {
     'other': 'data-film-slug'
 }
 
-LOG_STR = {
-    'diary': 'Retrieving %s\'s film diary from Letterboxd.',
-    'likes': 'Retrieving list of films %s has liked on Letterboxd.',
-    'rated': 'Retrieving list of films rated by %s on Letterboxd.',
-    'watched': 'Retrieving list of films watched by %s from Letterboxd.',
-    'watchlist': 'Retrieving %s\'s watchlist from Letterboxd.',
-    'other': 'Retrieving %s\'s Letterboxd list: %s.'
-}
-
 SORT_BY = {
     'added': 'by/added/',
     'length-ascending': 'by/shortest/',
@@ -81,17 +72,17 @@ class Letterboxd(object):
         if m_list in list(P_SLUGS.keys()):
             p_slug = P_SLUGS.get(m_list) % config['username']
             m_slug = M_SLUGS.get(m_list)
-            log.verbose(LOG_STR.get(m_list) % config['username'])
         else:
             p_slug = P_SLUGS.get('other') % (config['username'], m_list)
             m_slug = M_SLUGS.get('other')
-            log.verbose(LOG_STR.get('other') % (config['username'], m_list))
         
         if 'sort_by' in config:
             sort_by = SORT_BY.get(config['sort_by'])
 
         url = base_url + p_slug + sort_by
         entries = []
+
+        log.verbose('Retrieving list from Letterboxd: %s' % url)
 
         while next_page is not None and pagecount < max_pages:
             try:

--- a/flexget/plugins/input/letterboxd_list.py
+++ b/flexget/plugins/input/letterboxd_list.py
@@ -31,7 +31,7 @@ class LetterboxdList(object):
         'properties': {
             'username': {'type': 'string'},
             'list': {'type': 'string'},
-            'sort_by': {'type': 'string', 'enum': SORT_BY},
+            'sort_by': {'type': 'string', 'enum': list(SORT_BY.keys())},
             'max_pages': {'type': 'integer'}
         },
         'required': ['username', 'list'],

--- a/flexget/plugins/input/letterboxd_list.py
+++ b/flexget/plugins/input/letterboxd_list.py
@@ -119,12 +119,13 @@ class LetterboxdList(object):
                 entry['tmdb_id'] = re.search(r'\/(\d+)\/$', tmdb_url.get('href')).group(1)
                 entry['letterboxd_list'] = '%s (%s)' % (m_list, config['username'])
                 entry['letterboxd_score'] = 0
-                entry['letterboxd_score'] = m_soup.find('span', attrs={'class': 'average-rating'})\
+                avg_rating = m_soup.find('span', attrs={'class': 'average-rating'})\
                     .find('meta', attrs={'itemprop': 'average'}).get('content')
+                entry['letterboxd_score'] = float(avg_rating)
                 if m_list in ['diary', 'rated']:
                     try:
                         user_rating = movie.find('meta', attrs={'itemprop': 'rating'}).get('content')
-                        entry['letterboxd_score'] = user_rating
+                        entry['letterboxd_score'] = float(user_rating)
                     except AttributeError:
                         pass
                 entries.append(entry)

--- a/flexget/plugins/input/letterboxd_list.py
+++ b/flexget/plugins/input/letterboxd_list.py
@@ -1,0 +1,107 @@
+from __future__ import unicode_literals, division, absolute_import
+import logging
+import re
+
+from flexget import plugin
+from flexget.entry import Entry
+from flexget.event import event
+from flexget.utils.cached_input import cached
+from flexget.utils.imdb import extract_id
+from flexget.utils.requests import RequestException
+from flexget.utils.soup import get_soup
+
+log = logging.getLogger('letterboxd_list')
+
+
+class LetterboxdList(object):
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'username': {'type': 'string'},
+            'list': {'type': 'string'},
+            'maxpages': {'type': 'integer'}
+        },
+        'required': ['username', 'list'],
+        'addditionalProperties': False
+    }
+
+    @cached('letterboxd_list', persist='2 hours')
+    def on_task_input(self, task, config):        
+        base_url = 'http://letterboxd.com'
+        list = config['list'].lower().replace(' ', '-')
+        maxpages = config.get('maxpages', 1)
+
+        if list == 'watchlist':
+            next_page = '/%s/watchlist/' % config['username']
+            m_slug = 'data-film-slug'
+            log.verbose('Retrieving %s\'s watchlist from Letterboxd.' % config['username'])
+        elif list == 'diary':
+            next_page = '/%s/films/diary/' % config['username']
+            m_slug = 'data-film-link'
+            log.verbose('Retrieving %s\'s film diary from Letterboxd.' % config['username'])
+        elif list == 'likes':
+            next_page = '/%s/likes/films/' % config['username']
+            m_slug = 'data-film-link'
+            log.verbose('Retrieving list of films %s has liked on Letterboxd.' % config['username'])
+        else:
+            next_page =  '/%s/list/%s/' % (config['username'], list)
+            m_slug = 'data-film-slug'
+            log.verbose('Retrieving %s\'s Letterboxd list: %s.' % (config['username'], list))
+
+        pagecount = 0
+        entries = []
+        while next_page is not None and pagecount < maxpages:
+            url = base_url + next_page
+            try:
+                page = task.requests.get(url)
+            except RequestException as e:
+                raise plugin.PluginError('Can\'t retrieve Letterboxd list. If it\'s not set to private, it may not exist. Check your config.')
+            soup = get_soup(page.text)
+            if list == 'diary':
+                movies = soup.find_all('tr', attrs={'class': 'diary-entry-row'})
+            else:
+                movies = soup.find_all('li', attrs={'class': 'poster-container'})
+
+            for movie in movies:
+                if list == 'diary':
+                    m_url = base_url + movie.find('td', attrs={'class': 'td-actions'}).get(m_slug)
+                    try:
+                        user_rating = movie.find('meta', attrs={'itemprop': 'rating'}).get('content')
+                    except AttributeError:
+                        pass
+                else:
+                    m_url = base_url + movie.find('div').get(m_slug)
+                m_page = task.requests.get(m_url)
+                m_soup = get_soup(m_page.text)
+                
+                entry = Entry()
+                title = m_soup.find('section', attrs={'id': 'featured-film-header'}).find('h1').string
+                year = m_soup.find('section', attrs={'id': 'featured-film-header'}).find('small').string
+                entry['title'] = '%s (%s)' % (title, year)
+                entry['url'] = m_url
+                imdb_url = m_soup.find('p', attrs={'class': 'text-link'}).find(href=re.compile('imdb')).get('href')
+                entry['imdb_id'] = extract_id(imdb_url)
+                tmdb_url = m_soup.find('p', attrs={'class': 'text-link'}).find(href=re.compile('themoviedb'))
+                entry['tmdb_id'] = re.search(r'\/(\d+)\/$', tmdb_url.get('href')).group(1)
+                entry['letterboxd_list'] = '%s (%s)' % (list, config['username'])
+                entry['letterboxd_score'] = 0
+                if list == 'diary' and user_rating:
+                    entry['letterboxd_score'] = user_rating
+                else:
+                    entry['letterboxd_score'] = m_soup.find('span', attrs={'class': 'average-rating'})\
+                    .find('meta', attrs={'itemprop': 'average'}).get('content')                
+                entries.append(entry)
+
+            next_page = soup.find('a', attrs={'class': 'paginate-next'})
+            if next_page is not None:
+                next_page = next_page.get('href')
+            if config['maxpages']:
+                pagecount += 1
+
+        return entries
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(LetterboxdList, 'letterboxd_list', api_ver=2)

--- a/flexget/plugins/input/letterboxd_list.py
+++ b/flexget/plugins/input/letterboxd_list.py
@@ -41,33 +41,33 @@ class LetterboxdList(object):
     @cached('letterboxd_list', persist='2 hours')
     def on_task_input(self, task, config):        
         base_url = 'http://letterboxd.com'
-        list = config['list'].lower().replace(' ', '-')
+        m_list = config['list'].lower().replace(' ', '-')
         max_pages = config.get('max_pages', 1)
 
-        if list == 'watchlist':
+        if m_list == 'watchlist':
             p_slug = '/%s/watchlist/' % config['username']
             m_slug = 'data-film-slug'
             log.verbose('Retrieving %s\'s watchlist from Letterboxd.' % config['username'])
-        elif list == 'diary':
+        elif m_list == 'diary':
             p_slug = '/%s/films/diary/' % config['username']
             m_slug = 'data-film-link'
             log.verbose('Retrieving %s\'s film diary from Letterboxd.' % config['username'])
-        elif list == 'likes':
+        elif m_list == 'likes':
             p_slug = '/%s/likes/films/' % config['username']
             m_slug = 'data-film-link'
             log.verbose('Retrieving list of films %s has liked on Letterboxd.' % config['username'])
-        elif list == 'watched':
+        elif m_list == 'watched':
             p_slug = '/%s/films/' % config['username']
             m_slug = 'data-film-slug'
             log.verbose('Retrieving list of films watched by %s from Letterboxd.' % config['username'])
-        elif list == 'rated':
+        elif m_list == 'rated':
             p_slug = '/%s/films/ratings/' % config['username']
             m_slug = 'data-film-slug'
             log.verbose('Retrieving list of films rated by %s on Letterboxd.' % config['username'])
         else:
-            p_slug =  '/%s/list/%s/' % (config['username'], list)
+            p_slug =  '/%s/list/%s/' % (config['username'], m_list)
             m_slug = 'data-film-slug'
-            log.verbose('Retrieving %s\'s Letterboxd list: %s.' % (config['username'], list))
+            log.verbose('Retrieving %s\'s Letterboxd list: %s.' % (config['username'], m_list))
         
         next_page = ''
         sort_by = ''
@@ -83,13 +83,13 @@ class LetterboxdList(object):
                 raise plugin.PluginError('Can\'t retrieve Letterboxd list from %s. Make sure it\'s not set to private; ' + \
                                          'if not, the URL may be incorrect. Check your config.') % url
             soup = get_soup(page.text)
-            if list == 'diary':
+            if m_list == 'diary':
                 movies = soup.find_all('tr', attrs={'class': 'diary-entry-row'})
             else:
                 movies = soup.find_all('li', attrs={'class': 'poster-container'})
 
             for movie in movies:
-                if list == 'diary':
+                if m_list == 'diary':
                     m_url = base_url + movie.find('td', attrs={'class': 'td-actions'}).get(m_slug)
                 else:
                     m_url = base_url + movie.find('div').get(m_slug)
@@ -105,11 +105,11 @@ class LetterboxdList(object):
                 entry['imdb_id'] = extract_id(imdb_url)
                 tmdb_url = m_soup.find('p', attrs={'class': 'text-link'}).find(href=re.compile('themoviedb'))
                 entry['tmdb_id'] = re.search(r'\/(\d+)\/$', tmdb_url.get('href')).group(1)
-                entry['letterboxd_list'] = '%s (%s)' % (list, config['username'])
+                entry['letterboxd_list'] = '%s (%s)' % (m_list, config['username'])
                 entry['letterboxd_score'] = 0
                 entry['letterboxd_score'] = m_soup.find('span', attrs={'class': 'average-rating'})\
                     .find('meta', attrs={'itemprop': 'average'}).get('content')
-                if list in ['diary', 'rated']:
+                if m_list in ['diary', 'rated']:
                     try:
                         user_rating = movie.find('meta', attrs={'itemprop': 'rating'}).get('content')
                         entry['letterboxd_score'] = user_rating


### PR DESCRIPTION
Uses BeautifulSoup to parse any **public** Letterboxd list, and generates entries with basic metainfo extracted from film pages identified within that list. Includes specific handling for built-in lists, but also works with custom lists.

The plugin is configured with the following settings:
* `username`: Your (or another user's) Letterboxd username, found in the profile URL.
* `list`: The name of a custom list, or one of the `watchlist`, `diary`, `likes`, `rated` or `watched` built-in lists.
* `sort_by` (optional): Sort films within the list according to one of the parameters allowed by Letterboxd, or leave unspecified to use the default sorting for the list type. The available options are:
    * `name`: Sorted by film name, in ascending alphabetical order.
    * `added`: Sorted by the date the film was added to the list, in reverse chronological order.
    * `popularity`: Sorted in descending order of popularity among Letterboxd users.
    * `length-ascending` or `length-descending`: Sorted by runtime.
    * `rating-ascending` or `rating-descending`: Sorted by average rating or user rating, depending on the list context (e.g. watchlists will be sorted by the average, rated lists by the individual).
    * `release-ascending` or `release-descending`: Sorted by release date.
* `max_pages` (optional): An integer specifying the maximum number of pages of the list for the plugin to loop over. This is useful, e.g., for parsing recent entries in another user's film diary. If unspecified, all pages will be parsed.

The `username` and `list` fields are primarily used to fill out the initial list URL for BeautifulSoup to parse. For example, the plugin will output the URL of a custom list as:
````
http://letterboxd.com/<username>/list/<list>/
````
This means that the input format for the list in your config will ideally match its appearance in the list URL. I've tried to include some substitution for spaces, capital letters, etc, but I haven't tested it thoroughly, so keep that in mind.

The plugin populates the following entry fields:
* `title`: In the format `film_name (film_year)`
* `url`: The URL of the film page.
* `imdb_id`
* `tmdb_id`
* `letterboxd_list`: In the format `list (username)`. Included in case you use the plugin as one of several inputs plugins in a task, but still apply additional filtering based on the source list and/or user.
* `letterboxd_score`: This is the average score (out of 10) given for the film by Letterboxd users, *unless* the entry was retrieved from a user's film diary, in which case it's the score (if any) that the user gave to the film.

As with the `imdb_list` plugin, results are cached for two hours to avoid swamping the site. Obviously it's not possible to modify lists, at least until the public API is released. If you notice any problems, let me know. I had some issues with error-handling, but there's probably other stuff I haven't noticed.