### PR TITLE
Move tmdb to tmdbsimple library

### DIFF
--- a/flexget/plugins/api_tmdb.py
+++ b/flexget/plugins/api_tmdb.py
@@ -1,26 +1,20 @@
 from __future__ import unicode_literals, division, absolute_import
 from datetime import datetime, timedelta
 import logging
-import os
-import posixpath
-import socket
-import sys
-from urllib2 import URLError
 
-from sqlalchemy import Table, Column, Integer, Float, String, Unicode, Boolean, DateTime, func
+from sqlalchemy import Table, Column, Integer, Float, Unicode, Boolean, DateTime, func, or_
+from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.schema import ForeignKey
 from sqlalchemy.orm import relation
 
 from flexget import db_schema, plugin
 from flexget.event import event
-from flexget.manager import Session
 from flexget.plugin import get_plugin_by_name
 from flexget.utils import requests
 from flexget.utils.database import text_date_synonym, year_property, with_session
-from flexget.utils.sqlalchemy_utils import table_add_column, table_schema
 
 try:
-    import tmdb3
+    import tmdbsimple
 except ImportError:
     raise plugin.DependencyError(issued_by='api_tmdb', missing='tmdb3',
                                  message='TMDB requires https://github.com/wagnerrp/pytmdb3')
@@ -29,27 +23,13 @@ log = logging.getLogger('api_tmdb')
 Base = db_schema.versioned_base('api_tmdb', 0)
 
 # This is a FlexGet API key
-tmdb3.tmdb_api.set_key('bdfc018dbdb7c243dc7cb1454ff74b95')
-tmdb3.locales.set_locale("en", "us", True)
-# There is a bug in tmdb3 library, where it uses the system encoding for query parameters, tmdb expects utf-8 #2392
-tmdb3.locales.syslocale.encoding = 'utf-8'
-tmdb3.set_cache('null')
+tmdbsimple.API_KEY = 'bdfc018dbdb7c243dc7cb1454ff74b95'
 
 
 @db_schema.upgrade('api_tmdb')
 def upgrade(ver, session):
-    if ver is None:
-        log.info('Adding columns to tmdb cache table, marking current cache as expired.')
-        table_add_column('tmdb_movies', 'runtime', Integer, session)
-        table_add_column('tmdb_movies', 'tagline', Unicode, session)
-        table_add_column('tmdb_movies', 'budget', Integer, session)
-        table_add_column('tmdb_movies', 'revenue', Integer, session)
-        table_add_column('tmdb_movies', 'homepage', String, session)
-        table_add_column('tmdb_movies', 'trailer', String, session)
-        # Mark all cached movies as expired, so new fields get populated next lookup
-        movie_table = table_schema('tmdb_movies', session)
-        session.execute(movie_table.update(values={'updated': datetime(1970, 1, 1)}))
-        ver = 0
+    if ver is None or ver == 0:
+        raise db_schema.UpgradeImpossible
     return ver
 
 
@@ -60,152 +40,107 @@ genres_table = Table('tmdb_movie_genres', Base.metadata,
 Base.register_table(genres_table)
 
 
-class TMDBContainer(object):
-    """Base class for TMDb objects"""
-
-    def __init__(self, init_object=None):
-        if isinstance(init_object, dict):
-            self.update_from_dict(init_object)
-        elif init_object:
-            self.update_from_object(init_object)
-
-    def update_from_dict(self, update_dict):
-        """Populates any simple (string or number) attributes from a dict"""
-        for col in self.__table__.columns:
-            if isinstance(update_dict.get(col.name), (basestring, int, float)):
-                setattr(self, col.name, update_dict[col.name])
-
-    def update_from_object(self, update_object):
-        """Populates any simple (string or number) attributes from object attributes"""
-        for col in self.__table__.columns:
-            if (hasattr(update_object, col.name) and
-                    isinstance(getattr(update_object, col.name), (basestring, int, float))):
-                setattr(self, col.name, getattr(update_object, col.name))
-
-
-class TMDBMovie(TMDBContainer, Base):
+class TMDBMovie(Base):
     __tablename__ = 'tmdb_movies'
 
     id = Column(Integer, primary_key=True, autoincrement=False, nullable=False)
-    updated = Column(DateTime, default=datetime.now, nullable=False)
-    popularity = Column(Integer)
-    translated = Column(Boolean)
-    adult = Column(Boolean)
-    language = Column(String)
-    original_name = Column(Unicode)
+    imdb_id = Column(Unicode)
+    url = Column(Unicode)
     name = Column(Unicode)
+    original_name = Column(Unicode)
     alternative_name = Column(Unicode)
-    movie_type = Column(String)
-    imdb_id = Column(String)
-    url = Column(String)
-    votes = Column(Integer)
-    rating = Column(Float)
-    certification = Column(String)
-    overview = Column(Unicode)
-    runtime = Column(Integer)
-    tagline = Column(Unicode)
-    budget = Column(Integer)
-    revenue = Column(Integer)
-    homepage = Column(String)
-    trailer = Column(String)
     _released = Column('released', DateTime)
     released = text_date_synonym('_released')
     year = year_property('released')
+    certification = Column(Unicode)
+    runtime = Column(Integer)
+    language = Column(Unicode)
+    overview = Column(Unicode)
+    tagline = Column(Unicode)
+    rating = Column(Float)
+    votes = Column(Integer)
+    popularity = Column(Integer)
+    adult = Column(Boolean)
+    budget = Column(Integer)
+    revenue = Column(Integer)
+    homepage = Column(Unicode)
     posters = relation('TMDBPoster', backref='movie', cascade='all, delete, delete-orphan')
-    genres = relation('TMDBGenre', secondary=genres_table, backref='movies')
+    _genres = relation('TMDBGenre', secondary=genres_table, backref='movies')
+    genres = association_proxy('_genres', 'name')
+    updated = Column(DateTime, default=datetime.now, nullable=False)
 
-    def update_from_object(self, update_object):
+    def update_from_tmdb(self):
         try:
-            TMDBContainer.update_from_object(self, update_object)
-            self.translated = len(update_object.translations) > 0
-            if len(update_object.languages) > 0:
-                self.language = update_object.languages[0].code # .code or .name ?
-            self.original_name = update_object.originaltitle
-            self.name = update_object.title
-            try:
-                if len(update_object.alternate_titles) > 0:
-                    # maybe we could choose alternate title from movie country only
-                    self.alternative_name = update_object.alternate_titles[0].title
-            except UnicodeEncodeError:
-                # Bug in tmdb3 library, see #2437. Just don't set alternate_name when it fails
-                pass
-            self.imdb_id = update_object.imdb
-            self.url = update_object.homepage
-            self.rating = update_object.userrating
-            if len(update_object.youtube_trailers) > 0:
-                self.trailer = update_object.youtube_trailers[0].source # unicode: ooNSm6Uug3g
-            elif len(update_object.apple_trailers) > 0:
-                self.trailer = update_object.apple_trailers[0].source
-            self.released = update_object.releasedate
-        except tmdb3.TMDBError as e:
+            movie = tmdbsimple.Movies(self.id).info(append_to_response='alternative_titles,images')
+        except requests.RequestException as e:
             raise LookupError('Error updating data from tmdb: %s' % e)
+        self.imdb_id = movie['imdb_id']
+        self.name = movie['title']
+        self.original_name = movie['original_title']
+        self.released = movie['release_date']
+        self.runtime = movie['runtime']
+        self.language = movie['original_language']
+        self.overview = movie['overview']
+        self.tagline = movie['tagline']
+        self.rating = movie['vote_average']
+        self.votes = movie['vote_count']
+        self.popularity = movie['popularity']
+        self.adult = movie['adult']
+        self.budget = movie['budget']
+        self.revenue = movie['revenue']
+        self.homepage = movie['homepage']
+        self.alternative_name = None
+        try:
+            self.alternative_name = movie['alternative_titles']['titles'][0]['title']
+        except (KeyError, IndexError):
+            pass  # No alternate titles
+        self._genres = [TMDBGenre(**g) for g in movie['genres']]
+        # Just grab the top 5 posters
+        self.posters = [TMDBPoster(**p) for p in movie['images']['posters'][:5]]
+        self.updated = datetime.now()
 
 
-class TMDBGenre(TMDBContainer, Base):
+class TMDBGenre(Base):
 
     __tablename__ = 'tmdb_genres'
 
-    id = Column(Integer, primary_key=True, autoincrement=False)
-    name = Column(String, nullable=False)
+    id = Column(Integer, primary_key=True)
+    name = Column(Unicode, nullable=False, unique=True)
 
 
-class TMDBPoster(TMDBContainer, Base):
+class TMDBPoster(Base):
 
     __tablename__ = 'tmdb_posters'
 
-    db_id = Column(Integer, primary_key=True)
+    id = Column(Integer, primary_key=True)
     movie_id = Column(Integer, ForeignKey('tmdb_movies.id'))
-    size = Column(String)
-    url = Column(String)
-    file = Column(Unicode)
+    file_path = Column(Unicode)
+    width = Column(Integer)
+    height = Column(Integer)
+    aspect_ratio = Column(Float)
+    vote_average = Column(Float)
+    vote_count = Column(Integer)
+    iso_639_1 = Column(Unicode)
 
-    def get_file(self, only_cached=False):
+    def get_file(self, only_cached=False, size='w500'):
         """Makes sure the poster is downloaded to the local cache (in userstatic folder) and
         returns the path split into a list of directory and file components"""
-        from flexget.manager import manager
-        base_dir = os.path.join(manager.config_base, 'userstatic')
-        if self.file and os.path.isfile(os.path.join(base_dir, self.file)):
-            return self.file.split(os.sep)
-        elif only_cached:
-            return
-        # If we don't already have a local copy, download one.
-        log.debug('Downloading poster %s' % self.url)
-        dirname = os.path.join('tmdb', 'posters', str(self.movie_id))
-        # Create folders if they don't exist
-        fullpath = os.path.join(base_dir, dirname)
-        if not os.path.isdir(fullpath):
-            os.makedirs(fullpath)
-        filename = os.path.join(dirname, posixpath.basename(self.url))
-        thefile = file(os.path.join(base_dir, filename), 'wb')
-        thefile.write(requests.get(self.url).content)
-        self.file = filename
-        # If we are detached from a session, update the db
-        if not Session.object_session(self):
-            session = Session()
-            try:
-                poster = session.query(TMDBPoster).filter(TMDBPoster.db_id == self.db_id).first()
-                if poster:
-                    poster.file = filename
-            finally:
-                session.close()
-        return filename.split(os.sep)
-
+        # TODO: Is this used anywhere? make it work
 
 class TMDBSearchResult(Base):
 
     __tablename__ = 'tmdb_search_results'
 
-    id = Column(Integer, primary_key=True)
-    search = Column(Unicode, nullable=False)
+    search = Column(Unicode, primary_key=True)
     movie_id = Column(Integer, ForeignKey('tmdb_movies.id'), nullable=True)
-    movie = relation(TMDBMovie, backref='search_strings')
+    movie = relation(TMDBMovie)
 
 
 class ApiTmdb(object):
     """Does lookups to TMDb and provides movie information. Caches lookups."""
 
     @staticmethod
-    @with_session(expire_on_commit=False)
+    @with_session
     def lookup(title=None, year=None, tmdb_id=None, imdb_id=None, smart_match=None, only_cached=False, session=None):
         """
         Do a lookup from TMDb for the movie matching the passed arguments.
@@ -226,35 +161,31 @@ class ApiTmdb(object):
 
         :raises: :class:`LookupError` if a match cannot be found or there are other problems with the lookup
         """
-
-        if not (tmdb_id or imdb_id or title) and smart_match:
-            # If smart_match was specified, and we don't have more specific criteria, parse it into a title and year
+        if smart_match and not (title or tmdb_id or imdb_id):
+            # If smart_match was specified, parse it into a title and year
             title_parser = get_plugin_by_name('parsing').instance.parse_movie(smart_match)
             title = title_parser.name
             year = title_parser.year
-
-        if title:
-            search_string = title.lower()
-            if year:
-                search_string = '%s (%s)' % (search_string, year)
-        elif not (tmdb_id or imdb_id):
+        if not (title or tmdb_id or imdb_id):
             raise LookupError('No criteria specified for TMDb lookup')
-        log.debug('Looking up TMDb information for %r' % {'title': title, 'tmdb_id': tmdb_id, 'imdb_id': imdb_id})
+        id_str = '<title={}, year={}, tmdb_id={}, imdb_id={}>'.format(title, year, tmdb_id, imdb_id)
 
+        log.debug('Looking up TMDb information for %s', id_str)
         movie = None
-
-        def id_str():
-            return '<title=%s,tmdb_id=%s,imdb_id=%s>' % (title, tmdb_id, imdb_id)
-        if tmdb_id:
-            movie = session.query(TMDBMovie).filter(TMDBMovie.id == tmdb_id).first()
-        if not movie and imdb_id:
-            movie = session.query(TMDBMovie).filter(TMDBMovie.imdb_id == imdb_id).first()
-        if not movie and title:
+        if imdb_id or tmdb_id:
+            ors = []
+            if tmdb_id:
+                ors.append(TMDBMovie.id == tmdb_id)
+            if imdb_id:
+                ors.append(TMDBMovie.imdb_id == imdb_id)
+            movie = session.query(TMDBMovie).filter(or_(*ors)).first()
+        elif title:
             movie_filter = session.query(TMDBMovie).filter(func.lower(TMDBMovie.name) == title.lower())
             if year:
                 movie_filter = movie_filter.filter(TMDBMovie.year == year)
             movie = movie_filter.first()
             if not movie:
+                search_string = title + ' ({})'.format(year) if year else ''
                 found = session.query(TMDBSearchResult). \
                     filter(func.lower(TMDBSearchResult.search) == search_string).first()
                 if found and found.movie:
@@ -270,105 +201,46 @@ class ApiTmdb(object):
                     age_in_years = (datetime.now() - movie.released).days / 365
                     refresh_time += timedelta(days=age_in_years * 5)
             if movie.updated < datetime.now() - refresh_time and not only_cached:
-                log.debug('Cache has expired for %s, attempting to refresh from TMDb.' % id_str())
+                log.debug('Cache has expired for %s, attempting to refresh from TMDb.', movie.name)
                 try:
-                    ApiTmdb.get_movie_details(movie, session)
-                except URLError:
+                    movie.update_from_tmdb()
+                except LookupError:
                     log.error('Error refreshing movie details from TMDb, cached info being used.')
             else:
-                log.debug('Movie %s information restored from cache.' % id_str())
+                log.debug('Movie %s information restored from cache.', movie.name)
         else:
             if only_cached:
-                raise LookupError('Movie %s not found from cache' % id_str())
+                raise LookupError('Movie %s not found from cache' % id_str)
             # There was no movie found in the cache, do a lookup from tmdb
-            log.verbose('Searching from TMDb %s' % id_str())
-            try:
-                if imdb_id and not tmdb_id:
-                    result = tmdb3.Movie.fromIMDB(imdb_id)
-                    if result:
-                        movie = session.query(TMDBMovie).filter(TMDBMovie.id == result.id).first()
-                        if movie:
-                            # Movie was in database, but did not have the imdb_id stored, force an update
-                            ApiTmdb.get_movie_details(movie, session, result)
-                        else:
-                            tmdb_id = result.id
-                if tmdb_id:
-                    movie = TMDBMovie()
-                    movie.id = tmdb_id
-                    ApiTmdb.get_movie_details(movie, session)
-                    if movie.name:
-                        session.merge(movie)
-                    else:
-                        movie = None
-                elif title:
-                    try:
-                        result = _first_result(tmdb3.tmdb_api.searchMovie(title.lower(), adult=True, year=year))
-                    except (socket.timeout, URLError):
-                        raise LookupError('Error contacting TMDb')
-                    if not result and year:
-                        result = _first_result(tmdb3.tmdb_api.searchMovie(title.lower(), adult=True))
-                    if result:
-                        movie = session.query(TMDBMovie).filter(TMDBMovie.id == result.id).first()
-                        if not movie:
-                            movie = TMDBMovie(result)
-                            ApiTmdb.get_movie_details(movie, session, result)
-                            session.merge(movie)
-                        if title.lower() != movie.name.lower():
-                            session.merge(TMDBSearchResult(search=search_string, movie=movie))
-            except tmdb3.TMDBError as e:
-                raise LookupError('Error looking up movie from TMDb (%s)' % e)
-            if movie:
-                log.verbose("Movie found from TMDb: %s (%s)" % (movie.name, movie.year))
+            log.verbose('Searching from TMDb %s', id_str)
+            if imdb_id and not tmdb_id:
+                try:
+                    result = tmdbsimple.Find(imdb_id).info(external_source='imdb_id')
+                except requests.RequestException as e:
+                    raise LookupError('Error searching imdb id on tmdb: {}'.format(e))
+                if result['movie_results']:
+                    tmdb_id = result['movie_results'][0]['id']
+            if not tmdb_id:
+                search_string = title + ' ({})'.format(year) if year else ''
+                searchparams = {'query': title}
+                if year:
+                    searchparams['year'] = year
+                try:
+                    results = tmdbsimple.Search().movie(**searchparams)
+                except requests.RequestException as e:
+                    raise LookupError('Error searching for tmdb item {}: {}'.format(search_string, e))
+                if not results['results']:
+                    raise LookupError('No resuts for {} from tmdb'.format(search_string))
+                tmdb_id = results['results'][0]['id']
+                session.add(TMDBSearchResult(search=search_string, movie_id=tmdb_id))
+            if tmdb_id:
+                movie = TMDBMovie(id=tmdb_id)
+                movie.update_from_tmdb()
+                movie = session.merge(movie)
+            else:
+                raise LookupError('Unable to find movie on tmdb: {}'.format(id_str))
 
-        if not movie:
-            raise LookupError('No results found from tmdb for %s' % id_str())
-        else:
-            session.commit()
-            return movie
-
-    @staticmethod
-    def get_movie_details(movie, session, result=None):
-        """Populate details for this :movie: from TMDb"""
-
-        if not result and not movie.id:
-            raise LookupError('Cannot get tmdb details without tmdb id')
-        if not result:
-            try:
-                result = tmdb3.Movie(movie.id)
-            except tmdb3.TMDBError:
-                raise LookupError('No results for tmdb_id: %s (%s)' % (movie.id, sys.exc_info()[1]))
-            try:
-                movie.update_from_object(result)
-            except tmdb3.TMDBRequestInvalid as e:
-                log.debug('Error updating tmdb info: %s' % e)
-                raise LookupError('Error getting tmdb info')
-        posters = result.posters
-        if posters:
-            # Add any posters we don't already have
-            # TODO: There are quite a few posters per movie, do we need to cache them all?
-            poster_urls = [p.url for p in movie.posters]
-            for item in posters:
-                for size in item.sizes():
-                    url = item.geturl(size)
-                    if url not in poster_urls:
-                        poster_data = {"movie_id": movie.id, "size": size, "url": url, "file": item.filename}
-                        movie.posters.append(TMDBPoster(poster_data))
-        genres = result.genres
-        if genres:
-            for genre in genres:
-                if not genre.id:
-                    continue
-                db_genre = session.query(TMDBGenre).filter(TMDBGenre.id == genre.id).first()
-                if not db_genre:
-                    db_genre = TMDBGenre(genre)
-                if db_genre not in movie.genres:
-                    movie.genres.append(db_genre)
-        movie.updated = datetime.now()
-
-
-def _first_result(results):
-    if results and len(results) >= 1:
-        return results[0]
+        return movie
 
 
 @event('plugin.register')

--- a/flexget/plugins/api_tmdb.py
+++ b/flexget/plugins/api_tmdb.py
@@ -114,8 +114,8 @@ class TMDBGenre(Base):
 
     __tablename__ = 'tmdb_genres'
 
-    id = Column(Integer, primary_key=True)
-    name = Column(Unicode, nullable=False, unique=True)
+    id = Column(Integer, primary_key=True, autoincrement=False)
+    name = Column(Unicode, nullable=False)
 
 
 class TMDBPoster(Base):

--- a/flexget/plugins/api_tmdb.py
+++ b/flexget/plugins/api_tmdb.py
@@ -25,6 +25,16 @@ Base = db_schema.versioned_base('api_tmdb', 0)
 # This is a FlexGet API key
 tmdbsimple.API_KEY = 'bdfc018dbdb7c243dc7cb1454ff74b95'
 
+_tmdb_config = None
+
+
+def get_tmdb_config():
+    """Gets and caches tmdb config on first call."""
+    global _tmdb_config
+    if not _tmdb_config:
+        _tmdb_config = tmdbsimple.Configuration().info()
+    return _tmdb_config
+
 
 @db_schema.upgrade('api_tmdb')
 def upgrade(ver, session):
@@ -122,10 +132,10 @@ class TMDBPoster(Base):
     vote_count = Column(Integer)
     iso_639_1 = Column(Unicode)
 
-    def get_file(self, only_cached=False, size='w500'):
-        """Makes sure the poster is downloaded to the local cache (in userstatic folder) and
-        returns the path split into a list of directory and file components"""
-        # TODO: Is this used anywhere? make it work
+    @property
+    def url(self):
+        return get_tmdb_config()['images']['base_url'] + 'original' + self.file_path
+
 
 class TMDBSearchResult(Base):
 

--- a/flexget/plugins/input/emit_movie_queue.py
+++ b/flexget/plugins/input/emit_movie_queue.py
@@ -60,10 +60,10 @@ class EmitMovieQueue(object):
                 if queue_item.tmdb_id:
                     entry['tmdb_id'] = queue_item.tmdb_id
 
-                plugin.get_plugin_by_name('tmdb_lookup').instance.lookup(entry)
                 # check if title is a imdb url (leftovers from old database?)
                 # TODO: maybe this should be fixed at the queue_get ...
                 if 'http://' in queue_item.title:
+                    plugin.get_plugin_by_name('tmdb_lookup').instance.lookup(entry)
                     log.debug('queue contains url instead of title')
                     if entry.get('movie_name'):
                         entry['title'] = entry['movie_name']
@@ -77,6 +77,7 @@ class EmitMovieQueue(object):
                 # Add the year and quality if configured to (make sure not to double it up)
                 if config.get('year') and entry.get('movie_year') \
                         and unicode(entry['movie_year']) not in entry['title']:
+                    plugin.get_plugin_by_name('tmdb_lookup').instance.lookup(entry)
                     entry['title'] += ' %s' % entry['movie_year']
                 # TODO: qualities can now be ranges.. how should we handle this?
                 if config.get('quality') and queue_item.quality != 'ANY':

--- a/flexget/plugins/metainfo/tmdb_lookup.py
+++ b/flexget/plugins/metainfo/tmdb_lookup.py
@@ -33,17 +33,17 @@ class PluginTmdbLookup(object):
         'tmdb_year': 'year',
         'tmdb_popularity': 'popularity',
         'tmdb_rating': 'rating',
-        'tmdb_genres': lambda movie: [genre.name for genre in movie.genres],
+        'tmdb_genres': 'genres',
         'tmdb_released': 'released',
         'tmdb_votes': 'votes',
         'tmdb_certification': 'certification',
-        'tmdb_posters': lambda movie: [poster.url for poster in sorted(movie.posters, key=lambda poster: poster.size)],
+        #'tmdb_posters': lambda movie: [poster.url for poster in sorted(movie.posters, key=lambda poster: poster.size)],
         'tmdb_runtime': 'runtime',
         'tmdb_tagline': 'tagline',
         'tmdb_budget': 'budget',
         'tmdb_revenue': 'revenue',
         'tmdb_homepage': 'homepage',
-        'tmdb_trailer': 'trailer',
+        #'tmdb_trailer': 'trailer',
         # Generic fields filled by all movie lookup plugins:
         'movie_name': 'name',
         'movie_year': 'year'}
@@ -55,7 +55,7 @@ class PluginTmdbLookup(object):
         imdb_id = (entry.get('imdb_id', eval_lazy=False) or
                    imdb.extract_id(entry.get('imdb_url', eval_lazy=False)))
         try:
-            with Session(expire_on_commit=False) as session:
+            with Session() as session:
                 movie = lookup(smart_match=entry['title'],
                                tmdb_id=entry.get('tmdb_id', eval_lazy=False),
                                imdb_id=imdb_id,

--- a/flexget/plugins/metainfo/tmdb_lookup.py
+++ b/flexget/plugins/metainfo/tmdb_lookup.py
@@ -37,13 +37,12 @@ class PluginTmdbLookup(object):
         'tmdb_released': 'released',
         'tmdb_votes': 'votes',
         'tmdb_certification': 'certification',
-        #'tmdb_posters': lambda movie: [poster.url for poster in sorted(movie.posters, key=lambda poster: poster.size)],
+        'tmdb_posters': lambda movie: [poster.url for poster in movie.posters],
         'tmdb_runtime': 'runtime',
         'tmdb_tagline': 'tagline',
         'tmdb_budget': 'budget',
         'tmdb_revenue': 'revenue',
         'tmdb_homepage': 'homepage',
-        #'tmdb_trailer': 'trailer',
         # Generic fields filled by all movie lookup plugins:
         'movie_name': 'name',
         'movie_year': 'year'}

--- a/flexget/plugins/metainfo/tmdb_lookup.py
+++ b/flexget/plugins/metainfo/tmdb_lookup.py
@@ -33,7 +33,8 @@ class PluginTmdbLookup(object):
         'tmdb_year': 'year',
         'tmdb_popularity': 'popularity',
         'tmdb_rating': 'rating',
-        'tmdb_genres': 'genres',
+        # Make sure we don't stor the db association proxy directly on the entry
+        'tmdb_genres': lambda movie: list(movie.genres),
         'tmdb_released': 'released',
         'tmdb_votes': 'votes',
         'tmdb_certification': 'certification',

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ jinja2
 requests>=1.0, !=2.4.0, <2.99
 python-dateutil!=2.0, !=2.2
 jsonschema>=2.0
-tmdb3
+tmdbsimple
 path.py
 guessit>=2.0.3
 apscheduler

--- a/tests/cassettes/test_tmdb.TestTmdbLookup.test_tmdb_lookup
+++ b/tests/cassettes/test_tmdb.TestTmdbLookup.test_tmdb_lookup
@@ -15,24 +15,24 @@ interactions:
           of human traffickers intent on selling her into forced prostitution. Working
           against the clock, her ex-spy father must pull out all the stops to save
           her. But with his best years possibly behind him, the job may be more than
-          he can handle.","release_date":"2008-02-24","poster_path":"/3zlffXmo7QpVBc17QIJWrRfasVr.jpg","popularity":5.250912,"title":"Taken","video":false,"vote_average":7.1,"vote_count":2510}],"person_results":[],"tv_results":[],"tv_episode_results":[],"tv_season_results":[]}'}
+          he can handle.","release_date":"2008-02-24","poster_path":"/3zlffXmo7QpVBc17QIJWrRfasVr.jpg","popularity":5.715136,"title":"Taken","video":false,"vote_average":7.1,"vote_count":2510}],"person_results":[],"tv_results":[],"tv_episode_results":[],"tv_season_results":[]}'}
       headers:
         access-control-allow-origin: ['*']
         cache-control: ['public, max-age=21600']
         connection: [Close]
         content-length: ['753']
         content-type: [application/json;charset=utf-8]
-        date: ['Mon, 07 Mar 2016 09:36:24 GMT']
-        etag: ['"6c745991d4175b1b972fd73694911ddd"']
+        date: ['Mon, 07 Mar 2016 23:15:12 GMT']
+        etag: ['"bf310754888f9d25dc3a572b847e0551"']
         server: [openresty]
         status: [200 OK]
         x-memc: [HIT]
-        x-memc-age: ['4983']
-        x-memc-expires: ['16617']
+        x-memc-age: ['3726']
+        x-memc-expires: ['17874']
         x-memc-key: [9b0814597a8fadbf986894816a029df4]
         x-ratelimit-limit: ['40']
         x-ratelimit-remaining: ['39']
-        x-ratelimit-reset: ['1457343394']
+        x-ratelimit-reset: ['1457392522']
       status: {code: 200, message: OK}
   - request:
       body: null
@@ -65,94 +65,132 @@ interactions:
           X7d1JdC/aGzn8eEC+g1A3yB8F+/b6E7ENiMkUgEQkbkWn91C7B8+y8ybBJ7LLPnF4F/vSxTkI8bR
           zJ+fiLOwzcB4YX2eM48f9Mmtf/9bxQwSs47q8DTrx9/+6e9+/K8ff//j7/70Dz/+a2JqsH6dGhhr
           0zveaMBun6nj57ve4x1rbFKoMCTnqHOGvmdG6lpHm9SUaGGEsalmKvqvYkNmHiu2RNPP2Ez9gtjc
