### PR TITLE
Normalize string according to scene standards

### DIFF
--- a/flexget/plugins/search_rarbg.py
+++ b/flexget/plugins/search_rarbg.py
@@ -7,7 +7,7 @@ from flexget.entry import Entry
 from flexget.event import event
 from flexget.config_schema import one_or_more
 from flexget.utils.requests import Session, get
-from flexget.utils.search import normalize_unicode
+from flexget.utils.search import normalize_scene
 
 log = logging.getLogger('rarbg')
 
@@ -117,7 +117,7 @@ class SearchRarBG(object):
             if entry.get('movie_name'):
                 params['search_imdb'] = entry.get('imdb_id')
             else:
-                query = normalize_unicode(search_string)
+                query = normalize_scene(search_string)
                 query_url_fragment = query.encode('utf8')
                 params['search_string'] = query_url_fragment
                 if config['use_tvdb']:

--- a/flexget/utils/search.py
+++ b/flexget/utils/search.py
@@ -30,6 +30,24 @@ def normalize_unicode(text):
     return text
 
 
+def normalize_scene(text):
+    """Normalize string according to scene standard.
+    Mainly, it replace accented chars by their 'normal' couterparts
+    and removes special chars.
+    https://en.wikipedia.org/wiki/Standard_(warez)#Naming for more information
+    """
+    if not isinstance(text, unicode):
+        text = unicode(text, "unicode-escape")
+
+    # Allowed chars in scene releases are:
+    #     ABCDEFGHIJKLMNOPQRSTUVWXYZ
+    #     abcdefghijklmnopqrstuvwxyz
+    #     0123456789-._()
+    return re.sub(r'[^a-zA-Z0-1 \-._()]',
+                  "",
+                  normalize('NFKD', text).encode('ASCII', 'ignore'))
+
+
 def torrent_availability(seeds, leeches):
     """Returns a rating based on seeds and leeches for a given torrent.
 


### PR DESCRIPTION
Some search engines provide scene based releases only (such as rarbg) so searching using actual movies/series names is pointless and won't return anything if it contains special chars.

According to the rules I found online, I added an utils/search function to normalize a string to scene format.
source: https://en.wikipedia.org/wiki/Standard_(warez)#Naming

As an exemple, I use it in search_rarbg input plugin. I guess it can be reused (and maybe useful) for many search plugins (as an option to search only scene releases, etc.)