### PR TITLE
Multiple movie queues support

### DIFF
--- a/flexget/plugins/api/movie_queue.py
+++ b/flexget/plugins/api/movie_queue.py
@@ -194,7 +194,7 @@ class MovieQueueManageAPI(APIResource):
         """ Delete movies from movie queue """
         try:
             mq.delete_movie_by_id(movie_id=id)
-        except NoResultFound as e:
+        except NoResultFound:
             return {'status': 'error',
                     'message': 'movie with ID {0} was not found'.format(id)}, 404
         return {}
@@ -206,7 +206,11 @@ class MovieQueueManageAPI(APIResource):
     def put(self, id, session=None):
         """ Updates movie quality or downloaded state in movie queue """
         data = request.json
-        movie = mq.get_movie_by_id(movie_id=id)
+        try:
+            movie = mq.get_movie_by_id(movie_id=id)
+        except NoResultFound:
+            return {'status': 'error',
+                    'message': 'movie with ID {0} was not found'.format(id)}, 404
         queue_name = movie.get('queue_name')
         if data.get('reset_downloaded'):
             try:

--- a/flexget/plugins/filter/movie_queue.py
+++ b/flexget/plugins/filter/movie_queue.py
@@ -295,6 +295,7 @@ def queue_add(title=None, imdb_id=None, tmdb_id=None, quality=None, session=None
     :param imdb_id: IMDB id for the movie. (optional)
     :param tmdb_id: TMDB id for the movie. (optional)
     :param quality: A QualityRequirements object defining acceptable qualities.
+    :param queue_name: Name of movie queue to get items from
     :param session: Optional session to use for database updates
     """
 
@@ -338,6 +339,7 @@ def queue_del(title=None, imdb_id=None, tmdb_id=None, session=None, movie_id=Non
     :param imdb_id: Imdb id
     :param tmdb_id: Tmdb id
     :param session: Optional session to use, new session used otherwise
+    :param queue_name: Name of movie queue to get items from
     :return: Title of forgotten movie
     :raises QueueError: If queued item could not be found with given arguments
     """
@@ -375,6 +377,7 @@ def queue_forget(title=None, imdb_id=None, tmdb_id=None, session=None, movie_id=
     :param imdb_id: Imdb id
     :param tmdb_id: Tmdb id
     :param session: Optional session to use, new session used otherwise
+    :param queue_name: Name of movie queue to get items from
     :return: Title of forgotten movie
     :raises QueueError: If queued item could not be found with given arguments
     """
@@ -409,6 +412,7 @@ def queue_edit(quality, imdb_id=None, tmdb_id=None, session=None, movie_id=None,
     :param imdb_id: Imdb id
     :param tmdb_id: Tmdb id
     :param session: Optional session to use, new session used otherwise
+    :param queue_name: Name of movie queue to get items from
     :return: Title of edited item
     :raises QueueError: If queued item could not be found with given arguments
     """
@@ -440,6 +444,7 @@ def queue_get(session=None, downloaded=None, queue_name=None):
 
     :param session: New session is used it not given
     :param bool downloaded: Whether or not to return only downloaded
+    :param queue_name: Name of movie queue to get items from
     :return: List of QueuedMovie objects (detached from session)
     """
     queue_name = queue_name or 'default'

--- a/flexget/plugins/filter/movie_queue.py
+++ b/flexget/plugins/filter/movie_queue.py
@@ -287,7 +287,7 @@ def parse_what(what, lookup=True, session=None):
 
 # API functions to edit queue
 @with_session
-def queue_add(title=None, imdb_id=None, tmdb_id=None, quality=None, session=None, queue_name=None):
+def queue_add(title=None, imdb_id=None, tmdb_id=None, quality=None, session=None, queue_name='default'):
     """
     Add an item to the queue with the specified quality requirements.
 
@@ -302,7 +302,6 @@ def queue_add(title=None, imdb_id=None, tmdb_id=None, quality=None, session=None
     """
 
     quality = quality or qualities.Requirements('any')
-    queue_name = queue_name or 'default'
 
     if not title or not (imdb_id or tmdb_id):
         # We don't have all the info we need to add movie, do a lookup for more info
@@ -333,7 +332,7 @@ def queue_add(title=None, imdb_id=None, tmdb_id=None, quality=None, session=None
 
 
 @with_session
-def queue_del(title=None, imdb_id=None, tmdb_id=None, session=None, movie_id=None, queue_name=None):
+def queue_del(title=None, imdb_id=None, tmdb_id=None, session=None, movie_id=None, queue_name='default'):
     """
     Delete the given item from the queue.
 
@@ -345,7 +344,6 @@ def queue_del(title=None, imdb_id=None, tmdb_id=None, session=None, movie_id=Non
     :return: Title of forgotten movie
     :raises QueueError: If queued item could not be found with given arguments
     """
-    queue_name = queue_name or 'default'
     log.debug('queue_del - title=%s, imdb_id=%s, tmdb_id=%s, movie_id=%s', title, imdb_id, tmdb_id, movie_id)
     query = session.query(QueuedMovie).filter(func.lower(QueuedMovie.queue_name) == queue_name.lower())
     if imdb_id:
@@ -371,7 +369,7 @@ def queue_del(title=None, imdb_id=None, tmdb_id=None, session=None, movie_id=Non
 
 
 @with_session
-def queue_forget(title=None, imdb_id=None, tmdb_id=None, session=None, movie_id=None, queue_name=None):
+def queue_forget(title=None, imdb_id=None, tmdb_id=None, session=None, movie_id=None, queue_name='default'):
     """
     Forget movie download  from the queue.
 
@@ -383,7 +381,6 @@ def queue_forget(title=None, imdb_id=None, tmdb_id=None, session=None, movie_id=
     :return: Title of forgotten movie
     :raises QueueError: If queued item could not be found with given arguments
     """
-    queue_name = queue_name or 'default'
     log.debug('queue_forget - title=%s, imdb_id=%s, tmdb_id=%s, movie_id=%s, queue_name=%s', title, imdb_id, tmdb_id,
               movie_id, queue_name)
     query = session.query(QueuedMovie).filter(func.lower(QueuedMovie.queue_name) == queue_name.lower())
@@ -408,7 +405,7 @@ def queue_forget(title=None, imdb_id=None, tmdb_id=None, session=None, movie_id=
 
 
 @with_session
-def queue_edit(quality, imdb_id=None, tmdb_id=None, session=None, movie_id=None, queue_name=None):
+def queue_edit(quality, imdb_id=None, tmdb_id=None, session=None, movie_id=None, queue_name='default'):
     """
     :param quality: Change the required quality for a movie in the queue
     :param imdb_id: Imdb id
@@ -419,7 +416,6 @@ def queue_edit(quality, imdb_id=None, tmdb_id=None, session=None, movie_id=None,
     :raises QueueError: If queued item could not be found with given arguments
     """
     # check if the item is queued
-    queue_name = queue_name or 'default'
     log.debug('queue_edit - quality=%s, imdb_id=%s, tmdb_id=%s, movie_id=%s, queue_name=%s', quality, imdb_id, tmdb_id,
               movie_id, queue_name)
     query = session.query(QueuedMovie).filter(func.lower(QueuedMovie.queue_name) == queue_name.lower())
@@ -440,7 +436,7 @@ def queue_edit(quality, imdb_id=None, tmdb_id=None, session=None, movie_id=None,
 
 
 @with_session
-def queue_get(session=None, downloaded=None, queue_name=None):
+def queue_get(session=None, downloaded=None, queue_name='default'):
     """
     Get the current movie queue.
 
@@ -449,7 +445,6 @@ def queue_get(session=None, downloaded=None, queue_name=None):
     :param queue_name: Name of movie queue to get items from
     :return: List of QueuedMovie objects (detached from session)
     """
-    queue_name = queue_name or 'default'
     query = session.query(QueuedMovie).filter(func.lower(QueuedMovie.queue_name) == queue_name.lower())
     if downloaded is False:
         return query.filter(QueuedMovie.downloaded == None).all()

--- a/flexget/plugins/filter/movie_queue.py
+++ b/flexget/plugins/filter/movie_queue.py
@@ -320,7 +320,7 @@ def queue_add(title=None, imdb_id=None, tmdb_id=None, quality=None, session=None
         item = QueuedMovie(title=title, imdb_id=imdb_id, tmdb_id=tmdb_id, quality=quality.text, queue_name=queue_name)
         session.add(item)
         session.commit()
-        log.info('Adding %s to movie queue %s with quality=%s.' % (queue_name, title, quality))
+        log.info('Adding %s to movie queue %s with quality=%s.' % (title, queue_name, quality))
         return item.to_dict()
     else:
         if item.downloaded:
@@ -453,16 +453,25 @@ def queue_get(session=None, downloaded=None, queue_name=None):
 
 
 @with_session
-def get_movie_by_id(movie_id, session=None, queue_name=None):
+def get_movie_by_id(movie_id, session=None):
     """
     Return movie item from movie_id
     :param movie_id: ID of queued movie
     :param session: Session
     :return: Dict of movie details
     """
-    queue_name = queue_name or 'default'
-    return session.query(QueuedMovie).filter(
-        and_(QueuedMovie.id == movie_id, func.lower(QueuedMovie.queue_name) == queue_name.lower())).one().to_dict()
+    return session.query(QueuedMovie).filter(QueuedMovie.id == movie_id).one().to_dict()
+
+
+@with_session
+def delete_movie_by_id(movie_id, session=None):
+    """
+    Deletes movie by its ID
+    :param movie_id: ID of queued movie
+    :param session: Session
+    """
+    movie = session.query(QueuedMovie).filter(QueuedMovie.id == movie_id).one()
+    session.delete(movie)
 
 
 @event('plugin.register')

--- a/flexget/plugins/filter/movie_queue.py
+++ b/flexget/plugins/filter/movie_queue.py
@@ -142,7 +142,7 @@ class MovieQueue(queue_base.FilterQueueBase):
         if config.get('action') != 'accept':
             return
 
-        queue_name = config.get('queue_name')
+        queue_name = config.get('queue_name', 'default')
 
         # Tell tmdb_lookup to add lazy lookup fields if not already present
         try:

--- a/flexget/plugins/filter/movie_queue.py
+++ b/flexget/plugins/filter/movie_queue.py
@@ -83,6 +83,7 @@ def upgrade(ver, session):
                                            {'title': parser.name}))
         ver = 3
     if ver == 3:
+        # adding queue_name column to movie_queue table and setting initial value to default)
         table_add_column('movie_queue', 'queue_name', Unicode, session, default='default')
         ver == 4
     return ver
@@ -111,6 +112,7 @@ class QueuedMovie(queue_base.QueuedItem, Base):
             'tmdb_id': self.tmdb_id,
             'quality': self.quality,
             'title': self.title,
+            'queue_name:': self.queue_name
         }
 
 
@@ -318,7 +320,7 @@ def queue_add(title=None, imdb_id=None, tmdb_id=None, quality=None, session=None
         item = QueuedMovie(title=title, imdb_id=imdb_id, tmdb_id=tmdb_id, quality=quality.text, queue_name=queue_name)
         session.add(item)
         session.commit()
-        log.info('Adding %s to movie queue with quality=%s.' % (title, quality))
+        log.info('Adding %s to movie queue %s with quality=%s.' % (queue_name, title, quality))
         return item.to_dict()
     else:
         if item.downloaded:

--- a/flexget/plugins/filter/movie_queue.py
+++ b/flexget/plugins/filter/movie_queue.py
@@ -142,6 +142,8 @@ class MovieQueue(queue_base.FilterQueueBase):
         if config.get('action') != 'accept':
             return
 
+        queue_name = config.get('queue_name')
+
         # Tell tmdb_lookup to add lazy lookup fields if not already present
         try:
             plugin.get_plugin_by_name('imdb_lookup').instance.register_lazy_fields(entry)
@@ -167,8 +169,8 @@ class MovieQueue(queue_base.FilterQueueBase):
 
         quality = entry.get('quality', qualities.Quality())
 
-        movie = task.session.query(QueuedMovie).filter(QueuedMovie.downloaded == None). \
-            filter(or_(*conditions)).first()
+        movie = task.session.query(QueuedMovie).filter(QueuedMovie.downloaded == None).filter(
+            QueuedMovie.queue_name == queue_name).filter(or_(*conditions)).first()
         if movie and movie.quality_req.allows(quality):
             return movie
 

--- a/flexget/plugins/filter/movie_queue.py
+++ b/flexget/plugins/filter/movie_queue.py
@@ -322,7 +322,7 @@ def queue_add(title=None, imdb_id=None, tmdb_id=None, quality=None, session=None
         item = QueuedMovie(title=title, imdb_id=imdb_id, tmdb_id=tmdb_id, quality=quality.text, queue_name=queue_name)
         session.add(item)
         session.commit()
-        log.info('Adding %s to movie queue %s with quality=%s.' % (title, queue_name, quality))
+        log.info('Adding %s to movie queue %s with quality=%s.', (title, queue_name, quality))
         return item.to_dict()
     else:
         if item.downloaded:

--- a/flexget/plugins/input/emit_movie_queue.py
+++ b/flexget/plugins/input/emit_movie_queue.py
@@ -75,8 +75,8 @@ class EmitMovieQueue(object):
                     entry['title'] = queue_item.title
 
                 # Add the year and quality if configured to (make sure not to double it up)
-                if config.get('year') and entry.get('movie_year') and unicode(entry['movie_year']) not in entry[
-                    'title']:
+                if config.get('year') and entry.get('movie_year') \
+                        and unicode(entry['movie_year']) not in entry['title']:
                     entry['title'] += ' %s' % entry['movie_year']
                 # TODO: qualities can now be ranges.. how should we handle this?
                 if config.get('quality') and queue_item.quality != 'ANY':

--- a/flexget/plugins/input/emit_movie_queue.py
+++ b/flexget/plugins/input/emit_movie_queue.py
@@ -1,9 +1,10 @@
 from __future__ import unicode_literals, division, absolute_import
+
 import logging
 
 from flexget import plugin
-from flexget.event import event
 from flexget.entry import Entry
+from flexget.event import event
 from flexget.manager import Session
 from flexget.utils.imdb import make_url as make_imdb_url
 
@@ -26,6 +27,7 @@ class EmitMovieQueue(object):
                 'properties': {
                     'year': {'type': 'boolean'},
                     'quality': {'type': 'boolean'},
+                    'queue_name': {'type': 'string'}
                 },
                 'additionalProperties': False
             }
@@ -37,6 +39,7 @@ class EmitMovieQueue(object):
             config = {}
         config.setdefault('year', True)
         config.setdefault('quality', False)
+        config.setdefault('queue_name', 'default')
         return config
 
     def on_task_input(self, task, config):
@@ -44,9 +47,10 @@ class EmitMovieQueue(object):
             return
         config = self.prepare_config(config)
         entries = []
+        queue_name = config.get('queue_name')
 
         with Session() as session:
-            for queue_item in queue_get(session=session, downloaded=False):
+            for queue_item in queue_get(session=session, downloaded=False, queue_name=queue_name):
                 entry = Entry()
                 # make sure the entry has IMDB fields filled
                 entry['url'] = ''
@@ -71,7 +75,8 @@ class EmitMovieQueue(object):
                     entry['title'] = queue_item.title
 
                 # Add the year and quality if configured to (make sure not to double it up)
-                if config.get('year') and entry.get('movie_year') and unicode(entry['movie_year']) not in entry['title']:
+                if config.get('year') and entry.get('movie_year') and unicode(entry['movie_year']) not in entry[
+                    'title']:
                     entry['title'] += ' %s' % entry['movie_year']
                 # TODO: qualities can now be ranges.. how should we handle this?
                 if config.get('quality') and queue_item.quality != 'ANY':
@@ -79,7 +84,7 @@ class EmitMovieQueue(object):
                     # entry['title'] += ' %s' % queue_item.quality
                 entries.append(entry)
                 log.debug('Added title and IMDB id to new entry: %s - %s' %
-                         (entry['title'], entry['imdb_id']))
+                          (entry['title'], entry['imdb_id']))
 
         return entries
 

--- a/flexget/plugins/input/imdb_list.py
+++ b/flexget/plugins/input/imdb_list.py
@@ -9,7 +9,6 @@ from flexget.utils.imdb import extract_id
 from flexget.utils.cached_input import cached
 from flexget.entry import Entry
 from flexget.utils.soup import get_soup
-
 log = logging.getLogger('imdb_list')
 USER_ID_RE = r'^ur\d{7,8}$'
 CUSTOM_LIST_RE = r'^ls\d{7,10}$'

--- a/tests/test_emit_movie_queue.py
+++ b/tests/test_emit_movie_queue.py
@@ -28,6 +28,17 @@ class TestEmitMovieQueue(FlexGetBase):
               imdb_id: tt0133093
               tmdb_id: 603
             movie_queue: accept
+          emit_from_separate_queue:
+            emit_movie_queue:
+              queue_name: queue 2
+          download_movie_separate_queue:
+            mock:
+            - title: The Matrix
+              imdb_id: tt0133093
+              tmdb_id: 603
+            movie_queue:
+              action: accept
+              queue_name: queue 2
         """
 
     def test_default(self):
@@ -49,3 +60,18 @@ class TestEmitMovieQueue(FlexGetBase):
         self.execute_task('download_movie')
         self.execute_task('test_default')
         assert len(self.task.entries) == 0, 'Should not emit already downloaded queue items.'
+
+    def test_emit_different_queue(self):
+        queue_add(title='The Matrix 1999', imdb_id='tt0133093', tmdb_id=603)
+        queue_add(title='The Matrix 1999', imdb_id='tt0133093', tmdb_id=603, queue_name='queue 2')
+
+        self.execute_task('test_default')
+        assert len(self.task.entries) == 1
+        self.execute_task('emit_from_separate_queue')
+        assert len(self.task.entries) == 1
+
+        self.execute_task('download_movie_separate_queue')
+        self.execute_task('test_default')
+        assert len(self.task.entries) == 1
+        self.execute_task('emit_from_separate_queue')
+        assert len(self.task.entries) == 0

--- a/tests/test_movie_queue.py
+++ b/tests/test_movie_queue.py
@@ -238,9 +238,10 @@ class TestMovieQueueAPI(APITest):
         assert rsp.status_code == 201, 'response code should be 201, is actually %s' % rsp.status_code
         assert mocked_queue_add.call_count == 4
 
+    @patch.object(movie_queue, 'get_movie_by_id')
     @patch.object(movie_queue, 'queue_forget')
     @patch.object(movie_queue, 'queue_edit')
-    def test_queue_movie_put(self, mocked_queue_edit, mocked_queue_forget):
+    def test_queue_movie_put(self, mocked_queue_edit, mocked_queue_forget, mocked_get_movie_by_id):
         payload = {
             "reset_downloaded": True,
             "quality": "720p"
@@ -259,15 +260,16 @@ class TestMovieQueueAPI(APITest):
         assert json.loads(rsp.data) == valid_response, 'response data is %s' % json.loads(rsp.data)
         assert rsp.status_code == 200, 'response code should be 200, is actually %s' % rsp.status_code
 
+        assert mocked_get_movie_by_id.called
         assert mocked_queue_edit.called
         assert mocked_queue_forget.called
 
-    @patch.object(movie_queue, 'queue_del')
-    def test_queue_movie_del(self, mocked_queue_del):
+    @patch.object(movie_queue, 'delete_movie_by_id')
+    def test_queue_movie_del(self, delete_movie_by_id):
         rsp = self.delete('/movie_queue/7/')
 
         assert rsp.status_code == 200, 'response code should be 200, is actually %s' % rsp.status_code
-        assert mocked_queue_del.called
+        assert delete_movie_by_id.called
 
     @patch.object(movie_queue, 'get_movie_by_id')
     def test_queue_get_movie(self, mocked_get_movie_by_id):

--- a/tests/test_movie_queue.py
+++ b/tests/test_movie_queue.py
@@ -126,13 +126,28 @@ class TestMovieQueue(FlexGetBase):
         assert len(queue) == 1
 
     def test_movie_queue_different_queue_accept(self):
+        default_queue = queue_get()
+        named_queue = queue_get(queue_name='A new queue')
+        assert len(default_queue) == len(named_queue) == 0
+
         queue_add(title=u'MovieInQueue', imdb_id=u'tt1931533', tmdb_id=603, queue_name='A new queue')
+        queue_add(title=u'MovieInQueue', imdb_id=u'tt1931533', tmdb_id=603)
+
+        default_queue = queue_get()
+        named_queue = queue_get(queue_name='A new queue')
+        assert len(named_queue) == len(default_queue) == 1
+
         self.execute_task('movie_queue_different_queue_accept')
         assert len(self.task.entries) == 1
 
         entry = self.task.entries[0]
         assert entry.get('imdb_id', eval_lazy=False) == 'tt1931533'
         assert entry.get('tmdb_id', eval_lazy=False) == 603
+
+        default_queue = queue_get()
+        named_queue = queue_get(queue_name='A new queue', downloaded=False)
+        assert len(named_queue) == 0
+        assert len(default_queue) == 1
 
         self.execute_task('movie_queue_different_queue_accept')
         assert len(self.task.entries) == 0, 'Movie should only be accepted once'


### PR DESCRIPTION
This enables multiple movie queues.

- Added attribute under `movie_queue` plugin. 
```yaml
movie_queue:
  action: add
  queue_name: Any Unicode name
```
- Added attribute under `emit_movie_queue` plugin:
```yaml
emit_movie_queue:
  queue_name: queue number 2
```

- Added REST API support
- Backwards compatible with current config, no upgrade actions needed. Default movie queue name is set to `default` in DB Upgrade. All operations use it by default if no specific `queue_name` was specified.
- Added and updated tests