-          eG+2MTXdfQk/GzfUvzCL94+OULqHT5uOOhBbC2RbFJtdxGEub6M/OscgjjbPv/E60hyfXDX3/X8H
-          60jXlIy58mzmN2d2isoMRieH/PSPf/jp7//nz//0mz9/95/JqcNi6tmrV86ez/JiyMAbsxq/Kjr2
-          97/b6CvmQJJzK/WTuYz0p+/+VhZ/+vfv/vwvf5OcnB2cTJbFTMWN/FfFeZlWOL2xJ8rMNxl2gBEf
-          kIlVPnlU9fTkVTezMVkgiQPW9/+RnFyOrfd58g//nPnhN3/86z/+1Q+//+EPP/wbU76vcch8tI9v
-          X4L+4wNWAo/lD1/8OOwx73IvnX6Yuc1ZWPwZGQzTUKa4sbuNA/qJUTgsLPFKSe4xIcxLCRgTICDh
-          XEMhu/rW1OIrQxmB+J5/Fqytroe5nOkfDmOCQHbfrguWZI1zhZr4TlhEiQSfRh5W+hisUqV2VFWb
-          3mTaMXd+UZWAl+35ldy2+D5YQaYUyAQJx/EXhm3OJj2se9VmdeUotXrD6SvTsjOf5pvvhIWIcIgf
-          I9SAc8jphVY729oq+8WqYtJsqQ1hGfU5Qgm9DRBQLBLxcTxHlV9REf35qMpw3G5r3V5BrjrezJIn
-          G7E7nNKqD8P3CRNRQSKSIFBCIOVYIfiYXMNhazbOl8IHWDqwRG7sktK0tPGaPhy8Fxaw/AdgTKEU
-          B/RTWPIx1nm/06rjPa1M9E5TlGT5sB3t1AYIuvN36QCSmBbICAuiLGF6EfU9OmDVO5OSsa2rolQl
-          pclkWq7SwLFA0Zm+D/XR6h9HfI6KP4a6sMbSDE1CNC1V7Ma079By6Bh+pVL+f4eaJRVDMzfbXb5a
-          qZuHVW++E8SgNPbL1jtRgUwlGUqEEMApwAdR7bWiaI3Cej/KFvF8vulsDrBcLduT0H0fKhQlSUCS
-          iCUsSb8oanYBZpK6aikKWDhwnT/kp4dcfWgIU975/5+jSm0HjP3mst+qUB27eqHddCRT3Xaqw1ve
-          6rFw4FmhLCGJyqxaFLHIeau3xFTKnAeAVGbumXCsxtyzvV7D6o/zCrBUVQZLSd+Eftd94Fgpxm8Q
-          K2SUWKSUCY6J9xz1JLEi4Fh6pqBC5u5kpvCY8GLV1t2mr3hqoxQWVBphoohiw1hV146WQBXehAqw
-          JD6PF6WKZTkd9YoG7IbryUMeL5W1pU18SyGrwoM/EVC/aNzSgAuslApYkGUsQAwvu6uLGnCFdSFI
-          S1SxA6iN94NytIrK3dGmUWyOa8+NkYusF7SVZdcAiY8jl1+dJC3vYcVzddtfN0uq3hJdg1Z22rbT
-          DVd1bVC7xXpBroiV+OR5PGeNC9WPwIq9vG5iz69DDBrRuu8v2lrRzJUG74tYzK4gIXH9HP/kUE/y
-          q/d4rN3DYozmXgfpD2unVvDD6txZTMcPrsibFs+argLMfmUAH0e+AfAx0nXJRoVOESlqNYrCkdl1
-          sO6T2qi92dwgTZcqkIU4EDDvKAqxczxFFT+GSnqH1r7ntdyOZ3eGpuKE65qaj8pmof0+ZQXSsef8
-          OHKJwAcNa9E5uJNtwa/YG8so7eadQ+lQD/0JnWffySrIIkXkceQc1gdZgxwpKMPiZKx1xsZcXtX3
-          i6E3ata6q/F7WPG9LCNZliCrXCWZt6wPFgNo42aDYR/UD9Fkva5CDUCvJ3XdsHoLNc2wwD04pzsx
-          +5gu7roeu95pPRZwL559JA71doP8hZXEyy83WMk9gaLAwhbLOVidzfctToIWAClyvUWroW5koxCU
-          /X5jXZuKG0spFuSs0RRuwh77rjwsJif/uOpV+CDrGkXzKTksZvvNtj/syTWy7YlOMVvc72/CpkpW
-          kJEEmHGxgkCOe9O/qGSXvb3RM8uOmStPNqVRreJAmPN8lbT4miBJq+lptJQZGAaUEElEnGhPXOwF
-          WAkcnXOsRQTEpfoZrPLQndmSGZLBMJ8dsmvugppNB/JYQwnYeBnwTLTx2kYSFouQPI1cUngSulho
-          S4O9LlmpNHZwvtie6HJtAoHbKR60mVTpHFoeD4t4yRrRu2FpumCvs1rdID8sbeekqOUK20arPK13
-          kVisdKwCz5rQgnSdRayABc8jp7MnmdYFNbhO60rNeXUil0Opqs8HTne9W7qmsKMll1cDBHlaP1Wy
-          1zqDOB2RmSRmaaSIsXzUtfMMq6GRFSJ+v9oqHLpCLZ/1Q9vTCNzyaUu81n7G5/5MPpZ3p+Fdl6DW
-          0FYbCKS52odWu9jSsrvaKqwilSYSgMTzNlKt/grhpYcsQeH0wyHawowEw/ZOXqparultq6V1Qwmj
-          Wd0OeBkSXiNTTf0KIXM2qYCAUIoEgmQMYdw1OAPULb1VFhewmyU1XQck35acelSb5KU1L0OJl6EZ
-          /kzC2EWkIV5/zEEDYlvolWa5aWdX6YurXCFfnhS2Uo2XYfIxpzp3JL+W0OAy7IUHfh1WlaxmfRGa
-          Ay8nTlR9Ewyq9ShX6+5XicWJBGyqD0IvGWk8crCn3j2dVoKQhTDmbQUgCZTvpPiTfKNVhGbQaO7U
-          8ixbEgtad9MvO7McTwsAeoN3RxSyqzyP57SvKQmzmVRWcE2y6/WqTQe+MQ73pfn20PPpfLpblpe+
-          w69TJCNRqi0h5rYEUWRxmkp8JHpt+1CcGjWvy3WuuoOSD1rZSb9nLRruoYl6K5AN1WGy5n+bXEWR
-          IEwQy6AIv1DxmjxdkitL1C+7qP1005VBtjce52ulfpHWulW/v6uMAsI3KZNyVVPlilkoeVn9u2Re
-          lKSynmpAUgcUH9SKWr4Zto0xPQw3g6AG6URoTeGOZ01YV7orYJkzgk8j5wreYFxYZrdBMEZIFuP+
-          3RmsY7aqqLcbF9Z+paw1SZAtVKr7CpAniUVVljCew6bm+2+ETa37j0kpM0mZPI580bfob0yFolAe
-          TOSHpSgVvJrj9Sf1rljmYUH8ptLNOPA2WElI1QIJUCyw68S1LYr1/YyVukOj4u36630xCGrStqtu
-          JhbZj8MyvwyIIOYEm25dVxZWTgICQSkN4FsquymWFkad9GcjqVJV9+WwXlpWArqsTxIdlYTKpgcE
-          gcUvLLPHIGO+NBHATZ29TqvmgRENZkF3etg1wwe6CNzaQ6tRqa5vJ6XptAz3+T0AxDnZt6SnJ68R
-          xIefewNAbNUq5fX6QhWor9ojJTJbXWGw5qNXInVJd1xvYsWPr6bxqNflavXMgdnuKD2lGVBAe+V8
-          sR7k29lRj/JakHCy6XIF8fLa03ixXXmhjLpuXt44VxwHSMkXBpER1GY9pwLyzdy0luirvdW8AKDy
-          8wsh/Cr7B82LFL1svQ+L1SAnFGC7MlxFnlqLxGIiwX6jYKFMMUTicZTOWV97gBfkeh2VLh82gaXq
-          e9RZVUNa78yxlFtohX0k86gJT5AaDyCVmU9nGQgivAqctADf5QdEaDOGpuVDa2Utu359WtSHe2G4
-          1MlN1nSxUgQklsvKUID8AstHYVEF5q12BQ56QX4V1lXfXBx2Yk5EJXgTNjUriNfzRPA8ci72Nixl
-          EY8iHC8mQAz5rEBfZSuKUQy0NXEszZxazUhs1CaFNb/MJsWp2imrZ6eyIijC5/GSIyDpqBJgqo6Q
-          xPwIq4kQhxqUUZnYziBYd0BBXdL1Uhivfc221iYv12MkeoNcIRReIu1FR3BBrhKQAcRYkhEkcTfm
-          3Lj83rgrRrhWGKukLc8L7TCsVUZrX0/JCeBbjOttrASmlgeiRE4ybj4znFUqGkFiq7Ls7XTFGNly
-          Yb5y52NN56OBcPzWwG3rYpUIYFW+KLN8i0+5X90WKx/SYxfzIq//+Xiwq+UCTe76pRmAE9n1sk2y
-          K/dtuz7iW4DMNjnYtDB7fCMAEUqAwGzkHFZ6DbPpHSGJhS1AZAri5aQ4ET3XAjKqrjCcrbR9bzQY
-          b6V2T68St25UEmsXUOBCV2pPDWLCcgfAKihJ4H3sa911IRwwVowpkljFhoDIZy+02BX94tprRxGW
-          +svAaFZystIf7p3EGxeY7w2lZtzMNpi6PI+XvVbaklDsYvmSIOiNxfa8Wx4b9hDlrSmc4SZtFhby
-          81diLnvVdCUV4rRVhKIgYj4NeK2344I4le+qRWlALdQO5eZODyRzWJI1DVWbaF3uVErvtChW11PM
-          EiWEeet/Zb1oT1fDlbablfaB3ZyODv3uAlWF6RjMBuNSfvZOuUJIJRHELzJCvtC6XQ9IzJpkFC9T
-          iKyw4A1qNdlO63kUtNTtPkuLyqHZ31acyoNDEmtWIFags3CVqqQgjjdP48W8VSLHb6AkWF+y8+PI
-          sa6N8c4XQFEVRdM5DMRolmstxWzOJ3y/Oi433mL8rMQicdksUeZvLinBZcGKp7QcrMHcV3a7KNKg
-          6ljDTaVanqzyuXWh7CRylgRsamwFEsAoXl9DMJG4vsLKNOXFIMbK0c13dKnlRntrppieCEm1nsMN
-          TJZje8TTvU1HwUkPk+8GnHUxL3l9CDErd1m1IgnxS8XnyWrerqFNwTM1edcvLGx1VFoWOoEZEN7r
-          xys5b6HFIvP7zKSwICB+3efkTQDy+D0qnva6+S8GB7HXK8w2g1o0wwLd7JAANkXV83lX9caKhdFC
-          mQUZgUAYNxNPaW/GKDEWyPmzF7LbvVLo9rej5sHcBmurVW3alQGZ8HgJxUzHE0RWojyNfHPlNfWX
-          H7+qleBjdwaQwNJUScCEtyIBliNxUcg7y17fKvUc1TMn2YJNQznRXAHHL0PehGVZFKQCZikmTHTb
-          X83ogn8SZULj154pISzS8TFK7rS8CraXs4ZenroerdrdLDY64wc94UsFev7eYhosvmfGLAgsJ5ZZ
-          IXj5dVBZTG2xsQqX1SmSzBRAlhNVSmiNen5hUyq1JWU8MM0m8nA+b5ZaTSXBGvcSz1iTZcqVl0Bk
-          nO6RmMWffDi8aFKHckCrTS/rmkWr3tXK4AF7NVrhRSnzOmollyav0InCO3oSJpqVd6pUFsQcsqJF
-          u7QXDwsrKhXthIXz3jPtZZ8reJdiz3U+VDWn4/yiQ7NWcd1sj0Sad6qL6TwQDjxfwgOl1KBX+C45
-          nat4cwvo80AhG+T2cbHr1Q75fM1SHki2x+El1kx/Ht2Fovg6HWqRiu5mc7n8tmnmlm1lorpbZdS1
-          93w19KYO6RW8S03R63xRu9HICeG259c366WKoLsbD2bzprDBt6SXkgRdwYul9+uvX/8Xwdk5+Ms/
-          AAA=
+          eG+2MTXdfQk/GzfUvzCL94+OULqHT5uOOhBbC8Sf7hSbXcRhLm+jPzrHII42z7/xOtIcn1w19/1/
+          B+tI15SMufJs5jdndorKDEYnh/z0j3/46e//58//9Js/f/efyanDYurZq1fOns/yYsjAG7Mavyo6
+          9ve/2+gr5kCScyv1k7mM9Kfv/lYWf/r37/78L3+TnJwdnEyWxUzFjfxXxXmZVji9sSfKzDcZdoAR
+          H5CJVT55VPX05FU3szFZIIkD1vf/kZxcjq33efIP/5z54Td//Os//tUPv//hDz/8G1O+r3HIfLSP
+          b1+C/uMDVgKP5Q9f/DjsMe9yL51+mLnNWVj8GRkM01CmuLG7jQP6iVE4LCzxSknuMSHMSwkYEyAg
+          4VxDIbv61tTiK0MZgfiefxasra6HuZzpHw5jgkB2364LlmSNc4Wa+E5YRIkEn0YeVvoYrFKldlRV
+          m95k2jF3flGVgJft+ZXctvg+WEGmFMgECcfxF4ZtziY9rHvVZnXlKLV6w+kr07Izn+ab74SFiHCI
+          HyPUgHPI6YVWO9vaKvvFqmLSbKkNYRn1OUIJvQ0QUCwS8XE8R5VfURH9+ajKcNxua91eQa463syS
+          JxuxO5zSqg/D9wkTUUEikiBQQiDlWCH4mFzDYWs2zpfCB1g6sERu7JLStLTxmj4cvBcWsPwHYEyh
+          FAf0U1jyMdZ5v9Oq4z2tTPROU5Rk+bAd7dQGCLrzd+kAkpgWyAgLoixhehH1PTpg1TuTkrGtq6JU
+          JaXJZFqu0sCxQNGZvg/10eofR3yOij+GurDG0gxNQjQtVezGtO/QcugYfqVS/n+HmiUVQzM3212+
+          Wqmbh1VvvhPEoDT2y9Y7UYFMJRlKhBDAKcAHUe21omiNwno/yhbxfL7pbA6wXC3bk9B9HyoUJUlA
+          koglLEm/KGp2AWaSumopClg4cJ0/5KeHXH1oCFPe+f+fo0ptB4z95rLfqlAdu3qh3XQkU912qsNb
+          3uqxcOBZoSwhicqsWhSxyHmrt8RUypwHgFRm7plwrMbcs71ew+qP8wqwVFUGS0nfhH7XfeBYKcZv
+          ECtklFiklAmOifcc9SSxIuBYeqagQubuZKbwmPBi1dbdpq94aqMUFlQaYaKIYsNYVdeOlkAV3oQK
+          sCQ+jxelimU5HfWKBuyG68lDHi+VtaVNfEshq8KDPxFQv2jc0oALrJQKWJBlLEAcF1AXtPWiBlxh
+          XQjSElXsAGrj/aAcraJyd7RpFJvj2nNj5CLrBW1l2TVA4uPI5VcnSct7WPFc3fbXzZKqt0TXoJWd
+          tu10w1VdG9RusV6QK2IlPnkez1nhB5NBsZfXTez5dYhBI1r3/UVbK5q50uB9EYvZFSSE1c/Hnxzq
+          SX71Ho+1e1iM0dzrIP1h7dQKflidO4vp+MEVedPiWdNVgNmvDODjyDcAPka6Ltmo0CkiRa1GUTgy
+          uw7WfVIbtTebG6TpUgWyEAcC5h1FIXaOp6jix1BJ79Da97yW2/HsztBUnHBdU/NR2Sy036esQDr2
+          nB9HLhH4oGEtOgd3si34FXtjGaXdvHMoHeqhP6Hz7DtZBVmkiDyOnMP6IGuQIwVlWJyMtc7YmMur
+          +n4x9EbNWnc1fg8rvpdlJMsSZJWrJPOW9cFiAG3cbDDsg/ohmqzXVagB6PWkrhtWb6GmGRa4B+d0
+          J2Yf08Vd12PXO63HAu7Fs4/Eod5ukL+wknj55QYruSdQFFjYYjkHq7P5vsVJ0AIgRa63aDXUjWwU
+          grLfb6xrU3FjKcWCnDWawk3YY9+Vh8Xk5B9XvQofZF2jaD4lh8Vsv9n2hz25RrY90Slmi/v9TdhU
+          yQoykgAzLlYQyHFv+heV7LK3N3pm2TFz5cmmNKpVHAhznq+SFl8TJGk1PY2WMgPDgBIiiYgT7YmL
+          vQArgaNzjrWIgLhUP4NVHrozWzJDMhjms0N2zV1Qs+lAHmsoARsvA56JNl7bSMJiEZKnkUsKT0IX
+          C21psNclK5XGDs4X2xNdrk0gcDvFgzaTKp1Dy+NhES9ZI3o3LE0X7HVWqxvkh6XtnBS1XGHbaJWn
+          9S4Si5WOVeBZE1qQrrOIFbDgeeR09iTTuqAG12ldqTmvTuRyKFX1+cDprndL1xR2tOTyaoAgT+un
+          SvZaZxCnIzKTxCyNFDGWj7p2nmE1NLJCxO9XW4VDV6jls35oexqBWz5tidfaz/jcn8nH8u40vOsS
+          1BraagOBNFf70GoXW1p2V1uFVaTSRAKQeN5GqtVfIbz0kCUonH44RFuYkWDY3slLVcs1vW21tG4o
+          YTSr2wEvQ8JrZKqpXyFkziYVEBBKkUCQjCGMuwZngLqlt8riAnazpKbrgOTbklOPapO8tOZlKPEy
+          NMOfSRi7iDTE6485aEBsC73SLDft7Cp9cZUr5MuTwlaq8TJMPuZU547k1xIaXIa98MCvw6qS1awv
+          QnPg5cSJqm+CQbUe5Wrd/SqxOJGATfVB6CUjjUcO9tS7p9NKELIQxrytACSB8p0Uf5JvtIrQDBrN
+          nVqeZUtiQetu+mVnluNpAUBv8O6IQnaV5/Gc9jUlYTaTygquSXa9XrXpwDfG4b403x56Pp1Pd8vy
+          0nf4dYpkJEq1JcTcliCKLE5TiY9Er20filOj5nW5zlV3UPJBKzvp96xFwz00UW8FsqE6TNb8b5Or
+          KBKECWIZFOEXKl6Tp0tyZYn6ZRe1n266Msj2xuN8rdQv0lq36vd3lVFA+CZlUq5qqlwxCyUvq3+X
+          zIuSVNZTDUjqgOKDWlHLN8O2MaaH4WYQ1CCdCK0p3PGsCetKdwUsc0bwaeRcwRuMC8vsNgjGCMli
+          3L87g3XMVhX1duPC2q+UtSYJsoVKdV8B8iSxqMoSxnPY1Hz/jbCpdf8xKWUmKZPHkS/6Fv2NqVAU
+          yoOJ/LAUpYJXc7z+pN4VyzwsiN9UuhkH3gYrCalaIAGKBXaduLZFsb6fsVJ3aFS8XX+9LwZBTdp2
+          1c3EIvtxWOaXARHEnGDTrevKwspJQCAopQF8S2U3xdLCqJP+bCRVquq+HNZLy0pAl/VJoqOSUNn0
+          gCCw+IVl9hhkzJcmArips9dp1TwwosEs6E4Pu2b4QBeBW3toNSrV9e2kNJ2W4T6/B4A4J/uW9PTk
+          NYL48HNvAIitWqW8Xl+oAvVVe6REZqsrDNZ89EqkLumO602s+PHVNB71ulytnjkw2x2lpzQDCmiv
+          nC/Wg3w7O+pRXgsSTjZdriBeXnsaL7YrL5RR183LG+eK4wAp+cIgMoLarOdUQL6Zm9YSfbW3mhcA
+          VH5+IYRfZf+geZGil633YbEa5IQCbFeGq8hTa5FYTCTYbxQslCmGSDyO0jnraw/wglyvo9Llwyaw
+          VH2POqtqSOudOZZyC62wj2QeNeEJUuMBpDLz6SwDQYRXgZMW4Lv8gAhtxtC0fGitrGXXr0+L+nAv
+          DJc6ucmaLlaKgMRyWRkKkF9g+SgsqsC81a7AQS/Ir8K66puLw07MiagEb8KmZgXxep4InkfOxd6G
+          pSziUYTjxQSIIZ8V6KtsRTGKgbYmjqWZU6sZiY3apLDml9mkOFU7ZfXsVFYERfg8XnIEJB1VAkzV
+          EZKYH2E1EeJQgzIqE9sZBOsOKKhLul4K47Wv2dba5OV6jERvkCuEwkukvegILshVAjKAGEsygiTu
+          xpwbl98bd8UI1wpjlbTleaEdhrXKaO3rKTkBfItxvY2VwNTyQJTIScbNZ4azSkUjSGxVlr2drhgj
+          Wy7MV+58rOl8NBCO3xq4bV2sEgGsyhdllm/xKfer22LlQ3rsYl7k9T8fD3a1XKDJXb80A3Aiu162
+          SXblvm3XR3wLkNkmB5sWZo9vBCBCCRCYjZzDSq9hNr0jJLGwBYhMQbycFCei51pARtUVhrOVtu+N
+          BuOt1O7pVeLWjUpi7QIKXOhK7alBTFjuAFgFJQm8j32tuy6EA8aKMUUSq9gQEPnshRa7ol9ce+0o
+          wlJ/GRjNSk5W+sO9k3jjAvO9odSMm9kGU5fn8bLXSlsSil0sXxIEvbHYnnfLY8Meorw1hTPcpM3C
+          Qn7+Ssxlr5qupEKctopQFETMpwGv9XZcEKfyXbUoDaiF2qHc3OmBZA5LsqahahOty51K6Z0Wxep6
+          ilmihDBv/a+sF+3parjSdrPSPrCb09Gh312gqjAdg9lgXMrP3ilXCKkkgvhFRsgXWrfrAYlZk4zi
+          ZQqRFRa8Qa0m22k9j4KWut1naVE5NPvbilN5cEhizQrECnQWrlKVFMTx5mm8mLdK5PgNlATrS3Z+
+          HDnWtTHe+QIoqqJoOoeBGM1yraWYzfmE71fH5cZbjJ+VWCQumyXK/M0lJbgsWPGUloM1mPvKbhdF
+          GlQda7ipVMuTVT63LpSdRM6SgE2NrUACGMXrawgmEtdXWJmmvBjEWDm6+Y4utdxob80U0xMhqdZz
+          uIHJcmyPeLq36Sg46WHy3YCzLuYlrw8hZuUuq1YkIX6p+DxZzds1tCl4pibv+oWFrY5Ky0InMAPC
+          e/14JecttFhkfp+ZFBYExK/7nLwJQB6/R8XTXjf/xeAg9nqF2WZQi2ZYoJsdEsCmqHo+76reWLEw
+          WiizICMQCONm4intzRglxgI5f/ZCdrtXCt3+dtQ8mNtgbbWqTbsyIBMeL6GY6XiCyEqUp5Fvrrym
+          /vLjV7USfOzOABJYmioJmPBWJMByJC4KeWfZ61ulnqN65iRbsGkoJ5or4PhlyJuwLIuCVMAsxYSJ
+          bvurGV3wT6JMaPzaMyWERTo+RsmdllfB9nLW0MtT16NVu5vFRmf8oCd8qUDP31tMg8X3zJgFgeXE
+          MisEL78OKoupLTZW4bI6RZKZAshyokoJrVHPL2xKpbakjAem2UQezufNUqupJFjjXuIZa7JMufIS
+          iIzTPRKz+JMPhxdN6lAOaLXpZV2zaNW7Whk8YK9GK7woZV5HreTS5BU6UXhHT8JEs/JOlcqCmENW
+          tGiX9uJhYUWlop2wcN57pr3scwXvUuy5zoeq5nScX3Ro1iqum+2RSPNOdTGdB8KB50t4oJQa9Arf
+          JadzFW9uAX0eKGSD3D4udr3aIZ+vWcoDyfY4vMSa6c+ju1AUX6dDLVLR3Wwul982zdyyrUxUd6uM
+          uvaer4be1CG9gnepKXqdL2o3Gjkh3Pb8+ma9VBF0d+PBbN4UNviW9FKSoCt4sfR+/fXr/wK5t9lA
+          yz8AAA==
       headers:
         access-control-allow-origin: ['*']
         cache-control: ['public, max-age=28800']
         connection: [Close]
         content-encoding: [gzip]
-        content-length: ['4904']
+        content-length: ['4906']
         content-type: [application/json;charset=utf-8]
-        date: ['Mon, 07 Mar 2016 09:36:24 GMT']
-        etag: [W/"fc551e53657f2a912eb94a2f6f6997b2"]
+        date: ['Mon, 07 Mar 2016 23:15:14 GMT']
+        etag: [W/"415ef9768645807442a8f2107abe2b8e"]
         server: [openresty]
         status: [200 OK]
         vary: [Accept-Encoding]
         x-memc: [HIT]
-        x-memc-age: ['9129']
-        x-memc-expires: ['19671']
+        x-memc-age: ['585']
+        x-memc-expires: ['28215']
         x-memc-key: [5a83165c56fc93c8aa4de882d3298a4a]
         x-ratelimit-limit: ['40']
         x-ratelimit-remaining: ['38']
-        x-ratelimit-reset: ['1457343394']
+        x-ratelimit-reset: ['1457392522']
+      status: {code: 200, message: OK}
+  - request:
+      body: null
+      headers:
+        Accept: [application/json]
+        Accept-Encoding: ['gzip, deflate']
+        Connection: [close]
+        Content-Type: [application/json]
+        User-Agent: [python-requests/2.5.3 CPython/2.7.10 Windows/8]
+      method: GET
+      uri: https://api.themoviedb.org/3/configuration?api_key=bdfc018dbdb7c243dc7cb1454ff74b95
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA3VS0W7bMAz8Fz0HTdcmW5dfGQaBthhbiCwJFOUgLfrvExmnddbtieT5eKTOfDN+
+          ggGLObyZDgraSsEczMicD9utfnvgyXUPiYYtb/PWbEzBvhLav+jlv/wO+pOjlG3xrzLplzk/Pz62
+          D+cfLxq+PWlM5AcfIZjfGxPSkFb83V54P5+Uvd9peFFsUdprWCvkVBhppfHP7p2C1+5lnTsRSkcf
+          8Msm1/bx+7O0rxsK+xC+Dl3v+kl/35h+hDigPeFF+eBq4MYBT9YBo6ShJHuK6RwtFK3bsyKwn9Gy
+          54ACdj4NBHm8aE48OtC0ugFFr4eiAYn90fetO0Xpa+MJevEpwqRKPWGb62wn/a04t+AatChi9iU5
+          2WvJbKxTh7QCqMa22CScIyHqmXi3riYtB4xIzQbNSIcPFQvbwkBSjWnC3A6qpcuRSuK6q1poxtUF
+          leUlIJ8TnczNY9unGplk75vp+s51rRYKMCPNXp+bgVhUc4AebTpadVSBxPKr2hCnBEqu9uJlm6Sm
+          3CFThuh1vztYVrrChAGbH9d0xlhFotm3uFfaxxQ/kk+nl5pwqAEUyOmE0a4taSZylYRhCD6K3u2p
+          TBBL+LgBnm+W8kyte8kvWbizd5husbST/QP844lDMQQAAA==
+      headers:
+        access-control-allow-origin: ['*']
+        cache-control: ['public, max-age=36000']
+        connection: [Close]
+        content-encoding: [gzip]
+        content-length: ['490']
+        content-type: [application/json;charset=utf-8]
+        date: ['Mon, 07 Mar 2016 23:15:15 GMT']
+        etag: [W/"acd3a349fca1f788ac931639278ad061"]
+        server: [openresty]
+        status: [200 OK]
+        vary: [Accept-Encoding]
+        x-ratelimit-limit: ['40']
+        x-ratelimit-remaining: ['37']
+        x-ratelimit-reset: ['1457392522']
       status: {code: 200, message: OK}
   - request:
       body: null
@@ -273,12 +311,12 @@ interactions:
         content-encoding: [gzip]
         content-length: ['5588']
         content-type: [application/json;charset=utf-8]
