### PR TITLE
Fix from_transmission with onlycomplete

### DIFF
--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -191,9 +191,9 @@ class PluginTransmissionInput(TransmissionBase):
         for torrent in self.client.get_torrents():
             downloaded, bigfella = self.torrent_info(torrent, config)
             seed_ratio_ok, idle_limit_ok = self.check_seed_limits(torrent, session)
-            if not config['onlycomplete'] or
-               (downloaded and ((torrent.status == 'stopped' and seed_ratio_ok is None and idle_limit_ok is None) or
-                                (seed_ratio_ok is True or idle_limit_ok is True))):
+            if not config['onlycomplete'] or (downloaded and
+                ((torrent.status == 'stopped' and seed_ratio_ok is None and idle_limit_ok is None) or
+                 (seed_ratio_ok is True or idle_limit_ok is True))):
                 entry = Entry(title=torrent.name,
                               url='file://%s' % torrent.torrentFile,
                               torrent_info_hash=torrent.hashString,

--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -191,9 +191,9 @@ class PluginTransmissionInput(TransmissionBase):
         for torrent in self.client.get_torrents():
             downloaded, bigfella = self.torrent_info(torrent, config)
             seed_ratio_ok, idle_limit_ok = self.check_seed_limits(torrent, session)
-            if not config['onlycomplete'] or (downloaded and torrent.status == 'stopped' and
-                                              (seed_ratio_ok is None and idle_limit_ok is None) or
-                                              (seed_ratio_ok is True or idle_limit_ok is True)):
+            if not config['onlycomplete'] or
+               (downloaded and ((torrent.status == 'stopped' and seed_ratio_ok is None and idle_limit_ok is None) or
+                                (seed_ratio_ok is True or idle_limit_ok is True))):
                 entry = Entry(title=torrent.name,
                               url='file://%s' % torrent.torrentFile,
                               torrent_info_hash=torrent.hashString,


### PR DESCRIPTION
Previously, including the onlycomplete option would return any torrents that had met the seed ratio/idle limit even if it had not finished downloading.  This fixes that logic to only return torrents who have both finished downloading AND met their seed ratio/idle limit (or are stopped if neither is specified).