### PR TITLE
fixed display issue with "flexget plugins"

### DIFF
--- a/flexget/plugins/cli/plugins.py
+++ b/flexget/plugins/cli/plugins.py
@@ -12,7 +12,7 @@ log = logging.getLogger('plugins')
 @event('manager.subcommand.plugins')
 def plugins_summary(manager, options):
     console('-' * 79)
-    console('%-20s%-30s%s' % ('Name', 'Roles (priority)', 'Info'))
+    console('%-30s%-s%-30s%-s%s' % ('Name', '|', 'Roles (priority)', '|', 'Info'))
     console('-' * 79)
 
     # print the list
@@ -29,7 +29,7 @@ def plugins_summary(manager, options):
             flags.append('debug')
         handlers = plugin.phase_handlers
         roles = ', '.join('%s(%s)' % (phase, handlers[phase].priority) for phase in handlers)
-        console('%-20s%-30s%s' % (plugin.name, roles, ', '.join(flags)))
+        console('%-30s%-s%-30s%-s%s' % (plugin.name, '|', roles, '|', ', '.join(flags)))
 
     console('-' * 79)
 


### PR DESCRIPTION
Some plugins names are too long and don't display correctly when running "flexget plugins". I've added a pipe as a visual split the columns and made the spacing between name and roles columns slightly wider.

The pipe also allow me to pipe the output through awk, which will be useful in the bash_completion script I'm writing for flexget.