-        date: ['Mon, 07 Mar 2016 09:36:25 GMT']
+        date: ['Mon, 07 Mar 2016 23:15:16 GMT']
         server: [openresty]
         vary: [Accept-Encoding]
         x-ratelimit-limit: ['40']
-        x-ratelimit-remaining: ['37']
-        x-ratelimit-reset: ['1457343394']
+        x-ratelimit-remaining: ['36']
+        x-ratelimit-reset: ['1457392522']
       status: {code: 200, message: OK}
   - request:
       body: null
@@ -294,86 +332,86 @@ interactions:
       body:
         string: !!binary |
           H4sIAAAAAAAAA82bSY/jyn3Av4rQ55ke1kJWcW7am6L2XQqMAUVSJCVu4qLNeEASJDk4+QIBcgqM
-          PMSAExu5GPGXeO82Tq7xIXDyHVJUd09LlFrSqP2cp8bUaJpF8sd//XfW/PRO0WI7uvs4VexQf3c3
+          PMSAExu5GPGXeO82Tq7xIXDyHVJUd09LlFrSqP2c142p0YhF8sd//XfW/PRO0WI7uvs4VexQf3c3
           UdS5Fnj+J1+JzLuPdx9IjPy1yslgtUZQsvXsvLoktCYbwep+5ht37BTd9lwj/BR5n1TPtnU1sjz3
           7uNP7yzt7iNEGL+7cxVHZxfrmnqmpkSBtc7kX2a+u/O9MNKDL7e0TayUfQ31xMARc7SxCIR8z2hV
-          o3H1+ZZpyknbgYWi0bNGqlVYIWfzEI9KklsgtrI75Rt2TqwZOntQAXG7z7s7Q3cDPbz7+GePqAB+
-          Ac1qS92N4kBnJz49B305+Ij9fIRHe88XWOyxgi/HKHk5raNauqvqmZL1dP5P3t2ZnqP7ipEcNqPI
-          //jhw2q1ul8pgasHk8AL71XP+eB4S0sPPyRz3zMqPYgUy3XYtw+Rqb93dvL8gAgCSFHJexFC8T0m
-          WHuvYIjeYzwhijBRgcLjezNybCa9hEzgGLblaJNPyb/uoogDCHEiYoe9wDIsV7E/2YprxI90erJM
-          Xw5EVmQfrmdydKkHDHS1+73nKGEme5/JupoehJ6bscKMknEUN2NbS8s1MtHKS77q4X0mt8loyibD
-          rpVMcjMKuxC7a4Y9ux+zx834gWcEiuOwr4qrZSabjGsZZrS7oK0vPZvJImMylWAT5q63YpcIM3Xd
+          o3H1+ZZpyknbgYWi0bNGqlVYIWfzEI9KklsgtrI75Rt2TqwZOntQAXG7n3d3hu4Genj38c8eUQH8
+          AprVlrobxYHOTnx6Dvpy8BH7+QiP9p4vsNhjBV+OUfJyWke1dFfVMyXr6fyfvLszPUf3FSM5bEaR
+          //HDh9Vqdb9SAlcPJoEX3que88HxlpYefkjmvmdUehApluuwTx8iU3/v7OT5AREEkKKS9yKE4ntM
+          sPZewRC9x3hCFGGiAoXH92bk2Ex6CZnAMWzL0Safkn/dRREHEOJExA57gWVYrmJ/shXXiB/p9GSZ
+          vhyIrMg+XM/k6FIPGOhq973nKGEme5/JupoehJ6bscKMknEUN2NbS8s1MtHKSz7q4X0mt8loyibD
+          rpVMcjMKuxC7a4Y9ux+zx834gWcEiuOwj4qrZSabjGsZZrS7oK0vPZvJImMylWAT5q63YpcIM3Xd
           e5dZmV5marlamDEtJ9TtaSZSAqYF+u4qTHwZ37MttigrU3efCFTPjRT1aUrNC3xTj8N37Ga2zhRG
           U4LNC9njTR/vE+hLndnQ7qqh6anz3WMGcWRmlIkXRxkvDtgkxbaizf1O6f3YVgL2L7Ya9xgJPCHH
           pjD2B35QWUykkl/s87H3MPVkTs673cGTKTDhaPFOoz4lWIprPan0k9r1mUYm0mx7isawVpkm0784
           0ftHRSBioqxPk8uBF6vsWSSJqantZJpKEDFVDE3Lf5qOCNyb37FstljpSwJK+b1Jg506Z3KJPj9r
           HxBxov8H8LHLNOnZHkPvEwKC8AkkBte7ezG+OIwCJkPl0cb2p/U6L9N6rpWsYCdSIj3MeNNMlmmP
-          pSo7qwt0W1dC/ZPGDrK5QBTF9xx6j7i75Biz/Jj9GguIBwRRZiYBI7OSywIkvLsLfW+uu1+M44VX
-          QOKOY2crTxxF17Ct0NzdNmQwMZt+1368v8amRQo77u6kpNts/fRM5O00qM0UJTPwAltLZHbS4JaW
-          pntfHPfSi/RPT6bDVvWePP1qJ1fmpUDyJIrNlMtVImZ4j0YcJn76+Vta7juBHt86A16R/fPUgalE
+          pSo7qwt0W1dC/ZPGDrK5QBTF9xx6j7i75Biz/Jh9jQXEA4IoM5OAkVnJZQES3t2FvjfX3S/G8cIr
+          IHHHsbOVJ46ia9hWaO5uGzKYmE2/az/eX2PTIoUdd3dS0m22fnom8nYa1GaKkhl4ga0lMjtpcEtL
+          070vjnvpRfqnJ9Nhq3pPnr7ayZV5KUDZN4rNlMtVImZ4j0YcJn76+VNa7juBHt86A16R/fPUgalE
           iSUlz/FEe3RCsbx3wudvf/dXv/vrz79gf379+V+PJzere5Nfu2JteMWkXPsrObuDvRP++9tf/v5f
           /vG/fvvb3//t3x9PLe7L4LXrtRNdfp703T9896vv//L7P//uN9//zXe/Op4s79P+4duf/+/PfvOH
           f/rl//zs58dTDxbg8ebvMmzNjmfms3szq4kPZZPVExPb+5d8Qf3u37//i+PJ0j4qW8dvP//i86//
-          8+/+458//xtT/m+SWPNoLD/9ErwfNU4JfZYHfAqYUjJlBvdk/8Oi59Sy9a9IRkw9CQ3sQhxlEX7P
-          LN3YttNWwt9jFik5kSAEIObgockkIX9lacmdgQi55JG/CnbT0ou1mZtrSNmotJDiom9u9PCBU4RN
-          CpbAa1iRCAkHecTzvCjQQ1aAX1gh/XpWOMlK7VWeEL9cW0uxbqgLJ6K0VCHl21h5jAhGHKECTLNC
-          9DZWo4Zk2apTbjGpGPLDrOk62elq3bHUNOuVSoAwTzksUioIEKAULHibEizlWmHBW2qhuqlIlFsr
-          zrSC3VURtVs3wiKBAiLwiIocTWksEN8GO9UXk9G8rIPZFg/8B9Mo+nphHOF5d3wjLIB8CvEKQhEz
-          LRcRpShRlQPC9cShkj0w4rwatarEXcj+zA82JZPXjwiJeED4GJfThFDkAKE8ARiy8etZz0jTGePS
-          OvdQ9to1NY6trfIgC/w4t2gGiyPWq6QJeUHAFABEROazXncAN8HmG+PSuun0uOLKkmF17RajYqGF
-          7AjfCIt5DMHTmFIC+DZW0dVm2XAwHxobZ1PhtFmcs6JpvT7omj861q2+cued4cptb0C1G1IftXoh
-          XpTarelNjpUjiAM8fRpTOrDHeotjdTu58bZe38iNVnm+Hi2dttCouE7AudptcuUEikUE+Me/U7Dc
-          2wS7sqwAN9rZIbB8xRNb6CH0e9t2Xeosb4TFLAXgeAgoD/l0eH0jrDbJrWSK+qExLzSXhepcLKn+
-          tlsorm/SWO6eO+R7I96GdyeVcTRsUFrolMuBuSysPVUyxZHxY8CLo22ZF6CW7Xp1dWoR/wEV+wM0
-          EhY3Bfw/Np7o+1ZJAP4ATYcDt7NVZllMWFnbG49+DHjTJSv95MCyK+UWRONhNuf2O3Zp5pXIDR7o
-          HN0tPqdk1evmzJO5jVcSZatH27nsdjioDn8UstuC5nKkb9bZRdSs5CFaTlvr6nxQzLqNH4HsgpnW
-          mXlIrxeKs2ZsRXQ9nyNvockN+qcTniCIIgdFAAWY9ipC3uwWhg+2tEFdaTwPisVKdgpbbbV7hIfe
-          hkcR2LWTds2zU3Uldy8cfEiKVRmUCuW8VM91ylyu9RCuW4VK1CkW1uu0kbBodsh650d3aVaeSQYL
-          mFAWqCES8SE4fQHnuBNyvQR7uSn4OuzJJFgAIofJ05iugveSiptojY2bq29XG5b+RsOFXZTlquXV
-          5zPZqN9Gy4sipiIReZGteyoFwnsV0E20k2lcK/ZAR8UyxDNod6RloVXIFwRrfZFW00/RUgoRD0UM
-          kqrtkJa/BjZJSA8QzQWaNaAb93ONkb+Qe932HFUFrFhxmEYU0oi7Hm0akeW9Lz/CIeJerc4JwmlE
-          wkp9VpSykg2RdMFW05Sy6YsNq65Trz3i4rhPpC5sNL0UKxMSPmQN4hOsiGIB8E+jmFLVF1ZW0J1i
-          JcxTUcpzPMGEeax0SkmG0lwaqaSt1Sejsp1DUI39TYO6+TQsIPwVTuBaWLjrwadhzysqaEudAZzb
-          XaFu5Q3Z7c7VVex7mtJIh6ZjRT1pVogiDkLmtxAkSSWxDytco6hnYKt5dbzMwZG7Nkil0TKWVnk1
-          RrYgPL/Qe511Gpxk5SAGrBim4rELeCMrDAo6n8+HNk/NptWskZWz1XQOVC14Efa0YIlIWVHBPACH
-          EUhpwV6P4SbacbNmPgyL5iiH0Mjrjsf1uqNvI5Pr3worIIw5KnAQ8ClY4a2w5no1to1mub3pU0mz
-          OXfB6syN1VO5wmXaU54L8TwC4Hl81cBuglX6QVUnwOrGiMbq8qFl9JtmZFW1h9JFWPOk64LMHZOn
-          Md1mfCOswHdr1UWV5nnZ1JyHXLuVX0o0RlLvqHQ/gj2tBxCynJTygMdcOiW4KmydgdWW/LJYEXnJ
-          s51BpzXJtpxCg32mgyML45J3opdhAQtA3NOYgn0JYATQr2fd9ArCnOtOJsWgk/VnRlfElqIUFJw7
-          crNQFK5iTXeYXqyKCvjrCWehVeW1zQavG3ZYduKODVbzdoXnzVtdwBnC2xZ8XsGxFKxdG5FZzgg7
-          XTj1kNQIV9Mr7P5Pg8hX5ay6Ks+QONvyYxRmXRNkvWLrwTtqJ/1wiCTxsIdR3jaX1kwWi7AR9QLT
-          cOcomA+Mh+1MTGPttrRcjpyARU7+eXzVVIST6dN5ERIl6yOJn6/QSJv33I6orVqzWF60+9s067Ui
-          vIb1NWGeh1XL7bAhW61+sFRCTHpuqxm3h5HVmQgp2GS70AHsqeI0eZHwXECx8dWVhzfBIr8UtaHT
-          XHegsJKKamU771mbBV9fHfXnrpMsFJhj//JzCJuo7ZtEO8sN6yVJnTVFYZID+VASJL6xXm/q+Ehn
-          r6TlIeJESkSWdfMp0b4529s0x3Vq2hUzHwQFadiv1kmDi6vTgXoR9qSBvQ2WcEkjBRLIsQr3qKNi
-          bGNj0aoPHWvmCZI9ZCmfLY22OU+apWFxUt1clux1Lz5egT0v2YlkqOzEgTidLKN2b42w1XjwJqO4
-          IqdhjyR7svT7IWGJF2m9dkMsml2pjQSntipVnV6lh8zLFcrJsv+NsITHoiBQSjAgSQcmFavQRrdX
-          TTHXXw1KumxISqc4HsyEYJ6CJYkGHiSmt7Py4CQq2Z1ywOeVMKIPHSE02q0hsEQn19A3tbIkOelw
-          T49kqZziY+WeyD+NqV7ai2vlyUm+8+uOi5XB2BPI2BtuR7OZt6wvWptRo7wCDxfX3TpV8kOGSTle
-          ZIaMxVQqetn8z8MunU6r0p0ZFU92ctCsj2h/2I+G28XgxhwFciLhOZ4pmohwuu93OV05TxvbpfqK
-          lO2KYmxHy5kRu+W+kuvSsj65lRZggX8aX9PSV1nPWhRuOJKNN9FDsbSYwsCflkM0FTuFUi8dsq60
-          qGtQXzGo81JdYmjVepqk20xoWtZGlTL0lna0lC4r7EmpgqSbyj+OKVTwVhXg+81hB+a3egC0/qAS
-          5Su1QG6OiBoWb4SlkCOQQhEgcEszlUeiCJGYbE466v75wF2vsmA7zFdiuWyqUd1AYalcX8dpr4UA
-          f01wBRRAJCTdUcJu+5orgOA0LBHwS5f7SLLWGgYW7FVCSc4OHWkT9mYVqaRsQLuTgmVuPS3ZU50U
-          QDlE+OfxEHYv16YEnYI9rwZT6Exb3KDTrQxdYvp5q21McqEskubRRrg068kUCxC2+tzz+Bor/4pc
-          k+T8AC8wnbppbUvt6ZTTF5paCAZ2q0RGjcpRyx+mtfRko4c5GCCA5/E186f4ZDudpPVyKvDFst2a
-          GGZhUh8vG0p1vWiWZHPWOWr3pyuV011pQABAXwJqyuS/4BHhpPjOr3QUNHvCYKUY1SherKKi7ZZC
-          EwndQu/ode6RwZ9eagEJX95NpTdlXGHw52CdbF4swJxjRvP+TM3bhUFQq1Yi/WF0YzgFmO4lKim9
-          vKJgpZAXEWXhmOehmIIFpE289rYNG/VJSVeCGHhk0y9vh5qdhmWKdw0sm0Y4QqkIjra7vHgn+hoq
-          J2CeqTcUueNNegul1Zfi2XSUE1FOt9S8Xl+7cWVuTLg0K8RXCfY6VnxD90wki0AZVEi7ImI58rLL
-          /LzVGpFCu3pUUl2nBFwS8jHiBSqIaUeaJK+XlOAsLeW2XexJ2ii/LTVrNU6Ve6AstLRGNncjLeJY
-          mOKowDKAJNzv015+TX2+WjVbExnFrdhQ4nhe3nDrSkWiQ7spL5ppt5/sur3MCpL9WQIHmdKkwulL
-          7H/F658XK/I7A7/kcIECidSeaJWxOzN9c1CGR9vKrxErvhdZjkJxklij3X8BO1AC7qJcz9Ou+04n
-          H1VWxREqtrfySlmM42Kj3lt46dh/JS0zLkwBYskRC+9fT0s4DBFLUlhmJhCS7mBCg6fjZo+uaW7i
-          N5aOD+QeXi7GuXnay0JAUm+AT9KmZbNPu78Dkkc39DDVmr2Sl8CsG+UtkRoWmndJR5r1I+so2KZl
-          e6otmNByT3uL2ZjS2iQ3uCDb87S+YHgsGcCBhmuFSjQPTH+oFlg5K920tYLRMksGALIiiZCj1OCy
-          PzhPOx82HyDNbvOdvh85616eCGE1oAVTaF+iPS1bnPhZVmQxa6PJxoMD2suvrJnbYs/KA8JTjiYx
-          81C21VUDC263ODbneKCNJ9kCgE24Yk+RpsVJPXlBtud2L3HwhsDlLwJ5UuPlbbUG/FnIL2oUGNm1
-          MSpd1NSv5jstv/N8+rqZry68qtPPCQvSA5sWymEZ5j2YbrD///Bhr5WzuiN/u274VaKO8+ugViGt
-          DTXSmz1+KD6mdxCzBEsEXKKGKb4Z7kSAKaA+lOl23h4ZQYvVUXonNznakE+SnGif70RVco4PoVeK
-          OlbuQcpBVsfitC3XDC/Mxm6NDiOto4gO6UO1u/AVK07RIZC4vQu2fIaOFfyv+PFkC84BFPGreFhu
-          9QuhbW3H9eKDbdkd2Sx7QXpJj/qOJxrOZ5h4dIPBooqz4lXSmvmjqUmMDWdPRCnb7OHsTZnmGbyd
-          wv3km2/+D9v9EJHcPwAA
+          8+/+458//xtT/m+SWPNoLD/9ErwfNU4JfZYHfAqYUjJlBvdk/4dFz6ll61+RjJh6EhrYhTjKIvye
+          WbqxbaethL/HLFJyIkEIQMzBQ5NJQv7K0pI7AxFyySN/FeympRdrMzfXkLJRaSHFRd/c6OEDpwib
+          FCyB17AiERIO8ojneVGgh6wAv7BC+vWscJKV2qs8IX65tpZi3VAXTkRpqULKt7HyGBGMOEIFmGaF
+          6G2sRg3JslWn3GJSMeSHWdN1stPVumOpadYrlQBhnnJYpFQQIEApWPA2JVjKtcKCt9RCdVORKLdW
+          nGkFu6siarduhEUCBUTgERU5mtJYIL4NdqovJqN5WQezLR74D6ZR9PXCOMLz7vhGWAD5FOIVhCJm
+          Wi4iSlGiKgeE64lDJXtgxHk1alWJu5D9mR9sSiavHxES8YDwMS6nCaHIAUJ5AjBk49eznpGmM8al
+          de6h7LVrahxbW+VBFvhxbtEMFkesV0kT8oKAKQCIiMxnve4AboLNN8alddPpccWVJcPq2i1GxUIL
+          2RG+ERbzGIKnMaUE8G2soqvNsuFgPjQ2zqbCabM4Z0XTen3QNX90rFt95c47w5Xb3oBqN6Q+avVC
+          vCi1W9ObHCtHEAd4+jSmdGCP9RbH6nZy4229vpEbrfJ8PVo6baFRcZ2Ac7Xb5MoJFIsI8I9/p2C5
+          twl2ZVkBbrSzQ2D5iie20EPo97btutRZ3giLWQrA8RBQHvLp8PpGWG2SW8kU9UNjXmguC9W5WFL9
+          bbdQXN+ksdw9d8j3RrwN704q42jYoLTQKZcDc1lYe6pkiiPjx4AXR9syL0At2/Xq6tQi/gMq9gdo
+          JCxuCvh/bDzR962SAPwBmg4HbmerzLKYsLK2Nx79GPCmS0CRHFh2pdyCaDzM5tx+xy7NvBK5wQOd
+          o7vF55Sset2ceTK38UqibPVoO5fdDgfV4Y9CdlvQXI70zTq7iJqVPETLaWtdnQ+KWbfxI5BdMNM6
+          Mw/p9UJx1oytiK7nc+QtNLlB/3TCEwRR5KAIoADTXkXIm93C8MGWNqgrjedBsVjJTmGrrXaP8NDb
+          8CgCu3bSrnl2qq7k7oWDH5JiVQalQjkv1XOdMpdrPYTrVqESdYqF9TptJCyaHbLe+dFdmpVnksEC
+          JpQFaohEfAhOX8A57oRcL8Febgq+DnsyCRaAyGHyNKar4L2k4iZaY+Pm6tvVhqW/0XBhF2W5ann1
+          +Uw26rfR8qKIqUhEXmTrnkqB8F4FdBPtZBrXij3QUbEM8QzaHWlZaBXyBcFaX6TV9FO0lELEQxGD
+          pGo7pOWvgU0S0gNEc4FmDejG/Vxj5C/kXrc9R1UBK1YcphGFNOKuR5tGZHnvy69wiLhXq3OCcBqR
+          sFKfFaWsZEMkXbDVNKVs+mLDquvUa4+4OO4TqQsbTS/FyoSED1mD+AQrolgA/NMoplT1hZUVdKdY
+          CfNUlPIcTzBhHiudUpKhNJdGKmlr9cmobOcQVGN/06BuPg0LCH+FE7gWFu568GnY84oK2lJnAOd2
+          V6hbeUN2u3N1FfuepjTSoelYUU+aFaKIg5D5LQRJUknswwrXKOoZ2GpeHS9zcOSuDVJptIylVV6N
+          kS0Izy/0XmedBidZOYgBK4apeOwC3sgKg4LO5/OhzVOzaTVrZOVsNZ0DVQtehD0tWCJSVlQwD8Bh
+          BFJasNdjuIl23KyZD8OiOcohNPK643G97ujbyOT6t8IKCGOOChwEfApWeCusuV6NbaNZbm/6VNJs
+          zl2wOnNj9VSucJn2lOdCPI8AeB5fNbCbYJV+UNUJsLoxorG6fGgZ/aYZWVXtoXQR1jzpuiBzx+Rp
+          TLcZ3wgr8N1adVGleV42Nech127llxKNkdQ7Kt2PYE/rAYQsJ6U84DGXTgmuCltnYLUlvyxWRF7y
+          bGfQaU2yLafQYD/TwZGFcck70cuwgAUg7mlMwb4EMALo17NuegVhznUnk2LQyfozoytiS1EKCs4d
+          uVkoClexpjtML1ZFBfz1hLPQqvLaZoPXDTssO3HHBqt5u8Lz5q0u4AzhbQs+r+BYCtaujcgsZ4Sd
+          Lpx6SGqEq+kVdv+nQeSrclZdlWdInG35MQqzrgmyXrH14B21k344RJJ42MMob5tLayaLRdiIeoFp
+          uHMUzAfGw3YmprF2W1ouR07AIif/PL5qKsLJ9Om8CImS9ZHEz1dopM17bkfUVq1ZLC/a/W2a9VoR
+          XsP6mjDPw6rldtiQrVY/WCohJj231Yzbw8jqTIQUbLJd6AD2VHGavEh4LqDY+OrKw5tgkV+K2tBp
+          rjtQWElFtbKd96zNgq+vjvpz10kWCsyxf/k9hE3U9k2ineWG9ZKkzpqiMMmBfCgJEt9Yrzd1fKSz
+          V9LyEHEiJSLLuvmUaN+c7W2a4zo17YqZD4KCNOxX66TBxdXpQL0Ie9LA3gZLuKSRAgnkWIV71FEx
+          trGxaNWHjjXzBMkespTPlkbbnCfN0rA4qW4uS/a6Fx+vwJ6X7EQyVHbiQJxOllG7t0bYajx4k1Fc
+          kdOwR5I9Wfr9kLDEi7ReuyEWza7URoJTW5WqTq/SQ+blCuVk2f9GWMJjURAoJRiQpAOTilVoo9ur
+          ppjrrwYlXTYkpVMcD2ZCME/BkkQDDxLT21l5cBKV7E454PNKGNGHjhAa7dYQWKKTa+ibWlmSnHS4
+          p0eyVE7xsXJP5J/GVC/txbXy5CTf+XXHxcpg7Alk7A23o9nMW9YXrc2oUV6Bh4vrbp0q+SHDpBwv
+          MkPGYioVvWz+52GXTqdV6c6Miic7OWjWR7Q/7EfD7WJwY44COZHwHM8UTUQ43fe7nK6cp43tUn1F
+          ynZFMbaj5cyI3XJfyXVpWZ/cSguwwD+Nr2npq6xnLQo3HMnGm+ihWFpMYeBPyyGaip1CqZcOWVda
+          1DWorxjUeakuMbRqPU3SbSY0LWujShl6SztaSpcV9qRUQdJN5R/HFCp4qwrw/eawA/NbPQBaf1CJ
+          8pVaIDdHRA2LN8JSyBFIoQgQuKWZyiNRhEhMNicddf984K5XWbAd5iuxXDbVqG6gsFSur+O010KA
+          vya4AgogEpLuKGG3fc0VQHAalgj4pct9JFlrDQML9iqhJGeHjrQJe7OKVFI2oN1JwTK3npbsqU4K
+          oBwi/PN4CLuXa1OCTsGeV4MpdKYtbtDpVoYuMf281TYmuVAWSfNoI1ya9WSKBQhbfe55fI2Vf0Wu
+          SXJ+gBeYTt20tqX2dMrpC00tBAO7VSKjRuWo5Q/TWnqy0cMcDBDA8/ia+VN8sp1O0no5Ffhi2W5N
+          DLMwqY+XDaW6XjRLsjnrHLX705XK6a40IACgLwE1ZfJf8IhwUnznVzoKmj1hsFKMahQvVlHRdkuh
+          iYRuoXf0OvfI4E8vtYCEL++m0psyrjD4c7BONi8WYM4xo3l/pubtwiCoVSuR/jC6MZwCTPcSlZRe
+          XlGwUsiLiLJwzPNQTMEC0iZee9uGjfqkpCtBDDyy6Ze3Q81OwzLFuwaWTSMcoVQER9tdXrwTfQ2V
+          EzDP1BuK3PEmvYXS6kvxbDrKiSinW2per6/duDI3JlyaFeKrBHsdK76heyaSRaAMKqRdEbEcedll
+          ft5qjUihXT0qqa5TAi4J+RjxAhXEtCNNktdLSnCWlnLbLvYkbZTflpq1GqfKPVAWWlojm7uRFnEs
+          THFUYBlAEu73aS+/pj5frZqtiYziVmwocTwvb7h1pSLRod2UF82020923V5mBcn+LIGDTGlS4fQl
+          9r/i9c+LFfmdgV9yuECBRGpPtMrYnZm+OSjDo23l14gV34ssR6E4SazR7r+AHSgBd1Gu52nXfaeT
+          jyqr4ggV21t5pSzGcbFR7y28dOy/kpYZF6YAseSIhfevpyUchoglKSwzEwhJdzChwdNxs0fXNDfx
+          G0vHB3IPLxfj3DztZSEgqTfAJ2nTstmn3d8ByaMbephqzV7JS2DWjfKWSA0LzbukI836kXUUbNOy
+          PdUWTGi5p73FbExpbZIbXJDteVpfMDyWDOBAw7VCJZoHpj9UC6yclW7aWsFomSUDAFmRRMhRanDZ
+          H5ynnQ+bD5Bmt/lO34+cdS9PhLAa0IIptC/RnpYtTvwsK7KYtdFk48EB7eVX1sxtsWflAeEpR5OY
+          eSjb6qqBBbdbHJtzPNDGk2wBwCZcsadI0+Kknrwg23O7lzh4Q+DyF4E8qfHytloD/izkFzUKjOza
+          GJUuaupX852W33k+fd3MVxde1ennhAXpgU0L5bAM8x5MN9j/f/iw18pZ3ZG/XTf8KlHH+XVQq5DW
+          hhrpzR4/FB/TO4hZgiUCLlHDFN8MdyLAFFAfynQ7b4+MoMXqKL2TmxxtyCdJTrTPd6IqOceH0CtF
+          HSv3IOUgq2Nx2pZrhhdmY7dGh5HWUUSH9KHaXfiKFafoEEjc3gVbPkPHCv5X/HiyBecAivhVPCy3
+          +oXQtrbjevHBtuyObJa9IL2kR33HEw3nM0w8usFgUcVZ8SppzfzR1CTGhrMnopRt9nD2pkzzDN5O
+          4X7yzTf/B4Kd9iTcPwAA
       headers:
         access-control-allow-origin: ['*']
         cache-control: ['public, max-age=28800']
@@ -381,17 +419,17 @@ interactions:
         content-encoding: [gzip]
         content-length: ['4575']
         content-type: [application/json;charset=utf-8]
-        date: ['Mon, 07 Mar 2016 09:36:25 GMT']
-        etag: [W/"40e2619c73fb0981c28e756c87c95dea"]
+        date: ['Mon, 07 Mar 2016 23:15:17 GMT']
+        etag: [W/"3715935231d53d565c92f6ecf201285a"]
         server: [openresty]
         status: [200 OK]
         vary: [Accept-Encoding]
         x-memc: [HIT]
-        x-memc-age: ['10506']
-        x-memc-expires: ['18294']
+        x-memc-age: ['1984']
+        x-memc-expires: ['26816']
         x-memc-key: [4ae7e11d99f36addb309e5d76b273d25]
         x-ratelimit-limit: ['40']
