### PR TITLE
Fix incorrect reference to path module

### DIFF
--- a/flexget/plugins/filter/exists.py
+++ b/flexget/plugins/filter/exists.py
@@ -49,7 +49,7 @@ class FilterExists(object):
                 filenames[key] = p
         for entry in task.accepted:
             # priority is: filename, location (filename only), title
-            name = path(entry.get('filename', entry.get('location', entry['title']))).name
+            name = Path(entry.get('filename', entry.get('location', entry['title']))).name
             if platform.system() == 'Windows':
                 name = name.lower()
             if name in filenames:


### PR DESCRIPTION
Commit dd7d32c4568aaeb871da05a8c2fe354e0dd935e7 missed a reference to Path which causes the plugin to crash (http://flexget.com/ticket/3069). This should fix it.