### PR TITLE
Adds trakt list entry reference.

### DIFF
--- a/flexget/plugins/input/trakt_emit.py
+++ b/flexget/plugins/input/trakt_emit.py
@@ -73,7 +73,8 @@ class TraktEmit(object):
                     listed_series[trakt_id] = {
                         'series_name': item['show']['title'],
                         'trakt_id': trakt_id,
-                        'tvdb_id': item['show']['ids']['tvdb']}
+                        'tvdb_id': item['show']['ids']['tvdb'],
+                        'trakt_list': config.get('list')}
         context = config['context']
         if context == 'collected':
             context = 'collection'


### PR DESCRIPTION
Adds *trakt_list* containing the list name the entry originates from. Useful to allow multiple trakt_emit configurations in the same task but specifying per-list configuration with the *if* plugin.

Basically i think it's a more elegant solution than several of the example configs that have separate tasks for each trakt list, each with a different target quality.

Example:
```
sometask:
  inputs:
    - trakt_emit:
        list: Followed Shows
    - trakt_emit:
        list: Followed 720p  
    - trakt_emit:
        list: Followed 1080p
  set:
      quality: sdtv|hdtv <720p h264|xvid !dd5.1
      target: sdtv|hdtv <720p h264 !dd5.1
  if:
    - trakt_list == 'Followed 1080p':
        set:
          quality: hdtv 1080p h264|xvid !dd5.1
          target: hdtv 1080p h264 !dd5.1
    - trakt_list == 'Followed 720p':
        set:
          quality: hdtv 720p h264|xvid !dd5.1
          target: hdtv 720p h264 !dd5.1
```