### PR TITLE
Optional regex module

### DIFF
--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, unicode_literals
 
 import os
-import re
 import urlparse
 from collections import defaultdict
 from datetime import datetime
@@ -11,6 +10,7 @@ from jsonschema.compat import str_types, int_types
 
 from flexget.event import fire_event
 from flexget.utils import qualities, template
+from flexget.utils import regex as re
 from flexget.utils.tools import parse_timedelta
 
 schema_paths = {}

--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -214,6 +214,8 @@ def is_regex(instance):
     try:
         return re.compile(instance)
     except re.error as e:
+        if re.regex_module == 're' and instance.startswith('(?'):
+            raise ValueError('Inline flags are only supported if `regex` module is installed. (pip install regex)')
         raise ValueError('Error parsing regex: %s' % e)
 
 

--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -5,8 +5,6 @@ from __future__ import absolute_import, division, unicode_literals
 
 import logging
 import os
-import re
-import sys
 import time
 import warnings
 from itertools import ifilter
@@ -18,6 +16,7 @@ from flexget import plugins as plugins_pkg
 from flexget import config_schema
 from flexget.event import add_event_handler as add_phase_handler
 from flexget.event import fire_event, remove_event_handlers
+from flexget.utils import regex as re
 
 log = logging.getLogger('plugin')
 

--- a/flexget/plugins/api_trakt.py
+++ b/flexget/plugins/api_trakt.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals, division, absolute_import
 from difflib import SequenceMatcher
 import logging
-import re
 import urllib
 
 import requests

--- a/flexget/plugins/filter/exists_movie.py
+++ b/flexget/plugins/filter/exists_movie.py
@@ -1,6 +1,4 @@
 from __future__ import unicode_literals, division, absolute_import
-import os
-import re
 import logging
 
 from path import path
@@ -9,6 +7,7 @@ from flexget import plugin
 from flexget.event import event
 from flexget.config_schema import one_or_more
 from flexget.plugin import get_plugin_by_name
+from flexget.utils import regex as re
 from flexget.utils.tools import TimedDict
 
 log = logging.getLogger('exists_movie')

--- a/flexget/plugins/filter/if_condition.py
+++ b/flexget/plugins/filter/if_condition.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals, division, absolute_import
 import __builtin__
 import logging
-import re
 import datetime
 from copy import copy
 
@@ -9,6 +8,7 @@ from flexget import plugin
 from flexget.event import event
 from flexget.task import Task
 from flexget.entry import Entry
+from flexget.utils import regex as re
 
 log = logging.getLogger('if')
 

--- a/flexget/plugins/filter/regexp.py
+++ b/flexget/plugins/filter/regexp.py
@@ -1,12 +1,12 @@
 from __future__ import unicode_literals, division, absolute_import
 import urllib
 import logging
-import re
 
 from flexget import plugin
 from flexget.config_schema import one_or_more
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 
 log = logging.getLogger('regexp')
 

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals, division, absolute_import
 import argparse
 import logging
-import re
 import time
 from copy import copy
 from datetime import datetime, timedelta
@@ -20,6 +19,7 @@ from flexget.utils import qualities
 from flexget.utils.log import log_once
 from flexget.plugins.parsers import SERIES_ID_TYPES
 from flexget.plugin import get_plugin_by_name
+from flexget.utils import regex as re
 from flexget.utils.sqlalchemy_utils import (table_columns, table_exists, drop_tables, table_schema, table_add_column,
                                             create_index)
 from flexget.utils.tools import merge_dict_from_to, parse_timedelta

--- a/flexget/plugins/generic/archive.py
+++ b/flexget/plugins/generic/archive.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals, division, absolute_import
 from collections import defaultdict
 import logging
-import re
 from datetime import datetime
 
 from sqlalchemy.orm import relationship
@@ -14,6 +13,7 @@ from flexget.event import event
 from flexget.entry import Entry
 from flexget.logger import console
 from flexget.options import ParseExtrasAction, get_parser
+from flexget.utils import regex as re
 from flexget.utils.sqlalchemy_utils import table_schema, get_index_by_name
 from flexget.utils.tools import strip_html
 from flexget.manager import Session

