### PR TITLE
Bugfix for 'cannot import name path' with path.py 8.0

### DIFF
--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -11,7 +11,7 @@ import time
 import warnings
 from itertools import ifilter
 
-from path import path
+from path import Path
 from requests import RequestException
 
 from flexget import plugins as plugins_pkg
@@ -372,7 +372,7 @@ def _load_plugins_from_dirs(dirs):
     """
 
     log.debug('Trying to load plugins from: %s' % dirs)
-    dirs = [path(d) for d in dirs if os.path.isdir(d)]
+    dirs = [Path(d) for d in dirs if os.path.isdir(d)]
     # add all dirs to plugins_pkg load path so that imports work properly from any of the plugin dirs
     plugins_pkg.__path__ = map(_strip_trailing_sep, dirs)
     for plugins_dir in dirs:

--- a/flexget/plugins/filter/exists.py
+++ b/flexget/plugins/filter/exists.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals, division, absolute_import
 import logging
 import platform
 
-from path import path
+from path import Path
 
 from flexget import plugin
 from flexget.event import event
@@ -38,7 +38,7 @@ class FilterExists(object):
         config = self.prepare_config(config)
         filenames = {}
         for folder in config:
-            folder = path(folder).expanduser()
+            folder = Path(folder).expanduser()
             if not folder.exists():
                 raise plugin.PluginWarning('Path %s does not exist' % folder, log)
             for p in folder.walk(errors='ignore'):

--- a/flexget/plugins/filter/exists_movie.py
+++ b/flexget/plugins/filter/exists_movie.py
@@ -3,7 +3,7 @@ import os
 import re
 import logging
 
-from path import path
+from path import Path
 
 from flexget import plugin
 from flexget.event import event
@@ -81,7 +81,7 @@ class FilterExistsMovie(object):
         qualities = {}
 
         for folder in config['path']:
-            folder = path(folder).expanduser()
+            folder = Path(folder).expanduser()
             # see if this path has already been scanned
             if folder in self.cache:
                 log.verbose('Using cached scan for %s ...' % folder)

--- a/flexget/plugins/filter/exists_series.py
+++ b/flexget/plugins/filter/exists_series.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals, division, absolute_import
 import copy
 import logging
 
-from path import path
+from path import Path
 
 from flexget import plugin
 from flexget.event import event
@@ -77,7 +77,7 @@ class FilterExistsSeries(object):
             # make new parser from parser in entry
             series_parser = accepted_series[series][0]['series_parser']
             for folder in paths:
-                folder = path(folder).expanduser()
+                folder = Path(folder).expanduser()
                 if not folder.isdir():
                     log.warning('Directory %s does not exist', folder)
                     continue

--- a/flexget/plugins/input/find.py
+++ b/flexget/plugins/input/find.py
@@ -4,7 +4,7 @@ import logging
 import re
 import sys
 
-from path import path
+from path import Path
 
 from flexget import plugin
 from flexget.config_schema import one_or_more
@@ -65,7 +65,7 @@ class InputFind(object):
         entries = []
         match = re.compile(config['regexp'], re.IGNORECASE).match
         for folder in config['path']:
-            folder = path(folder).expanduser()
+            folder = Path(folder).expanduser()
             log.debug('scanning %s' % folder)
             if config['recursive']:
                 files = folder.walk(errors='ignore')

--- a/flexget/plugins/input/listdir.py
+++ b/flexget/plugins/input/listdir.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals, division, absolute_import
 import os
 import logging
 
-from path import path
+from path import Path
 
 from flexget import plugin
 from flexget.entry import Entry
@@ -30,7 +30,7 @@ class Listdir(object):
             config = [config]
         entries = []
         for folder in config:
-            folder = path(folder).expanduser()
+            folder = Path(folder).expanduser()
             try:
                 dir_files = folder.listdir()
             except OSError as e:


### PR DESCRIPTION
The update to path.py removes the lowercase path alias which flexget relies on
Simply change it to use 'Path' instead of 'path.

http://flexget.com/ticket/3064 