### PR TITLE
Fix in imdb_list: Enable forcing movie title languages 

### DIFF
--- a/flexget/plugins/input/imdb_list.py
+++ b/flexget/plugins/input/imdb_list.py
@@ -58,7 +58,7 @@ class ImdbList(object):
             url = 'http://www.imdb.com/list/%s' % config['list']
 
         headers = {'Accept-Language': config.get('force_language')}
-        log.debug('Requesting: %s' % url, headers=headers)
+        log.debug('Requesting: %s %s' % (url, headers))
         page = task.requests.get(url, params=params, headers=headers)
         if page.status_code != 200:
             raise plugin.PluginError('Unable to get imdb list. Either list is private or does not exist.')

--- a/flexget/plugins/input/imdb_list.py
+++ b/flexget/plugins/input/imdb_list.py
@@ -32,7 +32,10 @@ class ImdbList(object):
                     {'pattern': CUSTOM_LIST_RE}
                 ],
                 'error_oneOf': 'list must be either %s, or a custom list name (lsXXXXXXXXX)' % ', '.join(USER_LISTS)
-            }
+            },
+            'force_language':
+                {'type': 'string',
+                 'default': 'en-us'}
         },
         'additionalProperties': False,
         'required': ['list'],
@@ -54,8 +57,9 @@ class ImdbList(object):
         else:
             url = 'http://www.imdb.com/list/%s' % config['list']
 
-        log.debug('Requesting: %s' % url)
-        page = task.requests.get(url, params=params)
+        headers = {'Accept-Language': config.get('force_language')}
+        log.debug('Requesting: %s' % url, headers=headers)
+        page = task.requests.get(url, params=params, headers=headers)
         if page.status_code != 200:
             raise plugin.PluginError('Unable to get imdb list. Either list is private or does not exist.')
 


### PR DESCRIPTION
Enable forcing different movie title languages based on LCID language strings. Default is en-us.:
http://www.science.co.il/Language/Locale-codes.asp

This fixes an issue where IMDB would force a language based on default HTML header