### PR TITLE
Adds full_path and parent_folder to filesystem

### DIFF
--- a/flexget/plugins/input/filesystem.py
+++ b/flexget/plugins/input/filesystem.py
@@ -4,6 +4,7 @@ import re
 import sys
 import urllib
 import urlparse
+import os
 from datetime import datetime
 
 from path import Path
@@ -110,6 +111,9 @@ class Filesystem(object):
         entry['location'] = filepath
         entry['url'] = urlparse.urljoin('file:', urllib.pathname2url(filepath.encode('utf8')))
         entry['filename'] = filepath.name
+        entry['full_path'] = os.path.dirname(filepath.encode('utf8'))
+        entry['parent_folder'] = os.path.split(entry['full_path'])[1]
+
         if filepath.isfile():
             entry['title'] = filepath.namebase
         else:
@@ -127,6 +131,8 @@ class Filesystem(object):
                 log.info("    Filename: %s" % entry["filename"])
                 log.info("    Location: %s" % entry["location"])
                 log.info("    Timestamp: %s" % entry["timestamp"])
+                log.info("    Parent Folder Name: %s" % entry["parent_folder"])
+                log.info("    Full Path: %s" % entry["full_path"])
             return entry
         else:
             log.error('Non valid entry created: %s ' % entry)


### PR DESCRIPTION
I thought these changes would be a good addition as it helps with a few scenarios that are a bit specific but also handy.

1. Moving subs (or any file out of a child folder). A number of private sites put subs in child folders meaning that the move plugin will not move the subs with the video file.
2. Compressed videos and many groups release movies with abbreviated file naming but the parent folder has the full release name. Sickbeard deals with this by checking a parent folder for a valid name if it can't find a match. This modification gives enough information that a user can have a rename task that will do a similar thing.

Moving subs into parent folder with video:
```
  sort_subs:
    no_entries_ok: yes
    template:
      - no_global
    disable:
      - retry_failed
      - seen
      - seen_info_hash
    filesystem:
      path: 
        - '{{ secrets.folder.stagingtv }}'
        - '{{ secrets.folder.stagingtvlocal }}'
        - '{{ secrets.folder.stagingmovies }}'
      regexp: '.*\.(sub|en.sub|idx|ass|srt)$'
      recursive: yes    
    pathscrub: windows
    regexp:
      accept:
        - '[Ss]ub(s|titles)'
      from: parent_folder
    move:
      to: >
        /{{ full_path|replace('/subs','')|replace('/Subs','')|replace('/subtitles','')|replace('/Subtitles','') }}
      filename: >
        {{ filename }}
```

Renaming files based on parent folder's name (Note that this only works well on movies as shows can have multiple video files in the same parent folder).
```
  rename_movies:
    no_entries_ok: yes    
    template:
      - no_global
    disable:
      - retry_failed
      - seen
      - seen_info_hash
    filesystem:
      path: 
        - '{{ secrets.folder.stagingmovies }}'
      regexp: '.*\.(avi|mkv|mp4|srt|sub|en.sub|ass|idx)$'
      recursive: yes
    pathscrub: windows
    if:
      - parent_folder != title: accept
      - full_path == '{{ secrets.folder.stagingmovies }}': reject
    move:
      to: >
        /{{ full_path }}
      filename: >
        {{ parent_folder }}
```

Note: I explored modifying the move plugin to handle child folder processing for "along" files but the variety of naming schemes for subs made processing them a pain and this seemed like a more open ended solution.