### PR TITLE
s/Path/path in plugins/filter/exists.py

### DIFF
--- a/flexget/plugins/filter/exists.py
+++ b/flexget/plugins/filter/exists.py
@@ -49,7 +49,7 @@ class FilterExists(object):
                 filenames[key] = p
         for entry in task.accepted:
             # priority is: filename, location (filename only), title
-            name = Path(entry.get('filename', entry.get('location', entry['title']))).name
+            name = path(entry.get('filename', entry.get('location', entry['title']))).name
             if platform.system() == 'Windows':
                 name = name.lower()
             if name in filenames:


### PR DESCRIPTION
Fix a typo that was merged by accident in 7ce23de951a6ebfe7937f9532d6a86cb1e0ea0a7 and results in:
`BUG: Unhandled error in plugin exists: global name 'Path' is not defined`