### PR TITLE
Add input plugin for Letterboxd lists

### DIFF
--- a/flexget/plugins/input/letterboxd.py
+++ b/flexget/plugins/input/letterboxd.py
@@ -1,0 +1,152 @@
+from __future__ import unicode_literals, division, absolute_import
+import logging, re
+
+from flexget import plugin
+from flexget.entry import Entry
+from flexget.event import event
+from flexget.plugin import get_plugin_by_name
+from flexget.utils.cached_input import cached
+from flexget.utils.requests import RequestException, Session
+from flexget.utils.soup import get_soup
+
+log = logging.getLogger('letterboxd')
+logging.getLogger('api_tmdb').setLevel(logging.CRITICAL)
+
+requests = Session(max_retries=5)
+requests.set_domain_delay('letterboxd.com', '1 seconds')
+base_url = 'http://letterboxd.com'
+
+SLUGS = {
+    'default': {
+        'p_slug': '/%(user)s/list/%(list)s/',
+        'f_slug': 'data-film-slug'},
+    'diary': {
+        'p_slug': '/%(user)s/films/diary/',
+        'f_slug': 'data-film-slug'},
+    'likes': {
+        'p_slug': '/%(user)s/likes/films/',
+        'f_slug': 'data-film-link'},
+    'rated': {
+        'p_slug': '/%(user)s/films/ratings/',
+        'f_slug': 'data-film-slug'},
+    'watched': {
+        'p_slug': '/%(user)s/films/',
+        'f_slug': 'data-film-slug'},
+    'watchlist': {
+        'p_slug': '/%(user)s/watchlist/',
+        'f_slug': 'data-film-slug'}
+}
+
+SORT_BY = {
+    'default': '',
+    'added': 'by/added/',
+    'length-ascending': 'by/shortest/',
+    'length-descending': 'by/longest/',
+    'name': 'by/name/',
+    'popularity': 'by/popular/',
+    'rating-ascending': 'by/rating-lowest/',
+    'rating-descending': 'by/rating/',
+    'release-ascending': 'by/release-earliest/',
+    'release-descending': 'by/release/'
+}
+
+
+class Letterboxd(object):
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'username': {'type': 'string'},
+            'list': {'type': 'string'},
+            'sort_by': {
+                'type': 'string',
+                'enum': list(SORT_BY.keys()),
+                'default': 'default'},
+            'max_results': {'type': 'integer'}
+        },
+        'required': ['username', 'list'],
+        'additionalProperties': False
+    }
+
+
+    def build_config(self, config):
+        config['list'] = config['list'].lower().replace(' ', '-')
+        list_key = config['list']
+        if list_key not in list(SLUGS.keys()):
+            list_key = 'default'
+        config['p_slug'] = SLUGS[list_key]['p_slug'] % {'user': config['username'], 'list': config['list']}
+        config['f_slug'] = SLUGS[list_key]['f_slug']
+        config['sort_by'] = SORT_BY[config['sort_by']]
+
+        return config
+
+
+    def tmdb_lookup(self, search):
+        tmdb = plugin.get_plugin_by_name('api_tmdb').instance.lookup(tmdb_id=search)
+        result = {
+            'title': '%s (%s)' % (tmdb.name, tmdb.year),
+            'imdb_id': tmdb.imdb_id,
+            'tmdb_id': tmdb.id,
+            'movie_name': tmdb.name,
+            'movie_year': tmdb.year
+        }
+
+        return result
+
+
+    def parse_film(self, film, config):
+        url = base_url + film.get(config['f_slug'])
+        soup = get_soup(requests.get(url).content)
+        result = self.tmdb_lookup(soup.find(attrs={'data-tmdb-id': True}).get('data-tmdb-id'))
+
+        entry = Entry(result)
+        entry['url'] = url
+        entry['letterboxd_list'] = '%s (%s)' % (config['list'], config['username'])
+        try:
+            entry['letterboxd_score'] = float(soup.find(itemprop='average').get('content'))
+        except AttributeError:
+            pass
+        if config['list'] == 'diary':
+            entry['letterboxd_uscore'] = int(film.find_next(attrs={'data-rating': True}).get('data-rating'))
+        elif config['list'] == 'rated':
+            entry['letterboxd_uscore'] = int(film.find_next(itemprop='rating').get('content'))
+
+        return entry
+
+
+    @cached('letterboxd', persist='2 hours')
+    def on_task_input(self, task, config=None):
+        config = self.build_config(config)
+        url = base_url + config['p_slug'] + config['sort_by']
+        max_results = config.get('max_results', 1)
+        rcount = 0
+        next_page = ''
+
+        log.verbose('Looking for films in Letterboxd list: %s' % url)
+
+        entries = []
+        while next_page is not None and rcount < max_results:
+            try:
+                page = requests.get(url).content
+            except RequestException as e:
+                raise plugin.PluginError('Error retrieving list from Letterboxd: %s' % e)
+            soup = get_soup(page)
+
+            for film in soup.find_all(attrs={config['f_slug']: True}):
+                if rcount < max_results:
+                    entry = self.parse_film(film, config)
+                    entries.append(entry)
+                    if 'max_results' in config:
+                        rcount += 1
+
+            next_page = soup.find(class_='paginate-next')
+            if next_page is not None:
+                next_page = next_page.get('href')
+                url = base_url + next_page
+
+        return entries
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(Letterboxd, 'letterboxd', api_ver=2)


