### PR TITLE
Subliminal should fail if no subs were downloaded

### DIFF
--- a/flexget/plugins/output/subtitles_subliminal.py
+++ b/flexget/plugins/output/subtitles_subliminal.py
@@ -130,7 +130,7 @@ class PluginSubliminal(object):
                     else:
                         subtitle = subliminal.download_best_subtitles([video], entry_langs, providers=providers_list,
                                                                       min_score=msc)
-                        if subtitle:
+                        if subtitle and any(subtitle.values()):
                             downloaded_subtitles.update(subtitle)
                             log.info('Subtitles found for %s' % entry['location'])
                         else:
@@ -142,7 +142,7 @@ class PluginSubliminal(object):
                                 subtitle = subliminal.download_best_subtitles([video], remaining_alts,
                                                                               providers=providers_list, min_score=msc)
                             # this potentially just checks an already checked assignment bleh
-                            if subtitle:
+                            if subtitle and any(subtitle.values()):
                                 downloaded_subtitles.update(subtitle)
                                 entry.fail('subtitles found for a second-choice language.')
                             else:


### PR DESCRIPTION
subliminal.download_best_subtitles might return dictionaries with keys but empty values (None or empty lists). In this case, no subtitle was downloaded and the entry should fail.