### PR TITLE
Fix numerous bugs and issues in FTP over TLS for ftp_list and ftp_download

### DIFF
--- a/flexget/plugins/input/ftp_list.py
+++ b/flexget/plugins/input/ftp_list.py
@@ -148,7 +148,8 @@ class InputFtpList(object):
                                   recursive, get_size, encoding)
 
             if not files_only or mlst.get('type') == 'file':
-                url = baseurl + urllib.quote_plus(path) + '/' + urllib.quote_plus(p)
+                url = baseurl + urllib.quote(path) + '/' + urllib.quote(p)
+                log.debug("Encoded URL: " + url)
                 title = os.path.basename(p)
                 log.info('Accepting entry "%s" [%s]' % (path + '/' + p, mlst.get('type') or "unknown",))
                 entry = Entry(title, url)

--- a/flexget/plugins/input/ftp_list.py
+++ b/flexget/plugins/input/ftp_list.py
@@ -2,6 +2,7 @@ import logging
 import ftplib
 import os
 import re
+import urllib
 
 from flexget import plugin
 from flexget.event import event
@@ -73,6 +74,8 @@ class InputFtpList(object):
         try:
             ftp.connect(connection_config['host'], connection_config['port'])
             ftp.login(connection_config['username'], connection_config['password'])
+            if connection_config['use-ssl']:
+                ftp.prot_p()
         except ftplib.all_errors as e:
             raise plugin.PluginError(e)
 
@@ -111,6 +114,8 @@ class InputFtpList(object):
 
             self._handle_path(entries, ftp, baseurl, path, mlst_supported, files_only, recursive, get_size, encoding)
 
+	ftp.close()
+
         return entries
 
     def _handle_path(self, entries, ftp, baseurl, path='', mlst_supported=False, files_only=False, recursive=False,
@@ -143,8 +148,7 @@ class InputFtpList(object):
                                   recursive, get_size, encoding)
 
             if not files_only or mlst.get('type') == 'file':
-                url = baseurl + path + '/' + p
-                url = url.replace(' ', '%20')
+                url = baseurl + urllib.quote_plus(path) + '/' + urllib.quote_plus(p)
                 title = os.path.basename(p)
                 log.info('Accepting entry "%s" [%s]' % (path + '/' + p, mlst.get('type') or "unknown",))
                 entry = Entry(title, url)
@@ -158,7 +162,7 @@ class InputFtpList(object):
                 elif get_size:
                     entry['content_size'] = float(mlst.get('size')) / (1024 * 1024)
                 entries.append(entry)
-        
+
     def parse_mlst(self, mlst):
         re_results = re.findall('(.*?)=(.*?);', mlst)
         parsed = {}

--- a/flexget/plugins/input/ftp_list.py
+++ b/flexget/plugins/input/ftp_list.py
@@ -73,8 +73,6 @@ class InputFtpList(object):
         try:
             ftp.connect(connection_config['host'], connection_config['port'])
             ftp.login(connection_config['username'], connection_config['password'])
-            if connection_config['use-ssl']:
-                ftp.prot_p()
         except ftplib.all_errors as e:
             raise plugin.PluginError(e)
 
@@ -112,8 +110,6 @@ class InputFtpList(object):
                                               connection_config['host'], connection_config['port'])
 
             self._handle_path(entries, ftp, baseurl, path, mlst_supported, files_only, recursive, get_size, encoding)
-
-	ftp.close()
 
         return entries
 

--- a/flexget/plugins/input/ftp_list.py
+++ b/flexget/plugins/input/ftp_list.py
@@ -73,6 +73,8 @@ class InputFtpList(object):
         try:
             ftp.connect(connection_config['host'], connection_config['port'])
             ftp.login(connection_config['username'], connection_config['password'])
+            if connection_config['use-ssl']:
+                ftp.prot_p()
         except ftplib.all_errors as e:
             raise plugin.PluginError(e)
 
