### PR TITLE
Simple JSONRPC plugin for Kodi library

### DIFF
--- a/flexget/plugins/services/kodi_library.py
+++ b/flexget/plugins/services/kodi_library.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals, division, absolute_import
 import logging
-import urlparse
 import json
 
 from flexget import plugin

--- a/flexget/plugins/services/kodi_library.py
+++ b/flexget/plugins/services/kodi_library.py
@@ -1,0 +1,66 @@
+from __future__ import unicode_literals, division, absolute_import
+import logging
+import urlparse
+import json
+
+from flexget import plugin
+from flexget.event import event
+from flexget.utils.requests import RequestException
+
+log = logging.getLogger('kodi_library')
+
+JSON_URI = '/jsonrpc'
+
+
+class KodiLibrary(object):
+    schema = {
+        'type': 'object',
+        'properties': {
+            'action': {'type': 'string', 'enum': ['clean', 'scan']},
+            'category': {'type': 'string', 'enum': ['audio', 'video']},
+            'url': {'type': 'string'},
+            'port': {'type': 'integer'},
+            'username': {'type': 'string'},
+            'password': {'type': 'string'},
+            'only_on_accepted': {'type': 'boolean', 'default': True}
+        },
+        'required': ['url', 'action', 'category'],
+        'additionalProperties': False,
+    }
+
+    @plugin.priority(-255)
+    def on_task_exit(self, task, config):
+        if task.accepted or not config['only_on_accepted']:
+            # make the url without trailing slash
+            base_url = config['url'][:-1] if config['url'].endswith('/') else config['url']
+            if config.get('port'):
+                base_url += ':{0}'.format(config['port'])
+
+            url = base_url + JSON_URI
+            # create the params
+            json_params = {"id": 1, "jsonrpc": "2.0",
+                           'method': '{category}Library.{action}'.format(category=config['category'].title(),
+                                                                         action=config['action'].title())}
+            params = {'request': json.dumps(json_params)}
+            log.debug('Sending request params %s', params)
+
+            try:
+                r = task.requests.get(url, params=params, auth=(config.get('username'), config.get('password'))).json()
+                if r.get('result') == 'OK':
+                    log.debug('Successfully sent a %s request for the %s library', config['action'], config['category'])
+                else:
+                    if r.get('error'):
+                        log.error('Kodi JSONRPC failed. Error %s: %s', r['error']['code'], r['error']['message'])
+                    else:
+                        # this should never happen as Kodi say they follow the JSON-RPC 2.0 spec
+                        log.trace('Received error response %s', json.dumps(r))
+                        log.error('Kodi JSONRPC failed with unrecognized message: %s', json.dumps(r))
+            except RequestException as e:
+                raise plugin.PluginError('Failed to send request to Kodi: %s', e.args[0])
+        else:
+            log.debug('No entries were accepted. No request is sent.')
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(KodiLibrary, 'kodi_library', api_ver=2)

--- a/flexget/plugins/services/kodi_library.py
+++ b/flexget/plugins/services/kodi_library.py
@@ -17,7 +17,7 @@ class KodiLibrary(object):
         'properties': {
             'action': {'type': 'string', 'enum': ['clean', 'scan']},
             'category': {'type': 'string', 'enum': ['audio', 'video']},
-            'url': {'type': 'string'},
+            'url': {'type': 'string', 'format': 'url'},
             'port': {'type': 'integer'},
             'username': {'type': 'string'},
             'password': {'type': 'string'},

--- a/flexget/plugins/services/kodi_library.py
+++ b/flexget/plugins/services/kodi_library.py
@@ -46,18 +46,18 @@ class KodiLibrary(object):
             try:
                 r = task.requests.get(url, params=params, auth=(config.get('username'), config.get('password'))).json()
                 if r.get('result') == 'OK':
-                    log.debug('Successfully sent a %s request for the %s library', config['action'], config['category'])
+                    log.info('Successfully sent a %s request for the %s library', config['action'], config['category'])
                 else:
                     if r.get('error'):
                         log.error('Kodi JSONRPC failed. Error %s: %s', r['error']['code'], r['error']['message'])
                     else:
                         # this should never happen as Kodi say they follow the JSON-RPC 2.0 spec
-                        log.trace('Received error response %s', json.dumps(r))
+                        log.debug('Received error response %s', json.dumps(r))
                         log.error('Kodi JSONRPC failed with unrecognized message: %s', json.dumps(r))
             except RequestException as e:
                 raise plugin.PluginError('Failed to send request to Kodi: %s', e.args[0])
         else:
-            log.debug('No entries were accepted. No request is sent.')
+            log.info('No entries were accepted. No request is sent.')
 
 
 @event('plugin.register')


### PR DESCRIPTION
Just a simple plugin to send a 'Clean' or 'Scan' request to a Kodi server listening on `<url>:<port>/jsonrpc`.

Kodi also supports sockets but it's incredibly poorly documented and the behaviour is annoying and slow.

The basic principle of this plugin is just to send a library scan/clean request upon accepted entries (can also be forced to run with `only_on_accepted: no`).
This PR is a very simplified version of #397.