### PR TITLE
Prefer particular atom:link types

### DIFF
--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -424,17 +424,48 @@ class InputRSS(object):
             e = Entry()
 
             if not isinstance(config.get('link'), list):
-                # If the link field is not a list, search for first valid url
+                # If the link field is not a list, search for preferred valid url
                 if config['link'] == 'auto':
                     # Auto mode, check for a single enclosure url first
                     if len(entry.get('enclosures', [])) == 1 and entry['enclosures'][0].get('href'):
                         self.add_enclosure_info(e, entry['enclosures'][0], config.get('filename', True))
                     else:
-                        # If there is no enclosure url, check link, then guid field for urls
-                        for field in ['link', 'guid']:
-                            if entry.get(field):
-                                e['url'] = entry[field]
-                                break
+                        # If there is no single enclosure url, check all links and the GUID,
+                        # choose highest scoring of them
+                        # Give a score boost to particular mime types and link relations
+                        boost_types = {
+                            'application/x-bittorrent': 3,
+                            'application/x-nzb': 3,
+                        }
+                        boost_relations = {
+                            'enclosure': -100, # For backwards compatibility, don't consider these
+                            'alternate': 2,
+                        }
+                        best_score = -1
+
+                        # If there is a GUID, use it with a score of 0
+                        if entry.get('guid'):
+                            log.debug("Entry URL from GUID '%s' has score 0", entry.get('guid'))
+                            e['url'] = entry.get('guid')
+                            best_score = 0
+
+                        # Loop over links and assign scores to them; use that with the best score
+                        for link in entry.get('links', []):
+                            if 'href' not in link:
+                                continue
+                            score = 0
+                            if 'type' in link and link['type'] in boost_types:
+                                score += boost_types[link['type']]
+                            if 'rel' in link and link['rel'] in boost_relations:
+                                score += boost_relations[link['rel']]
+                            log.debug("Link of relation %s, type %s, '%s' has score %d",
+                                    link['rel'] if 'rel' in link else '[none]',
+                                    link['type'] if 'type' in link else '[none]',
+                                    link['href'],
+                                    score)
+                            if score > best_score:
+                                e['url'] = link['href']
+                                best_score = score
                 else:
                     if entry.get(config['link']):
                         e['url'] = entry[config['link']]

--- a/tests/rss.xml
+++ b/tests/rss.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:other="http://localhost/flexget">
+<rss version="2.0" xmlns:other="http://localhost/flexget" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>FlexGet RSS test</title>
     <ttl>15</ttl>
@@ -22,6 +22,17 @@
       <enclosure url="http://localhost/enclosure1"/>
       <enclosure url="http://localhost/enclosure2"/>
       <enclosure url="http://localhost/enclosure3"/>
+    </item>
+
+    <item>
+      <title>Alternate links</title>
+      <link>http://localhost/alternate_links</link>
+      <pubDate>Sun, 28 Dec 2008 14:00:00 -0200</pubDate>
+      <description>Description, alternate_links</description>
+      <atom:link rel="alternate" type="text/html" href="http://localhost/alternate_1_html"/>
+      <atom:link rel="alternate" type="image/png" href="http://localhost/alternate_2_png"/>
+      <atom:link rel="alternate" type="application/x-bittorrent" href="http://localhost/alternate_3_bittorrent"/>
+      <atom:link rel="alternate" type="text/plain" href="http://localhost/alternate_4_plain"/>
     </item>
 
     <item>

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -27,6 +27,9 @@ class TestInputRSS(object):
             rss:
               <<: *rss
               group_links: yes
+          test_alternate_links:
+            rss:
+              <<: *rss
           test_multiple_links:
             rss:
               <<: *rss
@@ -116,6 +119,12 @@ class TestInputRSS(object):
         for url in urls:
             assert not task.find_entry(title='Multiple enclosures', url=url), \
                 'Should not have created an entry for each enclosure'
+
+    def test_alternate_links(self, execute_task):
+        task = execute_task('test_alternate_links')
+        # Test the link with the preferred type was chosen
+        entry = task.find_entry(title='Alternate links', url='http://localhost/alternate_3_bittorrent')
+        assert entry, 'Link with preferred type was not selected'
 
     def test_multiple_links(self, execute_task):
         task = execute_task('test_multiple_links')


### PR DESCRIPTION
When multiple atom:link elements are present, instead of choosing the first one, score each and pick the one with the highest score.
- Links with rel="alternate" are given a score boost
- Links with rel="enclosure" are given a significant score penalty (this is so old behaviour is followed when there are multiple enclosures; perhaps this should change; discussed below)
- Other "rel" values (the spec lists "self", "via", "related") have no effect
- Links with type="application/x-bittorrent" and "application/x-nzb" are given a score boost

Addresses http://flexget.com/ticket/2997

I wonder if I can get some thoughts on this.

The basic rationale is that links with type="alternate" and suitable mime types should be treated the same way as enclosures.

This is not quite what I've done, since the expected behaviour of group_links isn't clear to me with various combinations of enclosures and other types of links. This is why I've given rel="enclosure" links a penalty: otherwise, the "group_links"/"multiple enclosures" test fails. I really think it should have a boost, however. Can somebody shed some light on this? I have a feeling the code in this whole area could be massively simplified (not just the parts I've replaced), but I just don't know what's there for a real-world reason and what isn't.

Some other points to discuss:
- Should the mime types which get a boost and their score modifiers be configurable? Or should there be any others added to the hardcoded list?
- Should the link relationship types and their modifiers also be configurable?
