### PR TITLE
regex_extract plugin

### DIFF
--- a/flexget/plugins/modify/regex_extract.py
+++ b/flexget/plugins/modify/regex_extract.py
@@ -1,0 +1,87 @@
+from __future__ import unicode_literals, division, absolute_import
+import logging
+import re
+
+from flexget import plugin
+from flexget.event import event
+from flexget.utils.tools import ReList
+from flexget.config_schema import one_or_more
+
+log = logging.getLogger('regex_extract')
+
+
+class RegexExtract(object):
+    """
+    Updates an entry with the values of regex matched named groups
+
+    Usage:
+
+      regex_extract:
+        field: <string>
+        regex:
+          - <regex>
+        [prefix]: <string>
+
+
+    Example:
+
+      regex_extract:
+        prefix: f1_
+        field: title
+        regex:
+          - Formula\.?1.(?P<location>*?)
+
+    """
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'prefix': {'type': 'string'},
+            'field': {'type': 'string'},
+            'regex': one_or_more({'type': 'string', 'format': 'regex'}),
+        },
+    }
+
+    def on_task_start(self, task, config):
+        regex = config.get('regex')
+        if isinstance(regex, basestring):
+            regex = [regex]
+        self.regex_list = ReList(regex)
+
+        # Check the regex
+        try:
+            for rx in self.regex_list:
+                pass
+        except re.error, e:
+            raise plugin.PluginError('Error compiling regex: %s' % str(e))
+
+    def on_task_modify(self, task, config):
+
+        prefix = config.get('prefix')
+        modified = 0
+
+        for entry in task.entries:
+            for rx in self.regex_list:
+                entry_field = entry.get('title')
+                log.debug('Matching %s with regex: %s' % (entry_field, rx))
+                try:
+                    match = rx.match(entry_field)
+                except re.error, e:
+                    raise plugin.PluginError('Error encountered processing regex: %s' % str(e))
+                if match:
+                    log.debug('Successfully matched %s' % entry_field)
+                    data = match.groupdict()
+                    if prefix:
+                        for key in data.keys():
+                            data[prefix + key] = data[key]
+                            del data[key]
+                    log.debug('Values added to entry: %s' % data)
+                    entry.update(data)
+                    modified += 1
+
+        log.info('%d entries matched and modified' % modified)
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(RegexExtract, 'regex_extract', api_ver=2)

--- a/tests/test_regex_extract.py
+++ b/tests/test_regex_extract.py
@@ -1,0 +1,73 @@
+from __future__ import unicode_literals, division, absolute_import
+from tests import FlexGetBase
+
+
+class TestRegexExtract(FlexGetBase):
+    __yaml__ = """
+        tasks:
+
+          test_1:
+            mock:
+              - {title: 'The.Event.New.York'}
+            regex_extract:
+              prefix: event_
+              field: title
+              regex:
+                - The\.Event\.(?P<location>.*)
+
+          test_2:
+            mock:
+              - {title: 'TheShow.Detroit'}
+            regex_extract:
+              prefix: event_
+              field: title
+              regex:
+                - The\.Event\.(?P<location>.*)
+
+          test_3:
+            mock:
+              - {title: 'The.Event.New.York'}
+            regex_extract:
+              field: title
+              regex:
+                - The\.Event\.(?P<location>.*)
+
+          test_4:
+            mock:
+              - {title: 'The.Event.New.York.2015'}
+            regex_extract:
+              prefix: event_
+              field: title
+              regex:
+                - The\.Event\.(?P<location>[\w\.]*?)\.(?P<year>\d{4})
+
+    """
+
+    def test_single_group(self):
+        self.execute_task('test_1')
+        entry = self.task.find_entry('entries', title='The.Event.New.York')
+        assert entry is not None
+        assert 'event_location' in entry
+        assert entry['event_location'] == 'New.York'
+
+    def test_single_group_non_match(self):
+        self.execute_task('test_2')
+        entry = self.task.find_entry('entries', title='TheShow.Detroit')
+        assert entry is not None
+        assert 'event_location' not in entry
+
+    def test_single_group_no_prefix(self):
+        self.execute_task('test_3')
+        entry = self.task.find_entry('entries', title='The.Event.New.York')
+        assert entry is not None
+        assert 'location' in entry
+        assert entry['location'] == 'New.York'
+
+    def test_multi_group(self):
+        self.execute_task('test_4')
+        entry = self.task.find_entry('entries', title='The.Event.New.York.2015')
+        assert entry is not None
+        assert 'event_location' in entry
+        assert 'event_year' in entry
+        assert entry['event_location'] == 'New.York'
+        assert entry['event_year'] == '2015'


### PR DESCRIPTION
This is a new plugin to allow an entry to be updated with the results of a regex over a specified field. This was created to scratch a personal itch of having to post-process Formula 1 from RFM, so with a good enough regex I can parse the title data and make it available for using with deluge ```movedone``` and ```content_filename```:

    regex_extract:
      prefix: f1_
      regex: ^Formula\.?1\.(?P<year>(?:19|20)\d{2})\.Round(?:\.)?(?P<round>\d{1,2})\.(?P<location>[a-zA-Z\.]*?)\.(?P<event>Teds\.(?:Qualifying|Race)\.Notebook|FP[1-3]|Quali(?:fying)?(?:\.Build-Up)?|Race(?:\.Build-Up)?|(?:Drivers\.|Team\.Principals\.)PC|Drivers\.Parade)(?:\.(?P<channel>SkySports(?:F1)?(?:HD)?|BBC(?:(?:One|Two)(?:HD)?)?|Sat\.Feed|ITV(?:HD)?|RTBF(?:HD)?|SkySportHD1|ORTF))?(?:\.(?P<quality>720p|1080(?:i|p)?|DVD|Web-Rip))?(?:\.(?P<codec>[XH]26[45]|MPEG-2|XVID|DIVX|MP3))?(?:\.(?P<language>English|French|German|Portuguese))?(?:\.(?P<comment>[\w\.]+))?(?:-(?P<group>[\w\.]+))?$
      field: title
    set:
      label: sport
      content_filename: "Formual 1 - Round {{ f1_round }} - {{ f1_location|int }} - {{ f1_event|replace('.', ' ') }}"
      movedone: "/srv/media/Sport/Motorsports/Formula 1/{{ f1_year }}/Round {{ f1_round|int }} - {{ f1_location|replace('.', ' ' }}/"

