### PR TITLE
Update plugin_transmission.py

### DIFF
--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -662,7 +662,7 @@ class PluginTransmissionClean(TransmissionBase):
         delete_files = bool(config['delete_files']) if 'delete_files' in config else False
         trans_checks = bool(config['transmission_seed_limits']) if 'transmission_seed_limits' in config else False
         tracker_re = re.compile(config['tracker'], re.IGNORECASE) if 'tracker' in config else None
-        directories_re = config['directories'] if 'directories' in config else None
+        directories_re = config.get('directories')
         
         session = self.client.get_session()
 

--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -647,6 +647,8 @@ class PluginTransmissionClean(TransmissionBase):
         advanced.accept('boolean', key='transmission_seed_limits')
         advanced.accept('boolean', key='delete_files')
         advanced.accept('regexp', key='tracker')
+        directories_re = advanced.accept('list', key='directories')
+        directories_re.accept('regexp')
         return root
     
     def on_task_exit(self, task, config):
@@ -660,6 +662,7 @@ class PluginTransmissionClean(TransmissionBase):
         delete_files = bool(config['delete_files']) if 'delete_files' in config else False
         trans_checks = bool(config['transmission_seed_limits']) if 'transmission_seed_limits' in config else False
         tracker_re = re.compile(config['tracker'], re.IGNORECASE) if 'tracker' in config else None
+        directories_re = config['directories'] if 'directories' in config else None
         
         session = self.client.get_session()
 
@@ -679,6 +682,7 @@ class PluginTransmissionClean(TransmissionBase):
             is_torrent_idlelimit_since_added_reached = nfor and (torrent.date_added + nfor) <= datetime.now()
             is_torrent_idlelimit_since_finished_reached = nfor and (torrent.date_done + nfor) <= datetime.now()
             is_tracker_matching = not tracker_re or any(tracker_re.search(host) for host in tracker_hosts)
+            is_directories_matching = not directories_re or any(re.compile(directory, re.IGNORECASE).search(torrent.downloadDir) for directory in directories_re)
             if (downloaded and (is_clean_all or
                                 is_transmission_seedlimit_unset or
                                 is_transmission_seedlimit_reached or
@@ -686,7 +690,7 @@ class PluginTransmissionClean(TransmissionBase):
                                 is_minratio_reached or
                                 (is_torrent_seed_only and is_torrent_idlelimit_since_added_reached) or
                                 (not is_torrent_seed_only and is_torrent_idlelimit_since_finished_reached))
-                           and is_tracker_matching):
+                           and is_tracker_matching and is_directories_matching):
                 if task.options.test:
                     log.info('Would remove finished torrent `%s` from transmission' % torrent.name)
                     continue


### PR DESCRIPTION
Added a new config option to remove torrents based on their download directory.

Useful when combined with automatic downloads when you don't know in advance the trackers from where they are downloaded. For example when downloading torrents from a showrrs.info.