### PR DESCRIPTION
Creates entries for input from any **public** user list on Letterboxd. The plugin uses BeautifulSoup to parse the list for site-specific metainfo (e.g. user scores, where applicable), extracts the `tmdb_id` and average score from the page of each film included on the list, then queries the TMDb API to fill the rest of the entry.

The plugin is configured with the following settings:
* **`username`**: Your or another user's Letterboxd username, which can be found in the profile URL.
* **`list`**: The name of a custom list, or one of the built-in lists, i.e. `watchlist`, `diary`, `likes`, `rated` or `watched`. It should be entered as it appears in the list URL; so for example, the a list at `http://letterboxd.com/user/list/some-list/` should be entered as `some-list`.
* **`sort_by`** (optional): Sort films within the list according to one of the parameters allowed by Letterboxd, or leave unspecified to use the default sorting for the list type. The available options are:
    * `name`: Sorted by film name, in ascending alphabetical order.
    * `added`: Sorted by the date the film was added to the list, in reverse chronological order.
    * `popularity`: Sorted in descending order of popularity among Letterboxd users.
    * `length-ascending` or `length-descending`: Sorted by runtime.
    * `rating-ascending` or `rating-descending`: Sorted by average rating or user rating, depending on the list context (e.g. watchlists will be sorted by the average, rated lists by the individual).
    * `release-ascending` or `release-descending`: Sorted by release date.
* **`max_results`** (optional): An integer specifying the maximum number of results that the plugin will loop over.

The `username` and `list` strings are used to fill in the URL for the initial parse, and so should be entered exactly as they appear in the URL for the list. So for example, to pull entries from a list at
````
http://letterboxd.com/some-user/list/some-users-list/
````
you would enter the `username` as `some-user`, and the `list` as `some-users-list`, not 'Some User' and 'Some user's list' (or whatever).

The plugin populates the following entry fields:
* **`title`**: Film Name (Year)
* **`url`**: The film's page on Letterboxd.
* **`imdb_id`** and **`tmdb_id`**
* **`letterboxd_list`**: In the format list (username), included in case the plugin is used as one of several input plugins, and you want to apply filtering against these.
* **`letterboxd_score`** (where available): A floating-point number representing the average score (out of 10) given to the film by Letterboxd users.
* **`letterboxd_uscore`** (where available): An integer representing the score (out of 10) given to the film by the list owner.
* **`movie_name`** and **`movie_year`**.

Results are cached for two hours to avoid swamping the site, and there is a short domain delay between requests. And that's about it. If anyone sees any problems, please let me know.