### PR TITLE
Enable preferred estimators with discover plugin

### DIFF
--- a/flexget/plugins/estimators/est_released.py
+++ b/flexget/plugins/estimators/est_released.py
@@ -12,7 +12,7 @@ class EstimateRelease(object):
     for various things (series, movies).
     """
 
-    def estimate(self, entry):
+    def estimate(self, entry, preferred_estimator=None):
         """
         Estimate release schedule for Entry
 
@@ -21,11 +21,12 @@ class EstimateRelease(object):
         """
 
         log.debug(entry['title'])
-        estimators = [e.instance.estimate for e in plugin.get_plugins(group='estimate_release')]
-        for estimator in sorted(
-                estimators, key=lambda e: getattr(e, 'priority', plugin.DEFAULT_PRIORITY), reverse=True
-        ):
-            estimate = estimator(entry)
+        estimators = [e.instance for e in plugin.get_plugins(group='estimate_release')]
+        estimators.sort(key=lambda e: getattr(e, 'priority', plugin.DEFAULT_PRIORITY), reverse=True)
+        if preferred_estimator:
+            estimators.insert(0, estimators.pop(estimators.index(lambda e: e.plugin_info.name == preferred_estimator)))
+        for estimator in estimators:
+            estimate = estimator.estimate(entry)
             # return first successful estimation
             if estimate is not None:
                 return estimate

--- a/flexget/plugins/estimators/est_released.py
+++ b/flexget/plugins/estimators/est_released.py
@@ -24,7 +24,10 @@ class EstimateRelease(object):
         estimators = [e.instance for e in plugin.get_plugins(group='estimate_release')]
         estimators.sort(key=lambda e: getattr(e, 'priority', plugin.DEFAULT_PRIORITY), reverse=True)
         if preferred_estimator:
-            estimators.insert(0, estimators.pop(estimators.index(lambda e: e.plugin_info.name == preferred_estimator)))
+            log.debug('preferred estimator detected, moving {0} to top of the list'.format(preferred_estimator))
+            estimator_match = filter(lambda e: e.plugin_info.name == preferred_estimator, estimators)[0]
+            estimators.remove(estimator_match)
+            estimators.insert(0, estimator_match)
         for estimator in estimators:
             estimate = estimator.estimate(entry)
             # return first successful estimation


### PR DESCRIPTION
This enable the user to manually select an estimator that will be used first with the discover plugin, potentially saving time, bandwidth and storage by using a estimator that searches on a cache that a user uses.
For example, if a user uses trakt as an input, he can select the trakt estimator (does not exist at this time) as the first priority.
If the preferred estimator does not yield an air date, all other estimators are still used as usual.
