### PR TITLE
TVMaze estimator

### DIFF
--- a/flexget/plugins/estimators/est_release_series_tvmaze.py
+++ b/flexget/plugins/estimators/est_release_series_tvmaze.py
@@ -1,0 +1,47 @@
+from __future__ import unicode_literals, division, absolute_import
+import logging
+from datetime import datetime
+import re
+
+from flexget import plugin
+from flexget.event import event
+
+try:
+    # TODO implement TVMaze API internally
+    from pytvmaze import get_show, lookup_tvrage, lookup_tvdb
+except ImportError as e:
+    raise plugin.PluginError('Could not import from pytvmaze')
+
+log = logging.getLogger('est_series_tvmaze')
+
+
+class EstimatesSeriesTVMaze(object):
+    @plugin.priority(2)
+    def estimate(self, entry):
+        if not all(field in entry for field in ['series_name', 'series_season', 'series_episode']):
+            return
+        series_name = re.sub('[()]', '', entry['series_name'])  # Remove parenthesis from year if present
+        season = entry['series_season']
+        episode_number = entry['series_episode']
+        log.debug('Search TVMaze for show %s' % series_name)
+        if entry.get('tvdb_id'):
+            tvmaze_show = lookup_tvdb(entry.get('tvdb_id'))
+        elif entry.get('tvrage_id'):
+            tvmaze_show = lookup_tvdb(entry.get('tvrage_id'))
+        else:
+            tvmaze_show = get_show(series_name)
+        if not tvmaze_show:
+            log.debug('TVMaze did not find match for %s' % series_name)
+            return
+        episode = tvmaze_show[season][episode_number]
+        if episode:
+            return datetime.strptime(episode.airdate, '%Y-%m-%d')
+        else:
+            log.debug('No episode info obtained from TVMaze for %s season %s episode %s' % (
+                entry['series_name'], entry['series_season'], entry['series_episode']))
+        return
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(EstimatesSeriesTVMaze, 'est_series_tvmaze', groups=['estimate_release'], api_ver=2)

--- a/flexget/plugins/estimators/est_release_series_tvmaze.py
+++ b/flexget/plugins/estimators/est_release_series_tvmaze.py
@@ -24,7 +24,7 @@ class EstimatesSeriesTVMaze(object):
         season = entry['series_season']
         episode_number = entry['series_episode']
         log.debug('Search TVMaze for show %s' % series_name)
-        if entry.get('maze_id'):
+        if entry.get('tvmaze_id'):
             tvmaze_show = get_show(int(entry.get('maze_id')))
         elif entry.get('tvdb_id'):
             tvmaze_show = get_show(int(lookup_tvdb(entry.get('tvdb_id'))['id']))

--- a/flexget/plugins/estimators/est_release_series_tvmaze.py
+++ b/flexget/plugins/estimators/est_release_series_tvmaze.py
@@ -25,7 +25,7 @@ class EstimatesSeriesTVMaze(object):
         episode_number = entry['series_episode']
         log.debug('Search TVMaze for show %s' % series_name)
         if entry.get('tvmaze_id'):
-            tvmaze_show = get_show(int(entry.get('maze_id')))
+            tvmaze_show = get_show(int(entry.get('tvmaze_id')))
         elif entry.get('tvdb_id'):
             tvmaze_show = get_show(int(lookup_tvdb(entry.get('tvdb_id'))['id']))
         elif entry.get('tvrage_id'):

--- a/flexget/plugins/estimators/est_release_series_tvmaze.py
+++ b/flexget/plugins/estimators/est_release_series_tvmaze.py
@@ -24,10 +24,12 @@ class EstimatesSeriesTVMaze(object):
         season = entry['series_season']
         episode_number = entry['series_episode']
         log.debug('Search TVMaze for show %s' % series_name)
-        if entry.get('tvdb_id'):
-            tvmaze_show = lookup_tvdb(entry.get('tvdb_id'))
+        if entry.get('maze_id'):
+            tvmaze_show = get_show(int(entry.get('maze_id')))
+        elif entry.get('tvdb_id'):
+            tvmaze_show = get_show(int(lookup_tvdb(entry.get('tvdb_id'))['id']))
         elif entry.get('tvrage_id'):
-            tvmaze_show = lookup_tvdb(entry.get('tvrage_id'))
+            tvmaze_show = get_show(int(lookup_tvdb(entry.get('tvrage_id'))['id']))
         else:
             tvmaze_show = get_show(series_name)
         if not tvmaze_show:

--- a/flexget/plugins/estimators/est_release_series_tvmaze.py
+++ b/flexget/plugins/estimators/est_release_series_tvmaze.py
@@ -41,7 +41,7 @@ class EstimatesSeriesTVMaze(object):
         kwargs['show_language'] = entry.get('language')
 
         log.debug('Searching TVMaze for airdate of {0} season {1} episode {2}'.format(kwargs['show_name'], season,
-                                                                                       episode_number))
+                                                                                      episode_number))
         for k, v in kwargs.items():
             if v:
                 log.debug('{0}: {1}'.format(k, v))
