### PR TITLE
Added show collection and watched status

### DIFF
--- a/flexget/plugins/api_trakt.py
+++ b/flexget/plugins/api_trakt.py
@@ -860,10 +860,9 @@ class ApiTrakt(object):
             if trakt_data.id in cache:
                 log.error('work')
                 series = cache[trakt_data.id]
-                num = 0
-                for s in series['seasons']:
-                    num += len(s['episodes'])
-                in_collection = num == trakt_data.aired_episodes
+                # specials are not included
+                number_of_collected_episodes = sum(len(s['episodes']) for s in series['seasons'] if s['number'] > 0)
+                in_collection = number_of_collected_episodes >= trakt_data.aired_episodes
         elif style == 'episode':
             if trakt_data.show.id in cache:
                 series = cache[trakt_data.show.id]
@@ -895,10 +894,9 @@ class ApiTrakt(object):
         if style == 'show':
             if trakt_data.id in cache:
                 series = cache[trakt_data.id]
-                num = 0
-                for s in series['seasons']:
-                    num += len(s['episodes'])
-                watched = num == trakt_data.aired_episodes
+                # specials are not included
+                number_of_watched_episodes = sum(len(s['episodes']) for s in series['seasons'] if s['number'] > 0)
+                watched = number_of_watched_episodes == trakt_data.aired_episodes
         elif style == 'episode':
             if trakt_data.show.id in cache:
                 series = cache[trakt_data.show.id]

--- a/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_collected_lookup
+++ b/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_collected_lookup
@@ -8,7 +8,7 @@ interactions:
       method: GET
       uri: https://api-v2launch.trakt.tv/search?query=Homeland&type=show&year=2011
     response:
-      body: {string: "[{\"type\":\"show\",\"score\":107.79788,\"show\":{\"title\"\
+      body: {string: "[{\"type\":\"show\",\"score\":107.85559,\"show\":{\"title\"\
           :\"Homeland\",\"overview\":\"When Marine Nicolas Brody is hailed as a hero\
           \ after he returns home from eight years of captivity in Iraq, intelligence\
           \ officer Carrie Mathison is the only one who suspects that he may have\
@@ -21,17 +21,17 @@ interactions:
           ,\"thumb\":\"https://walter.trakt.us/images/shows/000/001/398/fanarts/thumb/701b0475bf.jpg\"\
           }},\"ids\":{\"trakt\":1398,\"slug\":\"homeland\",\"tvdb\":247897,\"imdb\"\
           :\"tt1796960\",\"tmdb\":1407,\"tvrage\":27811}}},{\"type\":\"show\",\"score\"\
-          :0.89843214,\"show\":{\"title\":\"To Catch a Smuggler\",\"overview\":\"\
-          This NatGeo series follows Homeland Security officers at New York City's\
-          \ John F. Kennedy International Airport as they deal with cases ranging\
-          \ from fraudulent visas to human trafficking.\",\"year\":2011,\"status\"\
-          :\"returning series\",\"images\":{\"poster\":{\"full\":\"https://walter.trakt.us/images/shows/000/068/989/posters/original/d81847a5ab.jpg\"\
+          :0.8926569,\"show\":{\"title\":\"To Catch a Smuggler\",\"overview\":\"This\
+          \ NatGeo series follows Homeland Security officers at New York City's John\
+          \ F. Kennedy International Airport as they deal with cases ranging from\
+          \ fraudulent visas to human trafficking.\",\"year\":2011,\"status\":\"returning\
+          \ series\",\"images\":{\"poster\":{\"full\":\"https://walter.trakt.us/images/shows/000/068/989/posters/original/d81847a5ab.jpg\"\
           ,\"medium\":\"https://walter.trakt.us/images/shows/000/068/989/posters/medium/d81847a5ab.jpg\"\
           ,\"thumb\":\"https://walter.trakt.us/images/shows/000/068/989/posters/thumb/d81847a5ab.jpg\"\
           },\"fanart\":{\"full\":null,\"medium\":null,\"thumb\":null}},\"ids\":{\"\
           trakt\":68989,\"slug\":\"to-catch-a-smuggler\",\"tvdb\":264244,\"imdb\"\
           :\"tt2562174\",\"tmdb\":null,\"tvrage\":null}}},{\"type\":\"show\",\"score\"\
-          :0.2620427,\"show\":{\"title\":\"Return to Tuscany\",\"overview\":\"Join\
+          :0.26035827,\"show\":{\"title\":\"Return to Tuscany\",\"overview\":\"Join\
           \ Giancarlo Caldesi as he sets out to fulfil his dream - a cookery school\
           \ in his Tuscan homeland. But there\u2019s a lot of hard work to do before\
           \ he gets there\u2026After 30 years in the UK, successful restaurateur Giancarlo\
@@ -61,15 +61,15 @@ interactions:
       headers:
         cache-control: ['public, max-age=14400']
         cf-cache-status: [HIT]
-        cf-ray: [280714d009d43d61-CPH]
+        cf-ray: [280d44ddf00f3cd1-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Tue, 08 Mar 2016 14:47:15 GMT']
-        etag: [W/"da97ff600632588957ebeba0c0ec9bbf"]
-        expires: ['Tue, 08 Mar 2016 18:47:15 GMT']
+        date: ['Wed, 09 Mar 2016 08:48:38 GMT']
+        etag: [W/"356b125908dc54ca1309a7ff1b8dee31"]
+        expires: ['Wed, 09 Mar 2016 12:48:38 GMT']
         server: [cloudflare-nginx]
-        set-cookie: ['__cfduid=d8edc2bb9f4d822761c775322d647241f1457448435; expires=Wed,
-            08-Mar-17 14:47:15 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        set-cookie: ['__cfduid=d878cfe6d5b3e62a9250eb0896f80d5b61457513318; expires=Thu,
+            09-Mar-17 08:48:38 GMT; path=/; domain=.trakt.tv; HttpOnly']
         vary: [Accept-Encoding]
         x-content-type-options: [nosniff]
         x-frame-options: [SAMEORIGIN]
@@ -77,15 +77,15 @@ interactions:
         x-pagination-limit: ['10']
         x-pagination-page: ['1']
         x-pagination-page-count: ['1']
-        x-request-id: [a701eb9d-0584-4f9c-82b7-e63142bd8a7f]
-        x-runtime: ['0.020628']
+        x-request-id: [cf22d8ee-b876-4d77-9170-72e3385d50dc]
+        x-runtime: ['0.020701']
         x-xss-protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
       body: null
       headers:
         Content-Type: [application/json]
-        Cookie: [__cfduid=d8edc2bb9f4d822761c775322d647241f1457448435]
+        Cookie: [__cfduid=d878cfe6d5b3e62a9250eb0896f80d5b61457513318]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: [2]
       method: GET
@@ -99,12 +99,12 @@ interactions:
       headers:
         cache-control: ['public, max-age=14400']
         cf-cache-status: [HIT]
-        cf-ray: [280714d039d53d61-CPH]
+        cf-ray: [280d44de40103cd1-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Tue, 08 Mar 2016 14:47:15 GMT']
+        date: ['Wed, 09 Mar 2016 08:48:38 GMT']
         etag: [W/"546218f5a683fd4030afd55566a6a797"]
-        expires: ['Tue, 08 Mar 2016 18:47:15 GMT']
+        expires: ['Wed, 09 Mar 2016 12:48:38 GMT']
         last-modified: ['Sat, 27 Feb 2016 10:33:58 GMT']
         server: [cloudflare-nginx]
         vary: [Accept-Encoding]
@@ -130,24 +130,24 @@ interactions:
           asset from her former life comes in from the cold. Meanwhile, freshman Congressman
           Nick Brody discovers that Abu Nazir may not be content with his nonviolent
           approach to affecting change in American foreign policy. Brody''s daughter
-          Dana lets a vital secret slip.","rating":8.04625,"votes":1492,"first_aired":"2012-10-01T01:00:00.000Z","updated_at":"2016-03-08T13:02:11.000Z","available_translations":[]}'}
+          Dana lets a vital secret slip.","rating":8.04625,"votes":1492,"first_aired":"2012-10-01T01:00:00.000Z","updated_at":"2016-03-09T07:33:30.000Z","available_translations":[]}'}
       headers:
         cache-control: ['public, max-age=14400']
         cf-cache-status: [HIT]
-        cf-ray: [280714d0eacc3d31-CPH]
+        cf-ray: [280d44dee23c3d13-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Tue, 08 Mar 2016 14:47:15 GMT']
-        expires: ['Tue, 08 Mar 2016 18:47:15 GMT']
-        last-modified: ['Tue, 08 Mar 2016 13:02:11 GMT']
+        date: ['Wed, 09 Mar 2016 08:48:38 GMT']
+        expires: ['Wed, 09 Mar 2016 12:48:38 GMT']
+        last-modified: ['Wed, 09 Mar 2016 07:33:30 GMT']
         server: [cloudflare-nginx]
-        set-cookie: ['__cfduid=d8f6cdbd8a6b5b99a932d87f6b36386301457448435; expires=Wed,
-            08-Mar-17 14:47:15 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        set-cookie: ['__cfduid=d9383f82a3d365a473cc8dce7f7519ef31457513318; expires=Thu,
+            09-Mar-17 08:48:38 GMT; path=/; domain=.trakt.tv; HttpOnly']
         vary: [Accept-Encoding]
         x-content-type-options: [nosniff]
         x-frame-options: [SAMEORIGIN]
-        x-request-id: [b49dccf0-9e78-4217-a8f9-f8cfe6439db8]
-        x-runtime: ['0.012776']
+        x-request-id: [de66b021-e6ba-4e08-ad8d-d9fddcd956b3]
+        x-runtime: ['0.011247']
         x-xss-protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
@@ -159,24 +159,25 @@ interactions:
       method: GET
       uri: https://api-v2launch.trakt.tv/users/flexgettest/collection/shows
     response:
-      body: {string: '[{"last_collected_at":"2012-10-01T02:00:00.000Z","show":{"title":"Homeland","year":2011,"ids":{"trakt":1398,"slug":"homeland","tvdb":247897,"imdb":"tt1796960","tmdb":1407,"tvrage":27811}},"seasons":[{"number":2,"episodes":[{"number":1,"collected_at":"2012-10-01T02:00:00.000Z"}]}]}]'}
+      body: {string: '[{"last_collected_at":"2016-03-08T21:36:33.000Z","show":{"title":"White
+          Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}},"seasons":[{"number":1,"episodes":[{"number":1,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":2,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":3,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":4,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":5,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":6,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":7,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":8,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":9,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":10,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":11,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":12,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":13,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":14,"collected_at":"2016-03-08T21:36:33.000Z"}]},{"number":2,"episodes":[{"number":1,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":2,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":3,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":4,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":5,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":6,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":7,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":8,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":9,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":10,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":11,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":12,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":13,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":14,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":15,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":16,"collected_at":"2016-03-08T21:36:33.000Z"}]},{"number":3,"episodes":[{"number":1,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":2,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":3,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":4,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":5,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":6,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":7,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":8,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":9,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":10,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":11,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":12,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":13,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":14,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":15,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":16,"collected_at":"2016-03-08T21:36:33.000Z"}]},{"number":4,"episodes":[{"number":1,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":2,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":3,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":4,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":5,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":6,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":7,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":8,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":9,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":10,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":11,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":12,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":13,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":14,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":15,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":16,"collected_at":"2016-03-08T21:36:33.000Z"}]},{"number":5,"episodes":[{"number":1,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":2,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":3,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":4,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":5,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":6,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":7,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":8,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":9,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":10,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":11,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":12,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":13,"collected_at":"2016-03-08T21:36:33.000Z"}]},{"number":6,"episodes":[{"number":1,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":2,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":3,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":4,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":5,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":6,"collected_at":"2016-03-08T21:36:33.000Z"}]}]},{"last_collected_at":"2012-10-01T02:00:00.000Z","show":{"title":"Homeland","year":2011,"ids":{"trakt":1398,"slug":"homeland","tvdb":247897,"imdb":"tt1796960","tmdb":1407,"tvrage":27811}},"seasons":[{"number":2,"episodes":[{"number":1,"collected_at":"2012-10-01T02:00:00.000Z"}]}]}]'}
       headers:
         cache-control: ['max-age=0, private, must-revalidate']
-        cf-ray: [280714d19f603d61-CPH]
+        cf-ray: [280d44df93493cbf-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Tue, 08 Mar 2016 14:47:15 GMT']
-        etag: [W/"52ef265bae52b2a23afa10631657d1b1"]
-        last-modified: ['Tue, 08 Mar 2016 08:22:57 GMT']
+        date: ['Wed, 09 Mar 2016 08:48:38 GMT']
+        etag: [W/"6f63e6fe51d44162fba8527e426907bd"]
+        last-modified: ['Tue, 08 Mar 2016 21:36:33 GMT']
         server: [cloudflare-nginx]
-        set-cookie: ['__cfduid=d8edc2bb9f4d822761c775322d647241f1457448435; expires=Wed,
-            08-Mar-17 14:47:15 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        set-cookie: ['__cfduid=d517c7dbea5a40841cf77dbf0dff4f1401457513318; expires=Thu,
+            09-Mar-17 08:48:38 GMT; path=/; domain=.trakt.tv; HttpOnly']
         vary: [Accept-Encoding]
         x-content-type-options: [nosniff]
         x-frame-options: [SAMEORIGIN]
         x-private-user: ['false']
-        x-request-id: [dc4be2b8-e5dc-4916-aa67-3ba8fc3b19c4]
-        x-runtime: ['0.008470']
+        x-request-id: [00f09653-2d19-4cf9-aca3-51ee3038c700]
+        x-runtime: ['0.008447']
         x-xss-protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
@@ -188,12 +189,12 @@ interactions:
       method: GET
       uri: https://api-v2launch.trakt.tv/search?query=The+Flash&type=show&year=2014
     response:
-      body: {string: "[{\"type\":\"show\",\"score\":59.710606,\"show\":{\"title\"\
-          :\"The Flash\",\"overview\":\"After a particle accelerator causes a freak\
-          \ storm, CSI Investigator Barry Allen is struck by lightning and falls into\
-          \ a coma. Months later he awakens with the power of super speed, granting\
-          \ him the ability to move through Central City like an unseen guardian angel.\
-          \ Though initially excited by his newfound powers, Barry is shocked to discover\
+      body: {string: "[{\"type\":\"show\",\"score\":59.70133,\"show\":{\"title\":\"\
+          The Flash\",\"overview\":\"After a particle accelerator causes a freak storm,\
+          \ CSI Investigator Barry Allen is struck by lightning and falls into a coma.\
+          \ Months later he awakens with the power of super speed, granting him the\
+          \ ability to move through Central City like an unseen guardian angel. Though\
+          \ initially excited by his newfound powers, Barry is shocked to discover\
           \ he is not the only \\\"meta-human\\\" who was created in the wake of the\
           \ accelerator explosion \u2013 and not everyone is using their new powers\
           \ for good. Barry partners with S.T.A.R. Labs and dedicates his life to\
@@ -209,7 +210,7 @@ interactions:
           ,\"thumb\":\"https://walter.trakt.us/images/shows/000/060/300/fanarts/thumb/df36c9a731.jpg\"\
           }},\"ids\":{\"trakt\":60300,\"slug\":\"the-flash-2014\",\"tvdb\":279121,\"\
           imdb\":\"tt3107288\",\"tmdb\":60735,\"tvrage\":36939}}},{\"type\":\"show\"\
-          ,\"score\":0.45692617,\"show\":{\"title\":\"Tornado Hunters\",\"overview\"\
+          ,\"score\":0.45470023,\"show\":{\"title\":\"Tornado Hunters\",\"overview\"\
           :\"Greg Johnson, Chris Chittick, and Ricky Forbes are the Tornado Hunters.Outfitted\
           \ with their truck Flash and the best equipment money can buy, they target\
           \ the biggest tornadoes in North America. From Regina to Mexico, there\u2019\
@@ -222,7 +223,7 @@ interactions:
           ,\"thumb\":\"https://walter.trakt.us/images/shows/000/081/448/posters/thumb/ecede5e037.jpg\"\
           },\"fanart\":{\"full\":null,\"medium\":null,\"thumb\":null}},\"ids\":{\"\
           trakt\":81448,\"slug\":\"tornado-hunters\",\"tvdb\":287638,\"imdb\":null,\"\
-          tmdb\":null,\"tvrage\":null}}},{\"type\":\"show\",\"score\":0.33522034,\"\
+          tmdb\":null,\"tvrage\":null}}},{\"type\":\"show\",\"score\":0.33350223,\"\
           show\":{\"title\":\"Stop Skeletons From Fighting\",\"overview\":\"Hello,\
           \ I'm Derek Alexander, and I've been producing video reviews of retro (and\
           \ sometimes modern) video games for over 7 years.When I started producing\
@@ -242,15 +243,15 @@ interactions:
       headers:
         cache-control: ['public, max-age=14400']
         cf-cache-status: [HIT]
-        cf-ray: [280714d2ed573ca7-CPH]
+        cf-ray: [280d44e297d63cad-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Tue, 08 Mar 2016 14:47:15 GMT']
-        etag: [W/"cfa644be5dd3678b6f2d73a1fb729267"]
-        expires: ['Tue, 08 Mar 2016 18:47:15 GMT']
+        date: ['Wed, 09 Mar 2016 08:48:38 GMT']
+        etag: [W/"dba971bef3e1b830cff48be0354bae13"]
+        expires: ['Wed, 09 Mar 2016 12:48:38 GMT']
         server: [cloudflare-nginx]
-        set-cookie: ['__cfduid=dd9616a138868375ecc5d0839eefa2f1f1457448435; expires=Wed,
-            08-Mar-17 14:47:15 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        set-cookie: ['__cfduid=d41df18a4fdbe62bb9005add912ae19831457513318; expires=Thu,
+            09-Mar-17 08:48:38 GMT; path=/; domain=.trakt.tv; HttpOnly']
         vary: [Accept-Encoding]
         x-content-type-options: [nosniff]
         x-frame-options: [SAMEORIGIN]
@@ -258,15 +259,15 @@ interactions:
         x-pagination-limit: ['10']
         x-pagination-page: ['1']
         x-pagination-page-count: ['1']
-        x-request-id: [a6a73bb6-4a3d-45c6-87b7-00ec211023d2]
-        x-runtime: ['0.021743']
+        x-request-id: [08caa6ab-0f16-4c00-8953-dc1f8734c31d]
+        x-runtime: ['0.025738']
         x-xss-protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
       body: null
       headers:
         Content-Type: [application/json]
-        Cookie: [__cfduid=dd9616a138868375ecc5d0839eefa2f1f1457448435]
+        Cookie: [__cfduid=d41df18a4fdbe62bb9005add912ae19831457513318]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: [2]
       method: GET
@@ -289,8 +290,8 @@ interactions:
           ,\"time\":\"20:00\",\"timezone\":\"America/New_York\"},\"runtime\":43,\"\
           certification\":\"TV-14\",\"network\":\"The CW\",\"country\":\"us\",\"trailer\"\
           :\"http://youtube.com/watch?v=aZxhA_Jihmw\",\"homepage\":\"http://www.cwtv.com/shows/the-flash/\"\
-          ,\"status\":\"returning series\",\"rating\":8.32357,\"votes\":8839,\"updated_at\"\
-          :\"2016-03-08T09:56:11.000Z\",\"language\":\"en\",\"available_translations\"\
+          ,\"status\":\"returning series\",\"rating\":8.3235,\"votes\":8844,\"updated_at\"\
+          :\"2016-03-08T10:51:36.000Z\",\"language\":\"en\",\"available_translations\"\
           :[\"pl\",\"sv\",\"fr\",\"en\",\"zh\",\"da\",\"pt\",\"el\",\"de\",\"es\"\
           ,\"bg\",\"it\",\"tr\",\"ru\",\"nl\",\"hu\",\"ko\",\"lt\",\"cs\",\"hr\",\"\
           bs\",\"za\",\"he\",\"id\",\"ro\",\"fa\",\"th\",\"ar\",\"te\",\"uk\"],\"\
@@ -299,19 +300,19 @@ interactions:
       headers:
         cache-control: ['public, max-age=14400']
         cf-cache-status: [HIT]
-        cf-ray: [280714d33d613ca7-CPH]
+        cf-ray: [280d44e2c7da3cad-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Tue, 08 Mar 2016 14:47:15 GMT']
-        etag: [W/"7f4a8031d23055732c5d2fbd0c72eb89"]
-        expires: ['Tue, 08 Mar 2016 18:47:15 GMT']
-        last-modified: ['Tue, 08 Mar 2016 09:56:11 GMT']
+        date: ['Wed, 09 Mar 2016 08:48:38 GMT']
+        etag: [W/"7d0ce737896bd5396bce7bb85f7f7091"]
+        expires: ['Wed, 09 Mar 2016 12:48:38 GMT']
+        last-modified: ['Tue, 08 Mar 2016 10:51:36 GMT']
         server: [cloudflare-nginx]
         vary: [Accept-Encoding]
         x-content-type-options: [nosniff]
         x-frame-options: [SAMEORIGIN]
-        x-request-id: [55450444-6b1f-4e18-be67-42d1562b8e5e]
-        x-runtime: ['0.018100']
+        x-request-id: [860da557-2d99-4d3e-80cb-e4cd9f800a88]
+        x-runtime: ['0.016743']
         x-xss-protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
@@ -336,26 +337,26 @@ interactions:
           \ Barry asks Dr. Wells, Caitlin and Cisco to help him double his training\
           \ efforts so he\u2019s ready for the Reverse Flash when he returns to Central\
           \ City. Iris deals with the aftermath of Barry\u2019s confession, and Cisco\
-          \ makes the CCPD a new shield.\",\"rating\":7.67576,\"votes\":1539,\"first_aired\"\
-          :\"2015-01-21T01:00:00.000Z\",\"updated_at\":\"2016-03-08T01:57:13.000Z\"\
+          \ makes the CCPD a new shield.\",\"rating\":7.67683,\"votes\":1541,\"first_aired\"\
+          :\"2015-01-21T01:00:00.000Z\",\"updated_at\":\"2016-03-08T19:22:35.000Z\"\
           ,\"available_translations\":[]}"}
       headers:
         cache-control: ['public, max-age=14400']
         cf-cache-status: [HIT]
-        cf-ray: [280714d3d98d3d1f-CPH]
+        cf-ray: [280d44e39da73d67-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Tue, 08 Mar 2016 14:47:15 GMT']
-        expires: ['Tue, 08 Mar 2016 18:47:15 GMT']
-        last-modified: ['Tue, 08 Mar 2016 01:57:13 GMT']
+        date: ['Wed, 09 Mar 2016 08:48:38 GMT']
+        expires: ['Wed, 09 Mar 2016 12:48:38 GMT']
+        last-modified: ['Tue, 08 Mar 2016 19:22:35 GMT']
         server: [cloudflare-nginx]
-        set-cookie: ['__cfduid=d1e2312aa51e49e6cc7cb216bdbc446011457448435; expires=Wed,
-            08-Mar-17 14:47:15 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        set-cookie: ['__cfduid=d2b569bd4a84efd6d8af20e30781034531457513318; expires=Thu,
+            09-Mar-17 08:48:38 GMT; path=/; domain=.trakt.tv; HttpOnly']
         vary: [Accept-Encoding]
         x-content-type-options: [nosniff]
         x-frame-options: [SAMEORIGIN]
-        x-request-id: [e4913e58-6151-4012-8cf9-a8dfb0276136]
-        x-runtime: ['0.007533']
+        x-request-id: [5f26bc30-9449-404c-a298-e63de5910634]
+        x-runtime: ['0.008420']
         x-xss-protection: [1; mode=block]
       status: {code: 200, message: OK}
 version: 1

--- a/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_collected_movie_lookup
+++ b/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_collected_movie_lookup
@@ -8,36 +8,36 @@ interactions:
       method: GET
       uri: https://api-v2launch.trakt.tv/search?query=Inside+Out&type=movie&year=2015
     response:
-      body: {string: '[{"type":"movie","score":51.342567,"movie":{"title":"Inside
-          Out","overview":"Growing up can be a bumpy road, and it''s no exception
-          for Riley, who is uprooted from her Midwest life when her father starts
-          a new job in San Francisco. Like all of us, Riley is guided by her emotions
-          - Joy, Fear, Anger, Disgust and Sadness. The emotions live in Headquarters,
-          the control center inside Riley''s mind, where they help advise her through
-          everyday life. As Riley and her emotions struggle to adjust to a new life
-          in San Francisco, turmoil ensues in Headquarters. Although Joy, Riley''s
-          main and most important emotion, tries to keep things positive, the emotions
-          conflict on how best to navigate a new city, house and school.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/098/998/posters/original/09e0ae33aa.jpg","medium":"https://walter.trakt.us/images/movies/000/098/998/posters/medium/09e0ae33aa.jpg","thumb":"https://walter.trakt.us/images/movies/000/098/998/posters/thumb/09e0ae33aa.jpg"},"fanart":{"full":"https://walter.trakt.us/images/movies/000/098/998/fanarts/original/dd51480cb4.jpg","medium":"https://walter.trakt.us/images/movies/000/098/998/fanarts/medium/dd51480cb4.jpg","thumb":"https://walter.trakt.us/images/movies/000/098/998/fanarts/thumb/dd51480cb4.jpg"}},"ids":{"trakt":98998,"slug":"inside-out-2015","imdb":"tt2096673","tmdb":150540}}},{"type":"movie","score":21.362019,"movie":{"title":"Locked
+      body: {string: '[{"type":"movie","score":51.16567,"movie":{"title":"Inside Out","overview":"Growing
+          up can be a bumpy road, and it''s no exception for Riley, who is uprooted
+          from her Midwest life when her father starts a new job in San Francisco.
+          Like all of us, Riley is guided by her emotions - Joy, Fear, Anger, Disgust
+          and Sadness. The emotions live in Headquarters, the control center inside
+          Riley''s mind, where they help advise her through everyday life. As Riley
+          and her emotions struggle to adjust to a new life in San Francisco, turmoil
+          ensues in Headquarters. Although Joy, Riley''s main and most important emotion,
+          tries to keep things positive, the emotions conflict on how best to navigate
+          a new city, house and school.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/098/998/posters/original/09e0ae33aa.jpg","medium":"https://walter.trakt.us/images/movies/000/098/998/posters/medium/09e0ae33aa.jpg","thumb":"https://walter.trakt.us/images/movies/000/098/998/posters/thumb/09e0ae33aa.jpg"},"fanart":{"full":"https://walter.trakt.us/images/movies/000/098/998/fanarts/original/dd51480cb4.jpg","medium":"https://walter.trakt.us/images/movies/000/098/998/fanarts/medium/dd51480cb4.jpg","thumb":"https://walter.trakt.us/images/movies/000/098/998/fanarts/thumb/dd51480cb4.jpg"}},"ids":{"trakt":98998,"slug":"inside-out-2015","imdb":"tt2096673","tmdb":150540}}},{"type":"movie","score":21.267105,"movie":{"title":"Locked
           Out","overview":"Spoiled rich kid Greg Mardukas gets home from a long day
           to find out that he has been locked out of his own house. Realizing he won''t
           be able to get inside until his father gets home in a few days, Greg must
-          learn to live in the outdoors for the weekend. Will he survive?","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/220/954/posters/original/6a4c4e5bbb.jpg","medium":"https://walter.trakt.us/images/movies/000/220/954/posters/medium/6a4c4e5bbb.jpg","thumb":"https://walter.trakt.us/images/movies/000/220/954/posters/thumb/6a4c4e5bbb.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":220954,"slug":"locked-out-2015","imdb":"","tmdb":340509}}},{"type":"movie","score":0.37074518,"movie":{"title":"Containment","overview":"Neighbours
+          learn to live in the outdoors for the weekend. Will he survive?","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/220/954/posters/original/6a4c4e5bbb.jpg","medium":"https://walter.trakt.us/images/movies/000/220/954/posters/medium/6a4c4e5bbb.jpg","thumb":"https://walter.trakt.us/images/movies/000/220/954/posters/thumb/6a4c4e5bbb.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":220954,"slug":"locked-out-2015","imdb":"","tmdb":340509}}},{"type":"movie","score":0.36805022,"movie":{"title":"Containment","overview":"Neighbours
           in a block wake one morning to find they have been sealed inside their apartments.
           Can they work together to find out why? Or will they destroy each other
-          in their fight to escape?","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/223/348/posters/original/22f821f30c.jpg","medium":"https://walter.trakt.us/images/movies/000/223/348/posters/medium/22f821f30c.jpg","thumb":"https://walter.trakt.us/images/movies/000/223/348/posters/thumb/22f821f30c.jpg"},"fanart":{"full":"https://walter.trakt.us/images/movies/000/223/348/fanarts/original/fce4925aef.jpg","medium":"https://walter.trakt.us/images/movies/000/223/348/fanarts/medium/fce4925aef.jpg","thumb":"https://walter.trakt.us/images/movies/000/223/348/fanarts/thumb/fce4925aef.jpg"}},"ids":{"trakt":223348,"slug":"containment-2015","imdb":"tt3561236","tmdb":347548}}},{"type":"movie","score":0.37074518,"movie":{"title":"Necroland","overview":"In
+          in their fight to escape?","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/223/348/posters/original/22f821f30c.jpg","medium":"https://walter.trakt.us/images/movies/000/223/348/posters/medium/22f821f30c.jpg","thumb":"https://walter.trakt.us/images/movies/000/223/348/posters/thumb/22f821f30c.jpg"},"fanart":{"full":"https://walter.trakt.us/images/movies/000/223/348/fanarts/original/fce4925aef.jpg","medium":"https://walter.trakt.us/images/movies/000/223/348/fanarts/medium/fce4925aef.jpg","thumb":"https://walter.trakt.us/images/movies/000/223/348/fanarts/thumb/fce4925aef.jpg"}},"ids":{"trakt":223348,"slug":"containment-2015","imdb":"tt3561236","tmdb":347548}}},{"type":"movie","score":0.36805022,"movie":{"title":"Necroland","overview":"In
           an instant, 80% of the worlds population has turned into rage humans and
           the weather has gone out of control. Inside all of this chaos, the remaining
-          survivors attempt to unravel the answers to this convoluted mystery.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/155/649/posters/original/b13965b8e3.jpg","medium":"https://walter.trakt.us/images/movies/000/155/649/posters/medium/b13965b8e3.jpg","thumb":"https://walter.trakt.us/images/movies/000/155/649/posters/thumb/b13965b8e3.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":155649,"slug":"necroland-2014","imdb":"tt3518152","tmdb":255561}}},{"type":"movie","score":0.29659617,"movie":{"title":"A
+          survivors attempt to unravel the answers to this convoluted mystery.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/155/649/posters/original/b13965b8e3.jpg","medium":"https://walter.trakt.us/images/movies/000/155/649/posters/medium/b13965b8e3.jpg","thumb":"https://walter.trakt.us/images/movies/000/155/649/posters/thumb/b13965b8e3.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":155649,"slug":"necroland-2014","imdb":"tt3518152","tmdb":255561}}},{"type":"movie","score":0.29444018,"movie":{"title":"A
           Fall from Grace","overview":"Detective Michael Tabb knows the city of St.
           Louis inside and out. He has felt its true heart, as much as its dark underbelly:
           but he does not know who, in both the dark and light - is taking the lives
-          of young girls.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/107/827/posters/original/072c499c6a.jpg","medium":"https://walter.trakt.us/images/movies/000/107/827/posters/medium/072c499c6a.jpg","thumb":"https://walter.trakt.us/images/movies/000/107/827/posters/thumb/072c499c6a.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":107827,"slug":"a-fall-from-grace-1969","imdb":"tt1621415","tmdb":168781}}},{"type":"movie","score":0.29659617,"movie":{"title":"A
+          of young girls.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/107/827/posters/original/072c499c6a.jpg","medium":"https://walter.trakt.us/images/movies/000/107/827/posters/medium/072c499c6a.jpg","thumb":"https://walter.trakt.us/images/movies/000/107/827/posters/thumb/072c499c6a.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":107827,"slug":"a-fall-from-grace-1969","imdb":"tt1621415","tmdb":168781}}},{"type":"movie","score":0.29444018,"movie":{"title":"A
           Girl''s Best Friend","overview":"Penelope, better known as Polka-Dot, is
           a spunky young girl who has a knack for helping people, particularly her
           ailing mother. While out looking for a part-time job, Polka-Dot befriends
           a hard-nosed police officer and his tracking dog, Luey. When Polka-Dot''s
           mother''s condition worsens, Luey helps Polka-Dot find the strength and
-          faith inside to help her move forward.","year":2015,"images":{"poster":{"full":null,"medium":null,"thumb":null},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":207177,"slug":"a-girl-s-best-friend-2015","imdb":"tt4220166","tmdb":326261}}},{"type":"movie","score":0.24081501,"movie":{"title":"Bad
+          faith inside to help her move forward.","year":2015,"images":{"poster":{"full":null,"medium":null,"thumb":null},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":207177,"slug":"a-girl-s-best-friend-2015","imdb":"tt4220166","tmdb":326261}}},{"type":"movie","score":0.23913823,"movie":{"title":"Bad
           Building","overview":"The Desmond - the building''s pleasant sounding name
           hides a troubled past. The high rise has a long history of fires, murders,
           madness and even colonial era genocide upon the site. The towering building
@@ -48,14 +48,14 @@ interactions:
           way in, or out, Craig has contacted a group of urban explorers to help him
           and his film crew enter the building. But when Craig and his team set foot
           inside The Desmond the events that caused the building to be abandoned in
-          the first place begin to repeat.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/224/054/posters/original/7b6c4c9a56.jpg","medium":"https://walter.trakt.us/images/movies/000/224/054/posters/medium/7b6c4c9a56.jpg","thumb":"https://walter.trakt.us/images/movies/000/224/054/posters/thumb/7b6c4c9a56.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":224054,"slug":"bad-building-2015","imdb":"tt2257216","tmdb":350052}}},{"type":"movie","score":0.22244713,"movie":{"title":"The
+          the first place begin to repeat.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/224/054/posters/original/7b6c4c9a56.jpg","medium":"https://walter.trakt.us/images/movies/000/224/054/posters/medium/7b6c4c9a56.jpg","thumb":"https://walter.trakt.us/images/movies/000/224/054/posters/thumb/7b6c4c9a56.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":224054,"slug":"bad-building-2015","imdb":"tt2257216","tmdb":350052}}},{"type":"movie","score":0.22083014,"movie":{"title":"The
           New Family","overview":"The sleepy town of Murdoch is reawakened when young
           women in various stages of pregnancy begin to die at the hands of a brutal
           killer. As Blair Cassidy struggles with an overbearing mother and a less
           than happy father-to-be, she fears that the killer''s focus has shifted
           to her. With her life spiraling out-of-control, Blair must fight for her
           own life and for the baby growing inside her. But the killer has other plans
-          for Blair that are more terrifying than she could have ever imagined.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/200/981/posters/original/5a1f1646d8.jpg","medium":"https://walter.trakt.us/images/movies/000/200/981/posters/medium/5a1f1646d8.jpg","thumb":"https://walter.trakt.us/images/movies/000/200/981/posters/thumb/5a1f1646d8.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":200981,"slug":"the-new-family-2015","imdb":"tt3213960","tmdb":320323}}},{"type":"movie","score":0.18537259,"movie":{"title":"Exeter","overview":"During
+          for Blair that are more terrifying than she could have ever imagined.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/200/981/posters/original/5a1f1646d8.jpg","medium":"https://walter.trakt.us/images/movies/000/200/981/posters/medium/5a1f1646d8.jpg","thumb":"https://walter.trakt.us/images/movies/000/200/981/posters/thumb/5a1f1646d8.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":200981,"slug":"the-new-family-2015","imdb":"tt3213960","tmdb":320323}}},{"type":"movie","score":0.18402511,"movie":{"title":"Exeter","overview":"During
           an all-night, drug-fueled party at an abandoned asylum known for the horrific
           treatment of its patients, a group of ordinary teens decide to experiment
           with the occult, mysteriously leading to a violent possession. In an effort
@@ -66,7 +66,7 @@ interactions:
           unbeknownst to them, they unleash an even more powerful and vengeful spirit,
           one with a distinct motive and which wants them all dead. The teen''s only
           chance of survival is to uncover the asylum''s deep mysteries and find a
-          way out before it''s too late.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/138/557/posters/original/4fae1b8167.jpg","medium":"https://walter.trakt.us/images/movies/000/138/557/posters/medium/4fae1b8167.jpg","thumb":"https://walter.trakt.us/images/movies/000/138/557/posters/thumb/4fae1b8167.jpg"},"fanart":{"full":"https://walter.trakt.us/images/movies/000/138/557/fanarts/original/307e3e73e8.jpg","medium":"https://walter.trakt.us/images/movies/000/138/557/fanarts/medium/307e3e73e8.jpg","thumb":"https://walter.trakt.us/images/movies/000/138/557/fanarts/thumb/307e3e73e8.jpg"}},"ids":{"trakt":138557,"slug":"exeter-2015","imdb":"tt1945044","tmdb":226458}}},{"type":"movie","score":0.18537259,"movie":{"title":"Love
+          way out before it''s too late.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/138/557/posters/original/4fae1b8167.jpg","medium":"https://walter.trakt.us/images/movies/000/138/557/posters/medium/4fae1b8167.jpg","thumb":"https://walter.trakt.us/images/movies/000/138/557/posters/thumb/4fae1b8167.jpg"},"fanart":{"full":"https://walter.trakt.us/images/movies/000/138/557/fanarts/original/307e3e73e8.jpg","medium":"https://walter.trakt.us/images/movies/000/138/557/fanarts/medium/307e3e73e8.jpg","thumb":"https://walter.trakt.us/images/movies/000/138/557/fanarts/thumb/307e3e73e8.jpg"}},"ids":{"trakt":138557,"slug":"exeter-2015","imdb":"tt1945044","tmdb":226458}}},{"type":"movie","score":0.18402511,"movie":{"title":"Love
           Between the Covers","overview":"Love Between the Covers is a feature-length
           documentary film about the little-known, surprisingly powerful community
           of women who read and write romance novels. Romance fiction is a female-powered
@@ -84,15 +84,15 @@ interactions:
       headers:
         cache-control: ['public, max-age=14400']
         cf-cache-status: [HIT]
-        cf-ray: [280714dd368e3cdd-CPH]
+        cf-ray: [280d4539d2763cd1-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Tue, 08 Mar 2016 14:47:17 GMT']
-        etag: [W/"c8c1ead69d486869a2185840b940ecd5"]
-        expires: ['Tue, 08 Mar 2016 18:47:17 GMT']
+        date: ['Wed, 09 Mar 2016 08:48:52 GMT']
+        etag: [W/"dc83ca1af7612361873b85dd16eb1236"]
+        expires: ['Wed, 09 Mar 2016 12:48:52 GMT']
         server: [cloudflare-nginx]
-        set-cookie: ['__cfduid=d92a9f74c06bf6561ae572be84b63d3711457448437; expires=Wed,
-            08-Mar-17 14:47:17 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        set-cookie: ['__cfduid=dc498aedf3d448780f5bae6d97a2d0d1a1457513332; expires=Thu,
+            09-Mar-17 08:48:52 GMT; path=/; domain=.trakt.tv; HttpOnly']
         vary: [Accept-Encoding]
         x-content-type-options: [nosniff]
         x-frame-options: [SAMEORIGIN]
@@ -100,15 +100,15 @@ interactions:
         x-pagination-limit: ['10']
         x-pagination-page: ['1']
         x-pagination-page-count: ['2']
-        x-request-id: [a43d6b32-97ae-4d22-9d08-fa8e993e061f]
-        x-runtime: ['0.028573']
+        x-request-id: [112f5d5d-1782-4cef-ba69-0b82a4269499]
+        x-runtime: ['0.028823']
         x-xss-protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
       body: null
       headers:
         Content-Type: [application/json]
-        Cookie: [__cfduid=d92a9f74c06bf6561ae572be84b63d3711457448437]
+        Cookie: [__cfduid=dc498aedf3d448780f5bae6d97a2d0d1a1457513332]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: [2]
       method: GET
@@ -128,12 +128,12 @@ interactions:
       headers:
         cache-control: ['public, max-age=14400']
         cf-cache-status: [HIT]
-        cf-ray: [280714dd568f3cdd-CPH]
+        cf-ray: [280d453a02773cd1-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Tue, 08 Mar 2016 14:47:17 GMT']
+        date: ['Wed, 09 Mar 2016 08:48:52 GMT']
         etag: [W/"9c830c403f7c6d4687b45ce9126580c6"]
-        expires: ['Tue, 08 Mar 2016 18:47:17 GMT']
+        expires: ['Wed, 09 Mar 2016 12:48:52 GMT']
         last-modified: ['Wed, 02 Mar 2016 08:41:58 GMT']
         server: [cloudflare-nginx]
         vary: [Accept-Encoding]
@@ -156,21 +156,21 @@ interactions:
           Out","year":2015,"ids":{"trakt":98998,"slug":"inside-out-2015","imdb":"tt2096673","tmdb":150540}}}]'}
       headers:
         cache-control: ['max-age=0, private, must-revalidate']
-        cf-ray: [280714ddfbef3d31-CPH]
+        cf-ray: [280d453aa2ae3cf5-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Tue, 08 Mar 2016 14:47:17 GMT']
+        date: ['Wed, 09 Mar 2016 08:48:53 GMT']
         etag: [W/"52ef265bae52b2a23afa10631657d1b1"]
         last-modified: ['Tue, 08 Mar 2016 08:22:57 GMT']
         server: [cloudflare-nginx]
-        set-cookie: ['__cfduid=d0f7e3be96b7c81294b35a6c6379d64671457448437; expires=Wed,
-            08-Mar-17 14:47:17 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        set-cookie: ['__cfduid=de794c3b979e180b021100e62ecf0b0101457513332; expires=Thu,
+            09-Mar-17 08:48:52 GMT; path=/; domain=.trakt.tv; HttpOnly']
         vary: [Accept-Encoding]
         x-content-type-options: [nosniff]
         x-frame-options: [SAMEORIGIN]
         x-private-user: ['false']
-        x-request-id: [01d81673-6ab0-4c03-9f0d-5ecc0e1feb5d]
-        x-runtime: ['0.014566']
+        x-request-id: [386ac0d2-dd51-4064-9cfc-ed6ae65adebb]
+        x-runtime: ['0.011808']
         x-xss-protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
@@ -182,7 +182,7 @@ interactions:
       method: GET
       uri: https://api-v2launch.trakt.tv/search?query=The+Matrix&type=movie&year=1999
     response:
-      body: {string: "[{\"type\":\"movie\",\"score\":69.14697,\"movie\":{\"title\"\
+      body: {string: "[{\"type\":\"movie\",\"score\":68.78444,\"movie\":{\"title\"\
           :\"The Matrix\",\"overview\":\"Thomas A. Anderson is a man living two lives.\
           \ By day he is an average computer programmer and by night a malevolent\
           \ hacker known as Neo, who finds himself targeted by the police when he\
@@ -195,7 +195,7 @@ interactions:
           ,\"medium\":\"https://walter.trakt.us/images/movies/000/000/481/fanarts/medium/c556867276.jpg\"\
           ,\"thumb\":\"https://walter.trakt.us/images/movies/000/000/481/fanarts/thumb/c556867276.jpg\"\
           }},\"ids\":{\"trakt\":481,\"slug\":\"the-matrix-1999\",\"imdb\":\"tt0133093\"\
-          ,\"tmdb\":603}}},{\"type\":\"movie\",\"score\":55.31758,\"movie\":{\"title\"\
+          ,\"tmdb\":603}}},{\"type\":\"movie\",\"score\":55.02755,\"movie\":{\"title\"\
           :\"Making The Matrix\",\"overview\":\"A promotional making-of documentary\
           \ for the film Matrix, The (1999) that devotes its time to explaining the\
           \ digital and practical effects contained in the film. This is very interesting,\
@@ -207,7 +207,7 @@ interactions:
           ,\"thumb\":\"https://walter.trakt.us/images/movies/000/205/793/posters/thumb/9680ca459a.jpg\"\
           },\"fanart\":{\"full\":null,\"medium\":null,\"thumb\":null}},\"ids\":{\"\
           trakt\":205793,\"slug\":\"making-the-matrix-1999\",\"imdb\":\"tt0365467\"\
-          ,\"tmdb\":325251}}},{\"type\":\"movie\",\"score\":51.308258,\"movie\":{\"\
+          ,\"tmdb\":325251}}},{\"type\":\"movie\",\"score\":51.04809,\"movie\":{\"\
           title\":\"V-World Matrix\",\"overview\":\"Two friends take a cyber vacation\
           \ to experience a world where they can act out their virtual fantasies!\
           \ They soon realize they've entered a virtual free-for-all. Forbidden fantasies\
@@ -220,7 +220,7 @@ interactions:
           ,\"thumb\":\"https://walter.trakt.us/images/movies/000/158/764/posters/thumb/b5bd19302a.jpg\"\
           },\"fanart\":{\"full\":null,\"medium\":null,\"thumb\":null}},\"ids\":{\"\
           trakt\":158764,\"slug\":\"v-world-matrix-1969\",\"imdb\":\"tt0211096\",\"\
-          tmdb\":259464}}},{\"type\":\"movie\",\"score\":4.66576,\"movie\":{\"title\"\
+          tmdb\":259464}}},{\"type\":\"movie\",\"score\":4.6321526,\"movie\":{\"title\"\
           :\"The Tricky Master\",\"overview\":\"Undercover cop Leung Foon (Nick Cheung)\
           \ is having trouble taking down the illegal trading operation headed by\
           \ crime boss Ferrari (Wong Jing). So to accomplish his mission, he asks\
@@ -235,7 +235,7 @@ interactions:
           ,\"medium\":\"https://walter.trakt.us/images/movies/000/037/624/fanarts/medium/de31c092f7.jpg\"\
           ,\"thumb\":\"https://walter.trakt.us/images/movies/000/037/624/fanarts/thumb/de31c092f7.jpg\"\
           }},\"ids\":{\"trakt\":37624,\"slug\":\"the-tricky-master-1999\",\"imdb\"\
-          :\"tt0212864\",\"tmdb\":53281}}},{\"type\":\"movie\",\"score\":0.6681193,\"\
+          :\"tt0212864\",\"tmdb\":53281}}},{\"type\":\"movie\",\"score\":0.66419196,\"\
           movie\":{\"title\":\"Superstar\",\"overview\":\"Inspired by Yves Klein\u2019\
           s Leap into the Void (1960), Superstar was commissioned by Creative Time\
           \ to be presented on the Jumbotron screen in Times Square, New York City.\
@@ -249,15 +249,15 @@ interactions:
       headers:
         cache-control: ['public, max-age=14400']
         cf-cache-status: [HIT]
-        cf-ray: [280714df3fe53d61-CPH]
+        cf-ray: [280d453daa813d37-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Tue, 08 Mar 2016 14:47:17 GMT']
-        etag: [W/"dc49b456802091a08d2e99d7c3890272"]
-        expires: ['Tue, 08 Mar 2016 18:47:17 GMT']
+        date: ['Wed, 09 Mar 2016 08:48:53 GMT']
+        etag: [W/"6d633bbfa40b0ef09f1d6eff2ee0dbca"]
+        expires: ['Wed, 09 Mar 2016 12:48:53 GMT']
         server: [cloudflare-nginx]
-        set-cookie: ['__cfduid=dc48b05a82eb09c3d95537af70dce1c0d1457448437; expires=Wed,
-            08-Mar-17 14:47:17 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        set-cookie: ['__cfduid=d7ec4b03f4c01b19dd95bc53d0acbc2571457513333; expires=Thu,
+            09-Mar-17 08:48:53 GMT; path=/; domain=.trakt.tv; HttpOnly']
         vary: [Accept-Encoding]
         x-content-type-options: [nosniff]
         x-frame-options: [SAMEORIGIN]
@@ -265,15 +265,15 @@ interactions:
         x-pagination-limit: ['10']
         x-pagination-page: ['1']
         x-pagination-page-count: ['1']
-        x-request-id: [a4d52927-3c00-406b-99be-5e815b33b9ce]
-        x-runtime: ['0.025000']
+        x-request-id: [0cb21e86-65d6-4c78-a85b-dffe4bed3e7c]
+        x-runtime: ['0.028033']
         x-xss-protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
       body: null
       headers:
         Content-Type: [application/json]
-        Cookie: [__cfduid=dc48b05a82eb09c3d95537af70dce1c0d1457448437]
+        Cookie: [__cfduid=d7ec4b03f4c01b19dd95bc53d0acbc2571457513333]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: [2]
       method: GET
@@ -288,12 +288,12 @@ interactions:
       headers:
         cache-control: ['public, max-age=14400']
         cf-cache-status: [HIT]
-        cf-ray: [280714df5fe93d61-CPH]
+        cf-ray: [280d453dda823d37-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Tue, 08 Mar 2016 14:47:17 GMT']
+        date: ['Wed, 09 Mar 2016 08:48:53 GMT']
         etag: [W/"f15c2731d2036940b33b4213ef830d12"]
-        expires: ['Tue, 08 Mar 2016 18:47:17 GMT']
+        expires: ['Wed, 09 Mar 2016 12:48:53 GMT']
         last-modified: ['Tue, 08 Mar 2016 08:41:05 GMT']
         server: [cloudflare-nginx]
         vary: [Accept-Encoding]

--- a/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_show_collected_progress
+++ b/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_show_collected_progress
@@ -1,0 +1,140 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Content-Type: [application/json]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: [2]
+      method: GET
+      uri: https://api-v2launch.trakt.tv/users/flexgettest/lists/test/items
+    response:
+      body: {string: '[{"rank":1,"listed_at":"2016-03-08T21:36:36.000Z","type":"show","show":{"title":"White
+          Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}},{"rank":2,"listed_at":"2016-03-08T21:36:50.000Z","type":"show","show":{"title":"Chuck","year":2007,"ids":{"trakt":1395,"slug":"chuck","tvdb":80348,"imdb":"tt0934814","tmdb":1404,"tvrage":15614}}}]'}
+      headers:
+        cache-control: ['max-age=0, private, must-revalidate']
+        cf-ray: [280d459cdc373d37-CPH]
+        connection: [keep-alive]
+        content-type: [application/json; charset=utf-8]
+        date: ['Wed, 09 Mar 2016 08:49:09 GMT']
+        etag: [W/"14bdfd17b19d28c1251ef11711e88666"]
+        server: [cloudflare-nginx]
+        set-cookie: ['__cfduid=df9cb9fc9a782566d31a298bd786701191457513348; expires=Thu,
+            09-Mar-17 08:49:08 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        vary: [Accept-Encoding]
+        x-content-type-options: [nosniff]
+        x-frame-options: [SAMEORIGIN]
+        x-private-user: ['false']
+        x-request-id: [5da8fac8-ab34-4513-9b79-d35e5af7c06b]
+        x-runtime: ['0.012308']
+        x-sort-by: [rank]
+        x-sort-how: [asc]
+        x-xss-protection: [1; mode=block]
+      status: {code: 200, message: OK}
+  - request:
+      body: null
+      headers:
+        Content-Type: [application/json]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: [2]
+      method: GET
+      uri: https://api-v2launch.trakt.tv/shows/21410?extended=full
+    response:
+      body: {string: '{"title":"White Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720},"overview":"A
+          white collar criminal agrees to help the FBI catch other white collar criminals
+          using his expertise as an art and securities thief, counterfeiter, and conman.","first_aired":"2009-10-24T01:00:00.000Z","airs":{"day":"Thursday","time":"21:00","timezone":"America/New_York"},"runtime":40,"certification":"TV-14","network":"USA
+          Network","country":"us","trailer":null,"homepage":"http://www.usanetwork.com/series/whitecollar/","status":"ended","rating":8.44469,"votes":7376,"updated_at":"2016-03-05T09:36:29.000Z","language":"en","available_translations":["pt","de","es","fr","en","el","hu","zh","bs","ru","it","bg","da","nl","cs","ro"],"genres":["drama","mystery","action","adventure"],"aired_episodes":81}'}
+      headers:
+        cache-control: ['public, max-age=14400']
+        cf-cache-status: [HIT]
+        cf-ray: [280d45a00e3c3ce3-CPH]
+        connection: [keep-alive]
+        content-type: [application/json; charset=utf-8]
+        date: ['Wed, 09 Mar 2016 08:49:09 GMT']
+        etag: [W/"fbaa21f634d8ae50d41b30cccc86dcd3"]
+        expires: ['Wed, 09 Mar 2016 12:49:09 GMT']
+        last-modified: ['Sat, 05 Mar 2016 09:36:29 GMT']
+        server: [cloudflare-nginx]
+        set-cookie: ['__cfduid=ddc883945bb6df0c9d00d6f67d93eaa611457513349; expires=Thu,
+            09-Mar-17 08:49:09 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        vary: [Accept-Encoding]
+        x-content-type-options: [nosniff]
+        x-frame-options: [SAMEORIGIN]
+        x-request-id: [3fc387e6-e784-41d2-9176-120a01451bd3]
+        x-runtime: ['0.011416']
+        x-xss-protection: [1; mode=block]
+      status: {code: 200, message: OK}
+  - request:
+      body: null
+      headers:
+        Content-Type: [application/json]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: [2]
+      method: GET
+      uri: https://api-v2launch.trakt.tv/users/flexgettest/collection/shows
+    response:
+      body: {string: '[{"last_collected_at":"2016-03-08T21:36:33.000Z","show":{"title":"White
+          Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}},"seasons":[{"number":1,"episodes":[{"number":1,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":2,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":3,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":4,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":5,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":6,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":7,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":8,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":9,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":10,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":11,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":12,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":13,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":14,"collected_at":"2016-03-08T21:36:33.000Z"}]},{"number":2,"episodes":[{"number":1,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":2,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":3,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":4,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":5,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":6,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":7,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":8,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":9,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":10,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":11,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":12,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":13,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":14,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":15,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":16,"collected_at":"2016-03-08T21:36:33.000Z"}]},{"number":3,"episodes":[{"number":1,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":2,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":3,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":4,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":5,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":6,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":7,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":8,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":9,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":10,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":11,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":12,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":13,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":14,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":15,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":16,"collected_at":"2016-03-08T21:36:33.000Z"}]},{"number":4,"episodes":[{"number":1,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":2,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":3,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":4,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":5,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":6,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":7,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":8,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":9,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":10,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":11,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":12,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":13,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":14,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":15,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":16,"collected_at":"2016-03-08T21:36:33.000Z"}]},{"number":5,"episodes":[{"number":1,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":2,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":3,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":4,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":5,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":6,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":7,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":8,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":9,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":10,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":11,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":12,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":13,"collected_at":"2016-03-08T21:36:33.000Z"}]},{"number":6,"episodes":[{"number":1,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":2,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":3,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":4,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":5,"collected_at":"2016-03-08T21:36:33.000Z"},{"number":6,"collected_at":"2016-03-08T21:36:33.000Z"}]}]},{"last_collected_at":"2012-10-01T02:00:00.000Z","show":{"title":"Homeland","year":2011,"ids":{"trakt":1398,"slug":"homeland","tvdb":247897,"imdb":"tt1796960","tmdb":1407,"tvrage":27811}},"seasons":[{"number":2,"episodes":[{"number":1,"collected_at":"2012-10-01T02:00:00.000Z"}]}]}]'}
+      headers:
+        cache-control: ['max-age=0, private, must-revalidate']
+        cf-ray: [280d45a0a0a43d67-CPH]
+        connection: [keep-alive]
+        content-type: [application/json; charset=utf-8]
+        date: ['Wed, 09 Mar 2016 08:49:09 GMT']
+        etag: [W/"6f63e6fe51d44162fba8527e426907bd"]
+        last-modified: ['Tue, 08 Mar 2016 21:36:33 GMT']
+        server: [cloudflare-nginx]
+        set-cookie: ['__cfduid=dab7ea4f310439388a3b4251c99774c491457513349; expires=Thu,
+            09-Mar-17 08:49:09 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        vary: [Accept-Encoding]
+        x-content-type-options: [nosniff]
+        x-frame-options: [SAMEORIGIN]
+        x-private-user: ['false']
+        x-request-id: [8526c6e3-53e2-48c0-8976-8e1c7c2b1397]
+        x-runtime: ['0.010138']
+        x-xss-protection: [1; mode=block]
+      status: {code: 200, message: OK}
+  - request:
+      body: null
+      headers:
+        Content-Type: [application/json]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: [2]
+      method: GET
+      uri: https://api-v2launch.trakt.tv/shows/1395?extended=full
+    response:
+      body: {string: '{"title":"Chuck","year":2007,"ids":{"trakt":1395,"slug":"chuck","tvdb":80348,"imdb":"tt0934814","tmdb":1404,"tvrage":15614},"overview":"This
+          high-concept action comedy follows Chuck Bartowski as the Buy More computer
+          geek turned secret agent. When Chuck unwittingly downloads a database of
+          government information and deadly fighting skills into his head, he becomes
+          the CIA''s most vital secret. This sets Chuck on a path to become a full-fledged
+          spy, assisted by the stoic Colonel John Casey; Chuck''s best friend, Morgan
+          Grimes; and the CIA''s top agent (now Chuck''s wife) Sarah Walker. With
+          the help of this unlikely team and his unorthodox techniques, Chuck is ready
+          to take Operation Bartowski freelance. Chuck''s spy abilities will be put
+          to a new test when he and his team must save mankind without the help of
+          the CIA. Instead, they''ll use the cover of the Buy More electronics store
+          to fund their own operations, leading to new missions, new stakes and new
+          obstacles. With Chuck and Sarah as newlyweds and his family in on his secret,
+          it has never been harder for Chuck to separate his spy life from his personal
+          life.","first_aired":"2007-09-25T00:00:00.000Z","airs":{"day":"Friday","time":"20:00","timezone":"America/New_York"},"runtime":43,"certification":"TV-PG","network":"NBC","country":"us","trailer":null,"homepage":"http://www.nbc.com/Chuck/","status":"ended","rating":8.4683,"votes":8753,"updated_at":"2016-03-05T09:41:09.000Z","language":"en","available_translations":["en","de","pt","pl","bg","hu","fr","ja","he","da","zh","bs","sv","cs","tr","es","ru","it"],"genres":["comedy","drama","action"],"aired_episodes":91}'}
+      headers:
+        cache-control: ['public, max-age=14400']
+        cf-cache-status: [HIT]
+        cf-ray: [280d45a3ce0f3c9b-CPH]
+        connection: [keep-alive]
+        content-type: [application/json; charset=utf-8]
+        date: ['Wed, 09 Mar 2016 08:49:09 GMT']
+        etag: [W/"f34bdcb0803d159a6259faf85344cf88"]
+        expires: ['Wed, 09 Mar 2016 12:49:09 GMT']
+        last-modified: ['Sat, 05 Mar 2016 09:41:09 GMT']
+        server: [cloudflare-nginx]
+        set-cookie: ['__cfduid=d599892649c01d7523ed3cc993c7d15cb1457513349; expires=Thu,
+            09-Mar-17 08:49:09 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        vary: [Accept-Encoding]
+        x-content-type-options: [nosniff]
+        x-frame-options: [SAMEORIGIN]
+        x-request-id: [b776efee-1dc3-4f52-b97e-17e01c56ca9e]
+        x-runtime: ['0.017967']
+        x-xss-protection: [1; mode=block]
+      status: {code: 200, message: OK}
+version: 1

--- a/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_show_watched_progress
+++ b/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_show_watched_progress
@@ -6,70 +6,28 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: [2]
       method: GET
-      uri: https://api-v2launch.trakt.tv/search?query=Hawaii+Five-0&type=show
+      uri: https://api-v2launch.trakt.tv/users/flexgettest/lists/test/items
     response:
-      body: {string: '[{"type":"show","score":97.68111,"show":{"title":"Hawaii Five-0","overview":"Steve
-          McGarrett returns home to Oahu, in order to find his father''s killer. The
-          governor offers him the chance to run his own task force (Five-0). Steve''s
-          team is joined by Chin Ho Kelly, Danny \"Danno\" Williams, and Kono Kalakaua.","year":2010,"status":"returning
-          series","images":{"poster":{"full":"https://walter.trakt.us/images/shows/000/032/657/posters/original/ff94033565.jpg","medium":"https://walter.trakt.us/images/shows/000/032/657/posters/medium/ff94033565.jpg","thumb":"https://walter.trakt.us/images/shows/000/032/657/posters/thumb/ff94033565.jpg"},"fanart":{"full":"https://walter.trakt.us/images/shows/000/032/657/fanarts/original/03ff15aa9c.jpg","medium":"https://walter.trakt.us/images/shows/000/032/657/fanarts/medium/03ff15aa9c.jpg","thumb":"https://walter.trakt.us/images/shows/000/032/657/fanarts/thumb/03ff15aa9c.jpg"}},"ids":{"trakt":32657,"slug":"hawaii-five-0","tvdb":164541,"imdb":"tt1600194","tmdb":32798,"tvrage":24840}}},{"type":"show","score":23.032373,"show":{"title":"Hawaii
-          Five-O","overview":"The investigations of Hawaii Five-0, an elite branch
-          of the Hawaii State Police answerable only to the governor and headed by
-          stalwart Steve McGarrett.","year":1968,"status":"ended","images":{"poster":{"full":"https://walter.trakt.us/images/shows/000/002/289/posters/original/6847978a12.jpg","medium":"https://walter.trakt.us/images/shows/000/002/289/posters/medium/6847978a12.jpg","thumb":"https://walter.trakt.us/images/shows/000/002/289/posters/thumb/6847978a12.jpg"},"fanart":{"full":"https://walter.trakt.us/images/shows/000/002/289/fanarts/original/3456427ff9.jpg","medium":"https://walter.trakt.us/images/shows/000/002/289/fanarts/medium/3456427ff9.jpg","thumb":"https://walter.trakt.us/images/shows/000/002/289/fanarts/thumb/3456427ff9.jpg"}},"ids":{"trakt":2289,"slug":"hawaii-five-o","tvdb":71223,"imdb":"tt0062568","tmdb":2303,"tvrage":null}}}]'}
+      body: {string: '[{"rank":1,"listed_at":"2016-03-08T21:36:36.000Z","type":"show","show":{"title":"White
+          Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}},{"rank":2,"listed_at":"2016-03-08T21:36:50.000Z","type":"show","show":{"title":"Chuck","year":2007,"ids":{"trakt":1395,"slug":"chuck","tvdb":80348,"imdb":"tt0934814","tmdb":1404,"tvrage":15614}}}]'}
       headers:
-        cache-control: ['public, max-age=14400']
-        cf-cache-status: [HIT]
-        cf-ray: [280d44ae1edb3cbf-CPH]
+        cache-control: ['max-age=0, private, must-revalidate']
+        cf-ray: [280d456ea4853cd1-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Wed, 09 Mar 2016 08:48:30 GMT']
-        etag: [W/"43bb5db8253fd0a05e103ba5f2ecd2eb"]
-        expires: ['Wed, 09 Mar 2016 12:48:30 GMT']
+        date: ['Wed, 09 Mar 2016 08:49:01 GMT']
+        etag: [W/"14bdfd17b19d28c1251ef11711e88666"]
         server: [cloudflare-nginx]
-        set-cookie: ['__cfduid=db0f08c9b5a3a3b0f72414676f6cab2711457513310; expires=Thu,
-            09-Mar-17 08:48:30 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        set-cookie: ['__cfduid=d4b242ae5d94608a311447b212f7351561457513341; expires=Thu,
+            09-Mar-17 08:49:01 GMT; path=/; domain=.trakt.tv; HttpOnly']
         vary: [Accept-Encoding]
         x-content-type-options: [nosniff]
         x-frame-options: [SAMEORIGIN]
-        x-pagination-item-count: ['2']
-        x-pagination-limit: ['10']
-        x-pagination-page: ['1']
-        x-pagination-page-count: ['1']
-        x-request-id: [bfa21977-92a0-49fb-88f4-c7dcf50ee135]
-        x-runtime: ['0.016960']
-        x-xss-protection: [1; mode=block]
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Content-Type: [application/json]
-        Cookie: [__cfduid=db0f08c9b5a3a3b0f72414676f6cab2711457513310]
-        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
-        trakt-api-version: [2]
-      method: GET
-      uri: https://api-v2launch.trakt.tv/shows/32657?extended=full
-    response:
-      body: {string: '{"title":"Hawaii Five-0","year":2010,"ids":{"trakt":32657,"slug":"hawaii-five-0","tvdb":164541,"imdb":"tt1600194","tmdb":32798,"tvrage":24840},"overview":"Steve
-          McGarrett returns home to Oahu, in order to find his father''s killer. The
-          governor offers him the chance to run his own task force (Five-0). Steve''s
-          team is joined by Chin Ho Kelly, Danny \"Danno\" Williams, and Kono Kalakaua.","first_aired":"2010-09-20T07:00:00.000Z","airs":{"day":"Friday","time":"21:00","timezone":"America/New_York"},"runtime":45,"certification":"TV-14","network":"CBS","country":"us","trailer":"http://youtube.com/watch?v=EN6LMV4-Dfs","homepage":"http://www.cbs.com/shows/hawaii_five_0/","status":"returning
-          series","rating":7.78167,"votes":3142,"updated_at":"2016-03-08T11:06:25.000Z","language":"en","available_translations":["en","de","pl","bg","it","fr","el","es","zh","ru","hu","nl","sv","pt","he","bs","da","lt","fa","tr","ro"],"genres":["drama","action","crime"],"aired_episodes":134}'}
-      headers:
-        cache-control: ['public, max-age=14400']
-        cf-cache-status: [HIT]
-        cf-ray: [280d44ae4edc3cbf-CPH]
-        connection: [keep-alive]
-        content-type: [application/json; charset=utf-8]
-        date: ['Wed, 09 Mar 2016 08:48:30 GMT']
-        etag: [W/"1ed15e0561bca1809ba2934ee58c3734"]
-        expires: ['Wed, 09 Mar 2016 12:48:30 GMT']
-        last-modified: ['Tue, 08 Mar 2016 11:06:25 GMT']
-        server: [cloudflare-nginx]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [a2e671ef-7d7d-42a3-b417-b00d1d44ac79]
-        x-runtime: ['0.015114']
+        x-private-user: ['false']
+        x-request-id: [40e8fc51-7a90-4529-8262-dbdf8a3ad76a]
+        x-runtime: ['0.022622']
+        x-sort-by: [rank]
+        x-sort-how: [asc]
         x-xss-protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
@@ -79,33 +37,30 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: [2]
       method: GET
-      uri: https://api-v2launch.trakt.tv/shows/32657/seasons/4/episodes/13/?extended=full
+      uri: https://api-v2launch.trakt.tv/shows/21410?extended=full
     response:
-      body: {string: "{\"season\":4,\"number\":13,\"title\":\"Hana Lokomaika'i\",\"\
-          ids\":{\"trakt\":776972,\"tvdb\":4749328,\"imdb\":null,\"tmdb\":970659,\"\
-          tvrage\":0},\"number_abs\":null,\"overview\":\"Internal Affairs questions\
-          \ Chin about his father\u2019s murder 15 years earlier and how his then-new\
-          \ relationship with Malia and her family might have hurt the investigation.\"\
-          ,\"rating\":7.80446,\"votes\":404,\"first_aired\":\"2014-01-18T02:00:00.000Z\"\
-          ,\"updated_at\":\"2016-03-06T03:40:54.000Z\",\"available_translations\"\
-          :[]}"}
+      body: {string: '{"title":"White Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720},"overview":"A
+          white collar criminal agrees to help the FBI catch other white collar criminals
+          using his expertise as an art and securities thief, counterfeiter, and conman.","first_aired":"2009-10-24T01:00:00.000Z","airs":{"day":"Thursday","time":"21:00","timezone":"America/New_York"},"runtime":40,"certification":"TV-14","network":"USA
+          Network","country":"us","trailer":null,"homepage":"http://www.usanetwork.com/series/whitecollar/","status":"ended","rating":8.44469,"votes":7376,"updated_at":"2016-03-05T09:36:29.000Z","language":"en","available_translations":["pt","de","es","fr","en","el","hu","zh","bs","ru","it","bg","da","nl","cs","ro"],"genres":["drama","mystery","action","adventure"],"aired_episodes":81}'}
       headers:
         cache-control: ['public, max-age=14400']
         cf-cache-status: [HIT]
-        cf-ray: [280d44aee5323c9b-CPH]
+        cf-ray: [280d4571fa573cbf-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Wed, 09 Mar 2016 08:48:30 GMT']
-        expires: ['Wed, 09 Mar 2016 12:48:30 GMT']
-        last-modified: ['Sun, 06 Mar 2016 03:40:54 GMT']
+        date: ['Wed, 09 Mar 2016 08:49:01 GMT']
+        etag: [W/"fbaa21f634d8ae50d41b30cccc86dcd3"]
+        expires: ['Wed, 09 Mar 2016 12:49:01 GMT']
+        last-modified: ['Sat, 05 Mar 2016 09:36:29 GMT']
         server: [cloudflare-nginx]
-        set-cookie: ['__cfduid=dbffb4a7cef0d25f92d296ee83b5b7f661457513310; expires=Thu,
-            09-Mar-17 08:48:30 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        set-cookie: ['__cfduid=da77ece9bba9f4b7e9493b8ab1ab833221457513341; expires=Thu,
+            09-Mar-17 08:49:01 GMT; path=/; domain=.trakt.tv; HttpOnly']
         vary: [Accept-Encoding]
         x-content-type-options: [nosniff]
         x-frame-options: [SAMEORIGIN]
-        x-request-id: [f84818f5-37cf-4781-ad90-2b9c1ba83f16]
-        x-runtime: ['0.009537']
+        x-request-id: [3fc387e6-e784-41d2-9176-120a01451bd3]
+        x-runtime: ['0.011416']
         x-xss-protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
@@ -122,21 +77,21 @@ interactions:
           of Anarchy","year":2008,"ids":{"trakt":1400,"slug":"sons-of-anarchy","tvdb":82696,"imdb":"tt1124373","tmdb":1409,"tvrage":18174}},"seasons":[{"number":1,"episodes":[{"number":1,"plays":1,"last_watched_at":"2015-01-02T03:40:54.000Z"},{"number":2,"plays":1,"last_watched_at":"2015-01-02T03:40:54.000Z"},{"number":3,"plays":1,"last_watched_at":"2015-01-02T03:40:54.000Z"},{"number":4,"plays":1,"last_watched_at":"2015-01-02T03:40:54.000Z"},{"number":5,"plays":1,"last_watched_at":"2015-01-02T03:40:54.000Z"},{"number":6,"plays":1,"last_watched_at":"2015-01-02T03:40:54.000Z"},{"number":7,"plays":1,"last_watched_at":"2015-01-02T03:40:54.000Z"},{"number":8,"plays":1,"last_watched_at":"2015-01-02T03:40:54.000Z"},{"number":9,"plays":1,"last_watched_at":"2015-01-02T03:40:54.000Z"},{"number":10,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":11,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":12,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":13,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"}]},{"number":2,"episodes":[{"number":1,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":2,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":3,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":4,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":5,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":6,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":7,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":8,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":9,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":10,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":11,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":12,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":13,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"}]},{"number":3,"episodes":[{"number":1,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":2,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":3,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":4,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":5,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":6,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":7,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":8,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":9,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":10,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":11,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":12,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":13,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"}]},{"number":4,"episodes":[{"number":1,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":2,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":3,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":4,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":5,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":6,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":7,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":8,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":9,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":10,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":11,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":12,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":13,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"},{"number":14,"plays":1,"last_watched_at":"2015-01-02T03:40:55.000Z"}]},{"number":5,"episodes":[{"number":1,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":2,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":3,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":4,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":5,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":6,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":7,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":8,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":9,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":10,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":11,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":12,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":13,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"}]},{"number":6,"episodes":[{"number":1,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":2,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":3,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":4,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":5,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":6,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":7,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":8,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":9,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":10,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":11,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":12,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":13,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"}]},{"number":7,"episodes":[{"number":1,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":2,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":3,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":4,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":5,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":6,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":7,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":8,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":9,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":10,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":11,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":12,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"},{"number":13,"plays":1,"last_watched_at":"2015-01-02T03:40:56.000Z"}]}]},{"plays":12,"last_watched_at":"2015-01-02T03:40:06.000Z","show":{"title":"Homeland","year":2011,"ids":{"trakt":1398,"slug":"homeland","tvdb":247897,"imdb":"tt1796960","tmdb":1407,"tvrage":27811}},"seasons":[{"number":1,"episodes":[{"number":1,"plays":1,"last_watched_at":"2015-01-02T03:37:34.000Z"},{"number":2,"plays":1,"last_watched_at":"2015-01-02T03:40:06.000Z"},{"number":3,"plays":1,"last_watched_at":"2015-01-02T03:40:06.000Z"},{"number":4,"plays":1,"last_watched_at":"2015-01-02T03:40:06.000Z"},{"number":5,"plays":1,"last_watched_at":"2015-01-02T03:40:06.000Z"},{"number":6,"plays":1,"last_watched_at":"2015-01-02T03:40:06.000Z"},{"number":7,"plays":1,"last_watched_at":"2015-01-02T03:40:06.000Z"},{"number":8,"plays":1,"last_watched_at":"2015-01-02T03:40:06.000Z"},{"number":9,"plays":1,"last_watched_at":"2015-01-02T03:40:06.000Z"},{"number":10,"plays":1,"last_watched_at":"2015-01-02T03:40:06.000Z"},{"number":11,"plays":1,"last_watched_at":"2015-01-02T03:40:06.000Z"},{"number":12,"plays":1,"last_watched_at":"2015-01-02T03:40:06.000Z"}]}]},{"plays":91,"last_watched_at":"2012-01-28T01:00:00.000Z","show":{"title":"Chuck","year":2007,"ids":{"trakt":1395,"slug":"chuck","tvdb":80348,"imdb":"tt0934814","tmdb":1404,"tvrage":15614}},"seasons":[{"number":1,"episodes":[{"number":1,"plays":1,"last_watched_at":"2007-09-25T00:00:00.000Z"},{"number":2,"plays":1,"last_watched_at":"2007-10-02T00:00:00.000Z"},{"number":3,"plays":1,"last_watched_at":"2007-10-09T00:00:00.000Z"},{"number":4,"plays":1,"last_watched_at":"2007-10-16T00:00:00.000Z"},{"number":5,"plays":1,"last_watched_at":"2007-10-23T00:00:00.000Z"},{"number":6,"plays":1,"last_watched_at":"2007-10-30T00:00:00.000Z"},{"number":7,"plays":1,"last_watched_at":"2007-11-06T01:00:00.000Z"},{"number":8,"plays":1,"last_watched_at":"2007-11-13T01:00:00.000Z"},{"number":9,"plays":1,"last_watched_at":"2007-11-20T01:00:00.000Z"},{"number":10,"plays":1,"last_watched_at":"2007-11-27T01:00:00.000Z"},{"number":11,"plays":1,"last_watched_at":"2007-12-04T01:00:00.000Z"},{"number":12,"plays":1,"last_watched_at":"2008-01-25T01:00:00.000Z"},{"number":13,"plays":1,"last_watched_at":"2008-01-25T01:00:00.000Z"}]},{"number":2,"episodes":[{"number":1,"plays":1,"last_watched_at":"2008-09-30T00:00:00.000Z"},{"number":2,"plays":1,"last_watched_at":"2008-10-07T00:00:00.000Z"},{"number":3,"plays":1,"last_watched_at":"2008-10-14T00:00:00.000Z"},{"number":4,"plays":1,"last_watched_at":"2008-10-21T00:00:00.000Z"},{"number":5,"plays":1,"last_watched_at":"2008-10-28T00:00:00.000Z"},{"number":6,"plays":1,"last_watched_at":"2008-11-11T01:00:00.000Z"},{"number":7,"plays":1,"last_watched_at":"2008-11-18T01:00:00.000Z"},{"number":8,"plays":1,"last_watched_at":"2008-11-25T01:00:00.000Z"},{"number":9,"plays":1,"last_watched_at":"2008-12-02T01:00:00.000Z"},{"number":10,"plays":1,"last_watched_at":"2008-12-09T01:00:00.000Z"},{"number":11,"plays":1,"last_watched_at":"2008-12-16T01:00:00.000Z"},{"number":12,"plays":1,"last_watched_at":"2009-02-03T01:00:00.000Z"},{"number":13,"plays":1,"last_watched_at":"2009-02-17T01:00:00.000Z"},{"number":14,"plays":1,"last_watched_at":"2009-02-24T01:00:00.000Z"},{"number":15,"plays":1,"last_watched_at":"2009-03-03T01:00:00.000Z"},{"number":16,"plays":1,"last_watched_at":"2009-03-10T00:00:00.000Z"},{"number":17,"plays":1,"last_watched_at":"2009-03-24T00:00:00.000Z"},{"number":18,"plays":1,"last_watched_at":"2009-03-31T00:00:00.000Z"},{"number":19,"plays":1,"last_watched_at":"2009-04-07T00:00:00.000Z"},{"number":20,"plays":1,"last_watched_at":"2009-04-14T00:00:00.000Z"},{"number":21,"plays":1,"last_watched_at":"2009-04-21T00:00:00.000Z"},{"number":22,"plays":1,"last_watched_at":"2009-04-28T00:00:00.000Z"}]},{"number":3,"episodes":[{"number":1,"plays":1,"last_watched_at":"2010-01-11T01:00:00.000Z"},{"number":2,"plays":1,"last_watched_at":"2010-01-11T01:00:00.000Z"},{"number":3,"plays":1,"last_watched_at":"2010-01-12T01:00:00.000Z"},{"number":4,"plays":1,"last_watched_at":"2010-01-19T01:00:00.000Z"},{"number":5,"plays":1,"last_watched_at":"2010-01-26T01:00:00.000Z"},{"number":6,"plays":1,"last_watched_at":"2010-02-02T01:00:00.000Z"},{"number":7,"plays":1,"last_watched_at":"2010-02-09T01:00:00.000Z"},{"number":8,"plays":1,"last_watched_at":"2010-03-02T01:00:00.000Z"},{"number":9,"plays":1,"last_watched_at":"2010-03-09T01:00:00.000Z"},{"number":10,"plays":1,"last_watched_at":"2010-03-16T00:00:00.000Z"},{"number":11,"plays":1,"last_watched_at":"2010-03-23T00:00:00.000Z"},{"number":12,"plays":1,"last_watched_at":"2010-03-30T00:00:00.000Z"},{"number":13,"plays":1,"last_watched_at":"2010-04-06T00:00:00.000Z"},{"number":14,"plays":1,"last_watched_at":"2010-04-27T00:00:00.000Z"},{"number":15,"plays":1,"last_watched_at":"2010-05-04T00:00:00.000Z"},{"number":16,"plays":1,"last_watched_at":"2010-05-11T00:00:00.000Z"},{"number":17,"plays":1,"last_watched_at":"2010-05-18T00:00:00.000Z"},{"number":18,"plays":1,"last_watched_at":"2010-05-25T00:00:00.000Z"},{"number":19,"plays":1,"last_watched_at":"2010-05-25T00:00:00.000Z"}]},{"number":4,"episodes":[{"number":1,"plays":1,"last_watched_at":"2010-09-21T00:00:00.000Z"},{"number":2,"plays":1,"last_watched_at":"2010-09-28T00:00:00.000Z"},{"number":3,"plays":1,"last_watched_at":"2010-10-05T00:00:00.000Z"},{"number":4,"plays":1,"last_watched_at":"2010-10-12T00:00:00.000Z"},{"number":5,"plays":1,"last_watched_at":"2010-10-19T00:00:00.000Z"},{"number":6,"plays":1,"last_watched_at":"2010-10-26T00:00:00.000Z"},{"number":7,"plays":1,"last_watched_at":"2010-11-02T00:00:00.000Z"},{"number":8,"plays":1,"last_watched_at":"2010-11-16T01:00:00.000Z"},{"number":9,"plays":1,"last_watched_at":"2010-11-23T01:00:00.000Z"},{"number":10,"plays":1,"last_watched_at":"2010-11-30T01:00:00.000Z"},{"number":11,"plays":1,"last_watched_at":"2011-01-18T01:00:00.000Z"},{"number":12,"plays":1,"last_watched_at":"2011-01-25T01:00:00.000Z"},{"number":13,"plays":1,"last_watched_at":"2011-02-01T01:00:00.000Z"},{"number":14,"plays":1,"last_watched_at":"2011-02-08T01:00:00.000Z"},{"number":15,"plays":1,"last_watched_at":"2011-02-15T01:00:00.000Z"},{"number":16,"plays":1,"last_watched_at":"2011-02-22T01:00:00.000Z"},{"number":17,"plays":1,"last_watched_at":"2011-03-01T01:00:00.000Z"},{"number":18,"plays":1,"last_watched_at":"2011-03-15T00:00:00.000Z"},{"number":19,"plays":1,"last_watched_at":"2011-03-22T00:00:00.000Z"},{"number":20,"plays":1,"last_watched_at":"2011-04-12T00:00:00.000Z"},{"number":21,"plays":1,"last_watched_at":"2011-04-19T00:00:00.000Z"},{"number":22,"plays":1,"last_watched_at":"2011-05-03T00:00:00.000Z"},{"number":23,"plays":1,"last_watched_at":"2011-05-10T00:00:00.000Z"},{"number":24,"plays":1,"last_watched_at":"2011-05-17T00:00:00.000Z"}]},{"number":5,"episodes":[{"number":1,"plays":1,"last_watched_at":"2011-10-29T00:00:00.000Z"},{"number":2,"plays":1,"last_watched_at":"2011-11-05T00:00:00.000Z"},{"number":3,"plays":1,"last_watched_at":"2011-11-12T01:00:00.000Z"},{"number":4,"plays":1,"last_watched_at":"2011-11-19T01:00:00.000Z"},{"number":5,"plays":1,"last_watched_at":"2011-12-10T01:00:00.000Z"},{"number":6,"plays":1,"last_watched_at":"2011-12-17T01:00:00.000Z"},{"number":7,"plays":1,"last_watched_at":"2011-12-24T01:00:00.000Z"},{"number":8,"plays":1,"last_watched_at":"2011-12-31T01:00:00.000Z"},{"number":9,"plays":1,"last_watched_at":"2012-01-07T01:00:00.000Z"},{"number":10,"plays":1,"last_watched_at":"2012-01-14T01:00:00.000Z"},{"number":11,"plays":1,"last_watched_at":"2012-01-21T01:00:00.000Z"},{"number":12,"plays":1,"last_watched_at":"2012-01-28T01:00:00.000Z"},{"number":13,"plays":1,"last_watched_at":"2012-01-28T01:00:00.000Z"}]}]}]'}
       headers:
         cache-control: ['max-age=0, private, must-revalidate']
-        cf-ray: [280d44af6c8a3d25-CPH]
+        cf-ray: [280d457296883d43-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Wed, 09 Mar 2016 08:48:31 GMT']
+        date: ['Wed, 09 Mar 2016 08:49:01 GMT']
         etag: [W/"c2d9a9f116fbf361b14ca5967b4c526a"]
         last-modified: ['Tue, 08 Mar 2016 21:36:48 GMT']
         server: [cloudflare-nginx]
-        set-cookie: ['__cfduid=dfd80e0527790bd5087abc3e9f9d7ce611457513310; expires=Thu,
-            09-Mar-17 08:48:30 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        set-cookie: ['__cfduid=dc2ed1384008b1b54c09c8ecdd35a485a1457513341; expires=Thu,
+            09-Mar-17 08:49:01 GMT; path=/; domain=.trakt.tv; HttpOnly']
         vary: [Accept-Encoding]
         x-content-type-options: [nosniff]
         x-frame-options: [SAMEORIGIN]
         x-private-user: ['false']
-        x-request-id: [80da6b2f-ae24-4a5d-954f-e71fc0dbb8e1]
-        x-runtime: ['0.017570']
+        x-request-id: [3e255bf6-f984-4981-a594-41a30d2d9351]
+        x-runtime: ['0.016306']
         x-xss-protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
@@ -146,176 +101,41 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: [2]
       method: GET
-      uri: https://api-v2launch.trakt.tv/search?query=The+Flash&type=show&year=2014
+      uri: https://api-v2launch.trakt.tv/shows/1395?extended=full
     response:
-      body: {string: "[{\"type\":\"show\",\"score\":59.70133,\"show\":{\"title\":\"\
-          The Flash\",\"overview\":\"After a particle accelerator causes a freak storm,\
-          \ CSI Investigator Barry Allen is struck by lightning and falls into a coma.\
-          \ Months later he awakens with the power of super speed, granting him the\
-          \ ability to move through Central City like an unseen guardian angel. Though\
-          \ initially excited by his newfound powers, Barry is shocked to discover\
-          \ he is not the only \\\"meta-human\\\" who was created in the wake of the\
-          \ accelerator explosion \u2013 and not everyone is using their new powers\
-          \ for good. Barry partners with S.T.A.R. Labs and dedicates his life to\
-          \ protect the innocent. For now, only a few close friends and associates\
-          \ know that Barry is literally the fastest man alive, but it won't be long\
-          \ before the world learns what Barry Allen has become... The Flash.\",\"\
-          year\":2014,\"status\":\"returning series\",\"images\":{\"poster\":{\"full\"\
-          :\"https://walter.trakt.us/images/shows/000/060/300/posters/original/79bd96a4d3.jpg\"\
-          ,\"medium\":\"https://walter.trakt.us/images/shows/000/060/300/posters/medium/79bd96a4d3.jpg\"\
-          ,\"thumb\":\"https://walter.trakt.us/images/shows/000/060/300/posters/thumb/79bd96a4d3.jpg\"\
-          },\"fanart\":{\"full\":\"https://walter.trakt.us/images/shows/000/060/300/fanarts/original/df36c9a731.jpg\"\
-          ,\"medium\":\"https://walter.trakt.us/images/shows/000/060/300/fanarts/medium/df36c9a731.jpg\"\
-          ,\"thumb\":\"https://walter.trakt.us/images/shows/000/060/300/fanarts/thumb/df36c9a731.jpg\"\
-          }},\"ids\":{\"trakt\":60300,\"slug\":\"the-flash-2014\",\"tvdb\":279121,\"\
-          imdb\":\"tt3107288\",\"tmdb\":60735,\"tvrage\":36939}}},{\"type\":\"show\"\
-          ,\"score\":0.45470023,\"show\":{\"title\":\"Tornado Hunters\",\"overview\"\
-          :\"Greg Johnson, Chris Chittick, and Ricky Forbes are the Tornado Hunters.Outfitted\
-          \ with their truck Flash and the best equipment money can buy, they target\
-          \ the biggest tornadoes in North America. From Regina to Mexico, there\u2019\
-          s nowhere they won\u2019t go as they risk life, limb and a lot of windshields\
-          \ to chase their passion for the world\u2019s worst weather. - See more\
-          \ at: http://www.cmt.ca/show/tornado-hunters/#sthash.FtuhY0T3.dpuf\",\"\
-          year\":2014,\"status\":\"returning series\",\"images\":{\"poster\":{\"full\"\
-          :\"https://walter.trakt.us/images/shows/000/081/448/posters/original/ecede5e037.jpg\"\
-          ,\"medium\":\"https://walter.trakt.us/images/shows/000/081/448/posters/medium/ecede5e037.jpg\"\
-          ,\"thumb\":\"https://walter.trakt.us/images/shows/000/081/448/posters/thumb/ecede5e037.jpg\"\
-          },\"fanart\":{\"full\":null,\"medium\":null,\"thumb\":null}},\"ids\":{\"\
-          trakt\":81448,\"slug\":\"tornado-hunters\",\"tvdb\":287638,\"imdb\":null,\"\
-          tmdb\":null,\"tvrage\":null}}},{\"type\":\"show\",\"score\":0.33350223,\"\
-          show\":{\"title\":\"Stop Skeletons From Fighting\",\"overview\":\"Hello,\
-          \ I'm Derek Alexander, and I've been producing video reviews of retro (and\
-          \ sometimes modern) video games for over 7 years.When I started producing\
-          \ reviews in 2007, I was known as the Happy Video Game Nerd (HVGN). In late-2014\
-          \ I dropped the HVGN name and established Stop Skeletons From Fighting,\
-          \ a new outlet for video reviews (and other future projects). Even though\
-          \ I\u2019ve dropped the HVGN name, I still strive to set myself apart from\
-          \ the typical review show by using a positive spin to highlight lesser-known\
-          \ or underrated games and occasionally entire series. Some of the titles\
-          \ I've covered include:-Earthbound-Jumping Flash!-Gargoyle's Quest-Splatterhouse-Parasite\
-          \ Eve-Sweet Home-Wild Guns-IllbleedHaven't heard of some of these games?\
-          \ That's the point! \",\"year\":2014,\"status\":\"returning series\",\"\
-          images\":{\"poster\":{\"full\":null,\"medium\":null,\"thumb\":null},\"fanart\"\
-          :{\"full\":null,\"medium\":null,\"thumb\":null}},\"ids\":{\"trakt\":101605,\"\
-          slug\":\"stop-skeletons-from-fighting\",\"tvdb\":300088,\"imdb\":null,\"\
-          tmdb\":null,\"tvrage\":null}}}]"}
+      body: {string: '{"title":"Chuck","year":2007,"ids":{"trakt":1395,"slug":"chuck","tvdb":80348,"imdb":"tt0934814","tmdb":1404,"tvrage":15614},"overview":"This
+          high-concept action comedy follows Chuck Bartowski as the Buy More computer
+          geek turned secret agent. When Chuck unwittingly downloads a database of
+          government information and deadly fighting skills into his head, he becomes
+          the CIA''s most vital secret. This sets Chuck on a path to become a full-fledged
+          spy, assisted by the stoic Colonel John Casey; Chuck''s best friend, Morgan
+          Grimes; and the CIA''s top agent (now Chuck''s wife) Sarah Walker. With
+          the help of this unlikely team and his unorthodox techniques, Chuck is ready
+          to take Operation Bartowski freelance. Chuck''s spy abilities will be put
+          to a new test when he and his team must save mankind without the help of
+          the CIA. Instead, they''ll use the cover of the Buy More electronics store
+          to fund their own operations, leading to new missions, new stakes and new
+          obstacles. With Chuck and Sarah as newlyweds and his family in on his secret,
+          it has never been harder for Chuck to separate his spy life from his personal
+          life.","first_aired":"2007-09-25T00:00:00.000Z","airs":{"day":"Friday","time":"20:00","timezone":"America/New_York"},"runtime":43,"certification":"TV-PG","network":"NBC","country":"us","trailer":null,"homepage":"http://www.nbc.com/Chuck/","status":"ended","rating":8.4683,"votes":8753,"updated_at":"2016-03-05T09:41:09.000Z","language":"en","available_translations":["en","de","pt","pl","bg","hu","fr","ja","he","da","zh","bs","sv","cs","tr","es","ru","it"],"genres":["comedy","drama","action"],"aired_episodes":91}'}
       headers:
         cache-control: ['public, max-age=14400']
         cf-cache-status: [HIT]
-        cf-ray: [280d44b2b6663d37-CPH]
+        cf-ray: [280d4573fde33d43-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Wed, 09 Mar 2016 08:48:31 GMT']
-        etag: [W/"dba971bef3e1b830cff48be0354bae13"]
-        expires: ['Wed, 09 Mar 2016 12:48:31 GMT']
+        date: ['Wed, 09 Mar 2016 08:49:02 GMT']
+        etag: [W/"f34bdcb0803d159a6259faf85344cf88"]
+        expires: ['Wed, 09 Mar 2016 12:49:02 GMT']
+        last-modified: ['Sat, 05 Mar 2016 09:41:09 GMT']
         server: [cloudflare-nginx]
-        set-cookie: ['__cfduid=d0da57913eb943729478c35190a8343c01457513311; expires=Thu,
-            09-Mar-17 08:48:31 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        set-cookie: ['__cfduid=df738281f50581e7fe4c1555cb5f027741457513342; expires=Thu,
+            09-Mar-17 08:49:02 GMT; path=/; domain=.trakt.tv; HttpOnly']
         vary: [Accept-Encoding]
         x-content-type-options: [nosniff]
         x-frame-options: [SAMEORIGIN]
-        x-pagination-item-count: ['3']
-        x-pagination-limit: ['10']
-        x-pagination-page: ['1']
-        x-pagination-page-count: ['1']
-        x-request-id: [08caa6ab-0f16-4c00-8953-dc1f8734c31d]
-        x-runtime: ['0.025738']
-        x-xss-protection: [1; mode=block]
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Content-Type: [application/json]
-        Cookie: [__cfduid=d0da57913eb943729478c35190a8343c01457513311]
-        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
-        trakt-api-version: [2]
-      method: GET
-      uri: https://api-v2launch.trakt.tv/shows/60300?extended=full
-    response:
-      body: {string: "{\"title\":\"The Flash\",\"year\":2014,\"ids\":{\"trakt\":60300,\"\
-          slug\":\"the-flash-2014\",\"tvdb\":279121,\"imdb\":\"tt3107288\",\"tmdb\"\
-          :60735,\"tvrage\":36939},\"overview\":\"After a particle accelerator causes\
-          \ a freak storm, CSI Investigator Barry Allen is struck by lightning and\
-          \ falls into a coma. Months later he awakens with the power of super speed,\
-          \ granting him the ability to move through Central City like an unseen guardian\
-          \ angel. Though initially excited by his newfound powers, Barry is shocked\
-          \ to discover he is not the only \\\"meta-human\\\" who was created in the\
-          \ wake of the accelerator explosion \u2013 and not everyone is using their\
-          \ new powers for good. Barry partners with S.T.A.R. Labs and dedicates his\
-          \ life to protect the innocent. For now, only a few close friends and associates\
-          \ know that Barry is literally the fastest man alive, but it won't be long\
-          \ before the world learns what Barry Allen has become... The Flash.\",\"\
-          first_aired\":\"2014-10-08T00:00:00.000Z\",\"airs\":{\"day\":\"Tuesday\"\
-          ,\"time\":\"20:00\",\"timezone\":\"America/New_York\"},\"runtime\":43,\"\
-          certification\":\"TV-14\",\"network\":\"The CW\",\"country\":\"us\",\"trailer\"\
-          :\"http://youtube.com/watch?v=aZxhA_Jihmw\",\"homepage\":\"http://www.cwtv.com/shows/the-flash/\"\
-          ,\"status\":\"returning series\",\"rating\":8.3235,\"votes\":8844,\"updated_at\"\
-          :\"2016-03-08T10:51:36.000Z\",\"language\":\"en\",\"available_translations\"\
-          :[\"pl\",\"sv\",\"fr\",\"en\",\"zh\",\"da\",\"pt\",\"el\",\"de\",\"es\"\
-          ,\"bg\",\"it\",\"tr\",\"ru\",\"nl\",\"hu\",\"ko\",\"lt\",\"cs\",\"hr\",\"\
-          bs\",\"za\",\"he\",\"id\",\"ro\",\"fa\",\"th\",\"ar\",\"te\",\"uk\"],\"\
-          genres\":[\"action\",\"adventure\",\"drama\",\"science-fiction\"],\"aired_episodes\"\
-          :38}"}
-      headers:
-        cache-control: ['public, max-age=14400']
-        cf-cache-status: [HIT]
-        cf-ray: [280d44b2f66b3d37-CPH]
-        connection: [keep-alive]
-        content-type: [application/json; charset=utf-8]
-        date: ['Wed, 09 Mar 2016 08:48:31 GMT']
-        etag: [W/"7d0ce737896bd5396bce7bb85f7f7091"]
-        expires: ['Wed, 09 Mar 2016 12:48:31 GMT']
-        last-modified: ['Tue, 08 Mar 2016 10:51:36 GMT']
-        server: [cloudflare-nginx]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [860da557-2d99-4d3e-80cb-e4cd9f800a88]
-        x-runtime: ['0.016743']
-        x-xss-protection: [1; mode=block]
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Content-Type: [application/json]
-        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
-        trakt-api-version: [2]
-      method: GET
-      uri: https://api-v2launch.trakt.tv/shows/60300/seasons/1/episodes/10/?extended=full
-    response:
-      body: {string: "{\"season\":1,\"number\":10,\"title\":\"Revenge of the Rogues\"\
-          ,\"ids\":{\"trakt\":999431,\"tvdb\":5052260,\"imdb\":\"tt4016102\",\"tmdb\"\
-          :1018355,\"tvrage\":1065644215},\"number_abs\":null,\"overview\":\"Leonard\
-          \ Snart AKA Captain Cold returns to Central City with a new hotheaded partner\
-          \ in tow \u2013 Mick Rory AKA Heat Wave. The duo plan to steal a multi-million\
-          \ dollar painting, but Cold has another agenda while in town \u2013 to set\
-          \ a trap for The Flash. Snart and Mick kidnap someone close to The Flash\
-          \ and threaten to kill them unless The Flash shows up for a battle of fire\
-          \ and ice. Barry tells Joe he isn\u2019t sure he should take on Snart again\
-          \ after the casualties that happened the last time they fought. Meanwhile,\
-          \ Barry asks Dr. Wells, Caitlin and Cisco to help him double his training\
-          \ efforts so he\u2019s ready for the Reverse Flash when he returns to Central\
-          \ City. Iris deals with the aftermath of Barry\u2019s confession, and Cisco\
-          \ makes the CCPD a new shield.\",\"rating\":7.67683,\"votes\":1541,\"first_aired\"\
-          :\"2015-01-21T01:00:00.000Z\",\"updated_at\":\"2016-03-08T19:22:35.000Z\"\
-          ,\"available_translations\":[]}"}
-      headers:
-        cache-control: ['public, max-age=14400']
-        cf-cache-status: [HIT]
-        cf-ray: [280d44b3d68b3cad-CPH]
-        connection: [keep-alive]
-        content-type: [application/json; charset=utf-8]
-        date: ['Wed, 09 Mar 2016 08:48:31 GMT']
-        expires: ['Wed, 09 Mar 2016 12:48:31 GMT']
-        last-modified: ['Tue, 08 Mar 2016 19:22:35 GMT']
-        server: [cloudflare-nginx]
-        set-cookie: ['__cfduid=de9a06b54fa7028486833dd864d4204241457513311; expires=Thu,
-            09-Mar-17 08:48:31 GMT; path=/; domain=.trakt.tv; HttpOnly']
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [5f26bc30-9449-404c-a298-e63de5910634]
-        x-runtime: ['0.008420']
+        x-request-id: [b776efee-1dc3-4f52-b97e-17e01c56ca9e]
+        x-runtime: ['0.017967']
         x-xss-protection: [1; mode=block]
       status: {code: 200, message: OK}
 version: 1

--- a/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_watched_movie_lookup
+++ b/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_watched_movie_lookup
@@ -8,36 +8,36 @@ interactions:
       method: GET
       uri: https://api-v2launch.trakt.tv/search?query=Inside+Out&type=movie&year=2015
     response:
-      body: {string: '[{"type":"movie","score":51.342567,"movie":{"title":"Inside
-          Out","overview":"Growing up can be a bumpy road, and it''s no exception
-          for Riley, who is uprooted from her Midwest life when her father starts
-          a new job in San Francisco. Like all of us, Riley is guided by her emotions
-          - Joy, Fear, Anger, Disgust and Sadness. The emotions live in Headquarters,
-          the control center inside Riley''s mind, where they help advise her through
-          everyday life. As Riley and her emotions struggle to adjust to a new life
-          in San Francisco, turmoil ensues in Headquarters. Although Joy, Riley''s
-          main and most important emotion, tries to keep things positive, the emotions
-          conflict on how best to navigate a new city, house and school.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/098/998/posters/original/09e0ae33aa.jpg","medium":"https://walter.trakt.us/images/movies/000/098/998/posters/medium/09e0ae33aa.jpg","thumb":"https://walter.trakt.us/images/movies/000/098/998/posters/thumb/09e0ae33aa.jpg"},"fanart":{"full":"https://walter.trakt.us/images/movies/000/098/998/fanarts/original/dd51480cb4.jpg","medium":"https://walter.trakt.us/images/movies/000/098/998/fanarts/medium/dd51480cb4.jpg","thumb":"https://walter.trakt.us/images/movies/000/098/998/fanarts/thumb/dd51480cb4.jpg"}},"ids":{"trakt":98998,"slug":"inside-out-2015","imdb":"tt2096673","tmdb":150540}}},{"type":"movie","score":21.362019,"movie":{"title":"Locked
+      body: {string: '[{"type":"movie","score":51.16567,"movie":{"title":"Inside Out","overview":"Growing
+          up can be a bumpy road, and it''s no exception for Riley, who is uprooted
+          from her Midwest life when her father starts a new job in San Francisco.
+          Like all of us, Riley is guided by her emotions - Joy, Fear, Anger, Disgust
+          and Sadness. The emotions live in Headquarters, the control center inside
+          Riley''s mind, where they help advise her through everyday life. As Riley
+          and her emotions struggle to adjust to a new life in San Francisco, turmoil
+          ensues in Headquarters. Although Joy, Riley''s main and most important emotion,
+          tries to keep things positive, the emotions conflict on how best to navigate
+          a new city, house and school.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/098/998/posters/original/09e0ae33aa.jpg","medium":"https://walter.trakt.us/images/movies/000/098/998/posters/medium/09e0ae33aa.jpg","thumb":"https://walter.trakt.us/images/movies/000/098/998/posters/thumb/09e0ae33aa.jpg"},"fanart":{"full":"https://walter.trakt.us/images/movies/000/098/998/fanarts/original/dd51480cb4.jpg","medium":"https://walter.trakt.us/images/movies/000/098/998/fanarts/medium/dd51480cb4.jpg","thumb":"https://walter.trakt.us/images/movies/000/098/998/fanarts/thumb/dd51480cb4.jpg"}},"ids":{"trakt":98998,"slug":"inside-out-2015","imdb":"tt2096673","tmdb":150540}}},{"type":"movie","score":21.267105,"movie":{"title":"Locked
           Out","overview":"Spoiled rich kid Greg Mardukas gets home from a long day
           to find out that he has been locked out of his own house. Realizing he won''t
           be able to get inside until his father gets home in a few days, Greg must
-          learn to live in the outdoors for the weekend. Will he survive?","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/220/954/posters/original/6a4c4e5bbb.jpg","medium":"https://walter.trakt.us/images/movies/000/220/954/posters/medium/6a4c4e5bbb.jpg","thumb":"https://walter.trakt.us/images/movies/000/220/954/posters/thumb/6a4c4e5bbb.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":220954,"slug":"locked-out-2015","imdb":"","tmdb":340509}}},{"type":"movie","score":0.37074518,"movie":{"title":"Containment","overview":"Neighbours
+          learn to live in the outdoors for the weekend. Will he survive?","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/220/954/posters/original/6a4c4e5bbb.jpg","medium":"https://walter.trakt.us/images/movies/000/220/954/posters/medium/6a4c4e5bbb.jpg","thumb":"https://walter.trakt.us/images/movies/000/220/954/posters/thumb/6a4c4e5bbb.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":220954,"slug":"locked-out-2015","imdb":"","tmdb":340509}}},{"type":"movie","score":0.36805022,"movie":{"title":"Containment","overview":"Neighbours
           in a block wake one morning to find they have been sealed inside their apartments.
           Can they work together to find out why? Or will they destroy each other
-          in their fight to escape?","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/223/348/posters/original/22f821f30c.jpg","medium":"https://walter.trakt.us/images/movies/000/223/348/posters/medium/22f821f30c.jpg","thumb":"https://walter.trakt.us/images/movies/000/223/348/posters/thumb/22f821f30c.jpg"},"fanart":{"full":"https://walter.trakt.us/images/movies/000/223/348/fanarts/original/fce4925aef.jpg","medium":"https://walter.trakt.us/images/movies/000/223/348/fanarts/medium/fce4925aef.jpg","thumb":"https://walter.trakt.us/images/movies/000/223/348/fanarts/thumb/fce4925aef.jpg"}},"ids":{"trakt":223348,"slug":"containment-2015","imdb":"tt3561236","tmdb":347548}}},{"type":"movie","score":0.37074518,"movie":{"title":"Necroland","overview":"In
+          in their fight to escape?","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/223/348/posters/original/22f821f30c.jpg","medium":"https://walter.trakt.us/images/movies/000/223/348/posters/medium/22f821f30c.jpg","thumb":"https://walter.trakt.us/images/movies/000/223/348/posters/thumb/22f821f30c.jpg"},"fanart":{"full":"https://walter.trakt.us/images/movies/000/223/348/fanarts/original/fce4925aef.jpg","medium":"https://walter.trakt.us/images/movies/000/223/348/fanarts/medium/fce4925aef.jpg","thumb":"https://walter.trakt.us/images/movies/000/223/348/fanarts/thumb/fce4925aef.jpg"}},"ids":{"trakt":223348,"slug":"containment-2015","imdb":"tt3561236","tmdb":347548}}},{"type":"movie","score":0.36805022,"movie":{"title":"Necroland","overview":"In
           an instant, 80% of the worlds population has turned into rage humans and
           the weather has gone out of control. Inside all of this chaos, the remaining
-          survivors attempt to unravel the answers to this convoluted mystery.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/155/649/posters/original/b13965b8e3.jpg","medium":"https://walter.trakt.us/images/movies/000/155/649/posters/medium/b13965b8e3.jpg","thumb":"https://walter.trakt.us/images/movies/000/155/649/posters/thumb/b13965b8e3.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":155649,"slug":"necroland-2014","imdb":"tt3518152","tmdb":255561}}},{"type":"movie","score":0.29659617,"movie":{"title":"A
+          survivors attempt to unravel the answers to this convoluted mystery.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/155/649/posters/original/b13965b8e3.jpg","medium":"https://walter.trakt.us/images/movies/000/155/649/posters/medium/b13965b8e3.jpg","thumb":"https://walter.trakt.us/images/movies/000/155/649/posters/thumb/b13965b8e3.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":155649,"slug":"necroland-2014","imdb":"tt3518152","tmdb":255561}}},{"type":"movie","score":0.29444018,"movie":{"title":"A
           Fall from Grace","overview":"Detective Michael Tabb knows the city of St.
           Louis inside and out. He has felt its true heart, as much as its dark underbelly:
           but he does not know who, in both the dark and light - is taking the lives
-          of young girls.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/107/827/posters/original/072c499c6a.jpg","medium":"https://walter.trakt.us/images/movies/000/107/827/posters/medium/072c499c6a.jpg","thumb":"https://walter.trakt.us/images/movies/000/107/827/posters/thumb/072c499c6a.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":107827,"slug":"a-fall-from-grace-1969","imdb":"tt1621415","tmdb":168781}}},{"type":"movie","score":0.29659617,"movie":{"title":"A
+          of young girls.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/107/827/posters/original/072c499c6a.jpg","medium":"https://walter.trakt.us/images/movies/000/107/827/posters/medium/072c499c6a.jpg","thumb":"https://walter.trakt.us/images/movies/000/107/827/posters/thumb/072c499c6a.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":107827,"slug":"a-fall-from-grace-1969","imdb":"tt1621415","tmdb":168781}}},{"type":"movie","score":0.29444018,"movie":{"title":"A
           Girl''s Best Friend","overview":"Penelope, better known as Polka-Dot, is
           a spunky young girl who has a knack for helping people, particularly her
           ailing mother. While out looking for a part-time job, Polka-Dot befriends
           a hard-nosed police officer and his tracking dog, Luey. When Polka-Dot''s
           mother''s condition worsens, Luey helps Polka-Dot find the strength and
-          faith inside to help her move forward.","year":2015,"images":{"poster":{"full":null,"medium":null,"thumb":null},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":207177,"slug":"a-girl-s-best-friend-2015","imdb":"tt4220166","tmdb":326261}}},{"type":"movie","score":0.24081501,"movie":{"title":"Bad
+          faith inside to help her move forward.","year":2015,"images":{"poster":{"full":null,"medium":null,"thumb":null},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":207177,"slug":"a-girl-s-best-friend-2015","imdb":"tt4220166","tmdb":326261}}},{"type":"movie","score":0.23913823,"movie":{"title":"Bad
           Building","overview":"The Desmond - the building''s pleasant sounding name
           hides a troubled past. The high rise has a long history of fires, murders,
           madness and even colonial era genocide upon the site. The towering building
@@ -48,14 +48,14 @@ interactions:
           way in, or out, Craig has contacted a group of urban explorers to help him
           and his film crew enter the building. But when Craig and his team set foot
           inside The Desmond the events that caused the building to be abandoned in
-          the first place begin to repeat.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/224/054/posters/original/7b6c4c9a56.jpg","medium":"https://walter.trakt.us/images/movies/000/224/054/posters/medium/7b6c4c9a56.jpg","thumb":"https://walter.trakt.us/images/movies/000/224/054/posters/thumb/7b6c4c9a56.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":224054,"slug":"bad-building-2015","imdb":"tt2257216","tmdb":350052}}},{"type":"movie","score":0.22244713,"movie":{"title":"The
+          the first place begin to repeat.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/224/054/posters/original/7b6c4c9a56.jpg","medium":"https://walter.trakt.us/images/movies/000/224/054/posters/medium/7b6c4c9a56.jpg","thumb":"https://walter.trakt.us/images/movies/000/224/054/posters/thumb/7b6c4c9a56.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":224054,"slug":"bad-building-2015","imdb":"tt2257216","tmdb":350052}}},{"type":"movie","score":0.22083014,"movie":{"title":"The
           New Family","overview":"The sleepy town of Murdoch is reawakened when young
           women in various stages of pregnancy begin to die at the hands of a brutal
           killer. As Blair Cassidy struggles with an overbearing mother and a less
           than happy father-to-be, she fears that the killer''s focus has shifted
           to her. With her life spiraling out-of-control, Blair must fight for her
           own life and for the baby growing inside her. But the killer has other plans
-          for Blair that are more terrifying than she could have ever imagined.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/200/981/posters/original/5a1f1646d8.jpg","medium":"https://walter.trakt.us/images/movies/000/200/981/posters/medium/5a1f1646d8.jpg","thumb":"https://walter.trakt.us/images/movies/000/200/981/posters/thumb/5a1f1646d8.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":200981,"slug":"the-new-family-2015","imdb":"tt3213960","tmdb":320323}}},{"type":"movie","score":0.18537259,"movie":{"title":"Exeter","overview":"During
+          for Blair that are more terrifying than she could have ever imagined.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/200/981/posters/original/5a1f1646d8.jpg","medium":"https://walter.trakt.us/images/movies/000/200/981/posters/medium/5a1f1646d8.jpg","thumb":"https://walter.trakt.us/images/movies/000/200/981/posters/thumb/5a1f1646d8.jpg"},"fanart":{"full":null,"medium":null,"thumb":null}},"ids":{"trakt":200981,"slug":"the-new-family-2015","imdb":"tt3213960","tmdb":320323}}},{"type":"movie","score":0.18402511,"movie":{"title":"Exeter","overview":"During
           an all-night, drug-fueled party at an abandoned asylum known for the horrific
           treatment of its patients, a group of ordinary teens decide to experiment
           with the occult, mysteriously leading to a violent possession. In an effort
@@ -66,7 +66,7 @@ interactions:
           unbeknownst to them, they unleash an even more powerful and vengeful spirit,
           one with a distinct motive and which wants them all dead. The teen''s only
           chance of survival is to uncover the asylum''s deep mysteries and find a
-          way out before it''s too late.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/138/557/posters/original/4fae1b8167.jpg","medium":"https://walter.trakt.us/images/movies/000/138/557/posters/medium/4fae1b8167.jpg","thumb":"https://walter.trakt.us/images/movies/000/138/557/posters/thumb/4fae1b8167.jpg"},"fanart":{"full":"https://walter.trakt.us/images/movies/000/138/557/fanarts/original/307e3e73e8.jpg","medium":"https://walter.trakt.us/images/movies/000/138/557/fanarts/medium/307e3e73e8.jpg","thumb":"https://walter.trakt.us/images/movies/000/138/557/fanarts/thumb/307e3e73e8.jpg"}},"ids":{"trakt":138557,"slug":"exeter-2015","imdb":"tt1945044","tmdb":226458}}},{"type":"movie","score":0.18537259,"movie":{"title":"Love
+          way out before it''s too late.","year":2015,"images":{"poster":{"full":"https://walter.trakt.us/images/movies/000/138/557/posters/original/4fae1b8167.jpg","medium":"https://walter.trakt.us/images/movies/000/138/557/posters/medium/4fae1b8167.jpg","thumb":"https://walter.trakt.us/images/movies/000/138/557/posters/thumb/4fae1b8167.jpg"},"fanart":{"full":"https://walter.trakt.us/images/movies/000/138/557/fanarts/original/307e3e73e8.jpg","medium":"https://walter.trakt.us/images/movies/000/138/557/fanarts/medium/307e3e73e8.jpg","thumb":"https://walter.trakt.us/images/movies/000/138/557/fanarts/thumb/307e3e73e8.jpg"}},"ids":{"trakt":138557,"slug":"exeter-2015","imdb":"tt1945044","tmdb":226458}}},{"type":"movie","score":0.18402511,"movie":{"title":"Love
           Between the Covers","overview":"Love Between the Covers is a feature-length
           documentary film about the little-known, surprisingly powerful community
           of women who read and write romance novels. Romance fiction is a female-powered
@@ -84,15 +84,15 @@ interactions:
       headers:
         cache-control: ['public, max-age=14400']
         cf-cache-status: [HIT]
-        cf-ray: [280714d65dc53d0d-CPH]
+        cf-ray: [280d450bb2f93cf5-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Tue, 08 Mar 2016 14:47:16 GMT']
-        etag: [W/"c8c1ead69d486869a2185840b940ecd5"]
-        expires: ['Tue, 08 Mar 2016 18:47:16 GMT']
+        date: ['Wed, 09 Mar 2016 08:48:45 GMT']
+        etag: [W/"dc83ca1af7612361873b85dd16eb1236"]
+        expires: ['Wed, 09 Mar 2016 12:48:45 GMT']
         server: [cloudflare-nginx]
-        set-cookie: ['__cfduid=db66e265ca847bb2af8a0dc1869dbf72f1457448436; expires=Wed,
-            08-Mar-17 14:47:16 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        set-cookie: ['__cfduid=d4760bf2f074f75ff32daca8d8026fc4f1457513325; expires=Thu,
+            09-Mar-17 08:48:45 GMT; path=/; domain=.trakt.tv; HttpOnly']
         vary: [Accept-Encoding]
         x-content-type-options: [nosniff]
         x-frame-options: [SAMEORIGIN]
@@ -100,15 +100,15 @@ interactions:
         x-pagination-limit: ['10']
         x-pagination-page: ['1']
         x-pagination-page-count: ['2']
-        x-request-id: [a43d6b32-97ae-4d22-9d08-fa8e993e061f]
-        x-runtime: ['0.028573']
+        x-request-id: [112f5d5d-1782-4cef-ba69-0b82a4269499]
+        x-runtime: ['0.028823']
         x-xss-protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
       body: null
       headers:
         Content-Type: [application/json]
-        Cookie: [__cfduid=db66e265ca847bb2af8a0dc1869dbf72f1457448436]
+        Cookie: [__cfduid=d4760bf2f074f75ff32daca8d8026fc4f1457513325]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: [2]
       method: GET
@@ -128,12 +128,12 @@ interactions:
       headers:
         cache-control: ['public, max-age=14400']
         cf-cache-status: [HIT]
-        cf-ray: [280714d68dc73d0d-CPH]
+        cf-ray: [280d450be2fa3cf5-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Tue, 08 Mar 2016 14:47:16 GMT']
+        date: ['Wed, 09 Mar 2016 08:48:45 GMT']
         etag: [W/"9c830c403f7c6d4687b45ce9126580c6"]
-        expires: ['Tue, 08 Mar 2016 18:47:16 GMT']
+        expires: ['Wed, 09 Mar 2016 12:48:45 GMT']
         last-modified: ['Wed, 02 Mar 2016 08:41:58 GMT']
         server: [cloudflare-nginx]
         vary: [Accept-Encoding]
@@ -156,21 +156,21 @@ interactions:
           Out","year":2015,"ids":{"trakt":98998,"slug":"inside-out-2015","imdb":"tt2096673","tmdb":150540}}}]'}
       headers:
         cache-control: ['max-age=0, private, must-revalidate']
-        cf-ray: [280714d711993ccb-CPH]
+        cf-ray: [280d450c79653cad-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Tue, 08 Mar 2016 14:47:16 GMT']
+        date: ['Wed, 09 Mar 2016 08:48:45 GMT']
         etag: [W/"52ef265bae52b2a23afa10631657d1b1"]
         last-modified: ['Tue, 08 Mar 2016 08:22:57 GMT']
         server: [cloudflare-nginx]
-        set-cookie: ['__cfduid=dbc7d16e684b3d6e7caa197402de2c4201457448436; expires=Wed,
-            08-Mar-17 14:47:16 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        set-cookie: ['__cfduid=d6ee524ae7639493fdbc242bf0674358a1457513325; expires=Thu,
+            09-Mar-17 08:48:45 GMT; path=/; domain=.trakt.tv; HttpOnly']
         vary: [Accept-Encoding]
         x-content-type-options: [nosniff]
         x-frame-options: [SAMEORIGIN]
         x-private-user: ['false']
-        x-request-id: [c86e9473-dd84-4ab3-aab5-b1a68f60526b]
-        x-runtime: ['0.040713']
+        x-request-id: [c890e26d-a0ab-4efc-95d2-e9b74f8bb3cd]
+        x-runtime: ['0.013674']
         x-xss-protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
@@ -182,7 +182,7 @@ interactions:
       method: GET
       uri: https://api-v2launch.trakt.tv/search?query=The+Matrix&type=movie&year=1999
     response:
-      body: {string: "[{\"type\":\"movie\",\"score\":69.14697,\"movie\":{\"title\"\
+      body: {string: "[{\"type\":\"movie\",\"score\":68.78444,\"movie\":{\"title\"\
           :\"The Matrix\",\"overview\":\"Thomas A. Anderson is a man living two lives.\
           \ By day he is an average computer programmer and by night a malevolent\
           \ hacker known as Neo, who finds himself targeted by the police when he\
@@ -195,7 +195,7 @@ interactions:
           ,\"medium\":\"https://walter.trakt.us/images/movies/000/000/481/fanarts/medium/c556867276.jpg\"\
           ,\"thumb\":\"https://walter.trakt.us/images/movies/000/000/481/fanarts/thumb/c556867276.jpg\"\
           }},\"ids\":{\"trakt\":481,\"slug\":\"the-matrix-1999\",\"imdb\":\"tt0133093\"\
-          ,\"tmdb\":603}}},{\"type\":\"movie\",\"score\":55.31758,\"movie\":{\"title\"\
+          ,\"tmdb\":603}}},{\"type\":\"movie\",\"score\":55.02755,\"movie\":{\"title\"\
           :\"Making The Matrix\",\"overview\":\"A promotional making-of documentary\
           \ for the film Matrix, The (1999) that devotes its time to explaining the\
           \ digital and practical effects contained in the film. This is very interesting,\
@@ -207,7 +207,7 @@ interactions:
           ,\"thumb\":\"https://walter.trakt.us/images/movies/000/205/793/posters/thumb/9680ca459a.jpg\"\
           },\"fanart\":{\"full\":null,\"medium\":null,\"thumb\":null}},\"ids\":{\"\
           trakt\":205793,\"slug\":\"making-the-matrix-1999\",\"imdb\":\"tt0365467\"\
-          ,\"tmdb\":325251}}},{\"type\":\"movie\",\"score\":51.308258,\"movie\":{\"\
+          ,\"tmdb\":325251}}},{\"type\":\"movie\",\"score\":51.04809,\"movie\":{\"\
           title\":\"V-World Matrix\",\"overview\":\"Two friends take a cyber vacation\
           \ to experience a world where they can act out their virtual fantasies!\
           \ They soon realize they've entered a virtual free-for-all. Forbidden fantasies\
@@ -220,7 +220,7 @@ interactions:
           ,\"thumb\":\"https://walter.trakt.us/images/movies/000/158/764/posters/thumb/b5bd19302a.jpg\"\
           },\"fanart\":{\"full\":null,\"medium\":null,\"thumb\":null}},\"ids\":{\"\
           trakt\":158764,\"slug\":\"v-world-matrix-1969\",\"imdb\":\"tt0211096\",\"\
-          tmdb\":259464}}},{\"type\":\"movie\",\"score\":4.66576,\"movie\":{\"title\"\
+          tmdb\":259464}}},{\"type\":\"movie\",\"score\":4.6321526,\"movie\":{\"title\"\
           :\"The Tricky Master\",\"overview\":\"Undercover cop Leung Foon (Nick Cheung)\
           \ is having trouble taking down the illegal trading operation headed by\
           \ crime boss Ferrari (Wong Jing). So to accomplish his mission, he asks\
@@ -235,7 +235,7 @@ interactions:
           ,\"medium\":\"https://walter.trakt.us/images/movies/000/037/624/fanarts/medium/de31c092f7.jpg\"\
           ,\"thumb\":\"https://walter.trakt.us/images/movies/000/037/624/fanarts/thumb/de31c092f7.jpg\"\
           }},\"ids\":{\"trakt\":37624,\"slug\":\"the-tricky-master-1999\",\"imdb\"\
-          :\"tt0212864\",\"tmdb\":53281}}},{\"type\":\"movie\",\"score\":0.6681193,\"\
+          :\"tt0212864\",\"tmdb\":53281}}},{\"type\":\"movie\",\"score\":0.66419196,\"\
           movie\":{\"title\":\"Superstar\",\"overview\":\"Inspired by Yves Klein\u2019\
           s Leap into the Void (1960), Superstar was commissioned by Creative Time\
           \ to be presented on the Jumbotron screen in Times Square, New York City.\
@@ -249,15 +249,15 @@ interactions:
       headers:
         cache-control: ['public, max-age=14400']
         cf-cache-status: [HIT]
-        cf-ray: [280714da74c03cdd-CPH]
+        cf-ray: [280d450fa0e63d67-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Tue, 08 Mar 2016 14:47:16 GMT']
-        etag: [W/"dc49b456802091a08d2e99d7c3890272"]
-        expires: ['Tue, 08 Mar 2016 18:47:16 GMT']
+        date: ['Wed, 09 Mar 2016 08:48:46 GMT']
+        etag: [W/"6d633bbfa40b0ef09f1d6eff2ee0dbca"]
+        expires: ['Wed, 09 Mar 2016 12:48:46 GMT']
         server: [cloudflare-nginx]
-        set-cookie: ['__cfduid=d1dbf352c72bc6baae8ad6cfe1981be1f1457448436; expires=Wed,
-            08-Mar-17 14:47:16 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        set-cookie: ['__cfduid=d0f2c9e4ea1dd47b222a225ed6ac7efe01457513326; expires=Thu,
+            09-Mar-17 08:48:46 GMT; path=/; domain=.trakt.tv; HttpOnly']
         vary: [Accept-Encoding]
         x-content-type-options: [nosniff]
         x-frame-options: [SAMEORIGIN]
@@ -265,15 +265,15 @@ interactions:
         x-pagination-limit: ['10']
         x-pagination-page: ['1']
         x-pagination-page-count: ['1']
-        x-request-id: [a4d52927-3c00-406b-99be-5e815b33b9ce]
-        x-runtime: ['0.025000']
+        x-request-id: [0cb21e86-65d6-4c78-a85b-dffe4bed3e7c]
+        x-runtime: ['0.028033']
         x-xss-protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
       body: null
       headers:
         Content-Type: [application/json]
-        Cookie: [__cfduid=d1dbf352c72bc6baae8ad6cfe1981be1f1457448436]
+        Cookie: [__cfduid=d0f2c9e4ea1dd47b222a225ed6ac7efe01457513326]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: [2]
       method: GET
@@ -288,12 +288,12 @@ interactions:
       headers:
         cache-control: ['public, max-age=14400']
         cf-cache-status: [HIT]
-        cf-ray: [280714dab4c23cdd-CPH]
+        cf-ray: [280d450fd0e83d67-CPH]
         connection: [keep-alive]
         content-type: [application/json; charset=utf-8]
-        date: ['Tue, 08 Mar 2016 14:47:16 GMT']
+        date: ['Wed, 09 Mar 2016 08:48:46 GMT']
         etag: [W/"f15c2731d2036940b33b4213ef830d12"]
-        expires: ['Tue, 08 Mar 2016 18:47:16 GMT']
+        expires: ['Wed, 09 Mar 2016 12:48:46 GMT']
         last-modified: ['Tue, 08 Mar 2016 08:41:05 GMT']
         server: [cloudflare-nginx]
         vary: [Accept-Encoding]

--- a/tests/test_trakt.py
+++ b/tests/test_trakt.py
@@ -225,6 +225,28 @@ class TestTraktWatchedAndCollected(object):
               - title: The.Matrix.1999.1080p.BDRip-FlexGet
             if:
               - trakt_collected: accept
+          test_trakt_show_collected_progress:
+            disable: builtins
+            trakt_lookup:
+              username: flexgettest
+            trakt_list:
+              username: flexgettest
+              list: test
+              type: shows
+              strip_dates: yes
+            if:
+              - trakt_collected: accept
+          test_trakt_show_watched_progress:
+            disable: builtins
+            trakt_lookup:
+              username: flexgettest
+            trakt_list:
+              username: flexgettest
+              list: test
+              type: shows
+              strip_dates: yes
+            if:
+              - trakt_watched: accept
     """
 
     def test_trakt_watched_lookup(self, execute_task):
@@ -259,6 +281,20 @@ class TestTraktWatchedAndCollected(object):
         assert entry['title'] == 'Inside.Out.2015.1080p.BDRip-FlexGet', 'title was not accepted?'
         assert entry['movie_name'] == 'Inside Out', 'wrong movie name'
         assert entry['trakt_collected'] == True, 'movie should be marked as collected'
+
+    def test_trakt_show_watched_progress(self, execute_task):
+        task = execute_task('test_trakt_show_watched_progress')
+        assert len(task.accepted) == 1, 'One show should have been accepted as it is watched on Trakt profile'
+        entry = task.accepted[0]
+        assert entry['trakt_series_name'] == 'Chuck', 'wrong series was accepted'
+        assert entry['trakt_watched'] == True, 'the whole series should be marked as watched'
+
+    def test_trakt_show_collected_progress(self, execute_task):
+        task = execute_task('test_trakt_show_collected_progress')
+        assert len(task.accepted) == 1, 'One show should have been accepted as it is collected on Trakt profile'
+        entry = task.accepted[0]
+        assert entry['trakt_series_name'] == 'White Collar', 'wrong series was accepted'
+        assert entry['trakt_collected'] == True, 'the whole series should be marked as collected'
 
 
 @pytest.mark.online


### PR DESCRIPTION
~~OAUTH is required, so it's not as nice as I would have liked it... Alternatively, we could just iterate over the entire collection and _count_ the number of collected episodes and compare it to `aired_episodes`. Speed might be an issue though.~~

It just iterates over the whole collection/watched to get the number of collected/watched episodes. Very simple and it allows people to check the progress for public profiles, so no OAUTH is required.