### PR TITLE
Session now retrieved from task.requests, respecting domain_delays an…

### DIFF
--- a/flexget/plugins/search_sceneaccess.py
+++ b/flexget/plugins/search_sceneaccess.py
@@ -235,7 +235,7 @@ class SceneAccessSearch(object):
         session = task.requests
 
         if not 'sceneaccess.eu' in session.domain_limiters:
-            session.add_domain_limiter(TimedLimiter('sceneaccess.eu', '4 seconds'))
+            session.add_domain_limiter(TimedLimiter('sceneaccess.eu', '7 seconds'))
 
         if not session.cookies:
             log.debug('Logging in to %s...' % URL)

--- a/flexget/plugins/search_sceneaccess.py
+++ b/flexget/plugins/search_sceneaccess.py
@@ -15,7 +15,7 @@ from flexget.utils.requests import Session, TimedLimiter
 log = logging.getLogger('search_sceneaccess')
 
 session = None
-#session = Session()
+
 CATEGORIES = {
     'browse':
         {
@@ -153,8 +153,7 @@ class SceneAccessSearch(object):
         root.accept('number', key='gravity_multiplier')
 
         # Scope as in pages like `browse`, `mp3/0day`, `foreign`, etc.
-        # Will only accept categories from `browse` which will it default to,
-        # unless user specifies other scopes
+        # Will only accept categories from `browse` which will it default to, unless user specifies other scopes
         # via dict
         root.accept('choice', key='category').accept_choices(CATEGORIES['browse'])
         root.accept('number', key='category')
@@ -199,8 +198,7 @@ class SceneAccessSearch(object):
                     elif not isinstance(category[scope], list):     # or convert single category into list
                         category[scope] = [category[scope]]
                     toProcess[scope] = category[scope]
-            else:                       # Will default to `browse` scope, because no scope was
-                                        # specified (only category)
+            else:                       # Will default to `browse` scope, because no scope was specified (only category)
                 category = [category]
                 toProcess[scope] = category
         except KeyError:    # Category was not set, will default to all categories within `browse`

--- a/flexget/plugins/search_sceneaccess.py
+++ b/flexget/plugins/search_sceneaccess.py
@@ -201,8 +201,7 @@ class SceneAccessSearch(object):
             else:                       # Will default to `browse` scope, because no scope was specified (only category)
                 category = [category]
                 toProcess[scope] = category
-        except KeyError:    # Category was not set, will default to all categories within `browse`
-                            # scope.
+        except KeyError:    # Category was not set, will default to all categories within `browse` scope.
             toProcess[scope] = []
 
         finally:    # Process the categories to use in search() method

--- a/flexget/plugins/search_sceneaccess.py
+++ b/flexget/plugins/search_sceneaccess.py
@@ -10,11 +10,9 @@ from flexget.entry import Entry
 from flexget.event import event
 from flexget.utils.soup import get_soup
 from flexget.utils.search import torrent_availability, normalize_unicode, clean_title
-from flexget.utils.requests import Session, TimedLimiter
+from flexget.utils.requests import TimedLimiter
 
 log = logging.getLogger('search_sceneaccess')
-
-session = None
 
 CATEGORIES = {
     'browse':

--- a/flexget/plugins/search_sceneaccess.py
+++ b/flexget/plugins/search_sceneaccess.py
@@ -10,11 +10,12 @@ from flexget.entry import Entry
 from flexget.event import event
 from flexget.utils.soup import get_soup
 from flexget.utils.search import torrent_availability, normalize_unicode, clean_title
-from flexget.utils.requests import Session
+from flexget.utils.requests import Session, TimedLimiter
 
 log = logging.getLogger('search_sceneaccess')
 
-session = Session()
+session = None
+#session = Session()
 
 CATEGORIES = {
     'browse':
@@ -233,6 +234,14 @@ class SceneAccessSearch(object):
         """
             Search for entries on SceneAccess
         """
+
+        try:
+            session = task.requests
+        except:
+            session = Session()
+
+        if not 'sceneaccess.eu' in session.domain_limiters:
+            session.add_domain_limiter(TimedLimiter('sceneaccess.eu', '4 seconds'))
 
         if not session.cookies:
             log.debug('Logging in to %s...' % URL)

--- a/flexget/plugins/search_sceneaccess.py
+++ b/flexget/plugins/search_sceneaccess.py
@@ -16,7 +16,6 @@ log = logging.getLogger('search_sceneaccess')
 
 session = None
 #session = Session()
-
 CATEGORIES = {
     'browse':
         {
@@ -154,7 +153,8 @@ class SceneAccessSearch(object):
         root.accept('number', key='gravity_multiplier')
 
         # Scope as in pages like `browse`, `mp3/0day`, `foreign`, etc.
-        # Will only accept categories from `browse` which will it default to, unless user specifies other scopes
+        # Will only accept categories from `browse` which will it default to,
+        # unless user specifies other scopes
         # via dict
         root.accept('choice', key='category').accept_choices(CATEGORIES['browse'])
         root.accept('number', key='category')
@@ -199,10 +199,12 @@ class SceneAccessSearch(object):
                     elif not isinstance(category[scope], list):     # or convert single category into list
                         category[scope] = [category[scope]]
                     toProcess[scope] = category[scope]
-            else:                       # Will default to `browse` scope, because no scope was specified (only category)
+            else:                       # Will default to `browse` scope, because no scope was
+                                        # specified (only category)
                 category = [category]
                 toProcess[scope] = category
-        except KeyError:    # Category was not set, will default to all categories within `browse` scope.
+        except KeyError:    # Category was not set, will default to all categories within `browse`
+                            # scope.
             toProcess[scope] = []
 
         finally:    # Process the categories to use in search() method
@@ -235,10 +237,7 @@ class SceneAccessSearch(object):
             Search for entries on SceneAccess
         """
 
-        try:
-            session = task.requests
-        except:
-            session = Session()
+        session = task.requests
 
         if not 'sceneaccess.eu' in session.domain_limiters:
             session.add_domain_limiter(TimedLimiter('sceneaccess.eu', '4 seconds'))

--- a/flexget/plugins/search_sceneaccess.py
+++ b/flexget/plugins/search_sceneaccess.py
@@ -234,7 +234,7 @@ class SceneAccessSearch(object):
 
         session = task.requests
 
-        if not 'sceneaccess.eu' in session.domain_limiters:
+        if 'sceneaccess.eu' not in session.domain_limiters:
             session.add_domain_limiter(TimedLimiter('sceneaccess.eu', '7 seconds'))
 
         if not session.cookies:


### PR DESCRIPTION
…d other task config items. Also added default domain delay of 4 seconds due to increased spam filters by SCC

Planning to do this for most search plugins, at least to use the task.requests session.
This is a needed fix in order to use SCC currently.