@@ -110,6 +112,8 @@ class InputFtpList(object):
                                               connection_config['host'], connection_config['port'])
 
             self._handle_path(entries, ftp, baseurl, path, mlst_supported, files_only, recursive, get_size, encoding)
+
+	ftp.close()
 
         return entries
 

--- a/flexget/plugins/output/ftp_download.py
+++ b/flexget/plugins/output/ftp_download.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import ftplib
-import urllib
 from urlparse import urlparse
 
 from flexget import plugin
@@ -19,9 +18,8 @@ class OutputFtp(object):
 
         config:
             ftp_download:
-              use-ssl: <True/False>
-              ftp_tmp_path: <path>
-              delete_origin: <True/False>
+              tls: False
+              ftp_tmp_path: /tmp
 
         TODO:
           - Resume downloads
@@ -51,16 +49,11 @@ class OutputFtp(object):
             ftp = ftplib.FTP_TLS()
         else:
             ftp = ftplib.FTP()
-
-	ftp.set_debuglevel(2)
         log.debug("Connecting to " + ftp_url.hostname)
         ftp.connect(ftp_url.hostname, ftp_url.port)
         ftp.login(ftp_url.username, ftp_url.password)
-	if config['use-ssl']:
-            ftp.prot_p()
         ftp.sendcmd('TYPE I')
         ftp.set_pasv(True)
-        log.debug("Changing directory to: " + current_path)
         ftp.cwd(current_path)
 
         return ftp
@@ -76,12 +69,11 @@ class OutputFtp(object):
         config = self.prepare_config(config, task)
         for entry in task.accepted:
             ftp_url = urlparse(entry.get('url'))
-            ftp_url = ftp_url._replace(path = urllib.unquote_plus(ftp_url.path))
             current_path = os.path.dirname(ftp_url.path)
             try:
                 ftp = self.ftp_connect(config, ftp_url, current_path)
-            except ftplib.all_errors as e:
-                entry.fail("Unable to connect to server : %s" % (e))
+            except:
+                entry.failed("Unable to connect to server")
                 break
 
             if not os.path.isdir(config['ftp_tmp_path']):

--- a/flexget/plugins/output/ftp_download.py
+++ b/flexget/plugins/output/ftp_download.py
@@ -52,7 +52,7 @@ class OutputFtp(object):
         else:
             ftp = ftplib.FTP()
 
-	ftp.set_debuglevel(2)
+	# ftp.set_debuglevel(2)
         log.debug("Connecting to " + ftp_url.hostname)
         ftp.connect(ftp_url.hostname, ftp_url.port)
         ftp.login(ftp_url.username, ftp_url.password)

--- a/flexget/plugins/output/ftp_download.py
+++ b/flexget/plugins/output/ftp_download.py
@@ -52,7 +52,7 @@ class OutputFtp(object):
         else:
             ftp = ftplib.FTP()
 
-	# ftp.set_debuglevel(2)
+	ftp.set_debuglevel(2)
         log.debug("Connecting to " + ftp_url.hostname)
         ftp.connect(ftp_url.hostname, ftp_url.port)
         ftp.login(ftp_url.username, ftp_url.password)

--- a/flexget/plugins/output/ftp_download.py
+++ b/flexget/plugins/output/ftp_download.py
@@ -76,7 +76,7 @@ class OutputFtp(object):
         config = self.prepare_config(config, task)
         for entry in task.accepted:
             ftp_url = urlparse(entry.get('url'))
-            ftp_url = ftp_url._replace(path = urllib.unquote_plus(ftp_url.path))
+            ftp_url = ftp_url._replace(path = urllib.unquote(ftp_url.path))
             current_path = os.path.dirname(ftp_url.path)
             try:
                 ftp = self.ftp_connect(config, ftp_url, current_path)