--- a/flexget/plugins/input/emit_series.py
+++ b/flexget/plugins/input/emit_series.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 
 from sqlalchemy import desc
 
@@ -8,6 +7,7 @@ from flexget import plugin
 from flexget.event import event
 from flexget.entry import Entry
 from flexget.manager import Session
+from flexget.utils import regex as re
 
 log = logging.getLogger('emit_series')
 

--- a/flexget/plugins/input/find.py
+++ b/flexget/plugins/input/find.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals, division, absolute_import
 from datetime import datetime
 import logging
-import re
 import sys
 
 from path import path
@@ -10,6 +9,7 @@ from flexget import plugin
 from flexget.config_schema import one_or_more
 from flexget.event import event
 from flexget.entry import Entry
+from flexget.utils import regex as re
 
 log = logging.getLogger('find')
 

--- a/flexget/plugins/input/ftp_list.py
+++ b/flexget/plugins/input/ftp_list.py
@@ -1,12 +1,12 @@
 import logging
 import ftplib
 import os
-import re
 
 from flexget import plugin
 from flexget.event import event
 from flexget.entry import Entry
 from flexget.config_schema import one_or_more
+from flexget.utils import regex as re
 
 log = logging.getLogger('ftp_list')
 

--- a/flexget/plugins/input/html.py
+++ b/flexget/plugins/input/html.py
@@ -3,7 +3,6 @@ import urlparse
 import logging
 import urllib
 import zlib
-import re
 from jinja2 import Template
 
 from flexget import plugin
@@ -11,6 +10,7 @@ from flexget.event import event
 from flexget.entry import Entry
 from flexget.utils.soup import get_soup
 from flexget.utils.cached_input import cached
+from flexget.utils import regex as re
 
 log = logging.getLogger('html')
 

--- a/flexget/plugins/input/myepisodes_list.py
+++ b/flexget/plugins/input/myepisodes_list.py
@@ -1,11 +1,11 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 from itertools import chain
 
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils.cached_input import cached
 from flexget.utils.soup import get_soup
 

--- a/flexget/plugins/input/plex.py
+++ b/flexget/plugins/input/plex.py
@@ -1,6 +1,5 @@
 """Plugin for plex media server (www.plexapp.com)."""
 from xml.dom.minidom import parseString
-import re
 import logging
 import os
 from os.path import basename
@@ -9,6 +8,7 @@ from socket import gethostbyname
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils import requests
 
 log = logging.getLogger('plex')

--- a/flexget/plugins/input/regexp_parse.py
+++ b/flexget/plugins/input/regexp_parse.py
@@ -1,12 +1,12 @@
 from __future__ import unicode_literals, division, absolute_import
 import codecs
-import re
 import logging
 import os
 
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils.cached_input import cached
 
 log = logging.getLogger('regexp_parse')

--- a/flexget/plugins/input/rlslog.py
+++ b/flexget/plugins/input/rlslog.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 import time
 
 from requests import RequestException
@@ -8,6 +7,7 @@ from requests import RequestException
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils.imdb import extract_id
 from flexget.utils.log import log_once
 from flexget.utils.soup import get_soup

--- a/flexget/plugins/input/tail.py
+++ b/flexget/plugins/input/tail.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals, division, absolute_import
 import os
-import re
 import logging
 
 from sqlalchemy import Column, Integer, Unicode
@@ -10,6 +9,7 @@ from flexget.db_schema import versioned_base
 from flexget.entry import Entry
 from flexget.event import event
 from flexget.manager import Session
+from flexget.utils import regex as re
 
 log = logging.getLogger('tail')
 Base = versioned_base('tail', 0)

--- a/flexget/plugins/input/text.py
+++ b/flexget/plugins/input/text.py
@@ -1,11 +1,11 @@
 """Plugin for text file or URL feeds via regex."""
 from __future__ import unicode_literals, division, absolute_import
-import re
 import logging
 
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils.cached_input import cached
 
 log = logging.getLogger('text')

