### PR TITLE
Archive tags

### DIFF
--- a/flexget/plugins/generic/archive.py
+++ b/flexget/plugins/generic/archive.py
@@ -236,12 +236,16 @@ class UrlrewriteArchive(object):
 
         session = Session()
         entries = set()
+        if isinstance(config, bool):
+            tag_names = None
+        else:
+            tag_names = config
         try:
             for query in entry.get('search_strings', [entry['title']]):
                 # clean some characters out of the string for better results
                 query = re.sub(r'[ \(\)]+', ' ', query).strip()
                 log.debug('looking for `%s` config: %s' % (query, config))
-                for archive_entry in search(session, query, desc=True):
+                for archive_entry in search(session, query, tags=tag_names, desc=True):
                     log.debug('rewrite search result: %s' % archive_entry)
                     entry = Entry()
                     entry.update_using_map(self.entry_map, archive_entry, ignore_none=True)

--- a/flexget/plugins/generic/archive.py
+++ b/flexget/plugins/generic/archive.py
@@ -408,7 +408,8 @@ def cli_search(options):
         console('Please wait...')
         console('')
         results = False
-        for ae in search(session, search_term, tags=tags, sources=sources):
+        query = re.sub(r'[ \(\)]+', ' ', search_term).strip()
+        for ae in search(session, query, tags=tags, sources=sources):
             print_ae(ae)
             results = True
         if not results:


### PR DESCRIPTION
Cleans up titles to remove brackets around years in the same way that *flexget_archive* search does. Causes cli *flexget archive search Blah.Movie.(2015)* to return the same results as using *flexget_archive* in a task.

Also enables tags in *flexget_archive* plugin to match the *archive* command and the example documentation. Before this only *flexget_archive: yes* was implemented and you couldn't filter searches by tags set in the *archive* plugin.

This now works, before it searched the entire archive regardless of specified tags:
```
sometask:
  archive: [movies, tv]

searchtask:
  discover:
    what:
      - emit_movie_queue: yes
    from:
      - flexget_archive: [movies]
```