-        x-ratelimit-remaining: ['36']
-        x-ratelimit-reset: ['1457343394']
+        x-ratelimit-remaining: ['35']
+        x-ratelimit-reset: ['1457392522']
       status: {code: 200, message: OK}
 version: 1

--- a/tests/cassettes/test_tmdb.TestTmdbLookup.test_tmdb_lookup
+++ b/tests/cassettes/test_tmdb.TestTmdbLookup.test_tmdb_lookup
@@ -3,730 +3,395 @@ interactions:
       body: null
       headers:
         Accept: [application/json]
+        Accept-Encoding: ['gzip, deflate']
         Connection: [close]
-        Host: [api.themoviedb.org]
-        User-Agent: [Python-urllib/2.7]
+        Content-Type: [application/json]
+        User-Agent: [python-requests/2.5.3 CPython/2.7.10 Windows/8]
       method: GET
-      uri: http://api.themoviedb.org/3/movie/tt0936501?api_key=bdfc018dbdb7c243dc7cb1454ff74b95&language=en
+      uri: https://api.themoviedb.org/3/find/tt0936501?external_source=imdb_id&api_key=bdfc018dbdb7c243dc7cb1454ff74b95
     response:
-      body: {string: "{\"adult\":false,\"backdrop_path\":\"/d5vwBiuJI1a2hBcGjhsWhpmAkL7.jpg\"\
-          ,\"belongs_to_collection\":{\"id\":135483,\"name\":\"Taken Collection\"\
-          ,\"poster_path\":\"/4PNFiSaJWvWhkdOw0KF9Vf7v3gC.jpg\",\"backdrop_path\"\
-          :\"/hO1R1TI429PjkOjby4dTPBrWFwn.jpg\"},\"budget\":25000000,\"genres\":[{\"\
-          id\":28,\"name\":\"Action\"},{\"id\":53,\"name\":\"Thriller\"},{\"id\":80,\"\
-          name\":\"Crime\"}],\"homepage\":\"\",\"id\":8681,\"imdb_id\":\"tt0936501\"\
-          ,\"original_language\":\"en\",\"original_title\":\"Taken\",\"overview\"\
-          :\"While vacationing with a friend in Paris, an American girl is kidnapped\
-          \ by a gang of human traffickers intent on selling her into forced prostitution.\
-          \ Working against the clock, her ex-spy father must pull out all the stops\
-          \ to save her. But with his best years possibly behind him, the job may\
-          \ be more than he can handle.\",\"popularity\":4.143412,\"poster_path\"\
-          :\"/3zlffXmo7QpVBc17QIJWrRfasVr.jpg\",\"production_companies\":[{\"name\"\
-          :\"20th Century Fox\",\"id\":25},{\"name\":\"Canal Plus\",\"id\":104},{\"\
-          name\":\"M6 Films\",\"id\":1115},{\"name\":\"TPS Star\",\"id\":6586},{\"\
-          name\":\"Grive Productions\",\"id\":6877},{\"name\":\"EuropaCorp\",\"id\"\
-          :6896},{\"name\":\"M6\",\"id\":11261},{\"name\":\"Wintergreen Productions\"\
-          ,\"id\":11845},{\"name\":\"All Pictures Media\",\"id\":23614}],\"production_countries\"\
-          :[{\"iso_3166_1\":\"FR\",\"name\":\"France\"},{\"iso_3166_1\":\"GB\",\"\
-          name\":\"United Kingdom\"},{\"iso_3166_1\":\"US\",\"name\":\"United States\
-          \ of America\"}],\"release_date\":\"2008-02-24\",\"revenue\":226830568,\"\
-          runtime\":93,\"spoken_languages\":[{\"iso_639_1\":\"en\",\"name\":\"English\"\
-          },{\"iso_639_1\":\"fr\",\"name\":\"Fran\xE7ais\"},{\"iso_639_1\":\"ar\"\
-          ,\"name\":\"\u0627\u0644\u0639\u0631\u0628\u064A\u0629\"},{\"iso_639_1\"\
-          :\"sq\",\"name\":\"shqip\"}],\"status\":\"Released\",\"tagline\":\"They\
-          \ took his daughter.  He'll take their lives.\",\"title\":\"Taken\",\"video\"\
-          :false,\"vote_average\":7.1,\"vote_count\":2500}"}
-      headers:
-        access-control-allow-origin: ['*']
-        cache-control: ['public, max-age=28800']
-        connection: [Close]
-        content-length: ['1715']
-        content-type: [application/json;charset=utf-8]
-        date: ['Fri, 04 Mar 2016 01:54:57 GMT']
-        etag: ['"98cc1b78d839ad97194f4d1a933f71f6"']
-        server: [openresty]
-        status: [200 OK]
-        vary: [Accept-Encoding]
-        x-memc: [HIT]
-        x-memc-age: ['26252']
-        x-memc-expires: ['2548']
-        x-memc-key: [97e03187858c21f61b2d44d29dbc10db]
-        x-ratelimit-limit: ['40']
-        x-ratelimit-remaining: ['39']
-        x-ratelimit-reset: ['1457056507']
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: [application/json]
-        Connection: [close]
-        Host: [api.themoviedb.org]
-        User-Agent: [Python-urllib/2.7]
-      method: GET
-      uri: http://api.themoviedb.org/3/movie/8681?api_key=bdfc018dbdb7c243dc7cb1454ff74b95&language=en
-    response:
-      body: {string: "{\"adult\":false,\"backdrop_path\":\"/d5vwBiuJI1a2hBcGjhsWhpmAkL7.jpg\"\
-          ,\"belongs_to_collection\":{\"id\":135483,\"name\":\"Taken Collection\"\
-          ,\"poster_path\":\"/4PNFiSaJWvWhkdOw0KF9Vf7v3gC.jpg\",\"backdrop_path\"\
-          :\"/hO1R1TI429PjkOjby4dTPBrWFwn.jpg\"},\"budget\":25000000,\"genres\":[{\"\
-          id\":28,\"name\":\"Action\"},{\"id\":53,\"name\":\"Thriller\"},{\"id\":80,\"\
-          name\":\"Crime\"}],\"homepage\":\"\",\"id\":8681,\"imdb_id\":\"tt0936501\"\
-          ,\"original_language\":\"en\",\"original_title\":\"Taken\",\"overview\"\
-          :\"While vacationing with a friend in Paris, an American girl is kidnapped\
-          \ by a gang of human traffickers intent on selling her into forced prostitution.\
-          \ Working against the clock, her ex-spy father must pull out all the stops\
-          \ to save her. But with his best years possibly behind him, the job may\
-          \ be more than he can handle.\",\"popularity\":4.143412,\"poster_path\"\
-          :\"/3zlffXmo7QpVBc17QIJWrRfasVr.jpg\",\"production_companies\":[{\"name\"\
-          :\"20th Century Fox\",\"id\":25},{\"name\":\"Canal Plus\",\"id\":104},{\"\
-          name\":\"M6 Films\",\"id\":1115},{\"name\":\"TPS Star\",\"id\":6586},{\"\
-          name\":\"Grive Productions\",\"id\":6877},{\"name\":\"EuropaCorp\",\"id\"\
-          :6896},{\"name\":\"M6\",\"id\":11261},{\"name\":\"Wintergreen Productions\"\
-          ,\"id\":11845},{\"name\":\"All Pictures Media\",\"id\":23614}],\"production_countries\"\
-          :[{\"iso_3166_1\":\"FR\",\"name\":\"France\"},{\"iso_3166_1\":\"GB\",\"\
-          name\":\"United Kingdom\"},{\"iso_3166_1\":\"US\",\"name\":\"United States\
-          \ of America\"}],\"release_date\":\"2008-02-24\",\"revenue\":226830568,\"\
-          runtime\":93,\"spoken_languages\":[{\"iso_639_1\":\"en\",\"name\":\"English\"\
-          },{\"iso_639_1\":\"fr\",\"name\":\"Fran\xE7ais\"},{\"iso_639_1\":\"ar\"\
-          ,\"name\":\"\u0627\u0644\u0639\u0631\u0628\u064A\u0629\"},{\"iso_639_1\"\
-          :\"sq\",\"name\":\"shqip\"}],\"status\":\"Released\",\"tagline\":\"They\
-          \ took his daughter.  He'll take their lives.\",\"title\":\"Taken\",\"video\"\
-          :false,\"vote_average\":7.1,\"vote_count\":2500}"}
-      headers:
-        access-control-allow-origin: ['*']
-        cache-control: ['public, max-age=28800']
-        connection: [Close]
-        content-length: ['1715']
-        content-type: [application/json;charset=utf-8]
-        date: ['Fri, 04 Mar 2016 01:54:57 GMT']
-        etag: ['"98cc1b78d839ad97194f4d1a933f71f6"']
-        server: [openresty]
-        status: [200 OK]
-        vary: [Accept-Encoding]
-        x-memc: [HIT]
-        x-memc-age: ['10462']
-        x-memc-expires: ['18338']
-        x-memc-key: [5a83165c56fc93c8aa4de882d3298a4a]
-        x-ratelimit-limit: ['40']
-        x-ratelimit-remaining: ['38']
-        x-ratelimit-reset: ['1457056507']
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: [application/json]
-        Connection: [close]
-        Host: [api.themoviedb.org]
-        User-Agent: [Python-urllib/2.7]
-      method: GET
-      uri: http://api.themoviedb.org/3/movie/8681/translations?api_key=bdfc018dbdb7c243dc7cb1454ff74b95
-    response:
-      body: {string: "{\"id\":8681,\"translations\":[{\"iso_639_1\":\"en\",\"name\"\
-          :\"English\",\"english_name\":\"English\"},{\"iso_639_1\":\"de\",\"name\"\
-          :\"Deutsch\",\"english_name\":\"German\"},{\"iso_639_1\":\"ru\",\"name\"\
-          :\"P\u0443\u0441\u0441\u043A\u0438\u0439\",\"english_name\":\"Russian\"\
-          },{\"iso_639_1\":\"sk\",\"name\":\"Sloven\u010Dina\",\"english_name\":\"\
-          Slovak\"},{\"iso_639_1\":\"da\",\"name\":\"Dansk\",\"english_name\":\"Danish\"\
-          },{\"iso_639_1\":\"cs\",\"name\":\"\u010Cesk\xFD\",\"english_name\":\"Czech\"\
-          },{\"iso_639_1\":\"hu\",\"name\":\"Magyar\",\"english_name\":\"Hungarian\"\
-          },{\"iso_639_1\":\"nl\",\"name\":\"Nederlands\",\"english_name\":\"Dutch\"\
-          },{\"iso_639_1\":\"it\",\"name\":\"Italiano\",\"english_name\":\"Italian\"\
-          },{\"iso_639_1\":\"tr\",\"name\":\"T\xFCrk\xE7e\",\"english_name\":\"Turkish\"\
-          },{\"iso_639_1\":\"pt\",\"name\":\"Portugu\xEAs\",\"english_name\":\"Portuguese\"\
-          },{\"iso_639_1\":\"fr\",\"name\":\"Fran\xE7ais\",\"english_name\":\"French\"\
-          },{\"iso_639_1\":\"fr\",\"name\":\"Fran\xE7ais\",\"english_name\":\"French\"\
-          },{\"iso_639_1\":\"sv\",\"name\":\"svenska\",\"english_name\":\"Swedish\"\
-          },{\"iso_639_1\":\"zh\",\"name\":\"\u666E\u901A\u8BDD\",\"english_name\"\
-          :\"Mandarin\"},{\"iso_639_1\":\"pl\",\"name\":\"Polski\",\"english_name\"\
-          :\"Polish\"},{\"iso_639_1\":\"fi\",\"name\":\"suomi\",\"english_name\":\"\
-          Finnish\"},{\"iso_639_1\":\"es\",\"name\":\"Espa\xF1ol\",\"english_name\"\
-          :\"Spanish\"},{\"iso_639_1\":\"bg\",\"name\":\"\u0431\u044A\u043B\u0433\u0430\
-          \u0440\u0441\u043A\u0438 \u0435\u0437\u0438\u043A\",\"english_name\":\"\
-          Bulgarian\"},{\"iso_639_1\":\"he\",\"name\":\"\u05E2\u05B4\u05D1\u05B0\u05E8\
-          \u05B4\u05D9\u05EA\",\"english_name\":\"Hebrew\"},{\"iso_639_1\":\"no\"\
-          ,\"name\":\"Norsk\",\"english_name\":\"Norwegian\"},{\"iso_639_1\":\"th\"\
-          ,\"name\":\"\u0E20\u0E32\u0E29\u0E32\u0E44\u0E17\u0E22\",\"english_name\"\
-          :\"Thai\"},{\"iso_639_1\":\"el\",\"name\":\"\u03B5\u03BB\u03BB\u03B7\u03BD\
-          \u03B9\u03BA\u03AC\",\"english_name\":\"Greek\"},{\"iso_639_1\":\"ja\",\"\
-          name\":\"\u65E5\u672C\u8A9E\",\"english_name\":\"Japanese\"},{\"iso_639_1\"\
-          :\"ro\",\"name\":\"Rom\xE2n\u0103\",\"english_name\":\"Romanian\"},{\"iso_639_1\"\
-          :\"ko\",\"name\":\"\uD55C\uAD6D\uC5B4/\uC870\uC120\uB9D0\",\"english_name\"\
-          :\"Korean\"}]}"}
-      headers:
-        access-control-allow-origin: ['*']
-        cache-control: ['public, max-age=28800']
-        connection: [Close]
-        content-length: ['1693']
-        content-type: [application/json;charset=utf-8]
-        date: ['Fri, 04 Mar 2016 01:54:57 GMT']
-        etag: ['"5c1b72cb9be9f0f063ea88875d4a163a"']
-        server: [openresty]
-        status: [200 OK]
-        vary: [Accept-Encoding]
-        x-memc: [HIT]
-        x-memc-age: ['7278']
-        x-memc-expires: ['21522']
-        x-memc-key: [d4f64d83f7764856670da65c2f13d113]
-        x-ratelimit-limit: ['40']
-        x-ratelimit-remaining: ['37']
-        x-ratelimit-reset: ['1457056507']
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: [application/json]
-        Connection: [close]
-        Host: [api.themoviedb.org]
-        User-Agent: [Python-urllib/2.7]
-      method: GET
-      uri: http://api.themoviedb.org/3/movie/8681/alternative_titles?api_key=bdfc018dbdb7c243dc7cb1454ff74b95
-    response:
-      body: {string: "{\"id\":8681,\"titles\":[{\"iso_3166_1\":\"MX\",\"title\":\"\
-          B\xFAsqueda implacable\"},{\"iso_3166_1\":\"TW\",\"title\":\"\u5373\u523B\
-          \u6551\u63F4\"},{\"iso_3166_1\":\"VE\",\"title\":\"B\xFAsqueda Implacable\"\
-          },{\"iso_3166_1\":\"CA\",\"title\":\"Taken 1\"},{\"iso_3166_1\":\"CA\",\"\
-          title\":\"L'Enl\xE8vement\"},{\"iso_3166_1\":\"HK\",\"title\":\"\u6551\u53C3\
-          96\u5C0F\u6642\"},{\"iso_3166_1\":\"AT\",\"title\":\"96 Hours\"},{\"iso_3166_1\"\
-          :\"DE\",\"title\":\"Taken 1 - 96 hours 2008\"},{\"iso_3166_1\":\"IT\",\"\
-          title\":\"Io vi trover\xF2\"},{\"iso_3166_1\":\"GR\",\"title\":\"\u0397\
-          \ \u0391\u03C1\u03C0\u03B1\u03B3\u03AE\"}]}"}
-      headers:
-        access-control-allow-origin: ['*']
-        cache-control: ['public, max-age=28800']
-        connection: [Close]
-        content-length: ['478']
-        content-type: [application/json;charset=utf-8]
-        date: ['Fri, 04 Mar 2016 01:54:57 GMT']
-        etag: ['"ba3bab2a7f053f5e0fd1041e922309dd"']
-        server: [openresty]
-        status: [200 OK]
-        x-memc: [HIT]
-        x-memc-age: ['2353']
-        x-memc-expires: ['26447']
-        x-memc-key: [8ccd30827fd22a02fafdfa16c87252c4]
-        x-ratelimit-limit: ['40']
-        x-ratelimit-remaining: ['36']
-        x-ratelimit-reset: ['1457056507']
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: [application/json]
-        Connection: [close]
-        Host: [api.themoviedb.org]
-        User-Agent: [Python-urllib/2.7]
-      method: GET
-      uri: http://api.themoviedb.org/3/movie/8681/trailers?api_key=bdfc018dbdb7c243dc7cb1454ff74b95&language=en
-    response:
-      body: {string: '{"id":8681,"quicktime":[],"youtube":[{"name":"Trailer 1","size":"HD","source":"CvUxdQ4q-Lg","type":"Trailer"}]}'}
-      headers:
-        access-control-allow-origin: ['*']
-        cache-control: ['public, max-age=28800']
-        connection: [Close]
-        content-length: ['111']
-        content-type: [application/json;charset=utf-8]
-        date: ['Fri, 04 Mar 2016 01:54:57 GMT']
-        etag: ['"140aec4d2edabc05f9bdfab809117a6c"']
-        server: [openresty]
-        status: [200 OK]
-        x-memc: [HIT]
-        x-memc-age: ['16799']
-        x-memc-expires: ['12001']
-        x-memc-key: [df5c8c7006034b60c4d0b17b0575c8f6]
-        x-ratelimit-limit: ['40']
-        x-ratelimit-remaining: ['35']
-        x-ratelimit-reset: ['1457056507']
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: [application/json]
-        Connection: [close]
-        Host: [api.themoviedb.org]
-        User-Agent: [Python-urllib/2.7]
-      method: GET
-      uri: http://api.themoviedb.org/3/movie/8681/images?api_key=bdfc018dbdb7c243dc7cb1454ff74b95
-    response:
-      body: {string: '{"id":8681,"backdrops":[{"aspect_ratio":1.77777777777778,"file_path":"/d5vwBiuJI1a2hBcGjhsWhpmAkL7.jpg","height":1080,"iso_639_1":null,"vote_average":5.45561434450323,"vote_count":18,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/lcqVBBirzzX520AyOK3k7kXBDJ6.jpg","height":1080,"iso_639_1":null,"vote_average":5.42857142857143,"vote_count":17,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/aI8luIcMpYZPixrEc70pARrHBwE.jpg","height":1080,"iso_639_1":null,"vote_average":5.39880952380952,"vote_count":17,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/aMbYR4epIMImnaJKLnSaZGnfZCM.jpg","height":1080,"iso_639_1":null,"vote_average":5.3125,"vote_count":1,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/d0nzBeDNOANwaygmHi8AFO11G2S.jpg","height":720,"iso_639_1":null,"vote_average":5.31084656084656,"vote_count":9,"width":1280},{"aspect_ratio":1.77777777777778,"file_path":"/aVXOOdQRD9Inpbk9Yv6QVZ8Ir1t.jpg","height":1080,"iso_639_1":null,"vote_average":5.28375733855186,"vote_count":10,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/tVNbXCFtU1Fz3zlXo5FZFvpMr1T.jpg","height":1080,"iso_639_1":null,"vote_average":5.28011204481793,"vote_count":5,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/fSPNK4y8HYePM6799zwWxcL0sQf.jpg","height":720,"iso_639_1":null,"vote_average":5.27310924369748,"vote_count":5,"width":1280},{"aspect_ratio":1.77777777777778,"file_path":"/kKPYFhwKc67I5FYYZGI8snk0EnZ.jpg","height":720,"iso_639_1":null,"vote_average":5.23809523809524,"vote_count":4,"width":1280},{"aspect_ratio":1.77777777777778,"file_path":"/gkX7b2Yt2ZFHlLZSn8GtnhrHHGZ.jpg","height":720,"iso_639_1":null,"vote_average":5.23809523809524,"vote_count":4,"width":1280},{"aspect_ratio":1.77777777777778,"file_path":"/A5HhdivwxCIHKizmRfx36sFXrGk.jpg","height":720,"iso_639_1":null,"vote_average":5.23098791755508,"vote_count":4,"width":1280},{"aspect_ratio":1.77777777777778,"file_path":"/lqaadLDqyWAE4ffvPvz1GIGlYto.jpg","height":720,"iso_639_1":null,"vote_average":5.21677327647477,"vote_count":4,"width":1280},{"aspect_ratio":1.77777777777778,"file_path":"/Ag0b7cmNaa0gn1qCzCZzBKVh3ZM.jpg","height":720,"iso_639_1":null,"vote_average":5.21677327647477,"vote_count":4,"width":1280},{"aspect_ratio":1.77777777777778,"file_path":"/7On0XrMjSNH8e4oeDOMn7icwPIV.jpg","height":1080,"iso_639_1":"en","vote_average":5.19727891156463,"vote_count":7,"width":1920},{"aspect_ratio":1.77843601895735,"file_path":"/hfplpRLkSXCa0kcc90j7evtrQoU.jpg","height":844,"iso_639_1":null,"vote_average":5.19114688128773,"vote_count":8,"width":1501},{"aspect_ratio":1.77817319098458,"file_path":"/dqQMrapcLFtDc8u45a66LhmIqnd.jpg","height":843,"iso_639_1":null,"vote_average":5.19047619047619,"vote_count":7,"width":1499},{"aspect_ratio":1.77777777777778,"file_path":"/xVqYUC4jaqkdYrka5mDUrY32SEh.jpg","height":1080,"iso_639_1":null,"vote_average":5.18834399431414,"vote_count":4,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/g37j2Hls1dXyTGumuGQWvLEMXJr.jpg","height":1080,"iso_639_1":"en","vote_average":5.14550264550265,"vote_count":9,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/4fcwSqMFceN6oh8HxdwPQtmKdTJ.jpg","height":1080,"iso_639_1":null,"vote_average":5.12226512226512,"vote_count":11,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/6RCei4prK140LuqSrgOdEiBFTZ.jpg","height":720,"iso_639_1":null,"vote_average":5.11415525114155,"vote_count":10,"width":1280},{"aspect_ratio":1.77777777777778,"file_path":"/xUgX2fpP2eUqnJDrtIfngZXUo6d.jpg","height":720,"iso_639_1":"en","vote_average":5.0989010989011,"vote_count":2,"width":1280},{"aspect_ratio":1.77777777777778,"file_path":"/qFl2DPE2acIuutWiQn4er5JWOvv.jpg","height":720,"iso_639_1":null,"vote_average":5.09316770186335,"vote_count":6,"width":1280},{"aspect_ratio":1.77777777777778,"file_path":"/5RzNyRpNoPplPViantqJcCuGiDO.jpg","height":1080,"iso_639_1":null,"vote_average":5.07936507936508,"vote_count":9,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/gPzoYwDrHlvkhFxfPzFzKtrY8fA.jpg","height":1080,"iso_639_1":null,"vote_average":5.03968253968254,"vote_count":9,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/sB5DaVEYXdPXhf9mKygVpWMJQmX.jpg","height":1080,"iso_639_1":null,"vote_average":4.99299719887955,"vote_count":5,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/2voAsVS0KzuYqqI1d01pR7QotI.jpg","height":1080,"iso_639_1":"en","vote_average":0.0,"vote_count":0,"width":1920}],"posters":[{"aspect_ratio":0.666666666666667,"file_path":"/3zlffXmo7QpVBc17QIJWrRfasVr.jpg","height":1500,"iso_639_1":"en","vote_average":5.51638837353123,"vote_count":14,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/d2Qul2t0GrSLqJZ6vkaED9AhM3.jpg","height":1500,"iso_639_1":"fr","vote_average":5.45454545454546,"vote_count":3,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/q2ufZ5zgbyvwSVR9J5wR6nEAEyy.jpg","height":1500,"iso_639_1":"en","vote_average":5.39270253555968,"vote_count":14,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/jRyhRiGniBGYvFWJHn11Bprc5No.jpg","height":1500,"iso_639_1":"de","vote_average":5.38992408557626,"vote_count":6,"width":1000},{"aspect_ratio":0.707018673535093,"file_path":"/aUQbl7it5TVCAVverxsJl8T9Xd2.jpg","height":1553,"iso_639_1":"es","vote_average":5.38461538461539,"vote_count":2,"width":1098},{"aspect_ratio":0.666666666666667,"file_path":"/7FXn4CEOYe9JY10oPEzdb7HPzNp.jpg","height":1200,"iso_639_1":"hu","vote_average":5.38461538461539,"vote_count":2,"width":800},{"aspect_ratio":0.666666666666667,"file_path":"/kQsCVFwf5EdBDwLNGZKQ26EHPkD.jpg","height":1500,"iso_639_1":"en","vote_average":5.32175032175032,"vote_count":11,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/o7MfIY9Gt7IefTnQqxjoi3x8Fo2.jpg","height":2100,"iso_639_1":"ru","vote_average":5.3125,"vote_count":1,"width":1400},{"aspect_ratio":0.70242656449553,"file_path":"/xLd5m25rSINDzQ3JCArtlpd51w.jpg","height":783,"iso_639_1":"ro","vote_average":5.3125,"vote_count":1,"width":550},{"aspect_ratio":0.666666666666667,"file_path":"/dLdmv107fcS1kOENdAxJmtI2c8A.jpg","height":1500,"iso_639_1":"he","vote_average":5.3125,"vote_count":1,"width":1000},{"aspect_ratio":0.713333333333333,"file_path":"/l3b5sVOx9jcdBMpwIFqLatubKls.jpg","height":750,"iso_639_1":"es","vote_average":5.3125,"vote_count":1,"width":535},{"aspect_ratio":0.705882352941177,"file_path":"/ekeNG6g1QA5Jee05CO7nKuJYC7q.jpg","height":1700,"iso_639_1":"it","vote_average":5.3125,"vote_count":1,"width":1200},{"aspect_ratio":0.666666666666667,"file_path":"/sL14l3RFbBZPxHS6mBDCGYDw7Js.jpg","height":1500,"iso_639_1":"de","vote_average":5.29761904761905,"vote_count":1,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/c7kMKgtiTpB6YcevsTIKuBJQymE.jpg","height":1500,"iso_639_1":"en","vote_average":5.28253968253968,"vote_count":12,"width":1000},{"aspect_ratio":0.711576846307385,"file_path":"/rYCLNE1isLMxcGbAF6DdQvSGnbB.jpg","height":1002,"iso_639_1":"hu","vote_average":5.28138528138528,"vote_count":3,"width":713},{"aspect_ratio":0.706666666666667,"file_path":"/qqmO8TrhXtyFfwzRr8fZxjGjrnS.jpg","height":1200,"iso_639_1":"es","vote_average":5.27833668678739,"vote_count":8,"width":848},{"aspect_ratio":0.711576846307385,"file_path":"/fcoTFr0NAYSRkgLozM2Rm0AtcVJ.jpg","height":1002,"iso_639_1":"hu","vote_average":5.26652452025586,"vote_count":4,"width":713},{"aspect_ratio":0.710833333333333,"file_path":"/yZvQ90ARXXCJFSE8JQIrSxHWs5M.jpg","height":1200,"iso_639_1":"cs","vote_average":5.24553571428571,"vote_count":1,"width":853},{"aspect_ratio":0.666666666666667,"file_path":"/ar0JEdCMtOhX8zVvTsJ18Y3NZ1x.jpg","height":1500,"iso_639_1":"de","vote_average":5.24542124542125,"vote_count":2,"width":1000},{"aspect_ratio":0.749853544229643,"file_path":"/niNI2RxXDqrHGdM5sADHIyH09Y6.jpg","height":1707,"iso_639_1":"fr","vote_average":5.24542124542125,"vote_count":2,"width":1280},{"aspect_ratio":0.707528957528958,"file_path":"/gSvia82t9TY9Uj67DpJnpSYKQ6G.jpg","height":1036,"iso_639_1":"it","vote_average":5.24542124542125,"vote_count":2,"width":733},{"aspect_ratio":0.708430367955286,"file_path":"/8oVhHpxSqyEssJ7wQcvYk5yXtGt.jpg","height":2147,"iso_639_1":"hu","vote_average":5.23809523809524,"vote_count":1,"width":1521},{"aspect_ratio":0.666666666666667,"file_path":"/vEFghK5SbW7HIcyGtKFjHs8jKYO.jpg","height":1500,"iso_639_1":"en","vote_average":5.23297491039426,"vote_count":30,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/cC0huTbsQZzxMtU8gsoJUNLHIq2.jpg","height":2100,"iso_639_1":"en","vote_average":5.22321428571429,"vote_count":1,"width":1400},{"aspect_ratio":0.708571428571429,"file_path":"/a05lckFCeKgc38rclWauiNQ3TqB.jpg","height":700,"iso_639_1":"cs","vote_average":5.22321428571429,"vote_count":1,"width":496},{"aspect_ratio":0.666666666666667,"file_path":"/kRiTiOPaRaMs808RGCEKsCOAWR8.jpg","height":1200,"iso_639_1":"en","vote_average":5.20879120879121,"vote_count":2,"width":800},{"aspect_ratio":0.708430367955286,"file_path":"/pXBEXs2aCDTuhsJbRnH0CMBZJfA.jpg","height":2147,"iso_639_1":"hu","vote_average":5.20089285714286,"vote_count":1,"width":1521},{"aspect_ratio":0.666666666666667,"file_path":"/5EpAKS1EIsB3D1OHVmupcJu6Els.jpg","height":1200,"iso_639_1":"en","vote_average":5.1984126984127,"vote_count":9,"width":800},{"aspect_ratio":0.666666666666667,"file_path":"/8jUvskcey2PmIt8KPf47BgdDyu9.jpg","height":1500,"iso_639_1":"fr","vote_average":5.1890756302521,"vote_count":5,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/61l500Mkr1kmkjQrKZEeVy3Vje5.jpg","height":1500,"iso_639_1":"en","vote_average":5.18207282913165,"vote_count":5,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/2H1CkOH1TRsCmtKcrigzx6B62F1.jpg","height":1500,"iso_639_1":"de","vote_average":5.17316017316017,"vote_count":3,"width":1000},{"aspect_ratio":0.682128240109141,"file_path":"/nemAHahEsdq5nkdiZkMu6LJYDqh.jpg","height":733,"iso_639_1":"pl","vote_average":5.17216117216117,"vote_count":2,"width":500},{"aspect_ratio":0.701262272089762,"file_path":"/sG2G5lnTsqP0Dcj8qj3Xqrdlkqi.jpg","height":1426,"iso_639_1":"de","vote_average":5.17113095238095,"vote_count":1,"width":1000},{"aspect_ratio":0.70901447921532,"file_path":"/8rRXQ6u4JDXc5O9fDOttJHWqret.jpg","height":2141,"iso_639_1":"fr","vote_average":5.17113095238095,"vote_count":1,"width":1518},{"aspect_ratio":0.675333333333333,"file_path":"/bHHd526NHjRxeahWl9DfmofXde8.jpg","height":3000,"iso_639_1":"en","vote_average":5.16840882694541,"vote_count":19,"width":2026},{"aspect_ratio":0.675675675675676,"file_path":"/xJBsd9QrFb01Y9opAM5xGSllKWp.jpg","height":666,"iso_639_1":"es","vote_average":5.15646258503401,"vote_count":7,"width":450},{"aspect_ratio":0.703605980650836,"file_path":"/85WIm41bmdyRWTXw7OReI5oKhHI.jpg","height":1137,"iso_639_1":"ru","vote_average":5.14570007107321,"vote_count":4,"width":800},{"aspect_ratio":0.703448275862069,"file_path":"/8EQ6rEqpOuu47SjshMHB9aSVynV.jpg","height":1450,"iso_639_1":"it","vote_average":5.14430014430014,"vote_count":3,"width":1020},{"aspect_ratio":0.668,"file_path":"/sRX6OfQGXhlV2CkZ1b4M8MDg9C.jpg","height":1500,"iso_639_1":"en","vote_average":5.13749161636486,"vote_count":8,"width":1002},{"aspect_ratio":0.675333333333333,"file_path":"/d0cDJzGMxes7iVF9dd2IM2qGPHF.jpg","height":3000,"iso_639_1":"en","vote_average":5.1307847082495,"vote_count":8,"width":2026},{"aspect_ratio":0.666666666666667,"file_path":"/dxbFyslMZWzSQg2I3ZX0bTXFCb.jpg","height":1500,"iso_639_1":"en","vote_average":5.1118760757315,"vote_count":20,"width":1000},{"aspect_ratio":0.705992509363296,"file_path":"/mYwZKC2sNcwyA8EazMSwHnHUn53.jpg","height":1068,"iso_639_1":"pt","vote_average":5.10622710622711,"vote_count":2,"width":754},{"aspect_ratio":0.714285714285714,"file_path":"/qhXxr30Ec66inzT6ubBNj6ABr5w.jpg","height":1400,"iso_639_1":"ru","vote_average":5.10395707578806,"vote_count":8,"width":1000},{"aspect_ratio":0.706428571428571,"file_path":"/h508AwgE8sInkVvHIGYmCBqDGn1.jpg","height":1400,"iso_639_1":"de","vote_average":5.07042253521127,"vote_count":8,"width":989},{"aspect_ratio":0.7,"file_path":"/fx8jdBWykbaip615IKB4L45jXlW.jpg","height":1500,"iso_639_1":"en","vote_average":5.05396825396825,"vote_count":12,"width":1050},{"aspect_ratio":0.701149425287356,"file_path":"/6ClJ2vDpid9xSDglcWFjDPsis5I.jpg","height":2175,"iso_639_1":"en","vote_average":5.04645760743322,"vote_count":19,"width":1525},{"aspect_ratio":0.666666666666667,"file_path":"/gTz6RRDbvTJub438vx230vEcprF.jpg","height":1200,"iso_639_1":"en","vote_average":5.04619758351102,"vote_count":4,"width":800},{"aspect_ratio":0.675,"file_path":"/f3AwyaDQSwWMziwsqkNIMlHT5Y.jpg","height":1400,"iso_639_1":"en","vote_average":5.03663003663004,"vote_count":15,"width":945},{"aspect_ratio":0.697502312673451,"file_path":"/31Gu6gDCnjRSkFRncpiYADl8t9O.jpg","height":1081,"iso_639_1":"en","vote_average":5.00881834215168,"vote_count":18,"width":754},{"aspect_ratio":0.695809248554913,"file_path":"/9PNpH4ljbLeGZop8IlQA4hPXUe3.jpg","height":1384,"iso_639_1":"en","vote_average":4.98933901918977,"vote_count":4,"width":963},{"aspect_ratio":0.698821796759941,"file_path":"/tkWRrDvFFO7aXTiiM2p4CCiFNMa.jpg","height":1358,"iso_639_1":"el","vote_average":0.0,"vote_count":0,"width":949},{"aspect_ratio":0.701111111111111,"file_path":"/uYK19s8IMpAoiEkKQdG0U4pJ8H3.jpg","height":900,"iso_639_1":"ko","vote_average":0.0,"vote_count":0,"width":631},{"aspect_ratio":0.666666666666667,"file_path":"/i2bGxc7G36B2kugOFy6zgkuFElF.jpg","height":1500,"iso_639_1":null,"vote_average":0.0,"vote_count":0,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/2IiZXCgP8AkEqMOW68CnIgZfs3z.jpg","height":1200,"iso_639_1":"pl","vote_average":0.0,"vote_count":0,"width":800},{"aspect_ratio":0.666666666666667,"file_path":"/fk0efsa5v2oS4EQpJzCCJkaU5AR.jpg","height":750,"iso_639_1":"pl","vote_average":0.0,"vote_count":0,"width":500},{"aspect_ratio":0.666666666666667,"file_path":"/2N5HeoABBCwMiBjOaYcowaWQlyp.jpg","height":2100,"iso_639_1":"en","vote_average":0.0,"vote_count":0,"width":1400},{"aspect_ratio":0.666666666666667,"file_path":"/uOLLB3twRrKvqjc21oxXTbfM3v4.jpg","height":750,"iso_639_1":"ru","vote_average":0.0,"vote_count":0,"width":500}]}'}
-      headers:
-        access-control-allow-origin: ['*']
-        cache-control: ['public, max-age=28800']
-        connection: [Close]
-        content-length: ['14126']
-        content-type: [application/json;charset=utf-8]
-        date: ['Fri, 04 Mar 2016 01:54:57 GMT']
-        etag: ['"2b29a91404a64ff243201f687cf04db8"']
-        server: [openresty]
-        status: [200 OK]
-        vary: [Accept-Encoding]
-        x-memc: [HIT]
-        x-memc-age: ['3389']
-        x-memc-expires: ['25411']
-        x-memc-key: [8a47e034351297845dd6a7aa9b96c910]
-        x-ratelimit-limit: ['40']
-        x-ratelimit-remaining: ['34']
-        x-ratelimit-reset: ['1457056507']
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: [application/json]
-        Connection: [close]
-        Host: [api.themoviedb.org]
-        User-Agent: [Python-urllib/2.7]
-      method: GET
-      uri: http://api.themoviedb.org/3/configuration?api_key=bdfc018dbdb7c243dc7cb1454ff74b95
-    response:
-      body: {string: '{"images":{"base_url":"http://image.tmdb.org/t/p/","secure_base_url":"https://image.tmdb.org/t/p/","backdrop_sizes":["w300","w780","w1280","original"],"logo_sizes":["w45","w92","w154","w185","w300","w500","original"],"poster_sizes":["w92","w154","w185","w342","w500","w780","original"],"profile_sizes":["w45","w185","h632","original"],"still_sizes":["w92","w185","w300","original"]},"change_keys":["adult","air_date","also_known_as","alternative_titles","biography","birthday","budget","cast","certifications","character_names","created_by","crew","deathday","episode","episode_number","episode_run_time","freebase_id","freebase_mid","general","genres","guest_stars","homepage","images","imdb_id","languages","name","network","origin_country","original_name","original_title","overview","parts","place_of_birth","plot_keywords","production_code","production_companies","production_countries","releases","revenue","runtime","season","season_number","season_regular","spoken_languages","status","tagline","title","translations","tvdb_id","tvrage_id","type","video","videos"]}'}
-      headers:
-        access-control-allow-origin: ['*']
-        cache-control: ['public, max-age=36000']
-        connection: [Close]
-        content-length: ['1073']
-        content-type: [application/json;charset=utf-8]
-        date: ['Fri, 04 Mar 2016 01:54:57 GMT']
-        etag: ['"acd3a349fca1f788ac931639278ad061"']
-        server: [openresty]
-        status: [200 OK]
-        vary: [Accept-Encoding]
-        x-ratelimit-limit: ['40']
-        x-ratelimit-remaining: ['33']
-        x-ratelimit-reset: ['1457056507']
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: [application/json]
-        Connection: [close]
-        Host: [api.themoviedb.org]
-        User-Agent: [Python-urllib/2.7]
-      method: GET
-      uri: http://api.themoviedb.org/3/search/movie?query=the+matrix&api_key=bdfc018dbdb7c243dc7cb1454ff74b95&include_adult=True&page=1&language=en
-    response:
-      body: {string: "{\"page\":1,\"results\":[{\"poster_path\":\"\\/lZpWprJqbIFpEV5uoHfoK0KCnTW.jpg\"\
-          ,\"adult\":false,\"overview\":\"Thomas A. Anderson is a man living two lives.\
-          \ By day he is an average computer programmer and by night a malevolent\
-          \ hacker known as Neo, who finds himself targeted by the police when he\
-          \ is contacted by Morpheus, a legendary computer hacker, who reveals the\
-          \ shocking truth about our reality.\",\"release_date\":\"1999-03-30\",\"\
-          genre_ids\":[12,28,53,878],\"id\":603,\"original_title\":\"The Matrix\"\
-          ,\"original_language\":\"en\",\"title\":\"The Matrix\",\"backdrop_path\"\
-          :\"\\/7u3pxc0K1wx32IleAkLv78MKgrw.jpg\",\"popularity\":7.582744,\"vote_count\"\
-          :5159,\"video\":false,\"vote_average\":7.67},{\"poster_path\":\"\\/sKogjhfs5q3azmpW7DFKKAeLEG8.jpg\"\
-          ,\"adult\":false,\"overview\":\"The human city of Zion defends itself against\
-          \ the massive invasion of the machines as Neo fights to end the war at another\
-          \ front while also opposing the rogue Agent Smith.\",\"release_date\":\"\
-          2003-05-23\",\"genre_ids\":[12,28,53,878],\"id\":605,\"original_title\"\
-          :\"The Matrix Revolutions\",\"original_language\":\"en\",\"title\":\"The\
-          \ Matrix Revolutions\",\"backdrop_path\":\"\\/pdVHUsb2eEz9ALNTr6wfRJe5xVa.jpg\"\
-          ,\"popularity\":4.440803,\"vote_count\":1797,\"video\":false,\"vote_average\"\
-          :6.35},{\"poster_path\":\"\\/ezIurBz2fdUc68d98Fp9dRf5ihv.jpg\",\"adult\"\
-          :false,\"overview\":\"Six months after the events depicted in The Matrix,\
-          \ Neo has proved to be a good omen for the free humans, as more and more\
-          \ humans are being freed from the matrix and brought to Zion, the one and\
-          \ only stronghold of the Resistance.  Neo himself has discovered his superpowers\
-          \ including super speed, ability to see the codes of the things inside the\
-          \ matrix and a certain degree of pre-cognition. But a nasty piece of news\
-          \ hits the human resistance: 250,000 machine sentinels are digging to Zion\
-          \ and would reach them in 72 hours. As Zion prepares for the ultimate war,\
-          \ Neo, Morpheus and Trinity are advised by the Oracle to find the Keymaker\
-          \ who would help them reach the Source.  Meanwhile Neo's recurrent dreams\
-          \ depicting Trinity's death have got him worried and as if it was not enough,\
-          \ Agent Smith has somehow escaped deletion, has become more powerful than\
-          \ before and has fixed Neo as his next target.\",\"release_date\":\"2003-05-06\"\
-          ,\"genre_ids\":[12,28,53,878],\"id\":604,\"original_title\":\"The Matrix\
-          \ Reloaded\",\"original_language\":\"en\",\"title\":\"The Matrix Reloaded\"\
-          ,\"backdrop_path\":\"\\/1jgulSytTJcATkGX8syGbD2glXD.jpg\",\"popularity\"\
-          :3.981007,\"vote_count\":1991,\"video\":false,\"vote_average\":6.57},{\"\
-          poster_path\":\"\\/9ZqM6eePUCa52iCAJXpx2PvwR1e.jpg\",\"adult\":false,\"\
-          overview\":\"The film goes behind the scenes of the 1999 sci-fi movie The\
-          \ Matrix.\",\"release_date\":\"2001-11-19\",\"genre_ids\":[99],\"id\":14543,\"\
-          original_title\":\"The Matrix Revisited\",\"original_language\":\"en\",\"\
-          title\":\"The Matrix Revisited\",\"backdrop_path\":\"\\/izgye3aEdT40m1audRDnRuXLaiP.jpg\"\
-          ,\"popularity\":1.872091,\"vote_count\":35,\"video\":true,\"vote_average\"\
-          :6.46},{\"poster_path\":\"\\/8guQp7yX4CBOAz0jqj4lqSIIOo8.jpg\",\"adult\"\
-          :false,\"overview\":\"Disc 4 of 10 of 'The Matrix: Ultimate Edition':  An\
-          \ \\\"extras-only\\\" DVD, packed with documentaries and behind-the-scenes\
-          \ footage. Go to the middle movie\u2019s furthest reaches via five documentary\
-          \ paths revealing 21 featurettes. Plus 23 extra scenes shot for the Enter\
-          \ the Matrix consol videogame\",\"release_date\":\"2004-12-07\",\"genre_ids\"\
-          :[99],\"id\":274849,\"original_title\":\"The Matrix Reloaded Revisited\"\
-          ,\"original_language\":\"en\",\"title\":\"The Matrix Reloaded Revisited\"\
-          ,\"backdrop_path\":null,\"popularity\":1.126972,\"vote_count\":11,\"video\"\
-          :false,\"vote_average\":5.32},{\"poster_path\":null,\"adult\":false,\"overview\"\
-          :\"A spoof created for the 2000 MTV Movie Awards, combining The Matrix and\
-          \ \\\"Sex in the City\\\".\",\"release_date\":\"2000-01-01\",\"genre_ids\"\
-          :[],\"id\":344225,\"original_title\":\"Sex and the Matrix\",\"original_language\"\
-          :\"en\",\"title\":\"Sex and the Matrix\",\"backdrop_path\":null,\"popularity\"\
-          :1.000174,\"vote_count\":0,\"video\":false,\"vote_average\":0},{\"poster_path\"\
-          :null,\"adult\":false,\"overview\":\"Disc 6 of 10 of 'The Matrix: Ultimate\
-          \ Edition':  An \\\"extras-only\\\" DVD, packed with documentaries and behind-the-scenes\
-          \ footage.  The cataclysmic final confrontation chronicled through six documentary\
-          \ pods revealing 28 featurettes.\",\"release_date\":\"2004-12-07\",\"genre_ids\"\
-          :[99],\"id\":274850,\"original_title\":\"The Matrix Revolutions Revisited\"\
-          ,\"original_language\":\"en\",\"title\":\"The Matrix Revolutions Revisited\"\
-          ,\"backdrop_path\":null,\"popularity\":1.04345,\"vote_count\":3,\"video\"\
-          :false,\"vote_average\":5.5},{\"poster_path\":\"\\/hCP7abUsyhw6zuO8Am68Xc418N8.jpg\"\
-          ,\"adult\":false,\"overview\":\"A promotional making-of documentary for\
-          \ the film Matrix, The (1999) that devotes its time to explaining the digital\
-          \ and practical effects contained in the film. This is very interesting,\
-          \ seeing as how they're giving away the cinematic secrets that they created\
-          \ solely for the this movie, that have now been spoofed and referenced in\
-          \ countless other films.\",\"release_date\":\"1999-09-01\",\"genre_ids\"\
-          :[99,878],\"id\":325251,\"original_title\":\"Making The Matrix\",\"original_language\"\
-          :\"en\",\"title\":\"Making The Matrix\",\"backdrop_path\":null,\"popularity\"\
-          :1.00042,\"vote_count\":4,\"video\":true,\"vote_average\":7},{\"poster_path\"\
-          :null,\"adult\":false,\"overview\":\"The making of Matrix Revolutions, The\
-          \ (2003) is briefly touched on here in this documentary. Interviews with\
-          \ various cast and crew members inform us how they were affected by the\
-          \ deaths of Gloria Foster and Aaliyah, and also delve into the making of\
-          \ the visual effects that takes up a lot of screen time. Written by Rhyl\
-          \ Donnelly\",\"release_date\":\"2004-04-06\",\"genre_ids\":[99,878],\"id\"\
-          :221495,\"original_title\":\"The Matrix Recalibrated\",\"original_language\"\
-          :\"en\",\"title\":\"The Matrix Recalibrated\",\"backdrop_path\":null,\"\
-          popularity\":1.018911,\"vote_count\":3,\"video\":false,\"vote_average\"\
-          :5.5},{\"poster_path\":\"\\/tf9MDM8oBygRSG3TALLQX6Q6tyL.jpg\",\"adult\"\
-          :false,\"overview\":\"Becker's documentary presents the arguments of the\
-          \ new-age practice of \\\"bio-energetic medicine.\\\"  Presented as a medical\
-          \ documentary, The Living Matrix, promotes healing through energy reading\
-          \ and manipulation.  Director Greg Becker presents his arguments through\
-          \ anecdotal patient stories, and interviews with parapsychology professionals.\"\
-          ,\"release_date\":\"2009-10-22\",\"genre_ids\":[99],\"id\":119742,\"original_title\"\
-          :\"The Living Matrix\",\"original_language\":\"de\",\"title\":\"The Living\
-          \ Matrix\",\"backdrop_path\":null,\"popularity\":1.001181,\"vote_count\"\
-          :2,\"video\":false,\"vote_average\":4.5},{\"poster_path\":\"\\/tz4Mm2Nfgx4Y9Iwxrh5aPrlK9Xm.jpg\"\
-          ,\"adult\":false,\"overview\":\"This work is a parody.  As such I do not\
-          \ believe that this DVD has any  possibility of competing with the original\
-          \ in any market.  It is not for  sale. The Matrix ASCII is the original\
-          \ Matrix movie encoded in text. The finished product is an MPEG-2 file 7989979136\
-          \ bytes in size.\",\"release_date\":\"2003-12-15\",\"genre_ids\":[28,16,35],\"\
-          id\":380218,\"original_title\":\"The Matrix ASCII\",\"original_language\"\
-          :\"en\",\"title\":\"The Matrix ASCII\",\"backdrop_path\":\"\\/wXWFjNcuh0eqPm3BEgV8T1XunZl.jpg\"\
-          ,\"popularity\":1.000338,\"vote_count\":1,\"video\":false,\"vote_average\"\
-          :6},{\"poster_path\":null,\"adult\":false,\"overview\":\"Disc 8 of 10 of\
-          \ 'The Matrix: Ultimate Edition': Probe the philosophical and technological\
-          \ inspirations of The Matrix Trilogy through two insightful documentaries:\
-          \  - Return to Source: Philosophy &amp; The Matrix documentary \u2013 Scholars,\
-          \ philosophers and theorists deconstruct the intellectual underpinnings\
-          \ of the trilogy  - The Hard Problem: The Science Behind the Fiction documentary\
-          \ \u2013 Is the notion of a real Matrix plausible? An investigation of the\
-          \ technologies that inspire the metaphor of the Matrix.\",\"release_date\"\
-          :\"2004-12-07\",\"genre_ids\":[99],\"id\":274866,\"original_title\":\"The\
-          \ Roots of the Matrix\",\"original_language\":\"en\",\"title\":\"The Roots\
-          \ of the Matrix\",\"backdrop_path\":null,\"popularity\":1.002457,\"vote_count\"\
-          :0,\"video\":false,\"vote_average\":0},{\"poster_path\":\"\\/bQ4cjN4HJ96ddYVljgNQ64klN8k.jpg\"\
-          ,\"adult\":false,\"overview\":\"A shocking new 2 hour film by B.A. Brooks.\
-          \ This 2010 release is a follow up to \\\"The Decline And Fall Of America\\\
-          \" which was released in 2008. \\\"The American Matrix - Age Of Deception\\\
-          \" details news items that all people should be aware of such as the economic\
-          \ collapse of The United States and the formation of the a New World Order.\
-          \ See what has really been going on in America today.\",\"release_date\"\
-          :\"2010-01-01\",\"genre_ids\":[99],\"id\":26214,\"original_title\":\"The\
-          \ American Matrix - Age Of Deception\",\"original_language\":\"en\",\"title\"\
-          :\"The American Matrix - Age Of Deception\",\"backdrop_path\":\"\\/f09oCCFxLkm81WI9crc2UZzNv4F.jpg\"\
-          ,\"popularity\":1.042705,\"vote_count\":11,\"video\":false,\"vote_average\"\
-          :4.09},{\"poster_path\":null,\"adult\":false,\"overview\":\"Since 1990 David\
-          \ Icke has been on an amazing journey of self and collective discovery to\
-          \ establish the real power behind apparently \\\"random\\\" world events\
-          \ like 9\\/11 and the \\\"war on terrorism\\\".\\r Here he reveals that\
-          \ a network of interbreeding bloodlines manipulating through their web of\
-          \ interconnecting secret societies have been pursuing an agenda for thousands\
-          \ of years to impose a globally centralized fascist state with total control\
-          \ and surveillance of the population.  The attacks of September 11th - not\
-          \ the work of \\\"bin Laden\\\" - and the subsequent \\\"war on terrorism\\\
-          \" are a means through which this is designed to be achieved.  Over more\
-          \ than six hours and with hundreds of illustrations, David Icke also reveals\
-          \ the illusion that is life in this \\\"physical\\\" reality. How is the\
-          \ \\\"world\\\" a provable illusion - just a lucid dream? How do we create\
-          \ it and how can we change the dream to one that we would like to experience?\"\
-          ,\"release_date\":\"2004-10-05\",\"genre_ids\":[],\"id\":371610,\"original_title\"\
-          :\"David Icke - Secrets of the Matrix\",\"original_language\":\"en\",\"\
-          title\":\"David Icke - Secrets of the Matrix\",\"backdrop_path\":null,\"\
-          popularity\":1.000429,\"vote_count\":0,\"video\":false,\"vote_average\"\
-          :0},{\"poster_path\":\"\\/nrL7EO7Izrgr4f8ReHuc7V0omFl.jpg\",\"adult\":false,\"\
-          overview\":\"\\\"The Happiness Matrix\\\" is a 2-hour personal growth DVD,\
-          \ manifesting, in a practical, authentic and engaging manner, a powerful\
-          \ thought process that anyone can use to transform their lives. Sourced\
-          \ from wisdom traditions, \\\"The Happiness Matrix\\\" is a thoroughly tested\
-          \ and proven program based on the life-changing MBA course, \\\"Creativity\
-          \ &amp; Personal Mastery\\\", taught at some of the world's top ranking\
-          \ business schools. \\\"The Happiness Matrix\\\" will open you up to possibilities\
-          \ you never dreamed of and give you the tools you need to begin your transformation.\
-          \ Your internal changes will be rapidly reflected in the world outside and\
-          \ lead you to an immeasurably more fulfilling life. For further information,\
-          \ please email support@TheHappinessMatrix.com To view the Trailer, visit:\
-          \ http:\\/\\/www.thehappinessmatrix.com\\/trailer.html\",\"release_date\"\
-          :\"2011-08-03\",\"genre_ids\":[],\"id\":323256,\"original_title\":\"The\
-          \ Happiness Matrix: Creativity and Personal Mastery\",\"original_language\"\
-          :\"en\",\"title\":\"The Happiness Matrix: Creativity and Personal Mastery\"\
-          ,\"backdrop_path\":null,\"popularity\":1.001479,\"vote_count\":0,\"video\"\
-          :true,\"vote_average\":0},{\"poster_path\":\"\\/4bld8IsrzXKNRRU9uCgZfWcgqAe.jpg\"\
-          ,\"adult\":false,\"overview\":\"An hour long discussion on the philosophical\
-          \ concepts that inspired, and are presented in the trilogy. This is one\
-          \ of the two feature-length documentaries on disc number 8 of the 10-Disc\
-          \ Ultimate Set.\",\"release_date\":\"2004-12-07\",\"genre_ids\":[99],\"\
-          id\":174615,\"original_title\":\"Return to Source: The Philosophy of The\
-          \ Matrix\",\"original_language\":\"en\",\"title\":\"Return to Source: The\
-          \ Philosophy of The Matrix\",\"backdrop_path\":\"\\/zpY5aIOy7C8Nta86kFxGlcSMNld.jpg\"\
-          ,\"popularity\":1.00059,\"vote_count\":2,\"video\":false,\"vote_average\"\
-          :4.25},{\"poster_path\":\"\\/rDmcA1VMZ67ayuw6I43UYMy9Bhw.jpg\",\"adult\"\
-          :false,\"overview\":\"Dylan can't get enough of the new action-packed video\
-          \ game \\\"Insectoids\\\". So when he and his friend Sal are invited to\
-          \ play Insectoids \\\"for real\\\" in the virtual-reality Room of Consequence\
-          \ at Whit's End, they jump at the chance. But when the game gets too predictable,\
-          \ Dylan throws caution to the wind and enters the \\\"forbidden matrix.\\\
-          \" Soon they're engaged in a life-sized, three-dimensional jungle war, fighting\
-          \ giant insect warriors and facing an even more dangerous foe.\",\"release_date\"\
-          :\"2000-01-23\",\"genre_ids\":[16,10751],\"id\":268477,\"original_title\"\
-          :\"Adventures in Odyssey: Escape from the Forbidden Matrix\",\"original_language\"\
-          :\"en\",\"title\":\"Adventures in Odyssey: Escape from the Forbidden Matrix\"\
-          ,\"backdrop_path\":null,\"popularity\":1.000494,\"vote_count\":0,\"video\"\
-          :false,\"vote_average\":0},{\"poster_path\":\"\\/1ISkdhJ48PDvETdxjllQ1AswTGv.jpg\"\
-          ,\"adult\":false,\"overview\":\"Straight from the creators of the groundbreaking\
-          \ Matrix trilogy, this collection of short animated films from the world's\
-          \ leading anime directors fuses computer graphics and Japanese anime to\
-          \ provide the background of the Matrix universe and the conflict between\
-          \ man and machines. The shorts include Final Flight of the Osiris, The Second\
-          \ Renaissance, Kid's Story, Program, World Record, Beyond, A Detective Story\
-          \ and Matriculated.\",\"release_date\":\"2003-06-02\",\"genre_ids\":[16,878],\"\
-          id\":55931,\"original_title\":\"The Animatrix\",\"original_language\":\"\
-          en\",\"title\":\"The Animatrix\",\"backdrop_path\":\"\\/jbkrE2uiUuz29AHfJ9LralFR0KA.jpg\"\
-          ,\"popularity\":2.267635,\"vote_count\":192,\"video\":false,\"vote_average\"\
-          :6.5},{\"poster_path\":\"\\/5oU0gsrU47gthpNt2GtVNiS6A5w.jpg\",\"adult\"\
-          :false,\"overview\":\"It is the year 2005. The war between The Autobots\
-          \ and Decepticons has escalated all the way to Cybertron, which the Decepticons\
-          \ have reclaimed. The Autobots must now face an uncertain future. Megatron\
-          \ and a group of forsaken Decepticons have been reformed by the ultimate\
-          \ transformer, a planet-consuming demon known as Unicron, into even deadlier\
-          \ warriors. Now Galvatron, Scourge and Cyclonus must destroy the Autobot\
-          \ Matrix of Leadership for Unicron's glory or suffer the horrific destruction\
-          \ of Cybertron. However, Optimus Prime has decreed that an Autobot will\
-          \ rise from his rank and use the power of the Matrix to light the darkest\
-          \ hour of the Autobots.\",\"release_date\":\"1986-08-08\",\"genre_ids\"\
-          :[16],\"id\":1857,\"original_title\":\"The Transformers: The Movie\",\"\
-          original_language\":\"en\",\"title\":\"The Transformers: The Movie\",\"\
-          backdrop_path\":\"\\/e9WDDxgkmZG1LvxbGfKiCvsrNAp.jpg\",\"popularity\":1.596292,\"\
-          vote_count\":53,\"video\":false,\"vote_average\":6.96}],\"total_results\"\
-          :19,\"total_pages\":1}"}
+      body: {string: '{"movie_results":[{"adult":false,"backdrop_path":"/d5vwBiuJI1a2hBcGjhsWhpmAkL7.jpg","genre_ids":[28,53,80],"id":8681,"original_language":"en","original_title":"Taken","overview":"While
+          vacationing with a friend in Paris, an American girl is kidnapped by a gang
+          of human traffickers intent on selling her into forced prostitution. Working
+          against the clock, her ex-spy father must pull out all the stops to save
+          her. But with his best years possibly behind him, the job may be more than
+          he can handle.","release_date":"2008-02-24","poster_path":"/3zlffXmo7QpVBc17QIJWrRfasVr.jpg","popularity":5.250912,"title":"Taken","video":false,"vote_average":7.1,"vote_count":2510}],"person_results":[],"tv_results":[],"tv_episode_results":[],"tv_season_results":[]}'}
       headers:
         access-control-allow-origin: ['*']
         cache-control: ['public, max-age=21600']
         connection: [Close]
-        content-length: ['14434']
+        content-length: ['753']
         content-type: [application/json;charset=utf-8]
-        date: ['Fri, 04 Mar 2016 01:54:58 GMT']
-        etag: [e1f9b39289e1893622852cf8de6e14db]
+        date: ['Mon, 07 Mar 2016 09:36:24 GMT']
+        etag: ['"6c745991d4175b1b972fd73694911ddd"']
         server: [openresty]
-        vary: [Accept-Encoding]
+        status: [200 OK]
+        x-memc: [HIT]
+        x-memc-age: ['4983']
+        x-memc-expires: ['16617']
+        x-memc-key: [9b0814597a8fadbf986894816a029df4]
         x-ratelimit-limit: ['40']
-        x-ratelimit-remaining: ['32']
-        x-ratelimit-reset: ['1457056507']
+        x-ratelimit-remaining: ['39']
+        x-ratelimit-reset: ['1457343394']
       status: {code: 200, message: OK}
   - request:
       body: null
       headers:
         Accept: [application/json]
+        Accept-Encoding: ['gzip, deflate']
         Connection: [close]
-        Host: [api.themoviedb.org]
-        User-Agent: [Python-urllib/2.7]
+        Content-Type: [application/json]
+        User-Agent: [python-requests/2.5.3 CPython/2.7.10 Windows/8]
       method: GET
-      uri: http://api.themoviedb.org/3/movie/603?api_key=bdfc018dbdb7c243dc7cb1454ff74b95&language=en
+      uri: https://api.themoviedb.org/3/movie/8681?api_key=bdfc018dbdb7c243dc7cb1454ff74b95&append_to_response=alternative_titles%2Cimages
     response:
-      body: {string: '{"adult":false,"backdrop_path":"/7u3pxc0K1wx32IleAkLv78MKgrw.jpg","belongs_to_collection":{"id":2344,"name":"The
-          Matrix Collection","poster_path":"/lh4aGpd3U9rm9B8Oqr6CUgQLtZL.jpg","backdrop_path":"/bRm2DEgUiYciDw3myHuYFInD7la.jpg"},"budget":63000000,"genres":[{"id":12,"name":"Adventure"},{"id":28,"name":"Action"},{"id":53,"name":"Thriller"},{"id":878,"name":"Science
-          Fiction"}],"homepage":"http://www.warnerbros.com/movies/home-entertainment/the-matrix/37313ac7-9229-474d-a423-44b7a6bc1a54.html","id":603,"imdb_id":"tt0133093","original_language":"en","original_title":"The
-          Matrix","overview":"Thomas A. Anderson is a man living two lives. By day
-          he is an average computer programmer and by night a malevolent hacker known
-          as Neo, who finds himself targeted by the police when he is contacted by
-          Morpheus, a legendary computer hacker, who reveals the shocking truth about
-          our reality.","popularity":6.582744,"poster_path":"/lZpWprJqbIFpEV5uoHfoK0KCnTW.jpg","production_companies":[{"name":"Village
-          Roadshow Pictures","id":79},{"name":"Groucho II Film Partnership","id":372},{"name":"Silver
-          Pictures","id":1885},{"name":"Warner Bros.","id":6194}],"production_countries":[{"iso_3166_1":"AU","name":"Australia"},{"iso_3166_1":"US","name":"United
-          States of America"}],"release_date":"1999-03-30","revenue":463517383,"runtime":136,"spoken_languages":[{"iso_639_1":"en","name":"English"}],"status":"Released","tagline":"Welcome
-          to the Real World.","title":"The Matrix","video":false,"vote_average":7.7,"vote_count":5162}'}
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA82byY7jSHqAX0XIy1yq0xHBCDJYN+37rtRmDAoUSYkUKZLioq1RgLeDYcBozMEw
+          /AQzvhgejy+2j33vufY8QM9zOKjcpCAlZWc2YKsKkZlkkPz489+D+vZO0SI7vPs8V+xA/3Q3U1RL
+          813vi6eExt3nu7/QyGabM6NaFSrIyKnlpRGMDG+VtRrS/dJb3LFDdNt1FsGX0P2iuratq6HpOnef
+          v70ztbvPUCCYCp/uHGWls9MNFEt3MvnXaZ/uPDcIdf/lerjTKpl9pTbajAxLa29BvSQP59JGWOSf
+          r8cjGm3Yg4MqRnJnabWXsz3WBp2cPyptneMhX9kxkbbQ2V0iAo6fT3cL3fH14O7zXz5yIvrCmH0k
+          +/rpcQ85oTd8k5H7L/soeNmX90328+uvP90Z7kr3lEW8kdEep4kUst9W2uxL/OddGAJZEAmAbL/r
+          mwvTUewvtuIsosfD9FguLztCM7RfZBfv2Oj+xtS3bNPIMG09s1FUJUY2nUVma4ZGRsnMfVN3tIzp
+          ZDqKbwafMoqTya5031TZLwvTtzNmkLFMzVE8T9cysz07ZsEAMu48Y0QrNin0lfncVC3dD9hpQt0J
+          M66TCXTbji9j6H681c3MXV9lJ/B89hTNMIox7jMj17fiWcpCMZ0gzISGnlFtV7U+HQ/Ud98E3j4z
+          Z4+P/bWK2Awvsu2MG4UZhf2Mpweh6wUZdoFA2ejxUfeZHNt9vD2Dsc90dtReVxgdU6DAnNl7ts0w
+          2U0b5urT8RxLd5ZZKfH2zMr1dbaN3VeMEv9QHM3W74/6xy7OhBTu7z7jewkSKIgJrRQO9nw+XrlS
+          1xvmVCh1q7WR35srwdB/0komAS06ag6zgpWnOOaTdj3pBwKMPM/EGPn7TMndPakGIrEuPeuQwp53
+          pmNHwdNeCPDJ7qaYKZn26mUnhKcHDzr9TD9U/Ke9IqHiyd6ybzI5dl4gn08iUkk6mVaMmGEpedf3
+          XvbLp6dpii8XRyI82TGKdcRf+Doz7+RVIKT4lDXLnnLHVJks9CDT1DVTeRaHIEIcG9GZOCMn9J/F
+          aQbuFwGK4hfIzlPq3b0YYMlXHFV/NM3TOeXc65wHxwyZttaZcmruKjn3oZ+Yy0QaMkhmF0/2c7Rx
+          X7d1JdC/aGzn8eEC+g1A3yB8F+/b6E7ENiMkUgEQkbkWn91C7B8+y8ybBJ7LLPnF4F/vSxTkI8bR
+          zJ+fiLOwzcB4YX2eM48f9Mmtf/9bxQwSs47q8DTrx9/+6e9+/K8ff//j7/70Dz/+a2JqsH6dGhhr
+          0zveaMBun6nj57ve4x1rbFKoMCTnqHOGvmdG6lpHm9SUaGGEsalmKvqvYkNmHiu2RNPP2Ez9gtjc
+          eG+2MTXdfQk/GzfUvzCL94+OULqHT5uOOhBbC2RbFJtdxGEub6M/OscgjjbPv/E60hyfXDX3/X8H
+          60jXlIy58mzmN2d2isoMRieH/PSPf/jp7//nz//0mz9/95/JqcNi6tmrV86ez/JiyMAbsxq/Kjr2
+          97/b6CvmQJJzK/WTuYz0p+/+VhZ/+vfv/vwvf5OcnB2cTJbFTMWN/FfFeZlWOL2xJ8rMNxl2gBEf
+          kIlVPnlU9fTkVTezMVkgiQPW9/+RnFyOrfd58g//nPnhN3/86z/+1Q+//+EPP/wbU76vcch8tI9v
+          X4L+4wNWAo/lD1/8OOwx73IvnX6Yuc1ZWPwZGQzTUKa4sbuNA/qJUTgsLPFKSe4xIcxLCRgTICDh
+          XEMhu/rW1OIrQxmB+J5/Fqytroe5nOkfDmOCQHbfrguWZI1zhZr4TlhEiQSfRh5W+hisUqV2VFWb
+          3mTaMXd+UZWAl+35ldy2+D5YQaYUyAQJx/EXhm3OJj2se9VmdeUotXrD6SvTsjOf5pvvhIWIcIgf
+          I9SAc8jphVY729oq+8WqYtJsqQ1hGfU5Qgm9DRBQLBLxcTxHlV9REf35qMpw3G5r3V5BrjrezJIn
+          G7E7nNKqD8P3CRNRQSKSIFBCIOVYIfiYXMNhazbOl8IHWDqwRG7sktK0tPGaPhy8Fxaw/AdgTKEU
+          B/RTWPIx1nm/06rjPa1M9E5TlGT5sB3t1AYIuvN36QCSmBbICAuiLGF6EfU9OmDVO5OSsa2rolQl
+          pclkWq7SwLFA0Zm+D/XR6h9HfI6KP4a6sMbSDE1CNC1V7Ma079By6Bh+pVL+f4eaJRVDMzfbXb5a
+          qZuHVW++E8SgNPbL1jtRgUwlGUqEEMApwAdR7bWiaI3Cej/KFvF8vulsDrBcLduT0H0fKhQlSUCS
+          iCUsSb8oanYBZpK6aikKWDhwnT/kp4dcfWgIU975/5+jSm0HjP3mst+qUB27eqHddCRT3Xaqw1ve
+          6rFw4FmhLCGJyqxaFLHIeau3xFTKnAeAVGbumXCsxtyzvV7D6o/zCrBUVQZLSd+Eftd94Fgpxm8Q
+          K2SUWKSUCY6J9xz1JLEi4Fh6pqBC5u5kpvCY8GLV1t2mr3hqoxQWVBphoohiw1hV146WQBXehAqw
+          JD6PF6WKZTkd9YoG7IbryUMeL5W1pU18SyGrwoM/EVC/aNzSgAuslApYkGUsQAwvu6uLGnCFdSFI
+          S1SxA6iN94NytIrK3dGmUWyOa8+NkYusF7SVZdcAiY8jl1+dJC3vYcVzddtfN0uq3hJdg1Z22rbT
+          DVd1bVC7xXpBroiV+OR5PGeNC9WPwIq9vG5iz69DDBrRuu8v2lrRzJUG74tYzK4gIXH9HP/kUE/y
+          q/d4rN3DYozmXgfpD2unVvDD6txZTMcPrsibFs+argLMfmUAH0e+AfAx0nXJRoVOESlqNYrCkdl1
+          sO6T2qi92dwgTZcqkIU4EDDvKAqxczxFFT+GSnqH1r7ntdyOZ3eGpuKE65qaj8pmof0+ZQXSsef8
+          OHKJwAcNa9E5uJNtwa/YG8so7eadQ+lQD/0JnWffySrIIkXkceQc1gdZgxwpKMPiZKx1xsZcXtX3
+          i6E3ata6q/F7WPG9LCNZliCrXCWZt6wPFgNo42aDYR/UD9Fkva5CDUCvJ3XdsHoLNc2wwD04pzsx
+          +5gu7roeu95pPRZwL559JA71doP8hZXEyy83WMk9gaLAwhbLOVidzfctToIWAClyvUWroW5koxCU
+          /X5jXZuKG0spFuSs0RRuwh77rjwsJif/uOpV+CDrGkXzKTksZvvNtj/syTWy7YlOMVvc72/CpkpW
+          kJEEmHGxgkCOe9O/qGSXvb3RM8uOmStPNqVRreJAmPN8lbT4miBJq+lptJQZGAaUEElEnGhPXOwF
+          WAkcnXOsRQTEpfoZrPLQndmSGZLBMJ8dsmvugppNB/JYQwnYeBnwTLTx2kYSFouQPI1cUngSulho
+          S4O9LlmpNHZwvtie6HJtAoHbKR60mVTpHFoeD4t4yRrRu2FpumCvs1rdID8sbeekqOUK20arPK13
+          kVisdKwCz5rQgnSdRayABc8jp7MnmdYFNbhO60rNeXUil0Opqs8HTne9W7qmsKMll1cDBHlaP1Wy
+          1zqDOB2RmSRmaaSIsXzUtfMMq6GRFSJ+v9oqHLpCLZ/1Q9vTCNzyaUu81n7G5/5MPpZ3p+Fdl6DW
+          0FYbCKS52odWu9jSsrvaKqwilSYSgMTzNlKt/grhpYcsQeH0wyHawowEw/ZOXqparultq6V1Qwmj
+          Wd0OeBkSXiNTTf0KIXM2qYCAUIoEgmQMYdw1OAPULb1VFhewmyU1XQck35acelSb5KU1L0OJl6EZ
+          /kzC2EWkIV5/zEEDYlvolWa5aWdX6YurXCFfnhS2Uo2XYfIxpzp3JL+W0OAy7IUHfh1WlaxmfRGa
+          Ay8nTlR9Ewyq9ShX6+5XicWJBGyqD0IvGWk8crCn3j2dVoKQhTDmbQUgCZTvpPiTfKNVhGbQaO7U
+          8ixbEgtad9MvO7McTwsAeoN3RxSyqzyP57SvKQmzmVRWcE2y6/WqTQe+MQ73pfn20PPpfLpblpe+
+          w69TJCNRqi0h5rYEUWRxmkp8JHpt+1CcGjWvy3WuuoOSD1rZSb9nLRruoYl6K5AN1WGy5n+bXEWR
+          IEwQy6AIv1DxmjxdkitL1C+7qP1005VBtjce52ulfpHWulW/v6uMAsI3KZNyVVPlilkoeVn9u2Re
+          lKSynmpAUgcUH9SKWr4Zto0xPQw3g6AG6URoTeGOZ01YV7orYJkzgk8j5wreYFxYZrdBMEZIFuP+
+          3RmsY7aqqLcbF9Z+paw1SZAtVKr7CpAniUVVljCew6bm+2+ETa37j0kpM0mZPI580bfob0yFolAe
+          TOSHpSgVvJrj9Sf1rljmYUH8ptLNOPA2WElI1QIJUCyw68S1LYr1/YyVukOj4u36630xCGrStqtu
+          JhbZj8MyvwyIIOYEm25dVxZWTgICQSkN4FsquymWFkad9GcjqVJV9+WwXlpWArqsTxIdlYTKpgcE
+          gcUvLLPHIGO+NBHATZ29TqvmgRENZkF3etg1wwe6CNzaQ6tRqa5vJ6XptAz3+T0AxDnZt6SnJ68R
+          xIefewNAbNUq5fX6QhWor9ojJTJbXWGw5qNXInVJd1xvYsWPr6bxqNflavXMgdnuKD2lGVBAe+V8
+          sR7k29lRj/JakHCy6XIF8fLa03ixXXmhjLpuXt44VxwHSMkXBpER1GY9pwLyzdy0luirvdW8AKDy
+          8wsh/Cr7B82LFL1svQ+L1SAnFGC7MlxFnlqLxGIiwX6jYKFMMUTicZTOWV97gBfkeh2VLh82gaXq
+          e9RZVUNa78yxlFtohX0k86gJT5AaDyCVmU9nGQgivAqctADf5QdEaDOGpuVDa2Utu359WtSHe2G4
+          1MlN1nSxUgQklsvKUID8AstHYVEF5q12BQ56QX4V1lXfXBx2Yk5EJXgTNjUriNfzRPA8ci72Nixl
+          EY8iHC8mQAz5rEBfZSuKUQy0NXEszZxazUhs1CaFNb/MJsWp2imrZ6eyIijC5/GSIyDpqBJgqo6Q
+          xPwIq4kQhxqUUZnYziBYd0BBXdL1Uhivfc221iYv12MkeoNcIRReIu1FR3BBrhKQAcRYkhEkcTfm
+          3Lj83rgrRrhWGKukLc8L7TCsVUZrX0/JCeBbjOttrASmlgeiRE4ybj4znFUqGkFiq7Ls7XTFGNly
+          Yb5y52NN56OBcPzWwG3rYpUIYFW+KLN8i0+5X90WKx/SYxfzIq//+Xiwq+UCTe76pRmAE9n1sk2y
+          K/dtuz7iW4DMNjnYtDB7fCMAEUqAwGzkHFZ6DbPpHSGJhS1AZAri5aQ4ET3XAjKqrjCcrbR9bzQY
+          b6V2T68St25UEmsXUOBCV2pPDWLCcgfAKihJ4H3sa911IRwwVowpkljFhoDIZy+02BX94tprRxGW
+          +svAaFZystIf7p3EGxeY7w2lZtzMNpi6PI+XvVbaklDsYvmSIOiNxfa8Wx4b9hDlrSmc4SZtFhby
+          81diLnvVdCUV4rRVhKIgYj4NeK2344I4le+qRWlALdQO5eZODyRzWJI1DVWbaF3uVErvtChW11PM
+          EiWEeet/Zb1oT1fDlbablfaB3ZyODv3uAlWF6RjMBuNSfvZOuUJIJRHELzJCvtC6XQ9IzJpkFC9T
+          iKyw4A1qNdlO63kUtNTtPkuLyqHZ31acyoNDEmtWIFags3CVqqQgjjdP48W8VSLHb6AkWF+y8+PI
+          sa6N8c4XQFEVRdM5DMRolmstxWzOJ3y/Oi433mL8rMQicdksUeZvLinBZcGKp7QcrMHcV3a7KNKg
+          6ljDTaVanqzyuXWh7CRylgRsamwFEsAoXl9DMJG4vsLKNOXFIMbK0c13dKnlRntrppieCEm1nsMN
+          TJZje8TTvU1HwUkPk+8GnHUxL3l9CDErd1m1IgnxS8XnyWrerqFNwTM1edcvLGx1VFoWOoEZEN7r
+          xys5b6HFIvP7zKSwICB+3efkTQDy+D0qnva6+S8GB7HXK8w2g1o0wwLd7JAANkXV83lX9caKhdFC
+          mQUZgUAYNxNPaW/GKDEWyPmzF7LbvVLo9rej5sHcBmurVW3alQGZ8HgJxUzHE0RWojyNfHPlNfWX
+          H7+qleBjdwaQwNJUScCEtyIBliNxUcg7y17fKvUc1TMn2YJNQznRXAHHL0PehGVZFKQCZikmTHTb
+          X83ogn8SZULj154pISzS8TFK7rS8CraXs4ZenroerdrdLDY64wc94UsFev7eYhosvmfGLAgsJ5ZZ
+          IXj5dVBZTG2xsQqX1SmSzBRAlhNVSmiNen5hUyq1JWU8MM0m8nA+b5ZaTSXBGvcSz1iTZcqVl0Bk
+          nO6RmMWffDi8aFKHckCrTS/rmkWr3tXK4AF7NVrhRSnzOmollyav0InCO3oSJpqVd6pUFsQcsqJF
+          u7QXDwsrKhXthIXz3jPtZZ8reJdiz3U+VDWn4/yiQ7NWcd1sj0Sad6qL6TwQDjxfwgOl1KBX+C45
+          nat4cwvo80AhG+T2cbHr1Q75fM1SHki2x+El1kx/Ht2Fovg6HWqRiu5mc7n8tmnmlm1lorpbZdS1
+          93w19KYO6RW8S03R63xRu9HICeG259c366WKoLsbD2bzprDBt6SXkgRdwYul9+uvX/8Xwdk5+Ms/
+          AAA=
       headers:
         access-control-allow-origin: ['*']
         cache-control: ['public, max-age=28800']
         connection: [Close]
-        content-length: ['1517']
+        content-encoding: [gzip]
+        content-length: ['4904']
         content-type: [application/json;charset=utf-8]
-        date: ['Fri, 04 Mar 2016 01:54:58 GMT']
-        etag: ['"7a1793f6996ea84a88c9daa4364ac489"']
+        date: ['Mon, 07 Mar 2016 09:36:24 GMT']
+        etag: [W/"fc551e53657f2a912eb94a2f6f6997b2"]
         server: [openresty]
         status: [200 OK]
         vary: [Accept-Encoding]
         x-memc: [HIT]
-        x-memc-age: ['11780']
-        x-memc-expires: ['17020']
+        x-memc-age: ['9129']
+        x-memc-expires: ['19671']
+        x-memc-key: [5a83165c56fc93c8aa4de882d3298a4a]
+        x-ratelimit-limit: ['40']
+        x-ratelimit-remaining: ['38']
+        x-ratelimit-reset: ['1457343394']
+      status: {code: 200, message: OK}
+  - request:
+      body: null
+      headers:
+        Accept: [application/json]
+        Accept-Encoding: ['gzip, deflate']
+        Connection: [close]
+        Content-Type: [application/json]
+        User-Agent: [python-requests/2.5.3 CPython/2.7.10 Windows/8]
+      method: GET
+      uri: https://api.themoviedb.org/3/search/movie?query=The+Matrix&api_key=bdfc018dbdb7c243dc7cb1454ff74b95
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA8Vb2XLbyJL9lQo+jOdGkGyCOzUPPbQ2y1qtxVZ7NOEoAkUAEoCCsZCibnTE/Yd5
+          mt+7XzInswCSEiGJ7vswEQ5bBlBrnjx5Mqv091osXVXbseq1RKV5kKW1nf/6ey3WaaaSH7HMvNpO
+          7e634Hv8LU4+/5wcHcT7X3u5/jTVx63j3ej6W/M+dmv1mnTQuLYzlUGq6jU9U8nMV3M0vvZ0KFMx
+          bopx5Kgk1ZHwUyFFKCMR+DM/ckU21/SjSpvi40I4ciE8xR9FQqIjTFDYOoxzTEnEiXYTGYb4UUaO
+          mCxE5Ltexh0GaqYDFWXCk/YDPniI9BxdpOJM6bqYe1pM/chJheeHqQqmIpOJqzLFvWQYMtaBbyt8
+          qKJiBraOMmkXn5zqJPZUntYxWKBcFTkyWaxmZgY14yRqprAT3GvqafuBl5nkmSfkROeZ0HmCj2Tg
+          Z4tmjfY+UDJVPxyZwRg1azQaNVqdRqeFdxgoUT98hyxjtevtYb3XqQ8Hw/+u13ynttNvdbDfie/6
+          kQx+ZH4WUA/XGPhUZon/WFt7G8jIzdneNRXhReXXE6zDSXS8sv4g78SPduvYmj922keBGj+czAbD
+          02M3mRfWj3WcBzLBamo7g2a30+8NBvXaTGfqh63zCMDoWcM2nviO0kuU8PvCwtSuP/yzvom99Fi7
+          99407f3syKcw/jbYOzg+HquT/cPh+9hTwssJaTamJvRUfPeBP0dNFeHAzxgG0pV+lGZsLEA1BRKF
+          H81kSt+ijXlue36k0gJNABJAB/tqgZ74i7kEIoHDSON/iZgmgA6w4AdKYF5a6BgLYxjgY4A4V2Ls
+          ElivQj/zKkDQbgEBrV6j3dkGBL03QSAuyTXyDCtKfw0QL1pugiN2vn66SSdttf80Gp+cXSf9+fTy
+          s+o9fpUV4Og1B53RqENQWAOHNaT5vwWOfrPTrwKHejrKk49P7alzY/eHzmh4EI+cy2nP92bvgeMK
+          iwthJA9GnZIDk2HgtxHs6qjYZ7f3I7Haizqb3gMEwEIzvIX5JzCvcLV2hA5BG1Nt+pkmqoAe0UWK
+          gRLFhMU/mBdC4seJIkzQ5w5hJizQxlvPBJfonPgNQxF26/xeR6YzHQULkWaAmuvpwCnBeqlSP81k
+          ZKumMFMuCI+m7vipTbuA8TwwXJrHKon1HMyMxdpB7tB8+KlIY8wK05/4xFM0hRSrohFs7cAXiuEy
+          eIZLrVMY8OX8pbBVksHBsKcubQoaxYlq2NqNfEIVOD8n+o5kijFiX9n8TaTmRNTkY0snTpbr2hHt
+          XqvearVKx8TMogz/BmZXHd912dfMrvFM5jrHFoF0bY/6DMm2g7bwQMUIPOPUfIm5xeghXVoS6PGx
+          HnZwBkB9GQi42+vEj2h3aFjpzPx0FU/OE2nD/TMTd/jRsVqEkmITRQkzI08FsZnQcm7iCpNi650q
+          GRkSwcgfUnxi50lCtOHg67BEKq21mMgHegb3gLHBY67OyPoYKkl8zIxNAltNQX5YUSpAV6Awwlh9
+          nY8YKikg7em5UKktYzR2QFBksjq/nSiEPmUAzQCa5gEmDztN1LSEO3049R/RmHAoyaQYUz1mRfB9
+          g/da/W14r/se7wVaOsr5ZdJbNttkPOvezYOrRXb92R5fPxzeDtPF4WSv7Qa3exWM120OrWGvZ71g
+          vNGIAuSbjNcbVDHe6PvP075SFze7stf2d8efb+PH9sVsfmmp9xiPFjj1gxCoUGQ/r0RlaiuKbYU/
+          k/rAI78x9WFdtF2jwGp7WQ0Lf0Yv7DUaFVayur3u2yKFooyf+tlfMNSq3aal/Cd3oTpy37nutkJL
+          5s7lXnSZ355I/6LCUlYTWmrQHT63VGcVmSDgKszUrQxMQzf/Eg8Wt93dj+fjp9b9z/tu8PPq6Ohc
+          v6ta9sDQokvWsFr094fVenfETUlH+w7T54cdAWEt7mrwqUSmDQoJdzWx93WvLmJSpCA+8mdH2zkC
+          FLzOJxVDkYXt34DFG4X9p1pnWFRTHGoiLcJC6DtOQE6Ouf3zH/+Lb/IEz6GWmKzQaOZLgApUsxoB
+          NC4prBoVTNzUtsQUpJQnKstI5l8EYM92R/CkS/hBKGdL2t2PypBcWBpSPNWBYFO4MlSVQOw2rHaj
+          NXgNiG1Ytzt6D4nG9f8FSFZ08AKbUR4EL8Fntftgihc0QbTxBkn0mp32BvpM56/Ca4y4rgErGxYk
+          iVPueJvC6en1V4Q38vkx4p0D8QKSnyCwUIBZrZHwc1e7Uo8URKnxLhZxV6tmh1YDBNGyXhilMEmn
+          2223q8QrdU7DrCCwjR0qW22x+ZilNXix+a239771qxvPft3///RrNqEtkdIGizT0bdIlMiDX4nRF
+          0sDC9vCzD+FCu8jqU6Qw+TP31s4z7x4+8+5KEGzhmVB0mzB45ljLTORfcM7qPraByKjXolz7WXB4
+          GyK9Zm8DJIgN3u7FQE5u0oU37z/l58Nx2B/e2l1rePZubBhT6hFqWgAMBymJ/W8AS+vWWeYgFOrN
+          uuts+X+nyP430miQj4qmyjmwAPJYparHOJDG16k9RLSfYRQCVQwpm/k2/qemU2VnRWkEiptzpHK4
+          JsaBwMMfTHmBN1g3ggV6rFPuQD2TBoSmRIvFB4hE15SA5FwazWyjS/gBsJkqMBTrf8m5+WLJWIgD
+          KlitM6MhOUJRdiSp/INwFGGQiUJKxmxXSN8EmT/Us21mzUYMVArlk3HOjhVUwdeUY0abHDYarWnR
+          TrvXJpm3AeFTttIafW6D2apG24C01Rp1SbGsgbT7poDZFJnv0BhNyQCPSGzTrwqskYz/GyFhAmaa
+          BpQ+5hAMlLQi5UmoxGIstwbdpjgixNBAqaG3GVamoRVsZIdsQWBgLkIVTkzCCgyEIl9BSsypa8kY
+          XSVinBCxvj0MsPNSHPB6ucMxOGwhkf1wakSVGqQ5XAEqJdByrfQ/UEa+5gUGnMjoUpHHVBeEhMGX
+          KaYJ6JFjNcU3GCfD/zCZS28RiD0dIVENFptAY56kPy9Tn2dAa7et7qgqZK7AAnvAV/1JQv6yDdxe
+          b7oV6IaDF/nNXyPGbDo63Tsd6o8L9/LqsHM9Pjn5ctv/0s8WJ+8R40dF1VdKftfjFMhHUT2HLId8
+          k18s85xIzRuYTcltXHa4q0183UDUpOQUJBQqxydKaiL2igvTHXEJV7DpHbCwNqLB/onhtJJ6DWMD
+          IV4RL8uwysMsSElz0YUAGMrIp601lRGx5yPhz8Bzh4lyhVnjalXkPatVlb3KSNmOJuLGvvp4JVL0
+          AHVgIM6cvOZhsUxknC5sTwfapS0DWaZU+sQWV3AhIDpqWK1Gu70B0TLbs0aDbvsVeD7bmleA6ZC2
+          f6vRVpC0up0XmGy/jcnuK5h86p6G7bOp+9j9Y3Q0f0y8nrxIguPRbfgeJjkWznXyYE48sNPaAcdR
+          rSkFF4ojQIcLMBMV+FBTZajD19B5XDuR0UJAbsEgRRGOhLsOY8UlHzYgQbncRiJVahLK5EFlGOoo
+          o7FpDIqWIpWBohi9dPbx1e7REX3yrJfipUn+ES41pTPE1xCjpjmEo58SmwMvTm7zKDISpxf7h402
+          BVIlBqPhaDQYWZ0+mI+lBmKx/6SqQdUhfWj1XoCqPaxb/XqnV4bYYatNKVIltNZX9AqyXqO8ss1m
+          BWF+++3g/szOvZb6eRF2Pu67X4fX1m0efQ8qKwiIv+3Rc9i9k8JtVg/eib+cRgy3TyMuEj0xZdnY
+          8wOdavxDtMVpkrK9iByfn/hRGvsJcw+T5NoOXSc+00NJMnRkRwVf18uo7PcsC0Hm0kAUQT4Qkao0
+          tUzMoxx9If5NhvF/rHe/Ttr//Mf/iCuiI5mAspZzpnhfZHYwbcpFeqoJQNPY5uyGmC0IwJcUoHM6
+          bIz9iNTsqlJdrALzo8E/IcPl7QlUuMNPrmyf1CGYdlkbO6DyKh0avZjikfGZiLU4DSD5QK9cEZR0
+          DqcN1O+UxvnRjGSwazKscjbLzVeFkDAGKGroKpOxB6ctvjb9VjvPFslVv/+K21wiOVxu0Ju8vOE9
+          1U23Y+der//cTX4524Z3Tr507fuz7qfPo77j/PE1uHfPvvS7D8HZ8OE9bh6vzmWhA4Q5BzApE3Ta
+          x+a4KT4mWj+kRUrTbsHbip03dD7VQQDVCdkHkN/xhuwpO6DDiDGwcyCDQJxPxThUCbwL+mEOv/O4
+          6F70w5wK8w2bRfvi26gEUYNK8tQJOlYxYQfdOACGH1AVfU7pmwoL8NB4sdJxwEfOdLJAZ1NzmbCw
+          4YAjDWbJbzSl/zaWgODPH9D4NxGlw+Iqk8TXZR2FNPYz4Epxhi37phOMcZ7Az5riStG5OedetDzM
+          ZWGyL1ezeCYXKJeH/XJk1bE37XFlrWiF5D607ytAfn/ztsX1Vj1txoppa6R3dw8eTx7CofXtaGQn
+          dvvm+9PZrHtQHSuw3l8t+HWbrdGGJ7wTMK58ojQksS2xJ9G5OIKMLI5wYCE+HhMylE9kqXu4QaRY
+          Z5jDccq5NNMqF3mL00M+DQSlyUkAHcCoYPbjg6DyaEHGdJSGFHsBfCfoSYfkBoyb4qA18DGV0d1v
+          lrWE212NjtI1qY0kIapHo+ZdIj5RZsfjlHcrCPRwg4wlFibM0nZCR6m0kkmgtUPumK6p6jX1jbH8
+          BPniZNnUpsTMHKaZ4oNINQJCRvzMNQXerzhP0tzodSH5FkhRiUCeKulaAbpbKAQv2iI/hKX4iDjQ
+          E/YKG+tOkAc8UelVpjZCGQQ6hWyj5li5U3El0SZGp3kyUz4claxYeKABUpEkEGRllgGPPPYVIMr5
+          sbAsdNhg9UeNym2iHCcSJ9JRRCeN5can+SRVP3PKGKpsYE44EZfo6LrcRMNpLFkplVdQBFQSKg7G
+          bY9krYM5ngMz5qiQTwipoMgHrzw4L9xDxE6U2T6sNkdgN0qkvo5aTtDXb9fwp8RNJoASoqar2sJd
+          DXIjJXGD+Zf3bcQn0HYhebFQgiOtjg/1gee1PhviPqe6gwhyGzPgI9ffuTmE+1wVBSk6SqVlUA2C
+          WINeYJGuiePciDaEDu15knMyBfEzg9/U3UA4JDx+ryJFCu/gxZfauNTEA6tvVVVO13atAVCYYtrL
+          YP0uH27Vy1Yhv9V9qYz/SsiPkpPB/vng6Clxk+50eKk+5fbga0uHB6Ugf5UHTYz9BFYiUkiL6cP0
+          HM7bDVYAMV9Rgwu6iZ4DllxwJ/6YlnVMSrFW9VAk1Tn2IqJiAYFARa50iR3QJqLrYHL9cNzc5QDQ
+          bJqAYbBoQcgg4OQpwwHAj1IubBmKKq7GGR1d3BKZ+6lDl0USaXQ+vOTt5WFs9lgqxGElRT2U77HQ
+          pQe+VCcmLErYmRQ7UoOBzMn3xzHVSxPsKUbaJeAjK89KLX9RbtupJHst7mp1kUlerSQaDZfUxf72
+          gcgxFlgoK7AJ3I3nnEL36yAt9VDFYuZwTqFjTHqh80J8rfJjYmp6HiniG3Y9WpAJYy4FMHpL08ho
+          nOLbkrCwUHqSrCxQUOwf9JBDBC3RODeVTzAV0FwiY98JqI4zpTBZpMrlUoXOM74YQ1OAZztmCprC
+          hx+CTcHvYJ2FYUfABBqUq0S0/01xgNBizlxpBss5ITEyUlSFEIN0XyfWSfaf2LTlnhUJgw2YXGtB
+          PsCTuk7QgIDJhx87wsuyeOfuN6S683kTH3hl+3DZ/u63zDRqelkYVFGUBdE2bLRe3lRbVsY7bZL7
+          GxRVZeMdsQYu2rOX0NqGtf5qx1sRGZb7au5SVWGv5LHuJHCGR2nydHt8dnl5M8p33e/Tb7b7c/zu
+          NQ7kk0xVgQZKSJDlXK8r/fZ5lg8lQZr1eYJJl7pIn9HNnWVNswBtZnLk1UkOsVPhu5T1Fyd9jQBM
+          t3H+SHkylSeinAUIVymoIeIXly2W5Ymr167+vJPKWoNu36qqfW/WGwgDazUHvV7P2AZDv9zjZkbw
+          FP/Rk0fni8Hu8CyTw/7DweNhYF+dngVOdUaA9dNNmV+qWrYry5bJXmiPra+n3/sDucjn/aNu5+aP
+          08Xoo1fe2X0VX3sLbAkFpA+ZcFV5Paw0JWXLFPt01CjOoXl6wgXVgraPopQq1jAbVDt2bnmbmhUS
+          4DQlpYMckypQfAo045yTaDyQC7Fqj85IV5NqoyBm0DnzEyrvNAotRyWIkGa2ixDI2tUmLSy+eX6G
+          GLMfOXxhcgEdF8b0gvog/qbLdXTvkGdHD3n6Lp83ak1e4fg2ZTcId2Y/SPHO6SCKT7k4Tnuk2cmP
+          OO5nVKGiZzzvie9AXxc3Ien04Eob/+RTT1YJxuekCbRUGeXJIn1pOD5cytTgMfPIDYrbh3zrmGKD
+          68uIvRl7Ra8SXxdaeirtIjehDMsEFYfiVULHaFP9SvmV8+7Nm8b9utUa9Kxl9j3s0r3uDecbO5TN
+          5XRtEis6dxZpqhY7Yp/vDa6utR4st2V7L/zrXW/F5ZZlkYNVcnmlv1WSuXV09eB4n7vDi73Z/rXz
+          eB8EX6xxOr8+fP8WMoVWkknLpXBSQeYsHA5CFKkR0lpzDmnWV9I0Icanw3iToZsaTQqtR8KSqdYx
+          x9qr/ksBRlrEQIWO/53ipIlueKWKeix+rQHCkEKJQddnGUuEVPLm4s4AKUhSN9Qz7biZ7fMMQeQR
+          pFfCzUyqSTdOAjgY5FM2p6SarvfSy/KevTll4IWU95KpFEsOcRDwfhUjnKc+0lNz7nZFhS26dxVJ
+          P03Jyevi2Ke1XmFl2KsLo3PrRe3qEt8ncLqPChIc/47FnsqKQge34CnxGmxKt5HJVjpPp9HqN1ov
+          D8TgPKsz215vRMdRG55D0x6zobb0h5cNNoPO/eQh2W/n/k3+1B6NP00/j04SGRxcto7HFUGn3bRa
+          3U73xW9rWKN3wk6/+rCsp29abprcdAfQBvFZ1j7Mvp75V/1x792oY06qyKRUPKGyaM+AgCoRJUx4
+          9XmmJ1R4JuMUFTk6COCKFl1VZktxOZThThdLtNhdQJBkCSnnsmbB9dq11jOqLdmBBLIdM/RyqJDK
+          AHSjBPRKKAaiy2vt05zYqSlOlSupf6Os2GtjAiliQSofMPeNwbialNBdaUpSiqsKeamQljlIkUQC
+          ECprUOs8JLd1VIjBlr/idBP5Nq+O7y0w9ztw8MCHC5cBoinOsIRDGcx4pnVxRRmda9xyd2FDUObF
+          Wh1Fv1ZgplTsQunMWNMJeoY/e37Mpa9ibPiZG5DX4FGaT6fKXM/x6Or5FOkx95kvWWppES7IUMJW
+          F+fYIIwPRyV64V9XoJID6QOTKy8nw8kXPL+IAUSClE3yUjiP9opb6S+oKKNfNeNfqPAoMCYPdJeV
+          5XTxXWnzCle3RsM+5znDDVcv5emwVxUfCUvXK3umRkryPcttff715psMoEbf9vYe3Yfw+6F1Mnuc
+          HE6P/d1ZmpyN4woGsJqDdqdP50PrDNB75wZHvznq/4lVc73yx/J3B61R+Yh+r5Ae/Pl/Q2eiPmM4
+          AAA=
+      headers:
+        access-control-allow-origin: ['*']
+        cache-control: ['public, max-age=21600']
+        connection: [Close]
+        content-encoding: [gzip]
+        content-length: ['5588']
+        content-type: [application/json;charset=utf-8]
+        date: ['Mon, 07 Mar 2016 09:36:25 GMT']
+        server: [openresty]
+        vary: [Accept-Encoding]
+        x-ratelimit-limit: ['40']
+        x-ratelimit-remaining: ['37']
+        x-ratelimit-reset: ['1457343394']
+      status: {code: 200, message: OK}
+  - request:
+      body: null
+      headers:
+        Accept: [application/json]
+        Accept-Encoding: ['gzip, deflate']
+        Connection: [close]
+        Content-Type: [application/json]
+        User-Agent: [python-requests/2.5.3 CPython/2.7.10 Windows/8]
+      method: GET
+      uri: https://api.themoviedb.org/3/movie/603?api_key=bdfc018dbdb7c243dc7cb1454ff74b95&append_to_response=alternative_titles%2Cimages
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA82bSY/jyn3Av4rQ55ke1kJWcW7am6L2XQqMAUVSJCVu4qLNeEASJDk4+QIBcgqM
+          PMSAExu5GPGXeO82Tq7xIXDyHVJUd09LlFrSqP2cp8bUaJpF8sd//XfW/PRO0WI7uvs4VexQf3c3
+          UdS5Fnj+J1+JzLuPdx9IjPy1yslgtUZQsvXsvLoktCYbwep+5ht37BTd9lwj/BR5n1TPtnU1sjz3
+          7uNP7yzt7iNEGL+7cxVHZxfrmnqmpkSBtc7kX2a+u/O9MNKDL7e0TayUfQ31xMARc7SxCIR8z2hV
+          o3H1+ZZpyknbgYWi0bNGqlVYIWfzEI9KklsgtrI75Rt2TqwZOntQAXG7z7s7Q3cDPbz7+GePqAB+
+          Ac1qS92N4kBnJz49B305+Ij9fIRHe88XWOyxgi/HKHk5raNauqvqmZL1dP5P3t2ZnqP7ipEcNqPI
+          //jhw2q1ul8pgasHk8AL71XP+eB4S0sPPyRz3zMqPYgUy3XYtw+Rqb93dvL8gAgCSFHJexFC8T0m
+          WHuvYIjeYzwhijBRgcLjezNybCa9hEzgGLblaJNPyb/uoogDCHEiYoe9wDIsV7E/2YprxI90erJM
+          Xw5EVmQfrmdydKkHDHS1+73nKGEme5/JupoehJ6bscKMknEUN2NbS8s1MtHKS77q4X0mt8loyibD
+          rpVMcjMKuxC7a4Y9ux+zx834gWcEiuOwr4qrZSabjGsZZrS7oK0vPZvJImMylWAT5q63YpcIM3Xd
+          e5dZmV5marlamDEtJ9TtaSZSAqYF+u4qTHwZ37MttigrU3efCFTPjRT1aUrNC3xTj8N37Ga2zhRG
+          U4LNC9njTR/vE+hLndnQ7qqh6anz3WMGcWRmlIkXRxkvDtgkxbaizf1O6f3YVgL2L7Ya9xgJPCHH
+          pjD2B35QWUykkl/s87H3MPVkTs673cGTKTDhaPFOoz4lWIprPan0k9r1mUYm0mx7isawVpkm0784
+          0ftHRSBioqxPk8uBF6vsWSSJqantZJpKEDFVDE3Lf5qOCNyb37FstljpSwJK+b1Jg506Z3KJPj9r
+          HxBxov8H8LHLNOnZHkPvEwKC8AkkBte7ezG+OIwCJkPl0cb2p/U6L9N6rpWsYCdSIj3MeNNMlmmP
+          pSo7qwt0W1dC/ZPGDrK5QBTF9xx6j7i75Biz/Jj9GguIBwRRZiYBI7OSywIkvLsLfW+uu1+M44VX
+          QOKOY2crTxxF17Ct0NzdNmQwMZt+1368v8amRQo77u6kpNts/fRM5O00qM0UJTPwAltLZHbS4JaW
+          pntfHPfSi/RPT6bDVvWePP1qJ1fmpUDyJIrNlMtVImZ4j0YcJn76+Vta7juBHt86A16R/fPUgalE
+          iSUlz/FEe3RCsbx3wudvf/dXv/vrz79gf379+V+PJzere5Nfu2JteMWkXPsrObuDvRP++9tf/v5f
+          /vG/fvvb3//t3x9PLe7L4LXrtRNdfp703T9896vv//L7P//uN9//zXe/Op4s79P+4duf/+/PfvOH
+          f/rl//zs58dTDxbg8ebvMmzNjmfms3szq4kPZZPVExPb+5d8Qf3u37//i+PJ0j4qW8dvP//i86//
+          8+/+458//xtT/m+SWPNoLD/9ErwfNU4JfZYHfAqYUjJlBvdk/8Oi59Sy9a9IRkw9CQ3sQhxlEX7P
+          LN3YttNWwt9jFik5kSAEIObgockkIX9lacmdgQi55JG/CnbT0ou1mZtrSNmotJDiom9u9PCBU4RN
+          CpbAa1iRCAkHecTzvCjQQ1aAX1gh/XpWOMlK7VWeEL9cW0uxbqgLJ6K0VCHl21h5jAhGHKECTLNC
+          9DZWo4Zk2apTbjGpGPLDrOk62elq3bHUNOuVSoAwTzksUioIEKAULHibEizlWmHBW2qhuqlIlFsr
+          zrSC3VURtVs3wiKBAiLwiIocTWksEN8GO9UXk9G8rIPZFg/8B9Mo+nphHOF5d3wjLIB8CvEKQhEz
+          LRcRpShRlQPC9cShkj0w4rwatarEXcj+zA82JZPXjwiJeED4GJfThFDkAKE8ARiy8etZz0jTGePS
+          OvdQ9to1NY6trfIgC/w4t2gGiyPWq6QJeUHAFABEROazXncAN8HmG+PSuun0uOLKkmF17RajYqGF
+          7AjfCIt5DMHTmFIC+DZW0dVm2XAwHxobZ1PhtFmcs6JpvT7omj861q2+cued4cptb0C1G1IftXoh
+          XpTarelNjpUjiAM8fRpTOrDHeotjdTu58bZe38iNVnm+Hi2dttCouE7AudptcuUEikUE+Me/U7Dc
+          2wS7sqwAN9rZIbB8xRNb6CH0e9t2Xeosb4TFLAXgeAgoD/l0eH0jrDbJrWSK+qExLzSXhepcLKn+
+          tlsorm/SWO6eO+R7I96GdyeVcTRsUFrolMuBuSysPVUyxZHxY8CLo22ZF6CW7Xp1dWoR/wEV+wM0
+          EhY3Bfw/Np7o+1ZJAP4ATYcDt7NVZllMWFnbG49+DHjTJSv95MCyK+UWRONhNuf2O3Zp5pXIDR7o
+          HN0tPqdk1evmzJO5jVcSZatH27nsdjioDn8UstuC5nKkb9bZRdSs5CFaTlvr6nxQzLqNH4HsgpnW
+          mXlIrxeKs2ZsRXQ9nyNvockN+qcTniCIIgdFAAWY9ipC3uwWhg+2tEFdaTwPisVKdgpbbbV7hIfe
+          hkcR2LWTds2zU3Uldy8cfEiKVRmUCuW8VM91ylyu9RCuW4VK1CkW1uu0kbBodsh650d3aVaeSQYL
+          mFAWqCES8SE4fQHnuBNyvQR7uSn4OuzJJFgAIofJ05iugveSiptojY2bq29XG5b+RsOFXZTlquXV
+          5zPZqN9Gy4sipiIReZGteyoFwnsV0E20k2lcK/ZAR8UyxDNod6RloVXIFwRrfZFW00/RUgoRD0UM
+          kqrtkJa/BjZJSA8QzQWaNaAb93ONkb+Qe932HFUFrFhxmEYU0oi7Hm0akeW9Lz/CIeJerc4JwmlE
+          wkp9VpSykg2RdMFW05Sy6YsNq65Trz3i4rhPpC5sNL0UKxMSPmQN4hOsiGIB8E+jmFLVF1ZW0J1i
+          JcxTUcpzPMGEeax0SkmG0lwaqaSt1Sejsp1DUI39TYO6+TQsIPwVTuBaWLjrwadhzysqaEudAZzb
+          XaFu5Q3Z7c7VVex7mtJIh6ZjRT1pVogiDkLmtxAkSSWxDytco6hnYKt5dbzMwZG7Nkil0TKWVnk1
+          RrYgPL/Qe511Gpxk5SAGrBim4rELeCMrDAo6n8+HNk/NptWskZWz1XQOVC14Efa0YIlIWVHBPACH
+          EUhpwV6P4SbacbNmPgyL5iiH0Mjrjsf1uqNvI5Pr3worIIw5KnAQ8ClY4a2w5no1to1mub3pU0mz
+          OXfB6syN1VO5wmXaU54L8TwC4Hl81cBuglX6QVUnwOrGiMbq8qFl9JtmZFW1h9JFWPOk64LMHZOn
+          Md1mfCOswHdr1UWV5nnZ1JyHXLuVX0o0RlLvqHQ/gj2tBxCynJTygMdcOiW4KmydgdWW/LJYEXnJ
+          s51BpzXJtpxCg32mgyML45J3opdhAQtA3NOYgn0JYATQr2fd9ArCnOtOJsWgk/VnRlfElqIUFJw7
+          crNQFK5iTXeYXqyKCvjrCWehVeW1zQavG3ZYduKODVbzdoXnzVtdwBnC2xZ8XsGxFKxdG5FZzgg7
+          XTj1kNQIV9Mr7P5Pg8hX5ay6Ks+QONvyYxRmXRNkvWLrwTtqJ/1wiCTxsIdR3jaX1kwWi7AR9QLT
+          cOcomA+Mh+1MTGPttrRcjpyARU7+eXzVVIST6dN5ERIl6yOJn6/QSJv33I6orVqzWF60+9s067Ui
+          vIb1NWGeh1XL7bAhW61+sFRCTHpuqxm3h5HVmQgp2GS70AHsqeI0eZHwXECx8dWVhzfBIr8UtaHT
+          XHegsJKKamU771mbBV9fHfXnrpMsFJhj//JzCJuo7ZtEO8sN6yVJnTVFYZID+VASJL6xXm/q+Ehn
+          r6TlIeJESkSWdfMp0b4529s0x3Vq2hUzHwQFadiv1kmDi6vTgXoR9qSBvQ2WcEkjBRLIsQr3qKNi
+          bGNj0aoPHWvmCZI9ZCmfLY22OU+apWFxUt1clux1Lz5egT0v2YlkqOzEgTidLKN2b42w1XjwJqO4
+          IqdhjyR7svT7IWGJF2m9dkMsml2pjQSntipVnV6lh8zLFcrJsv+NsITHoiBQSjAgSQcmFavQRrdX
+          TTHXXw1KumxISqc4HsyEYJ6CJYkGHiSmt7Py4CQq2Z1ywOeVMKIPHSE02q0hsEQn19A3tbIkOelw
+          T49kqZziY+WeyD+NqV7ai2vlyUm+8+uOi5XB2BPI2BtuR7OZt6wvWptRo7wCDxfX3TpV8kOGSTle
+          ZIaMxVQqetn8z8MunU6r0p0ZFU92ctCsj2h/2I+G28XgxhwFciLhOZ4pmohwuu93OV05TxvbpfqK
+          lO2KYmxHy5kRu+W+kuvSsj65lRZggX8aX9PSV1nPWhRuOJKNN9FDsbSYwsCflkM0FTuFUi8dsq60
+          qGtQXzGo81JdYmjVepqk20xoWtZGlTL0lna0lC4r7EmpgqSbyj+OKVTwVhXg+81hB+a3egC0/qAS
+          5Su1QG6OiBoWb4SlkCOQQhEgcEszlUeiCJGYbE466v75wF2vsmA7zFdiuWyqUd1AYalcX8dpr4UA
+          f01wBRRAJCTdUcJu+5orgOA0LBHwS5f7SLLWGgYW7FVCSc4OHWkT9mYVqaRsQLuTgmVuPS3ZU50U
+          QDlE+OfxEHYv16YEnYI9rwZT6Exb3KDTrQxdYvp5q21McqEskubRRrg068kUCxC2+tzz+Bor/4pc
+          k+T8AC8wnbppbUvt6ZTTF5paCAZ2q0RGjcpRyx+mtfRko4c5GCCA5/E186f4ZDudpPVyKvDFst2a
+          GGZhUh8vG0p1vWiWZHPWOWr3pyuV011pQABAXwJqyuS/4BHhpPjOr3QUNHvCYKUY1SherKKi7ZZC
+          EwndQu/ode6RwZ9eagEJX95NpTdlXGHw52CdbF4swJxjRvP+TM3bhUFQq1Yi/WF0YzgFmO4lKim9
+          vKJgpZAXEWXhmOehmIIFpE289rYNG/VJSVeCGHhk0y9vh5qdhmWKdw0sm0Y4QqkIjra7vHgn+hoq
+          J2CeqTcUueNNegul1Zfi2XSUE1FOt9S8Xl+7cWVuTLg0K8RXCfY6VnxD90wki0AZVEi7ImI58rLL
+          /LzVGpFCu3pUUl2nBFwS8jHiBSqIaUeaJK+XlOAsLeW2XexJ2ii/LTVrNU6Ve6AstLRGNncjLeJY
+          mOKowDKAJNzv015+TX2+WjVbExnFrdhQ4nhe3nDrSkWiQ7spL5ppt5/sur3MCpL9WQIHmdKkwulL
+          7H/F658XK/I7A7/kcIECidSeaJWxOzN9c1CGR9vKrxErvhdZjkJxklij3X8BO1AC7qJcz9Ou+04n
+          H1VWxREqtrfySlmM42Kj3lt46dh/JS0zLkwBYskRC+9fT0s4DBFLUlhmJhCS7mBCg6fjZo+uaW7i
+          N5aOD+QeXi7GuXnay0JAUm+AT9KmZbNPu78Dkkc39DDVmr2Sl8CsG+UtkRoWmndJR5r1I+so2KZl
+          e6otmNByT3uL2ZjS2iQ3uCDb87S+YHgsGcCBhmuFSjQPTH+oFlg5K920tYLRMksGALIiiZCj1OCy
+          PzhPOx82HyDNbvOdvh85616eCGE1oAVTaF+iPS1bnPhZVmQxa6PJxoMD2suvrJnbYs/KA8JTjiYx
+          81C21VUDC263ODbneKCNJ9kCgE24Yk+RpsVJPXlBtud2L3HwhsDlLwJ5UuPlbbUG/FnIL2oUGNm1
+          MSpd1NSv5jstv/N8+rqZry68qtPPCQvSA5sWymEZ5j2YbrD///Bhr5WzuiN/u274VaKO8+ugViGt
+          DTXSmz1+KD6mdxCzBEsEXKKGKb4Z7kSAKaA+lOl23h4ZQYvVUXonNznakE+SnGif70RVco4PoVeK
+          OlbuQcpBVsfitC3XDC/Mxm6NDiOto4gO6UO1u/AVK07RIZC4vQu2fIaOFfyv+PFkC84BFPGreFhu
+          9QuhbW3H9eKDbdkd2Sx7QXpJj/qOJxrOZ5h4dIPBooqz4lXSmvmjqUmMDWdPRCnb7OHsTZnmGbyd
+          wv3km2/+D9v9EJHcPwAA
+      headers:
+        access-control-allow-origin: ['*']
+        cache-control: ['public, max-age=28800']
+        connection: [Close]
+        content-encoding: [gzip]
+        content-length: ['4575']
+        content-type: [application/json;charset=utf-8]
+        date: ['Mon, 07 Mar 2016 09:36:25 GMT']
+        etag: [W/"40e2619c73fb0981c28e756c87c95dea"]
+        server: [openresty]
+        status: [200 OK]
+        vary: [Accept-Encoding]
+        x-memc: [HIT]
+        x-memc-age: ['10506']
+        x-memc-expires: ['18294']
         x-memc-key: [4ae7e11d99f36addb309e5d76b273d25]
         x-ratelimit-limit: ['40']
-        x-ratelimit-remaining: ['31']
-        x-ratelimit-reset: ['1457056507']
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: [application/json]
-        Connection: [close]
-        Host: [api.themoviedb.org]
-        User-Agent: [Python-urllib/2.7]
-      method: GET
-      uri: http://api.themoviedb.org/3/movie/603/translations?api_key=bdfc018dbdb7c243dc7cb1454ff74b95
-    response:
-      body: {string: "{\"id\":603,\"translations\":[{\"iso_639_1\":\"en\",\"name\"\
-          :\"English\",\"english_name\":\"English\"},{\"iso_639_1\":\"de\",\"name\"\
-          :\"Deutsch\",\"english_name\":\"German\"},{\"iso_639_1\":\"es\",\"name\"\
-          :\"Espa\xF1ol\",\"english_name\":\"Spanish\"},{\"iso_639_1\":\"cs\",\"name\"\
-          :\"\u010Cesk\xFD\",\"english_name\":\"Czech\"},{\"iso_639_1\":\"ru\",\"\
-          name\":\"P\u0443\u0441\u0441\u043A\u0438\u0439\",\"english_name\":\"Russian\"\
-          },{\"iso_639_1\":\"fr\",\"name\":\"Fran\xE7ais\",\"english_name\":\"French\"\
-          },{\"iso_639_1\":\"pt\",\"name\":\"Portugu\xEAs\",\"english_name\":\"Portuguese\"\
-          },{\"iso_639_1\":\"hu\",\"name\":\"Magyar\",\"english_name\":\"Hungarian\"\
-          },{\"iso_639_1\":\"da\",\"name\":\"Dansk\",\"english_name\":\"Danish\"},{\"\
-          iso_639_1\":\"zh\",\"name\":\"\u666E\u901A\u8BDD\",\"english_name\":\"Mandarin\"\
-          },{\"iso_639_1\":\"it\",\"name\":\"Italiano\",\"english_name\":\"Italian\"\
-          },{\"iso_639_1\":\"tr\",\"name\":\"T\xFCrk\xE7e\",\"english_name\":\"Turkish\"\
-          },{\"iso_639_1\":\"nl\",\"name\":\"Nederlands\",\"english_name\":\"Dutch\"\
-          },{\"iso_639_1\":\"sv\",\"name\":\"svenska\",\"english_name\":\"Swedish\"\
-          },{\"iso_639_1\":\"fi\",\"name\":\"suomi\",\"english_name\":\"Finnish\"\
-          },{\"iso_639_1\":\"ja\",\"name\":\"\u65E5\u672C\u8A9E\",\"english_name\"\
-          :\"Japanese\"},{\"iso_639_1\":\"pl\",\"name\":\"Polski\",\"english_name\"\
-          :\"Polish\"},{\"iso_639_1\":\"mk\",\"name\":\"\",\"english_name\":\"Macedonian\"\
-          },{\"iso_639_1\":\"sk\",\"name\":\"Sloven\u010Dina\",\"english_name\":\"\
-          Slovak\"},{\"iso_639_1\":\"he\",\"name\":\"\u05E2\u05B4\u05D1\u05B0\u05E8\
-          \u05B4\u05D9\u05EA\",\"english_name\":\"Hebrew\"},{\"iso_639_1\":\"no\"\
-          ,\"name\":\"Norsk\",\"english_name\":\"Norwegian\"},{\"iso_639_1\":\"el\"\
-          ,\"name\":\"\u03B5\u03BB\u03BB\u03B7\u03BD\u03B9\u03BA\u03AC\",\"english_name\"\
-          :\"Greek\"},{\"iso_639_1\":\"bg\",\"name\":\"\u0431\u044A\u043B\u0433\u0430\
-          \u0440\u0441\u043A\u0438 \u0435\u0437\u0438\u043A\",\"english_name\":\"\
-          Bulgarian\"},{\"iso_639_1\":\"th\",\"name\":\"\u0E20\u0E32\u0E29\u0E32\u0E44\
-          \u0E17\u0E22\",\"english_name\":\"Thai\"},{\"iso_639_1\":\"ko\",\"name\"\
-          :\"\uD55C\uAD6D\uC5B4/\uC870\uC120\uB9D0\",\"english_name\":\"Korean\"},{\"\
-          iso_639_1\":\"uk\",\"name\":\"\u0423\u043A\u0440\u0430\u0457\u043D\u0441\
-          \u044C\u043A\u0438\u0439\",\"english_name\":\"Ukrainian\"},{\"iso_639_1\"\
-          :\"ro\",\"name\":\"Rom\xE2n\u0103\",\"english_name\":\"Romanian\"},{\"iso_639_1\"\
-          :\"sr\",\"name\":\"Srpski\",\"english_name\":\"Serbian\"},{\"iso_639_1\"\
-          :\"id\",\"name\":\"Bahasa indonesia\",\"english_name\":\"Indonesian\"},{\"\
-          iso_639_1\":\"fa\",\"name\":\"\u0641\u0627\u0631\u0633\u06CC\",\"english_name\"\
-          :\"Persian\"},{\"iso_639_1\":\"bs\",\"name\":\"Bosanski\",\"english_name\"\
-          :\"Bosnian\"}]}"}
-      headers:
-        access-control-allow-origin: ['*']
-        cache-control: ['public, max-age=28800']
-        connection: [Close]
-        content-length: ['2024']
-        content-type: [application/json;charset=utf-8]
-        date: ['Fri, 04 Mar 2016 01:54:58 GMT']
-        etag: ['"9105b99a86a55226dc6cb516675b4d61"']
-        server: [openresty]
-        status: [200 OK]
-        vary: [Accept-Encoding]
-        x-memc: [HIT]
-        x-memc-age: ['3298']
-        x-memc-expires: ['25502']
-        x-memc-key: [55e286608961b8d7084d036a246326a1]
-        x-ratelimit-limit: ['40']
-        x-ratelimit-remaining: ['30']
-        x-ratelimit-reset: ['1457056507']
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: [application/json]
-        Connection: [close]
-        Host: [api.themoviedb.org]
-        User-Agent: [Python-urllib/2.7]
-      method: GET
-      uri: http://api.themoviedb.org/3/movie/603/alternative_titles?api_key=bdfc018dbdb7c243dc7cb1454ff74b95
-    response:
-      body: {string: "{\"id\":603,\"titles\":[{\"iso_3166_1\":\"US\",\"title\":\"\
-          The Matrix 1\"},{\"iso_3166_1\":\"US\",\"title\":\"What is the Matrix\"\
-          },{\"iso_3166_1\":\"EG\",\"title\":\"\u0627\u0644\u0645\u062A\u0645\u0631\
-          \u062F\"},{\"iso_3166_1\":\"PL\",\"title\":\"Matrix\"},{\"iso_3166_1\":\"\
-          MX\",\"title\":\"Matrix\"},{\"iso_3166_1\":\"BR\",\"title\":\"What is the\
-          \ Matrix\"},{\"iso_3166_1\":\"TW\",\"title\":\"\u99ED\u5BA2\u4EFB\u52D9\"\
-          },{\"iso_3166_1\":\"ES\",\"title\":\"Matrix\"},{\"iso_3166_1\":\"RU\",\"\
-          title\":\"\u041C\u0430\u0442\u0440\u0438\u0446\u0430\"},{\"iso_3166_1\"\
-          :\"KR\",\"title\":\"\uB9E4\uD2B8\uB9AD\uC2A4\"},{\"iso_3166_1\":\"US\",\"\
-          title\":\"Matrix, The\"},{\"iso_3166_1\":\"CA\",\"title\":\"La matrice\"\
-          },{\"iso_3166_1\":\"RS\",\"title\":\"\u041C\u0430\u0442\u0440\u0438\u043A\
-          \u0441\"},{\"iso_3166_1\":\"IR\",\"title\":\"\u0645\u0627\u062A\u0631\u06CC\
-          \u06A9\u0633\"}]}"}
-      headers:
-        access-control-allow-origin: ['*']
-        cache-control: ['public, max-age=28800']
-        connection: [Close]
-        content-length: ['622']
-        content-type: [application/json;charset=utf-8]
-        date: ['Fri, 04 Mar 2016 01:54:58 GMT']
-        etag: ['"fe98e88014c6faa3a03484e50055bf70"']
-        server: [openresty]
-        status: [200 OK]
-        x-memc: [HIT]
-        x-memc-age: ['14132']
-        x-memc-expires: ['14668']
-        x-memc-key: [691623e9dde42af773f57f968ce3dee2]
-        x-ratelimit-limit: ['40']
-        x-ratelimit-remaining: ['29']
-        x-ratelimit-reset: ['1457056507']
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: [application/json]
-        Connection: [close]
-        Host: [api.themoviedb.org]
-        User-Agent: [Python-urllib/2.7]
-      method: GET
-      uri: http://api.themoviedb.org/3/movie/603/trailers?api_key=bdfc018dbdb7c243dc7cb1454ff74b95&language=en
-    response:
-      body: {string: '{"id":603,"quicktime":[],"youtube":[{"name":"Trailer 1","size":"HD","source":"m8e-FF8MsqU","type":"Trailer"}]}'}
-      headers:
-        access-control-allow-origin: ['*']
-        cache-control: ['public, max-age=28800']
-        connection: [Close]
-        content-length: ['110']
-        content-type: [application/json;charset=utf-8]
-        date: ['Fri, 04 Mar 2016 01:54:58 GMT']
-        etag: ['"b5177dc350b5bad79ffad28e4011eaf4"']
-        server: [openresty]
-        status: [200 OK]
-        x-memc: [HIT]
-        x-memc-age: ['1351']
-        x-memc-expires: ['27449']
-        x-memc-key: [69034a198c86dd552ce32b42ec36238c]
-        x-ratelimit-limit: ['40']
-        x-ratelimit-remaining: ['28']
-        x-ratelimit-reset: ['1457056507']
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: [application/json]
-        Connection: [close]
-        Host: [api.themoviedb.org]
-        User-Agent: [Python-urllib/2.7]
-      method: GET
-      uri: http://api.themoviedb.org/3/movie/603/images?api_key=bdfc018dbdb7c243dc7cb1454ff74b95
-    response:
-      body: {string: '{"id":603,"backdrops":[{"aspect_ratio":1.77777777777778,"file_path":"/7u3pxc0K1wx32IleAkLv78MKgrw.jpg","height":1080,"iso_639_1":null,"vote_average":5.44740973312402,"vote_count":28,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/yQeEMjnBOIAtFqIuEphyesH0a6y.jpg","height":720,"iso_639_1":null,"vote_average":5.39270253555968,"vote_count":14,"width":1280},{"aspect_ratio":1.77777777777778,"file_path":"/2bAIRwC77pGMxIuegcqmt88FJ7G.jpg","height":720,"iso_639_1":null,"vote_average":5.35437430786268,"vote_count":23,"width":1280},{"aspect_ratio":1.77777777777778,"file_path":"/gM3KKiN80qbJgKHjPnmAfwxSicG.jpg","height":1080,"iso_639_1":null,"vote_average":5.34580498866213,"vote_count":21,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/vKMDq5icDLyJI80xamfJ4nwE3RQ.jpg","height":1080,"iso_639_1":null,"vote_average":5.33681765389082,"vote_count":19,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/feqbYkGe1jz4WpHhgEpeDZt4kTZ.jpg","height":1080,"iso_639_1":null,"vote_average":5.3125,"vote_count":1,"width":1920},{"aspect_ratio":1.77942539388323,"file_path":"/xbm8IlWguCctQL7nqKpjpryFh5e.jpg","height":1079,"iso_639_1":"en","vote_average":5.29017857142857,"vote_count":1,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/mZ4FxBHGoRMcuuizaHK65ZBqPrq.jpg","height":1080,"iso_639_1":null,"vote_average":5.25664811379097,"vote_count":14,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/mCOZFxPmU0EwiK2LxnEtEDQ3lt4.jpg","height":1080,"iso_639_1":null,"vote_average":5.24542124542125,"vote_count":2,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/9ndjAsWkXgymyJ0djuBitfNNWTh.jpg","height":1080,"iso_639_1":null,"vote_average":5.24542124542125,"vote_count":2,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/zewnkSXwnRy1LTs8p3QUs4qFRQf.jpg","height":720,"iso_639_1":null,"vote_average":5.07301587301587,"vote_count":12,"width":1280},{"aspect_ratio":1.77777777777778,"file_path":"/nSBZzNNyKOQGkxYvmR6OJnmr0nd.jpg","height":1080,"iso_639_1":null,"vote_average":5.06849315068493,"vote_count":10,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/wiir4ORAX1ipao9Q3HspUzRNISv.jpg","height":1080,"iso_639_1":null,"vote_average":5.04240052185258,"vote_count":10,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/dbBwK83VsgkDPvDLk9FcpzTDExh.jpg","height":1080,"iso_639_1":null,"vote_average":0.0,"vote_count":0,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/y5nbJZtXO88DSGGrhvDxocIh9Yg.jpg","height":1080,"iso_639_1":null,"vote_average":0.0,"vote_count":0,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/utzG562dAToNcfi7pH3EVW3Y6qG.jpg","height":1080,"iso_639_1":null,"vote_average":0.0,"vote_count":0,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/9ppiF61pW3fXWnSzajA47ducUZY.jpg","height":1080,"iso_639_1":null,"vote_average":0.0,"vote_count":0,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/fv183KrilJGQ23ZXABnVSlFjoF7.jpg","height":720,"iso_639_1":null,"vote_average":0.0,"vote_count":0,"width":1280},{"aspect_ratio":1.77777777777778,"file_path":"/FiNNhjoK0yoF9KiU8RBAzXWLXY.jpg","height":1080,"iso_639_1":null,"vote_average":0.0,"vote_count":0,"width":1920},{"aspect_ratio":1.77777777777778,"file_path":"/z1PvYeyxAqtPJC23vfQxLkWEAnO.jpg","height":720,"iso_639_1":null,"vote_average":0.0,"vote_count":0,"width":1280},{"aspect_ratio":1.77777777777778,"file_path":"/rjdSjo3eNDEjPuit8xkk3oqdKO8.jpg","height":1080,"iso_639_1":null,"vote_average":0.0,"vote_count":0,"width":1920},{"aspect_ratio":1.77766990291262,"file_path":"/y6ChTDXHlIy3TIZkrEEJAf2QRcT.jpg","height":1030,"iso_639_1":null,"vote_average":0.0,"vote_count":0,"width":1831}],"posters":[{"aspect_ratio":0.666666666666667,"file_path":"/aWFDGCINBSG0BQHsxQDJtSEDxx7.jpg","height":1500,"iso_639_1":"pt","vote_average":5.77464788732394,"vote_count":8,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/lZpWprJqbIFpEV5uoHfoK0KCnTW.jpg","height":1500,"iso_639_1":"en","vote_average":5.61904761904762,"vote_count":22,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/gynBNzwyaHKtXqlEKKLioNkjKgN.jpg","height":1500,"iso_639_1":"en","vote_average":5.59948979591837,"vote_count":49,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/bfuMEU1Sc4K24j2lSIvDQDCD6ix.jpg","height":1500,"iso_639_1":"de","vote_average":5.58823529411765,"vote_count":5,"width":1000},{"aspect_ratio":0.66625,"file_path":"/hq3jO2nuVBOYpqKUTRk3L64aius.jpg","height":1600,"iso_639_1":"es","vote_average":5.45454545454546,"vote_count":3,"width":1066},{"aspect_ratio":0.667374681393373,"file_path":"/MdaGhp9OiNe8oRY0uuV7IT2OPo.jpg","height":2354,"iso_639_1":"ru","vote_average":5.38461538461539,"vote_count":2,"width":1571},{"aspect_ratio":0.702988505747126,"file_path":"/w7XIkIYc7RdNbYGlB32cupyO8nC.jpg","height":2175,"iso_639_1":"pt","vote_average":5.38461538461539,"vote_count":2,"width":1529},{"aspect_ratio":0.666666666666667,"file_path":"/1RISW2klT6NiCgKnTkcwupodaOO.jpg","height":1500,"iso_639_1":"en","vote_average":5.38302277432712,"vote_count":6,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/LCcZvB2Ynxg7JOQgviGwZ3l66L.jpg","height":1500,"iso_639_1":"fr","vote_average":5.38024164889837,"vote_count":4,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/2rDe5CCsl58hPiPM7wmzde01Li2.jpg","height":1500,"iso_639_1":"en","vote_average":5.37981859410431,"vote_count":21,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/ZPMhHXEhYB33YoTZZNNmezth0V.jpg","height":1500,"iso_639_1":"en","vote_average":5.37634408602151,"vote_count":61,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/hxwZlgPGRyV8Idl0nqGkxyiUc0D.jpg","height":1500,"iso_639_1":"es","vote_average":5.35531135531135,"vote_count":2,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/aVrLe71iTu38ucvHQgVPhtiLdHF.jpg","height":1500,"iso_639_1":"hu","vote_average":5.32600732600733,"vote_count":2,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/65TMLqL8C5KhdmHBRQCvI8u3IUd.jpg","height":1500,"iso_639_1":"en","vote_average":5.32212885154062,"vote_count":5,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/dv5vEJ95IolmWSQbAQmDOOOOfW2.jpg","height":1077,"iso_639_1":"en","vote_average":5.31746031746032,"vote_count":3,"width":718},{"aspect_ratio":0.666666666666667,"file_path":"/yUD6k0TbbErSApjgT94iaaDa4BO.jpg","height":1296,"iso_639_1":"en","vote_average":5.3125,"vote_count":1,"width":864},{"aspect_ratio":0.666666666666667,"file_path":"/jsiL5dyy4xOlsGmuSl1wkRJ55hV.jpg","height":1500,"iso_639_1":"en","vote_average":5.3125,"vote_count":1,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/kJ4uIrxnl37jBgsST2fo3IOswfD.jpg","height":1500,"iso_639_1":"en","vote_average":5.3125,"vote_count":1,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/5LKAcwGj39jz5Z3sAnh1AoEQHov.jpg","height":1500,"iso_639_1":"en","vote_average":5.3125,"vote_count":1,"width":1000},{"aspect_ratio":0.761,"file_path":"/1lhvijK9E2OtUrhgnk3rkWgHzj9.jpg","height":1000,"iso_639_1":"fr","vote_average":5.31024531024531,"vote_count":3,"width":761},{"aspect_ratio":0.666666666666667,"file_path":"/7aAp3I5kw3YdkUnS9dwQjuKqRVz.jpg","height":1500,"iso_639_1":"en","vote_average":5.31024531024531,"vote_count":3,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/cGRsOKiQVrvas47UnQPuRXtiSb6.jpg","height":3000,"iso_639_1":null,"vote_average":5.29761904761905,"vote_count":1,"width":2000},{"aspect_ratio":0.666666666666667,"file_path":"/3pFtR2mPxS26wIEcJzkUiyq5Nwg.jpg","height":1500,"iso_639_1":"en","vote_average":5.26515151515151,"vote_count":25,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/jBXNFIcjP96bB1CsI6I5OxxyN49.jpg","height":1500,"iso_639_1":"en","vote_average":5.25230987917555,"vote_count":4,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/2yPZN8hlJhCrrDIXVLN7O0uLfWc.jpg","height":1500,"iso_639_1":"fr","vote_average":5.25230987917555,"vote_count":4,"width":1000},{"aspect_ratio":0.701262272089762,"file_path":"/gzugqQNXmijo6IlX33YlIYzBoIj.jpg","height":1426,"iso_639_1":"en","vote_average":5.24542124542125,"vote_count":2,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/bIgc000W9fbvtRUx34iOHobYuJK.jpg","height":1500,"iso_639_1":"ru","vote_average":5.24542124542125,"vote_count":2,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/7otdURO9EhTIR36mMwFLmUJU3hL.jpg","height":1500,"iso_639_1":"de","vote_average":5.24542124542125,"vote_count":2,"width":1000},{"aspect_ratio":0.675496688741722,"file_path":"/5L3yelwP9BVwWFeKgIaSEZWj6rk.jpg","height":755,"iso_639_1":"he","vote_average":5.24542124542125,"vote_count":2,"width":510},{"aspect_ratio":0.7125,"file_path":"/oF438HS6sgRQX1i9mBOeyMGIImD.jpg","height":800,"iso_639_1":"da","vote_average":5.23809523809524,"vote_count":1,"width":570},{"aspect_ratio":0.666666666666667,"file_path":"/4EJWZo67ZoXzYjjovNqQyYOGw1H.jpg","height":1500,"iso_639_1":"it","vote_average":5.22388059701492,"vote_count":4,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/vmSQJTjgJoKmB2hNY8VXVtXzqWv.jpg","height":1500,"iso_639_1":"en","vote_average":5.20975056689342,"vote_count":21,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/ulFNw7GlJagzYvjgunGVaBT8Geb.jpg","height":1500,"iso_639_1":"en","vote_average":5.2014652014652,"vote_count":2,"width":1000},{"aspect_ratio":0.675496688741722,"file_path":"/4OmIl4ytHEFqf2rpfGs3f9SDFU9.jpg","height":755,"iso_639_1":"he","vote_average":5.2014652014652,"vote_count":2,"width":510},{"aspect_ratio":0.666666666666667,"file_path":"/v42iMUdIel500dAl3JG2ovltvIH.jpg","height":1500,"iso_639_1":"en","vote_average":5.1994851994852,"vote_count":11,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/5VPXS2Czer1dVWJtCJMrKPY7csE.jpg","height":1500,"iso_639_1":"en","vote_average":5.18207282913165,"vote_count":5,"width":1000},{"aspect_ratio":0.665399239543726,"file_path":"/p1nxwA1zXCJuKGhctNg3sFGNxuD.jpg","height":3156,"iso_639_1":"en","vote_average":5.18123667377399,"vote_count":4,"width":2100},{"aspect_ratio":0.764489795918367,"file_path":"/ix2ri2UJsIKAXmIysUjJIFay1RS.jpg","height":2450,"iso_639_1":"es","vote_average":5.18037518037518,"vote_count":3,"width":1873},{"aspect_ratio":0.666666666666667,"file_path":"/f2mfQ0WSTJXn7hpCiRgbBsK97Py.jpg","height":750,"iso_639_1":"fr","vote_average":5.17316017316017,"vote_count":3,"width":500},{"aspect_ratio":0.705,"file_path":"/rhmNhizFRff0eqdcDrWlQF7YOJx.jpg","height":1200,"iso_639_1":"hu","vote_average":5.17216117216117,"vote_count":2,"width":846},{"aspect_ratio":0.76,"file_path":"/f65EGlQbghDbNZvOaLxqPFKhjSs.jpg","height":1000,"iso_639_1":"pt","vote_average":5.17113095238095,"vote_count":1,"width":760},{"aspect_ratio":0.666666666666667,"file_path":"/trPU6WwagLtuqwtElnFsh36TDUY.jpg","height":1500,"iso_639_1":"fr","vote_average":5.16369047619048,"vote_count":1,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/mAC9D2BmhtkVjcClDWrMLJteHYv.jpg","height":1500,"iso_639_1":"en","vote_average":5.14880952380952,"vote_count":33,"width":1000},{"aspect_ratio":0.68259385665529,"file_path":"/17R7oRzR2ONbFearu1o7yVGzXdl.jpg","height":1172,"iso_639_1":"en","vote_average":5.11727078891258,"vote_count":4,"width":800},{"aspect_ratio":0.680645161290323,"file_path":"/qaQVIujfYB93BeicCeNxnuJkgb0.jpg","height":1240,"iso_639_1":"en","vote_average":5.11727078891258,"vote_count":4,"width":844},{"aspect_ratio":0.666666666666667,"file_path":"/97qraWJ7RJ94KtoAvCkQQY7DRLj.jpg","height":1500,"iso_639_1":"en","vote_average":5.04652435686918,"vote_count":24,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/80zT4oIdYCzFPMM0cKU1G6QdOAB.jpg","height":1500,"iso_639_1":"en","vote_average":5.03018108651911,"vote_count":8,"width":1000},{"aspect_ratio":0.701262272089762,"file_path":"/hQbK3uQugauukGy0xJJI8XlPKqP.jpg","height":713,"iso_639_1":"en","vote_average":5.0140056022409,"vote_count":5,"width":500},{"aspect_ratio":0.666666666666667,"file_path":"/3pSWpFm0ra27IRbdJZnjhphWG2w.jpg","height":1500,"iso_639_1":"en","vote_average":4.92828456683878,"vote_count":20,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/xVmSCtJwEY3ERzKwaqZuEONUqoS.jpg","height":1500,"iso_639_1":"en","vote_average":4.72748135398738,"vote_count":20,"width":1000},{"aspect_ratio":0.704231830726771,"file_path":"/2g58ZPU8x8BbpOvmp1KU4vqZBkv.jpg","height":2174,"iso_639_1":"en","vote_average":4.66666666666667,"vote_count":12,"width":1531},{"aspect_ratio":0.666666666666667,"file_path":"/cMlwKv1hNgGz7IOi3kT7SIjVtis.jpg","height":1500,"iso_639_1":null,"vote_average":4.66071428571429,"vote_count":17,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/p6goxqP4rd4MDJtkrhpXcDo67IN.jpg","height":1500,"iso_639_1":"en","vote_average":4.62081128747795,"vote_count":18,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/kXPH28AzCSVptmxUC76sLr8Dh6R.jpg","height":1500,"iso_639_1":null,"vote_average":4.42435201928873,"vote_count":16,"width":1000},{"aspect_ratio":0.720112517580872,"file_path":"/pLwO46nTEZhk4WdZbAD12P2wkXP.jpg","height":1422,"iso_639_1":"en","vote_average":0.0,"vote_count":0,"width":1024},{"aspect_ratio":0.666666666666667,"file_path":"/pqrKbM5KzLM1pjs5qM81gAxgYFs.jpg","height":1500,"iso_639_1":"en","vote_average":0.0,"vote_count":0,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/exPCLqoLmVB6q7U1yQ3B4K2Co26.jpg","height":1500,"iso_639_1":"en","vote_average":0.0,"vote_count":0,"width":1000},{"aspect_ratio":0.666666666666667,"file_path":"/4oQBiTYpzxOpL7cZCxrMJ7Qy8gC.jpg","height":1500,"iso_639_1":"en","vote_average":0.0,"vote_count":0,"width":1000},{"aspect_ratio":0.758248009101251,"file_path":"/j4St146neXK8zkRYgrQf2meSBb4.jpg","height":1758,"iso_639_1":"hu","vote_average":0.0,"vote_count":0,"width":1333},{"aspect_ratio":0.6618728028124,"file_path":"/kMgosAunM8XtdSa9m7V2cTqpaiu.jpg","height":3129,"iso_639_1":null,"vote_average":0.0,"vote_count":0,"width":2071},{"aspect_ratio":0.6675,"file_path":"/7pL4XGQVDslizZNEHlilSKhGorC.jpg","height":800,"iso_639_1":"ru","vote_average":0.0,"vote_count":0,"width":534},{"aspect_ratio":0.666666666666667,"file_path":"/3Jmw5c7QjpYfh7gy0lb9IAPU4Aj.jpg","height":1500,"iso_639_1":"en","vote_average":0.0,"vote_count":0,"width":1000}]}'}
-      headers:
-        access-control-allow-origin: ['*']
-        cache-control: ['public, max-age=28800']
-        connection: [Close]
-        content-length: ['14195']
-        content-type: [application/json;charset=utf-8]
-        date: ['Fri, 04 Mar 2016 01:54:58 GMT']
-        etag: ['"232aa5a0c5113ee200b0957e4a978fde"']
-        server: [openresty]
-        status: [200 OK]
-        vary: [Accept-Encoding]
-        x-memc: [HIT]
-        x-memc-age: ['21723']
-        x-memc-expires: ['7077']
-        x-memc-key: [524dd3e49aad18a3c850cb5c35b958dd]
-        x-ratelimit-limit: ['40']
-        x-ratelimit-remaining: ['27']
-        x-ratelimit-reset: ['1457056507']
+        x-ratelimit-remaining: ['36']
+        x-ratelimit-reset: ['1457343394']
       status: {code: 200, message: OK}
 version: 1

--- a/tests/test_tmdb.py
+++ b/tests/test_tmdb.py
@@ -13,9 +13,6 @@ class TestTmdbLookup(object):
               - {title: '[Group] Taken 720p', imdb_url: 'http://www.imdb.com/title/tt0936501/'}
               - {title: 'The Matrix'}
             tmdb_lookup: yes
-            # Access a field to cause lazy loading to occur
-            set:
-              afield: "{{ tmdb_id }}"
     """
 
     def test_tmdb_lookup(self, execute_task):


### PR DESCRIPTION
The tmdb3 library was overcomplicated and buggy, this replaces it in our api_tmdb plugin with tmdbsimple, which is just a thin wrapper around requests. Also, it doesn't support py3, which we are trying to get working.