### PR TITLE
Require a more recent version of FeedParser

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -27,7 +27,7 @@ options = environment.options
 # There is a bug in beautifulsoup 4.2.0 that breaks imdb parsing, see http://flexget.com/ticket/2091
 # There is a bug in requests 2.4.0 where it leaks urllib3 exceptions
 install_requires = [
-    'FeedParser>=5.1.3', 'SQLAlchemy >=0.7.5, !=0.9.0, <1.999', 'PyYAML',
+    'FeedParser>=5.2.1', 'SQLAlchemy >=0.7.5, !=0.9.0, <1.999', 'PyYAML',
     'beautifulsoup4>=4.1, !=4.2.0, <4.4', 'html5lib>=0.11', 'PyRSS2Gen', 'pynzb', 'progressbar', 'rpyc',
     'jinja2', 'requests>=1.0, !=2.4.0, <2.99', 'python-dateutil!=2.0, !=2.2', 'jsonschema>=2.0',
     'python-tvrage', 'tmdb3', 'path.py', 'guessit>=0.9.3, <0.10.4', 'apscheduler',


### PR DESCRIPTION
The newer versions drop the Python2-only BeautifulSoup3 requirement.