### PR TITLE
myepisodes_list: upgrade to new urls, fixes login

### DIFF
--- a/flexget/plugins/input/myepisodes_list.py
+++ b/flexget/plugins/input/myepisodes_list.py
@@ -53,12 +53,12 @@ class MyEpisodesList(object):
                 'password': password,
                 'action': 'Login'
             }
-            loginsrc = task.requests.post(URL + 'login.php', data=params).content
+            loginsrc = task.requests.post(URL + 'login.php?action=login', data=params).content
             if str(username) not in loginsrc:
                 raise plugin.PluginWarning(('Login to myepisodes.com failed, please check '
                                  'your account data or see if the site is down.'), log)
 
-        page = task.requests.get(URL + "shows.php?type=manage").content
+        page = task.requests.get(URL + "myshows/manage/").content
         try:
             soup = get_soup(page)
         except Exception as e:


### PR DESCRIPTION
myepisodes.com seems to have changed some URLs, and requires a
action=login GET (!) parameter in the URL for a successful login.
The "manage shows" URL used to parse the shows has been changed
as well (albeit the old url still working).