### PR TITLE
New requests domain limiter

### DIFF
--- a/flexget/plugins/api_rottentomatoes.py
+++ b/flexget/plugins/api_rottentomatoes.py
@@ -20,7 +20,7 @@ log = logging.getLogger('api_rottentomatoes')
 Base = db_schema.versioned_base('api_rottentomatoes', 2)
 session = requests.Session()
 # There is a 5 call per second rate limit per api key with multiple users on the same api key, this can be problematic
-session.set_domain_delay('api.rottentomatoes.com', '0.4 seconds')
+session.add_domain_limiter(requests.TimedLimiter('api.rottentomatoes.com', '0.4 seconds'))
 
 # This is developer Atlanta800's API key
 API_KEY = 'rh8chjzp8vu6gnpwj88736uv'

--- a/flexget/plugins/input/letterboxd.py
+++ b/flexget/plugins/input/letterboxd.py
@@ -1,20 +1,18 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import re
 
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
-from flexget.plugin import get_plugin_by_name
 from flexget.utils.cached_input import cached
-from flexget.utils.requests import RequestException, Session
+from flexget.utils.requests import RequestException, Session, TimedLimiter
 from flexget.utils.soup import get_soup
 
 log = logging.getLogger('letterboxd')
 logging.getLogger('api_tmdb').setLevel(logging.CRITICAL)
 
 requests = Session(max_retries=5)
