### PR TITLE
Removed guessit from pavement and added DependancyWarning

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -44,7 +44,6 @@ install_requires = [
     'jsonschema>=2.0',
     'tmdb3',
     'path.py',
-    'guessit>=2.0rc5',
     'apscheduler',
     'pytvmaze>=1.4.4',
     'ordereddict>=1.1',


### PR DESCRIPTION
Removed guessit for pavement and added DependancyWarning.
Right now there's a warning when manager is loaded:
`2016-01-26 11:26 WARNING  plugin                        Guessit is needed for this plugin. Please install via PIP`

I'm not sure why is it being called on load, it's not a bulitin.