--- a/flexget/plugins/output/ftp_download.py
+++ b/flexget/plugins/output/ftp_download.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import ftplib
+import urllib
 from urlparse import urlparse
 
 from flexget import plugin
@@ -18,8 +19,9 @@ class OutputFtp(object):
 
         config:
             ftp_download:
-              tls: False
-              ftp_tmp_path: /tmp
+              use-ssl: <True/False>
+              ftp_tmp_path: <path>
+              delete_origin: <True/False>
 
         TODO:
           - Resume downloads
@@ -49,11 +51,16 @@ class OutputFtp(object):
             ftp = ftplib.FTP_TLS()
         else:
             ftp = ftplib.FTP()
+
+        # ftp.set_debuglevel(2)
         log.debug("Connecting to " + ftp_url.hostname)
         ftp.connect(ftp_url.hostname, ftp_url.port)
         ftp.login(ftp_url.username, ftp_url.password)
+	if config['use-ssl']:
+            ftp.prot_p()
         ftp.sendcmd('TYPE I')
         ftp.set_pasv(True)
+        log.debug("Changing directory to: " + current_path)
         ftp.cwd(current_path)
 
         return ftp
@@ -69,11 +76,12 @@ class OutputFtp(object):
         config = self.prepare_config(config, task)
         for entry in task.accepted:
             ftp_url = urlparse(entry.get('url'))
+            ftp_url = ftp_url._replace(path = urllib.unquote_plus(ftp_url.path))
             current_path = os.path.dirname(ftp_url.path)
             try:
                 ftp = self.ftp_connect(config, ftp_url, current_path)
-            except:
-                entry.failed("Unable to connect to server")
+            except ftplib.all_errors as e:
+                entry.fail("Unable to connect to server : %s" % (e))
                 break
 
             if not os.path.isdir(config['ftp_tmp_path']):

--- a/flexget/plugins/output/ftp_download.py
+++ b/flexget/plugins/output/ftp_download.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import ftplib
+import urllib
 from urlparse import urlparse
 
 from flexget import plugin
@@ -18,8 +19,9 @@ class OutputFtp(object):
 
         config:
             ftp_download:
-              tls: False
-              ftp_tmp_path: /tmp
+              use-ssl: <True/False>
+              ftp_tmp_path: <path>
+              delete_origin: <True/False>
 
         TODO:
           - Resume downloads
@@ -49,11 +51,16 @@ class OutputFtp(object):
             ftp = ftplib.FTP_TLS()
         else:
             ftp = ftplib.FTP()
+
+	ftp.set_debuglevel(2)
         log.debug("Connecting to " + ftp_url.hostname)
         ftp.connect(ftp_url.hostname, ftp_url.port)
         ftp.login(ftp_url.username, ftp_url.password)
+	if config['use-ssl']:
+            ftp.prot_p()
         ftp.sendcmd('TYPE I')
         ftp.set_pasv(True)
+        log.debug("Changing directory to: " + current_path)
         ftp.cwd(current_path)
 
         return ftp
@@ -69,11 +76,12 @@ class OutputFtp(object):
         config = self.prepare_config(config, task)
         for entry in task.accepted:
             ftp_url = urlparse(entry.get('url'))
+            ftp_url = ftp_url._replace(path = urllib.unquote_plus(ftp_url.path))
             current_path = os.path.dirname(ftp_url.path)
             try:
                 ftp = self.ftp_connect(config, ftp_url, current_path)
-            except:
-                entry.failed("Unable to connect to server")
+            except ftplib.all_errors as e:
+                entry.fail("Unable to connect to server : %s" % (e))
                 break
 
             if not os.path.isdir(config['ftp_tmp_path']):


### PR DESCRIPTION
Fix some bugs that broke FTP over TLS as well as bugs that broke ftp_list and ftp_download when file and folder names had special characters. Added better logging in some instances to help diagnose issues. Also fixed a bug where the original coder was incorrectly calling entry.failed(...) instead of entry.fail(...).