-requests.set_domain_delay('letterboxd.com', '1 seconds')
+requests.add_domain_limiter(TimedLimiter('letterboxd.com', '1 seconds'))
 base_url = 'http://letterboxd.com'
 
 SLUGS = {

--- a/flexget/plugins/input/whatcd.py
+++ b/flexget/plugins/input/whatcd.py
@@ -8,7 +8,7 @@ from flexget.entry import Entry
 from flexget.event import event
 from flexget.plugin import PluginError
 from flexget.utils.cached_input import cached
-from flexget.utils.requests import Session
+from flexget.utils.requests import Session, TokenBucketLimiter
 
 log = logging.getLogger('whatcd')
 
@@ -293,7 +293,7 @@ class InputWhatCD(object):
         self.session = Session()
 
         # From the API docs: "Refrain from making more than five (5) requests every ten (10) seconds"
-        self.session.set_domain_delay('ssl.what.cd', '2 seconds')
+        self.session.add_domain_limiter(TokenBucketLimiter('ssl.what.cd', 2, '2 seconds'))
 
         # Custom user agent
         user_agent = config.pop('user_agent', None)

--- a/flexget/plugins/operate/domain_delay.py
+++ b/flexget/plugins/operate/domain_delay.py
@@ -3,6 +3,7 @@ import logging
 
 from flexget import plugin
 from flexget.event import event
+from flexget.utils.requests import TimedLimiter
 
 log = logging.getLogger('domain_delay')
 
@@ -21,7 +22,7 @@ class DomainDelay(object):
     def on_task_start(self, task, config):
         for domain, delay in config.iteritems():
             log.debug('Adding minimum interval of %s between requests to %s' % (delay, domain))
-            task.requests.set_domain_delay(domain, delay)
+            task.requests.add_domain_limiter(TimedLimiter(domain, delay))
 
 
 @event('plugin.register')

--- a/flexget/plugins/search_btn.py
+++ b/flexget/plugins/search_btn.py
@@ -7,17 +7,18 @@ from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
 from flexget.utils import requests, json
+from flexget.utils.requests import TBLimiter
 from flexget.utils.search import torrent_availability
 
 log = logging.getLogger('search_btn')
-
-# TODO: btn has a limit of 150 searches per hour
 
 
 class SearchBTN(object):
     schema = {'type': 'string'}
 
     def search(self, task, entry, config):
+        # Advertised limit is 150/hour (24s/request average). This may need some tweaking.
+        task.requests.add_domain_limiter(TBLimiter('api.btnapps.net', 75, '25 seconds'))
         api_key = config
 
         searches = entry.get('search_strings', [entry['title']])

--- a/flexget/plugins/search_btn.py
+++ b/flexget/plugins/search_btn.py
@@ -7,7 +7,7 @@ from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
 from flexget.utils import requests, json
-from flexget.utils.requests import TBLimiter
+from flexget.utils.requests import TokenBucketLimiter
 from flexget.utils.search import torrent_availability
 
 log = logging.getLogger('search_btn')
@@ -16,7 +16,7 @@ log = logging.getLogger('search_btn')
 class SearchBTN(object):
     schema = {'type': 'string'}
     # Advertised limit is 150/hour (24s/request average). This may need some tweaking.
-    request_limiter = TBLimiter('api.btnapps.net', 75, '25 seconds')
+    request_limiter = TokenBucketLimiter('api.btnapps.net', 75, '25 seconds')
 
     def search(self, task, entry, config):
         task.requests.add_domain_limiter(self.request_limiter)

--- a/flexget/plugins/search_btn.py
+++ b/flexget/plugins/search_btn.py
@@ -16,7 +16,7 @@ log = logging.getLogger('search_btn')
 class SearchBTN(object):
     schema = {'type': 'string'}
     # Advertised limit is 150/hour (24s/request average). This may need some tweaking.
-    request_limiter = TokenBucketLimiter('api.btnapps.net', 75, '25 seconds')
+    request_limiter = TokenBucketLimiter('api.btnapps.net', 100, '25 seconds')
 
     def search(self, task, entry, config):
         task.requests.add_domain_limiter(self.request_limiter)

--- a/flexget/plugins/search_rarbg.py
+++ b/flexget/plugins/search_rarbg.py
@@ -1,18 +1,17 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import urllib
 
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
 from flexget.config_schema import one_or_more
-from flexget.utils.requests import Session, get
+from flexget.utils.requests import Session, get, TimedLimiter
 from flexget.utils.search import normalize_scene
 
 log = logging.getLogger('rarbg')
 
 requests = Session()
-requests.set_domain_delay('torrentapi.org', '2.3 seconds')  # they only allow 1 request per 2 seconds
+requests.add_domain_limiter(TimedLimiter('torrentapi.org', '2.3 seconds'))  # they only allow 1 request per 2 seconds
 
 CATEGORIES = {
     'all': 0,

--- a/flexget/plugins/urlrewrite_google_cse.py
+++ b/flexget/plugins/urlrewrite_google_cse.py
@@ -7,7 +7,7 @@ import urlparse
 from flexget import plugin
 from flexget.event import event
 from flexget.plugins.plugin_urlrewriting import UrlRewritingError
-from flexget.utils.requests import Session
+from flexget.utils.requests import Session, TimedLimiter
 from flexget.utils.soup import get_soup
 from flexget.utils.tools import urlopener
 
@@ -15,7 +15,7 @@ log = logging.getLogger('google')
 
 requests = Session()
 requests.headers.update({'User-Agent': 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT)'})
-requests.set_domain_delay('imdb.com', '2 seconds')
+requests.add_domain_limiter(TimedLimiter('imdb.com', '2 seconds'))
 
 
 class UrlRewriteGoogleCse(object):

--- a/flexget/plugins/urlrewrite_newpct.py
+++ b/flexget/plugins/urlrewrite_newpct.py
@@ -5,14 +5,14 @@ import re
 from flexget import plugin
 from flexget.event import event
 from flexget.plugins.plugin_urlrewriting import UrlRewritingError
-from flexget.utils.requests import Session
+from flexget.utils.requests import Session, TimedLimiter
 from flexget.utils.soup import get_soup
 
 log = logging.getLogger('newpct')
 
 requests = Session()
 requests.headers.update({'User-Agent': 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT)'})
-requests.set_domain_delay('imdb.com', '2 seconds')
+requests.add_domain_limiter(TimedLimiter('imdb.com', '2 seconds'))
 
 
 class UrlRewriteNewPCT(object):

--- a/flexget/utils/imdb.py
+++ b/flexget/utils/imdb.py
@@ -6,7 +6,7 @@ import re
 from bs4.element import Tag
 
 from flexget.utils.soup import get_soup
-from flexget.utils.requests import Session
+from flexget.utils.requests import Session, TimedLimiter
 from flexget.utils.tools import str_to_int
 from flexget.plugin import get_plugin_by_name, PluginError
 
@@ -21,7 +21,7 @@ requests.headers.update({'User-Agent': 'Python-urllib/2.6'})
 requests.headers.update({'Accept-Language': 'en-US,en;q=0.8'})
 
 # give imdb a little break between requests (see: http://flexget.com/ticket/129#comment:1)
-requests.set_domain_delay('imdb.com', '3 seconds')
+requests.add_domain_limiter(TimedLimiter('imdb.com', '3 seconds'))
 
 
 def is_imdb_url(url):

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -60,7 +60,7 @@ class DomainLimiter(object):
         raise NotImplementedError
 
 
-class TBLimiter(DomainLimiter):
+class TokenBucketLimiter(DomainLimiter):
     """
     A token bucket rate limiter for domains.
     
@@ -76,7 +76,7 @@ class TBLimiter(DomainLimiter):
         :param rate: Amount of time to accrue 1 token. Either `timedelta` or interval string.
         :param bool wait: If true, will wait for a token to be available. If false, errors when token is not available.
         """
-        super(TBLimiter, self).__init__(domain)
+        super(TokenBucketLimiter, self).__init__(domain)
         self.max_tokens = tokens
         self.rate = parse_timedelta(rate)
         self.wait = wait
@@ -115,7 +115,7 @@ class TBLimiter(DomainLimiter):
         self.tokens -= 1
 
 
-class TimedLimiter(TBLimiter):
+class TimedLimiter(TokenBucketLimiter):
     """Enforces a minimum interval between requests to a given domain."""
     def __init__(self, domain, interval):
         super(TimedLimiter, self).__init__(domain, 1, interval)

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -13,7 +13,8 @@ from requests import RequestException, HTTPError
 from flexget import __version__ as version
 from flexget.utils.tools import parse_timedelta, TimedDict, timedelta_total_seconds
 
-log = logging.getLogger('requests')
+# If we use just 'requests' here, we'll get the logger created by requests, rather than our own
+log = logging.getLogger('utils.requests')
 
 # Don't emit info level urllib3 log messages or below
 logging.getLogger('requests.packages.urllib3').setLevel(logging.WARNING)

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -177,7 +177,7 @@ class Session(requests.Session):
         Registers a minimum interval between requests to `domain`
 
         :param domain: The domain to set the interval on
-        :param delay: An instance of :class:`Delay` (or an interval, which will create a `TimedDelay`)
+        :param delay: The amount of time between requests, can be a timedelta or string like '3 seconds'
         """
         warnings.warn('set_domain_delay is deprecated, use add_domain_limiter', DeprecationWarning, stacklevel=2)
         self.domain_limiters[domain] = TimedLimiter(domain, delay)

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -7,10 +7,11 @@ from urlparse import urlparse
 
 import requests
 # Allow some request objects to be imported from here instead of requests
+import warnings
 from requests import RequestException, HTTPError
 
 from flexget import __version__ as version
-from flexget.utils.tools import parse_timedelta, TimedDict
+from flexget.utils.tools import parse_timedelta, TimedDict, timedelta_total_seconds
 
 log = logging.getLogger('requests')
 
@@ -50,19 +51,74 @@ def set_unresponsive(url):
     unresponsive_hosts[host] = True
 
 
-def wait_for_domain(url, delay_dict):
-    for domain, domain_dict in delay_dict.iteritems():
-        if domain in url:
-            next_req = domain_dict.get('next_req')
-            if next_req and datetime.now() < next_req:
-                wait_time = next_req - datetime.now()
-                seconds = wait_time.seconds + (wait_time.microseconds / 1000000.0)
-                log.debug('Waiting %.2f seconds until next request to %s' % (seconds, domain))
-                # Sleep until it is time for the next request
-                time.sleep(seconds)
-            # Record the next allowable request time for this domain
-            domain_dict['next_req'] = datetime.now() + domain_dict['delay']
-            break
+class DomainLimiter(object):
+    def __init__(self, domain):
+        self.domain = domain
+
+    def __call__(self):
+        """This method will be called once before every request to the domain."""
+        raise NotImplementedError
+
+
+class TBLimiter(DomainLimiter):
+    """
+    A token bucket rate limiter for domains.
+    
+    New instances for the same domain will restore previous values.
+    """
+    # This is just an in memory cache right now, it works for the daemon, and across tasks in a single execution
+    # but not for multiple executions via cron. Do we need to store this to db?
+    state_cache = {}
+    
+    def __init__(self, domain, tokens, rate, wait=True):
+        """
+        :param int tokens: Size of bucket
+        :param rate: Amount of time to accrue 1 token. Either `timedelta` or interval string.
+        :param bool wait: If true, will wait for a token to be available. If false, errors when token is not available.
+        """
+        super(TBLimiter, self).__init__(domain)
+        self.max_tokens = tokens
+        self.rate = parse_timedelta(rate)
+        self.wait = wait
+        # Restore previous state for this domain, or establish new state cache
+        self.state = self.state_cache.setdefault(domain, {'tokens': self.max_tokens, 'last_update': datetime.now()})
+
+    @property
+    def tokens(self):
+        return min(self.max_tokens, self.state['tokens'])
+
+    @tokens.setter
+    def tokens(self, value):
+        self.state['tokens'] = value
+
+    @property
+    def last_update(self):
+        return self.state['last_update']
+
+    @last_update.setter
+    def last_update(self, value):
+        self.state['last_update'] = value
+
+    def __call__(self):
+        if self.tokens < self.max_tokens:
+            regen = (timedelta_total_seconds(datetime.now() - self.last_update) /
+                     timedelta_total_seconds(self.rate))
+            self.tokens += regen
+        self.last_update = datetime.now()
+        if self.tokens < 1:
+            if not self.wait:
+                raise RequestException('Requests to %s have exceeded their limit.' % self.domain)
+            wait = timedelta_total_seconds(self.rate) * (1 - self.tokens)
+            log.debug('Waiting %.2f seconds until next request to %s' % (wait, self.domain))
+            # Sleep until it is time for the next request
+            time.sleep(wait)
+        self.tokens -= 1
+
+
+class TimedLimiter(TBLimiter):
+    """Enforces a minimum interval between requests to a given domain."""
+    def __init__(self, domain, interval):
+        super(TimedLimiter, self).__init__(domain, 1, interval)
 
 
 def _wrap_urlopen(url, timeout=None):
@@ -103,7 +159,7 @@ class Session(requests.Session):
         self.stream = True
         self.adapters['http://'].max_retries = max_retries
         # Stores min intervals between requests for certain sites
-        self.domain_delay = {}
+        self.domain_limiters = {}
         self.headers.update({'User-Agent': 'FlexGet/%s (www.flexget.com)' % version})
 
     def add_cookiejar(self, cookiejar):
@@ -117,12 +173,22 @@ class Session(requests.Session):
 
     def set_domain_delay(self, domain, delay):
         """
+        DEPRECATED, use `add_domain_limiter`
         Registers a minimum interval between requests to `domain`
 
         :param domain: The domain to set the interval on
-        :param delay: The amount of time between requests, can be a timedelta or string like '3 seconds'
+        :param delay: An instance of :class:`Delay` (or an interval, which will create a `TimedDelay`)
         """
-        self.domain_delay[domain] = {'delay': parse_timedelta(delay)}
+        warnings.warn('set_domain_delay is deprecated, use add_domain_limiter', DeprecationWarning, stacklevel=2)
+        self.domain_limiters[domain] = TimedLimiter(domain, delay)
+            
+    def add_domain_limiter(self, limiter):
+        """
+        Add a limiter to throttle requests to a specific domain.
+
+        :param DomainLimiter limiter: The `DomainLimiter` to add to the session.
+        """
+        self.domain_limiters[limiter.domain] = limiter
 
     def request(self, method, url, *args, **kwargs):
         """
@@ -137,8 +203,11 @@ class Session(requests.Session):
             raise requests.Timeout('Requests to this site (%s) have timed out recently. Waiting before trying again.' %
                 urlparse(url).hostname)
 
-        # Delay, if needed, before another request to this site
-        wait_for_domain(url, self.domain_delay)
+        # Run domain limiters for this url
+        for domain, limiter in self.domain_limiters.iteritems():
+            if domain in url:
+                limiter()
+                break
 
         kwargs.setdefault('timeout', self.timeout)
         raise_status = kwargs.pop('raise_status', True)

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -109,7 +109,7 @@ class TokenBucketLimiter(DomainLimiter):
             if not self.wait:
                 raise RequestException('Requests to %s have exceeded their limit.' % self.domain)
             wait = timedelta_total_seconds(self.rate) * (1 - self.tokens)
-            log.debug('Waiting %.2f seconds until next request to %s' % (wait, self.domain))
+            log.verbose('Waiting %.2f seconds until next request to %s' % (wait, self.domain))
             # Sleep until it is time for the next request
             time.sleep(wait)
         self.tokens -= 1

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -339,11 +339,18 @@ def parse_timedelta(value):
         raise ValueError('Invalid time format \'%s\'' % value)
 
 
+def timedelta_total_seconds(td):
+    """replaces python 2.7+ timedelta.total_seconds()"""
+    # TODO: Remove this when we no longer support python 2.6
+    try:
+        return td.total_seconds()
+    except AttributeError:
+        return (td.days * 24 * 3600) + td.seconds + (td.microseconds / 1000000)
+
+
 def multiply_timedelta(interval, number):
-    """timedeltas can not normally be multiplied by floating points. This does that."""
-    # Python 2.6 doesn't have total seconds
-    total_seconds = interval.seconds + interval.days * 24 * 3600
-    return timedelta(seconds=total_seconds * number)
+    """`timedelta`s can not normally be multiplied by floating points. This does that."""
+    return timedelta(seconds=timedelta_total_seconds(interval) * number)
 
 
 if os.name == 'posix':

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -87,9 +87,9 @@ def use_vcr(func=None, **kwargs):
     elif vcr.record_mode == 'once':
         online = not os.path.exists(cassette_path)
     func = attr(online=online, vcr=True)(func)
-    # If we are not going online, disable domain delay during test
+    # If we are not going online, disable domain limiting during test
     if not online:
-        func = mock.patch('flexget.utils.requests.wait_for_domain', new=mock.MagicMock())(func)
+        func = mock.patch('flexget.utils.requests.limit_domains', new=mock.MagicMock())(func)
     if VCR_RECORD_MODE == 'off':
         return func
     else:


### PR DESCRIPTION
This generalizes the `set_domain_delay` method we had for requests sessions to allow more general limiters. Specifically, a token bucket limiter, to allow bursts of requests while still limiting the average requests per time. `add_domain_limiter` method can now be used to add an instance of an implementation of `DomainLimiter` class to session. The `DomainLimiter` instance will be called once before each request to the domain, and it is free to wait or abort as desired.

There are currently 2 limiter implementations, `TimedLimiter`, which enforces a strict minimum time between requests (directly replicates old set_domain_delay behavior,) and `TokenBucketLimiter`, which enforces an average requests/time, but allows bursting.

TODO:
- [ ] Should any of the plugins that were using `set_domain_delay` be switched to token bucket? EDIT: Meh, later.
- [x] Limiter states are cached and shared across all requests sessions during process execution. Store to db so it also works across cron executions (without daemon mode)? EDIT: Don't want requests util using the db if not needed. See example in btn plugin for how to adjust token bucket if over limit error is detected.
- [ ] deprecate `domain_delay` plugin and add `domain_limiter` which allows token bucket limiters as well EDIT: Meh, later.