--- a/flexget/plugins/input/thetvdb_favorites.py
+++ b/flexget/plugins/input/thetvdb_favorites.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
 import urllib2
-import re
 from datetime import datetime, timedelta
 
 from xml.etree import ElementTree
@@ -11,6 +10,7 @@ from flexget import db_schema, plugin
 from flexget.entry import Entry
 from flexget.event import event
 from flexget.manager import Session
+from flexget.utils import regex as re
 from flexget.utils.cached_input import cached
 from flexget.utils.database import pipe_list_synonym
 from flexget.utils.sqlalchemy_utils import drop_tables, table_columns

--- a/flexget/plugins/input/trakt_list.py
+++ b/flexget/plugins/input/trakt_list.py
@@ -1,12 +1,12 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 
 from requests import RequestException
 
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils.cached_input import cached
 from flexget.utils.trakt import get_api_url, get_session, make_list_slug
 

--- a/flexget/plugins/input/twitterfeed.py
+++ b/flexget/plugins/input/twitterfeed.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 
-from flexget import options, plugin
+from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 
 log = logging.getLogger('twitterfeed')
 

--- a/flexget/plugins/metainfo/content_size.py
+++ b/flexget/plugins/metainfo/content_size.py
@@ -1,11 +1,11 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 import math
 import os.path
 
 from flexget import plugin
 from flexget.event import event
+from flexget.utils import regex as re
 
 log = logging.getLogger('metanfo_csize')
 

--- a/flexget/plugins/metainfo/imdb_url.py
+++ b/flexget/plugins/metainfo/imdb_url.py
@@ -1,9 +1,9 @@
 from __future__ import unicode_literals, division, absolute_import
-import re
 import logging
 
 from flexget import plugin
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils.imdb import extract_id, make_url
 
 log = logging.getLogger('metainfo_imdb_url')

--- a/flexget/plugins/metainfo/magnet_info_hash.py
+++ b/flexget/plugins/metainfo/magnet_info_hash.py
@@ -1,9 +1,9 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 
 from flexget import plugin
 from flexget.event import event
+from flexget.utils import regex as re
 
 log = logging.getLogger('magnet_btih')
 

--- a/flexget/plugins/modify/manipulate.py
+++ b/flexget/plugins/modify/manipulate.py
@@ -1,9 +1,9 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 
 from flexget import plugin
 from flexget.event import event
+from flexget.utils import regex as re
 
 log = logging.getLogger('manipulate')
 

--- a/flexget/plugins/modify/plugin_rutracker.py
+++ b/flexget/plugins/modify/plugin_rutracker.py
@@ -8,16 +8,14 @@ from datetime import datetime, timedelta
 from sqlalchemy import Column, Unicode, Integer, DateTime
 from sqlalchemy.types import TypeDecorator, VARCHAR
 
-import re
 from flexget import plugin
 from flexget.event import event
 from flexget.db_schema import versioned_base
 from flexget.plugin import PluginError
 from flexget.manager import Session
-from requests import post
+from flexget.utils import regex as re
 from requests import Session as RSession
 from requests.auth import AuthBase
-from requests.cookies import cookiejar_from_dict
 from requests.utils import dict_from_cookiejar
 
 

--- a/flexget/plugins/modify/trackers.py
+++ b/flexget/plugins/modify/trackers.py
@@ -1,9 +1,9 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 
 from flexget import plugin
 from flexget.event import event
+from flexget.utils import regex as re
 
 log = logging.getLogger('modify_torrents')
 

--- a/flexget/plugins/output/decompress.py
+++ b/flexget/plugins/output/decompress.py
@@ -1,13 +1,12 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
 import os
-import re
 import shutil
 import zipfile
 
 from flexget import plugin
-from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils.template import render_from_entry, RenderError
 
 try:

--- a/flexget/plugins/output/rtorrent_magnet.py
+++ b/flexget/plugins/output/rtorrent_magnet.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 import os
 
 from flexget import plugin
 from flexget.event import event
