### PR TITLE
fix API calls missing trailing slash to avoid unnecessary redirections

### DIFF
--- a/flexget/ui/src/plugins/history/history.component.js
+++ b/flexget/ui/src/plugins/history/history.component.js
@@ -12,7 +12,7 @@
     var vm = this;
 
     vm.title = 'History';
-    $http.get('/api/history')
+    $http.get('/api/history/')
       .success(function (data) {
         vm.entries = data['entries'];
       })

--- a/flexget/ui/src/plugins/schedule/schedule.component.js
+++ b/flexget/ui/src/plugins/schedule/schedule.component.js
@@ -34,7 +34,7 @@
       }
     };
 
-    $http.get('/api/schema/config/schedules').
+    $http.get('/api/schema/config/schedules/').
       success(function (data, status, headers, config) {
         // schema-form doesn't allow forms with an array at root level
         vm.schema = {type: 'object', 'properties': {'schedules': data}, required: ['schedules']};
@@ -42,7 +42,7 @@
         error(function (data, status, headers, config) {
           // log error
         });
-        $http.get('/api/schedules').
+        $http.get('/api/schedules/').
           success(function (data, status, headers, config) {
             vm.models = [data];
           }).

--- a/flexget/ui/src/plugins/seen/seen.component.js
+++ b/flexget/ui/src/plugins/seen/seen.component.js
@@ -14,7 +14,7 @@
 
     vm.title = 'Seen';
 
-    $http.get('/api/seen', {params: {max: 20}})
+    $http.get('/api/seen/', {params: {max: 20}})
       .success(function handleSeen(data) {
         vm.entries = data.seen_entries;
       })


### PR DESCRIPTION
I'm hosting flexget ui behind an apache reverse proxy with ssl activated and some api calls don't work. When there's an api call without a trailing slash a redirection is made to an absolute url without ssl, thus cancelling the request