### PR TITLE
Add dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,3 +38,7 @@ flexget/ui/node_modules/
 flexget/ui/bower_components/
 flexget/ui/.tmp/
 flexget/ui/app/
+
+docs/
+tests/
+.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine
+MAINTAINER Rémi Alvergnat <toilal.dev@gmail.com>
+
+RUN apk add --update python py-pip ca-certificates && rm -rf /var/cache/apk/*
+
+ADD . /opt/flexget
+WORKDIR /opt/flexget
+
+RUN pip install paver
+RUN pip install -e .
+
+RUN mkdir /root/.flexget
+VOLUME /root/.flexget
+
+ENTRYPOINT ["flexget"]

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,12 @@ For more detailed instructions see the `installation guide`_.
 
 .. _installation guide: http://flexget.com/wiki/Install
 
+Install using Docker (Linux only)
+---------------------------------
+
+Docker can be used to install and run flexget::
+
+    docker run -it -v /home/<username>/.flexget:/root/.flexget --rm toilal/flexget
 
 How to use GIT checkout
 -----------------------


### PR DESCRIPTION
I like Docker, and I think Flexget should support Docker :)

To test this ...

- [install docker](https://docs.docker.com/engine/installation/)
- build the image from sources (`docker build -t toilal/flexget .`)
- run it (`docker run -it -v /home/<username>/.flexget:/root/.flexget --rm toilal/flexget`)

`/home/<username>/.flexget` should point to your flexget configuration.

After merge, the image will be automatically build after each commit ([thanks docker hub](https://hub.docker.com/r/toilal/flexget/)), so building the image from sources won't be required as docker run will download the image from hub.