+from flexget.utils import regex as re
 
 log = logging.getLogger('rtorrent_magnet')
 pat = re.compile('xt=urn:btih:([^&/]+)')

--- a/flexget/plugins/output/subtitles.py
+++ b/flexget/plugins/output/subtitles.py
@@ -1,12 +1,12 @@
 from __future__ import unicode_literals, division, absolute_import
 from xmlrpclib import ServerProxy
-import re
 import difflib
 import os.path
 import logging
 
 from flexget import plugin
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils.tools import urlopener
 
 """

--- a/flexget/plugins/parsers/parser_common.py
+++ b/flexget/plugins/parsers/parser_common.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals, division, absolute_import
 
 import logging
-import re
 from abc import abstractproperty, abstractmethod, ABCMeta
 from string import capwords
 
+from flexget.utils import regex as re
 from flexget.utils.tools import ReList
 
 

--- a/flexget/plugins/parsers/parser_guessit.py
+++ b/flexget/plugins/parsers/parser_guessit.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals, division, absolute_import
 
 import datetime
 import logging
-import re
 import time
 
 import guessit
@@ -13,6 +12,7 @@ from guessit.plugins.transformers import Transformer, add_transformer
 from flexget import plugin
 from flexget.event import event
 from flexget.utils import qualities
+from flexget.utils import regex as re
 from .parser_common import clean_value, old_assume_quality
 from .parser_common import ParsedEntry, ParsedVideoQuality, ParsedVideo, ParsedSerie, ParsedMovie
 

--- a/flexget/plugins/plugin_aria2.py
+++ b/flexget/plugins/plugin_aria2.py
@@ -1,13 +1,10 @@
 from __future__ import unicode_literals, division, absolute_import
-import os
 import logging
-import re
-import urlparse
 import xmlrpclib
 
 from flexget import plugin
 from flexget.event import event
-from flexget.entry import Entry
+from flexget.utils import regex as re
 from flexget.utils.template import RenderError
 from flexget.plugin import get_plugin_by_name
 

--- a/flexget/plugins/plugin_deluge.py
+++ b/flexget/plugins/plugin_deluge.py
@@ -4,7 +4,6 @@ import glob
 import logging
 import pkg_resources
 import os
-import re
 import sys
 import time
 import warnings
@@ -12,6 +11,7 @@ import warnings
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils.template import RenderError
 from flexget.utils.pathscrub import pathscrub
 

--- a/flexget/plugins/plugin_rtorrent.py
+++ b/flexget/plugins/plugin_rtorrent.py
@@ -3,7 +3,6 @@ import logging
 import sys
 import os
 import socket
-import re
 import xmlrpclib
 import httplib
 from time import sleep
@@ -15,6 +14,7 @@ from flexget import plugin
 from flexget.event import event
 from flexget.entry import Entry
 from flexget.config_schema import one_or_more
+from flexget.utils import regex as re
 from flexget.utils.bittorrent import Torrent, is_torrent_file
 
 

--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -5,12 +5,12 @@ from datetime import timedelta
 from netrc import netrc, NetrcParseError
 import logging
 import base64
-import re
 from urlparse import urlparse
 
 from flexget import plugin, validator
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils.template import RenderError
 from flexget.utils.pathscrub import pathscrub
 from flexget.utils.tools import parse_timedelta

--- a/flexget/plugins/search_cpasbien.py
+++ b/flexget/plugins/search_cpasbien.py
@@ -1,14 +1,14 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 import urllib 
 
-from flexget import plugin, validator
+from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils import requests
 from flexget.utils.soup import get_soup
-from flexget.utils.search import torrent_availability, normalize_unicode
+from flexget.utils.search import normalize_unicode
 
 log = logging.getLogger('search_cpasbien')
 

--- a/flexget/plugins/search_ptn.py
+++ b/flexget/plugins/search_ptn.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils import requests
 from flexget.utils.imdb import extract_id
 from flexget.utils.soup import get_soup

--- a/flexget/plugins/search_publichd.py
+++ b/flexget/plugins/search_publichd.py
@@ -1,12 +1,12 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
 import urllib
-import re
 
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
 from flexget.config_schema import one_or_more
+from flexget.utils import regex as re
 from flexget.utils import requests
 from flexget.utils.soup import get_soup
 from flexget.utils.search import torrent_availability, normalize_unicode

--- a/flexget/plugins/search_sceneaccess.py
+++ b/flexget/plugins/search_sceneaccess.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 
 from urllib import quote
 
@@ -8,6 +7,7 @@ from flexget import plugin
 from flexget import validator
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils.soup import get_soup
 from flexget.utils.search import torrent_availability, normalize_unicode, clean_title
 from flexget.utils.requests import Session

--- a/flexget/plugins/search_torrentshack.py
+++ b/flexget/plugins/search_torrentshack.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 
 from urllib import quote
 
@@ -8,6 +7,7 @@ from flexget import plugin
 from flexget import validator
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils.soup import get_soup
 from flexget.utils.search import torrent_availability, normalize_unicode, clean_title
 from flexget.utils.requests import Session

--- a/flexget/plugins/services/myepisodes.py
+++ b/flexget/plugins/services/myepisodes.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals, division, absolute_import
 import logging
 import urllib
 import urllib2
-import re
 import cookielib
 from datetime import datetime
 
@@ -10,6 +9,7 @@ from sqlalchemy import Column, Integer, String, DateTime
 
 from flexget import db_schema, plugin
 from flexget.event import event
+from flexget.utils import regex as re
 
 try:
     from flexget.plugins.api_tvdb import lookup_series

--- a/flexget/plugins/services/pogcal_acquired.py
+++ b/flexget/plugins/services/pogcal_acquired.py
@@ -1,12 +1,12 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 from datetime import datetime
 
 from sqlalchemy import Column, Unicode, Integer
 
 from flexget import plugin
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils import requests
 from flexget.utils.soup import get_soup
 from flexget.utils.titles.series import name_to_re

--- a/flexget/plugins/services/torrent_cache.py
+++ b/flexget/plugins/services/torrent_cache.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 import random
 
 from flexget import plugin
 from flexget.event import event
+from flexget.utils import regex as re
 
 log = logging.getLogger('torrent_cache')
 

--- a/flexget/plugins/urlrewrite_deadfrog.py
+++ b/flexget/plugins/urlrewrite_deadfrog.py
@@ -1,11 +1,11 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 import urllib2
 
 from flexget import plugin
 from flexget.event import event
 from flexget.plugins.plugin_urlrewriting import UrlRewritingError
+from flexget.utils import regex as re
 from flexget.utils.tools import urlopener
 from flexget.utils.soup import get_soup
 

--- a/flexget/plugins/urlrewrite_divxatope.py
+++ b/flexget/plugins/urlrewrite_divxatope.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 
 from flexget import plugin
 from flexget.event import event
 from flexget.plugins.plugin_urlrewriting import UrlRewritingError
+from flexget.utils import regex as re
 from flexget.utils import requests
 from flexget.utils.soup import get_soup
 

--- a/flexget/plugins/urlrewrite_extratorrent.py
+++ b/flexget/plugins/urlrewrite_extratorrent.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import
 import logging
-import re
 import urllib
 import feedparser
 
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils.search import normalize_unicode
 
 log = logging.getLogger('extratorrent')

--- a/flexget/plugins/urlrewrite_eztv.py
+++ b/flexget/plugins/urlrewrite_eztv.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals, division, absolute_import
-import re
 import logging
 from urlparse import urlparse, urlunparse
 from requests import RequestException
@@ -7,7 +6,7 @@ from requests import RequestException
 from flexget import plugin
 from flexget.event import event
 from flexget.plugins.plugin_urlrewriting import UrlRewritingError
-from flexget.utils import requests
+from flexget.utils import regex as re
 from flexget.utils.soup import get_soup
 
 log = logging.getLogger('eztv')

--- a/flexget/plugins/urlrewrite_frenchtorrentdb.py
+++ b/flexget/plugins/urlrewrite_frenchtorrentdb.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals, division, absolute_import
-import re
 import logging
 
 from flexget import plugin
 from flexget.event import event
 from flexget.plugins.plugin_urlrewriting import UrlRewritingError
+from flexget.utils import regex as re
 from flexget.utils.tools import urlopener
 from flexget.utils.soup import get_soup
 

--- a/flexget/plugins/urlrewrite_google_cse.py
+++ b/flexget/plugins/urlrewrite_google_cse.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals, division, absolute_import
-import re
 import urllib2
 import logging
 import urlparse
@@ -7,6 +6,7 @@ import urlparse
 from flexget import plugin
 from flexget.event import event
 from flexget.plugins.plugin_urlrewriting import UrlRewritingError
+from flexget.utils import regex as re
 from flexget.utils.requests import Session
 from flexget.utils.soup import get_soup
 from flexget.utils.tools import urlopener

--- a/flexget/plugins/urlrewrite_iptorrents.py
+++ b/flexget/plugins/urlrewrite_iptorrents.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals, division, absolute_import
-import re
 import urllib
 import logging
 
@@ -9,6 +8,7 @@ from flexget.config_schema import one_or_more
 from flexget.entry import Entry
 from flexget.event import event
 from flexget.plugins.plugin_urlrewriting import UrlRewritingError
+from flexget.utils import regex as re
 from flexget.utils import requests
 from flexget.utils.soup import get_soup
 from flexget.utils.search import torrent_availability, normalize_unicode

--- a/flexget/plugins/urlrewrite_isohunt.py
+++ b/flexget/plugins/urlrewrite_isohunt.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 import urllib
 
 import feedparser
@@ -8,6 +7,7 @@ import feedparser
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils.search import torrent_availability, normalize_unicode
 
 log = logging.getLogger('isohunt')

--- a/flexget/plugins/urlrewrite_koreus.py
+++ b/flexget/plugins/urlrewrite_koreus.py
@@ -1,11 +1,11 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 import urllib2
 
 from flexget import plugin
 from flexget.event import event
 from flexget.plugins.plugin_urlrewriting import UrlRewritingError
+from flexget.utils import regex as re
 from flexget.utils.tools import urlopener
 from flexget.utils.soup import get_soup
 

--- a/flexget/plugins/urlrewrite_newpct.py
+++ b/flexget/plugins/urlrewrite_newpct.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 
 from flexget import plugin
 from flexget.event import event
 from flexget.plugins.plugin_urlrewriting import UrlRewritingError
+from flexget.utils import regex as re
 from flexget.utils.requests import Session
 from flexget.utils.soup import get_soup
 

--- a/flexget/plugins/urlrewrite_newtorrents.py
+++ b/flexget/plugins/urlrewrite_newtorrents.py
@@ -2,13 +2,13 @@ from __future__ import unicode_literals, division, absolute_import
 import urllib
 import urllib2
 import logging
-import re
 import socket
 
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
 from flexget.plugins.plugin_urlrewriting import UrlRewritingError
+from flexget.utils import regex as re
 from flexget.utils.soup import get_soup
 from flexget.utils.tools import urlopener
 from flexget.utils.search import torrent_availability, normalize_unicode

--- a/flexget/plugins/urlrewrite_newzleech.py
+++ b/flexget/plugins/urlrewrite_newzleech.py
@@ -2,11 +2,11 @@ from __future__ import unicode_literals, division, absolute_import
 import urllib
 import urllib2
 import logging
-import re
 
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils.soup import get_soup
 from flexget.utils.tools import urlopener
 

--- a/flexget/plugins/urlrewrite_piratebay.py
+++ b/flexget/plugins/urlrewrite_piratebay.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals, division, absolute_import
-import re
 import urllib
 import logging
 
@@ -7,6 +6,7 @@ from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
 from flexget.plugins.plugin_urlrewriting import UrlRewritingError
+from flexget.utils import regex as re
 from flexget.utils import requests
 from flexget.utils.soup import get_soup
 from flexget.utils.search import torrent_availability, normalize_unicode

--- a/flexget/plugins/urlrewrite_serienjunkies.py
+++ b/flexget/plugins/urlrewrite_serienjunkies.py
@@ -1,12 +1,12 @@
 # coding=utf-8
 
 from __future__ import unicode_literals, division, absolute_import
-import re
 import logging
 
 from flexget import plugin
 from flexget.event import event
 from flexget.plugins.plugin_urlrewriting import UrlRewritingError
+from flexget.utils import regex as re
 from flexget.utils import requests
 from flexget.utils.soup import get_soup
 

--- a/flexget/plugins/urlrewrite_torrent411.py
+++ b/flexget/plugins/urlrewrite_torrent411.py
@@ -3,7 +3,6 @@ import urllib
 import urllib2
 import logging
 import json
-import re
 import cookielib
 
 from flexget import plugin
@@ -11,7 +10,7 @@ from flexget.config_schema import one_or_more
 from flexget.entry import Entry
 from flexget.event import event
 from flexget.plugins.plugin_urlrewriting import UrlRewritingError
-from flexget.utils import requests
+from flexget.utils import regex as re
 from flexget.utils.tools import arithmeticEval
 from flexget.utils.soup import get_soup
 from flexget.utils.search import torrent_availability, normalize_unicode

--- a/flexget/plugins/urlrewrite_torrentleech.py
+++ b/flexget/plugins/urlrewrite_torrentleech.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals, division, absolute_import
-import re
 import urllib
 import logging
 
@@ -8,6 +7,7 @@ from flexget.config_schema import one_or_more
 from flexget.entry import Entry
 from flexget.event import event
 from flexget.plugins.plugin_urlrewriting import UrlRewritingError
+from flexget.utils import regex as re
 from flexget.utils import requests
 from flexget.utils.soup import get_soup
 from flexget.utils.search import torrent_availability, normalize_unicode

--- a/flexget/plugins/urlrewrite_torrentz.py
+++ b/flexget/plugins/urlrewrite_torrentz.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 import urllib
 
 import feedparser
@@ -9,6 +8,7 @@ import requests
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils.search import torrent_availability, normalize_unicode
 
 log = logging.getLogger('torrentz')

--- a/flexget/plugins/urlrewrite_urlrewrite.py
+++ b/flexget/plugins/urlrewrite_urlrewrite.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals, division, absolute_import
-import re
 import logging
 
 from flexget import plugin
 from flexget.event import event
 from flexget.plugins.plugin_urlrewriting import UrlRewritingError
+from flexget.utils import regex as re
 
 log = logging.getLogger('urlrewrite')
 

--- a/flexget/utils/bittorrent.py
+++ b/flexget/utils/bittorrent.py
@@ -2,8 +2,9 @@
 # Torrent decoding is a short fragment from effbot.org. Site copyright says:
 # Test scripts and other short code fragments can be considered as being in the public domain.
 from __future__ import unicode_literals, division, absolute_import
-import re
 import logging
+
+from flexget.utils import regex as re
 
 log = logging.getLogger('torrent')
 

--- a/flexget/utils/imdb.py
+++ b/flexget/utils/imdb.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals, division, absolute_import
 import difflib
 import logging
-import re
 
 from bs4.element import Tag
 
+from flexget.utils import regex as re
 from flexget.utils.soup import get_soup
 from flexget.utils.requests import Session
 from flexget.utils.tools import str_to_int

--- a/flexget/utils/pathscrub.py
+++ b/flexget/utils/pathscrub.py
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals, division, absolute_import
 import ntpath
 import sys
-import re
+
+from flexget.utils import regex as re
 
 os_mode = None  # Can be 'windows', 'mac', 'linux' or None. None will auto-detect os.
 # Replacement order is important, don't use dicts to store

--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals, division, absolute_import
-import re
 import copy
 import logging
+
+from flexget.utils import regex as re
 
 log = logging.getLogger('utils.qualities')
 

--- a/flexget/utils/regex.py
+++ b/flexget/utils/regex.py
@@ -8,6 +8,8 @@ try:
     from regex import *
 except ImportError:
     from re import *
+    # This flag is not included in re.__all__
+    from re import DEBUG
     log.debug('Using stdlib `re` module for regex')
 else:
     log.debug('Using `regex` module for regex')

--- a/flexget/utils/regex.py
+++ b/flexget/utils/regex.py
@@ -4,14 +4,17 @@ import logging
 log = logging.getLogger('utils.regex')
 
 
+regex_module = 're'
+
 try:
-    from regex import *
+    from regexe import *
 except ImportError:
     from re import *
     # This flag is not included in re.__all__
     from re import DEBUG
     log.debug('Using stdlib `re` module for regex')
 else:
+    regex_module = 'regex'
     log.debug('Using `regex` module for regex')
     # Ensure we are in the backwards compatible mode by default
     import regex as _regex

--- a/flexget/utils/regex.py
+++ b/flexget/utils/regex.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+import logging
+
+log = logging.getLogger('utils.regex')
+
+
+try:
+    from regex import *
+except ImportError:
+    from re import *
+    log.debug('Using stdlib `re` module for regex')
+else:
+    log.debug('Using `regex` module for regex')
+    # Ensure we are in the backwards compatible mode by default
+    import regex as _regex
+    _regex.DEFAULT_VERSION = _regex.VERSION0

--- a/flexget/utils/search.py
+++ b/flexget/utils/search.py
@@ -1,8 +1,8 @@
 """ Common tools used by plugins implementing search plugin api """
 from __future__ import unicode_literals, division, absolute_import
-import re
 from unicodedata import normalize
 
+from flexget.utils import regex as re
 from flexget.utils.titles.parser import TitleParser
 
 

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -1,8 +1,6 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
 import os
-import re
-import sys
 from copy import copy
 from datetime import datetime, date, time
 import locale
@@ -13,6 +11,7 @@ from jinja2 import (Environment, StrictUndefined, ChoiceLoader, FileSystemLoader
                     TemplateNotFound, TemplateSyntaxError, Undefined)
 
 from flexget.event import event
+from flexget.utils import regex as re
 from flexget.utils.lazy_dict import LazyDict
 from flexget.utils.pathscrub import pathscrub
 

--- a/flexget/utils/titles/movie.py
+++ b/flexget/utils/titles/movie.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 
+from flexget.utils import regex as re
 from flexget.utils.titles.parser import TitleParser
 from flexget.utils import qualities
 from flexget.utils.tools import str_to_int

--- a/flexget/utils/titles/parser.py
+++ b/flexget/utils/titles/parser.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals, division, absolute_import
-import re
+from flexget.utils import regex as re
 
 
 class TitleParser(object):

--- a/flexget/utils/titles/series.py
+++ b/flexget/utils/titles/series.py
@@ -5,7 +5,7 @@ from string import capwords
 
 from dateutil.parser import parse as parsedate
 
-import re
+from flexget.utils import regex as re
 from flexget.utils.titles.parser import TitleParser
 from flexget.plugins.parsers import ParseWarning
 from flexget.plugins.parsers.parser_common import default_ignore_prefixes, name_to_re

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -7,7 +7,6 @@ import httplib
 import os
 import socket
 import time
-import re
 import sys
 import locale
 import Queue
@@ -18,6 +17,8 @@ from collections import MutableMapping
 from urlparse import urlparse
 from htmlentitydefs import name2codepoint
 from datetime import timedelta, datetime
+
+from flexget.utils import regex as re
 
 
 def str_to_boolean(string):

--- a/flexget/validator.py
+++ b/flexget/validator.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import re
-
 from flexget.config_schema import process_config
+from flexget.utils import regex as re
 
 
 # TODO: rename all validator.valid -> validator.accepts / accepted / accept ?


### PR DESCRIPTION
This branch uses the `regex` module from here if installed:
https://pypi.python.org/pypi/regex

This allows users to override regex flags in the config when this module is installed. e.g.
`(?i)something` to ignore case when the plugin doesn't by default
`(?V1-i)someTHING` to turn on case sensitivity even if plugin doesn't by default. (The V1 is necessary for toggling off flags)

TODO:
- [x] Add a better validator message if inline flags are attempted in config without regex module installed