### PR TITLE
Pin guessit to < 0.10.4, as it drops Py2.6 support.

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -25,7 +25,7 @@ options = environment.options
 install_requires = ['FeedParser>=5.1.3', 'SQLAlchemy >=0.7.5, !=0.9.0, <1.999', 'PyYAML',
                     'beautifulsoup4>=4.1, !=4.2.0, <4.4', 'html5lib>=0.11', 'PyRSS2Gen', 'pynzb', 'progressbar', 'rpyc',
                     'jinja2', 'requests>=1.0, !=2.4.0, <2.99', 'python-dateutil!=2.0, !=2.2', 'jsonschema>=2.0',
-                    'python-tvrage', 'tmdb3', 'path.py', 'guessit>=0.9.3', 'apscheduler']
+                    'python-tvrage', 'tmdb3', 'path.py', 'guessit>=0.9.3,<0.10.4', 'apscheduler']
 if sys.version_info < (2, 7):
     # argparse is part of the standard library in python 2.7+
     install_requires.append('argparse')


### PR DESCRIPTION
As title, recent test breakages are due to GuessIt dropping Python 2.6 support in a point release.