### PR TITLE
Fix BeautifulSoup warning in pogcal

### DIFF
--- a/flexget/plugins/input/pogcal.py
+++ b/flexget/plugins/input/pogcal.py
@@ -36,7 +36,7 @@ class InputPogDesign(object):
             page = session.get('http://www.pogdesign.co.uk/cat/showselect.php')
         except requests.RequestException as e:
             raise plugin.PluginError('Error retrieving source: %s' % e)
-        soup = BeautifulSoup(page.text)
+        soup = BeautifulSoup(page.text, "html5lib")
         entries = []
         for row in soup.find_all('label', {'class': 'label_check'}):
             if row.find(attrs={'checked': 'checked'}):


### PR DESCRIPTION
This silences a UserWarning emitted by BeautifulSoup when the pogcal plugin is enabled, by explicitly specifying a parser. Since bs4 is being used here to scrape a web page I've forced html5lib instead of lxml.

```
/usr/lib/python2.7/site-packages/bs4/__init__.py:166: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("lxml"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and
behave differently.

To get rid of this warning, change this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "lxml")

  markup_type=markup_type))
```