### PR TITLE
do not skip SSL verification on plugin piratebay

### DIFF
--- a/flexget/plugins/urlrewrite_piratebay.py
+++ b/flexget/plugins/urlrewrite_piratebay.py
@@ -89,7 +89,7 @@ class UrlRewritePirateBay(object):
 
     @plugin.internet(log)
     def parse_download_page(self, url):
-        page = requests.get(url, verify=False).content
+        page = requests.get(url).content
         try:
             soup = get_soup(page)
             tag_div = soup.find('div', attrs={'class': 'download'})
@@ -128,7 +128,7 @@ class UrlRewritePirateBay(object):
             # urllib.quote will crash if the unicode string has non ascii characters, so encode in utf-8 beforehand
             url = 'http://thepiratebay.%s/search/%s%s' % (CUR_TLD, urllib.quote(query.encode('utf-8')), filter_url)
             log.debug('Using %s as piratebay search url' % url)
-            page = requests.get(url, verify=False).content
+            page = requests.get(url).content
             soup = get_soup(page)
             for link in soup.find_all('a', attrs={'class': 'detLink'}):
                 entry = Entry()


### PR DESCRIPTION
There is no reason to disable SSL verification.