### PR TITLE
Ui build capitalisation

### DIFF
--- a/flexget/ui/gulpfile.js
+++ b/flexget/ui/gulpfile.js
@@ -1,7 +1,1 @@
-require('./gulp/gulpFile.js');
-
-
-
-
-
-
+require('./gulp/gulpfile.js');

--- a/flexget/ui/sass/flexget.scss
+++ b/flexget/ui/sass/flexget.scss
@@ -5,7 +5,7 @@
 @import "font-awesome";
 @import "angular-material";
 @import "ui-grid";
-@import '../bower_components/spinkit/scss/spinners/3-wave';
+@import '../bower_components/SpinKit/scss/spinners/3-wave';
 
 // Flexget includes
 @import "header";


### PR DESCRIPTION
There are two capitalisation typos in the UI build system files which prevent the tools from being used properly, at least on a case-sensitive filesystem.