### PR TITLE
Fix missing "host" variable which causes sftp_list to crash

### DIFF
--- a/flexget/plugins/plugin_sftp.py
+++ b/flexget/plugins/plugin_sftp.py
@@ -188,7 +188,7 @@ class SftpList(object):
         if not isinstance(dirs, list):
             dirs = [dirs]
         
-        log.debug('Connecting to %s' % host)
+        log.debug('Connecting to %s' % config['host'])
 
         sftp = sftp_from_config(config)
         url_prefix = sftp_prefix(config)


### PR DESCRIPTION
Simple fix for a regression introduced with changes for sftp_upload