### PR TITLE
Add "highres tv" to piratebay search plugin

### DIFF
--- a/flexget/plugins/urlrewrite_piratebay.py
+++ b/flexget/plugins/urlrewrite_piratebay.py
@@ -27,6 +27,7 @@ CATEGORIES = {
     'movies': 201,
     'tv': 205,
     'highres movies': 207,
+    'highres tv': 208,
     'comics': 602
 }
 


### PR DESCRIPTION
When using piratebay with 'tv' search, it won't find e.g. 1080p results. Instead, the 'highres tv' section must be used, which is added by this commit.