### PR TITLE
Duplicate data in imdb_movies table

### DIFF
--- a/flexget/utils/imdb.py
+++ b/flexget/utils/imdb.py
@@ -138,8 +138,8 @@ class ImdbSearch(object):
             movie = {}
             movie['match'] = 1.0
             movie['name'] = name
-            movie['url'] = actual_url
             movie['imdb_id'] = extract_id(actual_url)
+            movie['url'] = make_url(movie['imdb_id'])
             movie['year'] = None  # skips year check
             movies.append(movie)
             return movies
@@ -167,8 +167,8 @@ class ImdbSearch(object):
 
             link = row.find_next('a')
             movie['name'] = link.text
-            movie['url'] = 'http://www.imdb.com' + link.get('href')
-            movie['imdb_id'] = extract_id(movie['url'])
+            movie['imdb_id'] = extract_id(link.get('href'))
+            movie['url'] = make_url(movie['imdb_id'])
             log.debug('processing name: %s url: %s' % (movie['name'], movie['url']))
 
             # calc & set best matching ratio


### PR DESCRIPTION
It looks to me that the url field is used as a unique key in the imdb_movies table
depending on how it is scraped its sometimes has a query string referencing where in the search results the link was followed from
this means the same movie can be in the db under multiple urls
http://www.imdb.com/title/tt3311988/
http://www.imdb.com/title/tt3311988/?ref_=nv_sr_1
http://www.imdb.com/title/tt3311988/?ref_=nv_sr_2
etc.

I've had this patch running since 2015-12-17 and have no duplicates in this table
I believe some tables are connected via foreign keys to this table so duplicates here can mean many extra rows in other tables eg imdb_movie_actors
Cheers
mh