@@ -56,7 +56,7 @@ class EstimatesSeriesTVMaze(object):
             log.debug('received airdate: {0}'.format(airdate))
             return airdate
         else:
-            log.debug('No episode info obtained from TVMaze for %s season %s episode %s' % (
+            log.debug('No episode info obtained from TVMaze for {0} season {1} episode {2}'.format(
                 entry['series_name'], entry['series_season'], entry['series_episode']))
         return
 

--- a/flexget/plugins/estimators/est_release_series_tvmaze.py
+++ b/flexget/plugins/estimators/est_release_series_tvmaze.py
@@ -40,7 +40,7 @@ class EstimatesSeriesTVMaze(object):
         kwargs['show_country'] = entry.get('country') or entry.get('trakt_series_country')
         kwargs['show_language'] = entry.get('language')
 
-        log.debug('Searching  TVMaze for airdate of {0} season {1} episode {2}'.format(kwargs['show_name'], season,
+        log.debug('Searching TVMaze for airdate of {0} season {1} episode {2}'.format(kwargs['show_name'], season,
                                                                                        episode_number))
         for k, v in kwargs.items():
             if v:

--- a/flexget/plugins/estimators/est_release_series_tvmaze.py
+++ b/flexget/plugins/estimators/est_release_series_tvmaze.py
@@ -48,7 +48,7 @@ class EstimatesSeriesTVMaze(object):
         try:
             tvmaze_show = get_show(**kwargs)
         except ShowNotFound as e:
-            log.warning('Could not found show on TVMaze: %s' % e)
+            log.warning('Could not found show on TVMaze: {0}'.format(e))
             return
         episode = tvmaze_show[season][episode_number]
         if episode:

--- a/flexget/plugins/estimators/est_release_series_tvmaze.py
+++ b/flexget/plugins/estimators/est_release_series_tvmaze.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals, division, absolute_import
 import logging
 from datetime import datetime
 import re
-
 from flexget import plugin
 from flexget.event import event
 
@@ -23,14 +22,18 @@ class EstimatesSeriesTVMaze(object):
         series_name = re.sub('[()]', '', entry['series_name'])  # Remove parenthesis from year if present
         season = entry['series_season']
         episode_number = entry['series_episode']
-        log.debug('Search TVMaze for show %s' % series_name)
+        log.verbose('Search TVMaze for airdate of %s season %s episode %s' % (series_name, season, episode_number))
         if entry.get('tvmaze_id'):
+            log.debug('Searching via TVMaze ID')
             tvmaze_show = get_show(int(entry.get('tvmaze_id')))
         elif entry.get('tvdb_id'):
+            log.debug('Searching via TVDB ID')
             tvmaze_show = get_show(int(lookup_tvdb(entry.get('tvdb_id'))['id']))
         elif entry.get('tvrage_id'):
+            log.debug('Searching via TVRage ID')
             tvmaze_show = get_show(int(lookup_tvdb(entry.get('tvrage_id'))['id']))
         else:
+            log.debug('Searching via show name')
             tvmaze_show = get_show(series_name)
         if not tvmaze_show:
             log.debug('TVMaze did not find match for %s' % series_name)

--- a/pavement.py
+++ b/pavement.py
@@ -33,7 +33,7 @@ install_requires = [
     'python-tvrage', 'tmdb3', 'path.py', 'guessit>=0.9.3, <0.10.4', 'apscheduler',
     'flask>=0.7', 'flask-restful>=0.3.3', 'ordereddict>=1.1', 'flask-restplus==0.7.2', 'cherrypy>=3.7.0',
     'flask-assets>=0.11', 'cssmin>=0.2.0', 'flask-compress>=1.2.1', 'flask-login>=0.3.2', 'pyparsing>=2.0.3',
-    'pyScss>=1.3.4',
+    'pyScss>=1.3.4', 'pytvmaze'
 ]
 
 if sys.version_info < (2, 7):

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -22,3 +22,4 @@ flask-restful>=0.3.3
 ordereddict>=1.1
 flask-restplus>=0.7.2
 cherrypy
+pytvmaze


### PR DESCRIPTION
TVMaze estimator for discover plugin

@gazpachoking Currently, some 'print' command are shown on manual series search.
This should be fixed shortly at pytvmaze side, so we can wait with merging this until that is fixed, or add another commit to suppress them.

Edit: let's sit on this for now. I'm working with pytvmaze to do something different and those changes will break behavior. I'll update when this is ready.

EDIT: @gazpachoking this is ready to be merged IMO. worked with pytvmaze dev and now it doesn't have those 'print' and is way more robust.