### PR TITLE
Change the meaning of forget to fire `forget` event globally

### DIFF
--- a/flexget/plugins/api/series.py
+++ b/flexget/plugins/api/series.py
@@ -465,7 +465,7 @@ class SeriesGetShowsAPI(APIResource):
 
 delete_parser = api.parser()
 delete_parser.add_argument('forget', type=inputs.boolean, default=False,
-                           help="Enabling this will for 'forget' event that will delete the downloaded releases "
+                           help="Enabling this will fire a 'forget' event that will delete the downloaded releases "
                                 "from the entire DB, enabling to re-download them")
 
 

--- a/flexget/plugins/api/series.py
+++ b/flexget/plugins/api/series.py
@@ -497,7 +497,7 @@ class SeriesShowAPI(APIResource):
         name = show.name
 
         try:
-            series.forget_series(name)
+            series.remove_series(name)
         except ValueError as e:
             return {'status': 'error',
                     'message': e.args[0]

--- a/flexget/plugins/api/series.py
+++ b/flexget/plugins/api/series.py
@@ -318,8 +318,8 @@ series_list_parser.add_argument('order', choices=('desc', 'asc'), default='desc'
 series_list_parser.add_argument('lookup', choices=('tvdb', 'tvmaze'), action='append',
                                 help="Get lookup result for every show by sending another request to lookup API")
 
-
 ep_identifier_doc = "'episode_identifier' should be one of SxxExx, integer or date formatted such as 2012-12-12"
+
 
 @series_api.route('/')
 class SeriesListAPI(APIResource):
@@ -463,6 +463,12 @@ class SeriesGetShowsAPI(APIResource):
         })
 
 
+delete_parser = api.parser()
+delete_parser.add_argument('forget', type=inputs.boolean, default=False,
+                           help="Enabling this will for 'forget' event that will delete the downloaded releases "
+                                "from the entire DB, enabling to re-download them")
+
+
 @series_api.route('/<int:show_id>')
 @api.doc(params={'show_id': 'ID of the show'})
 class SeriesShowAPI(APIResource):
@@ -484,7 +490,8 @@ class SeriesShowAPI(APIResource):
 
     @api.response(200, 'Removed series from DB', empty_response)
     @api.response(404, 'Show ID not found', default_error_schema)
-    @api.doc(description='Delete a specific show using its ID')
+    @api.doc(description='Delete a specific show using its ID',
+             parser=delete_parser)
     def delete(self, show_id, session):
         """ Remove series from DB """
         try:
@@ -495,9 +502,9 @@ class SeriesShowAPI(APIResource):
                     }, 404
 
         name = show.name
-
+        args = delete_parser.parse_args()
         try:
-            series.remove_series(name)
+            series.remove_series(name, forget=args.get('forget'))
         except ValueError as e:
             return {'status': 'error',
                     'message': e.args[0]
@@ -605,30 +612,25 @@ class SeriesEpisodesAPI(APIResource):
 
     @api.response(500, 'Error when trying to forget episode', default_error_schema)
     @api.response(200, 'Successfully forgotten all episodes from show', empty_response)
-    @api.doc(description='Delete all show episodes via its ID. Deleting an episode will mark it as wanted again')
+    @api.doc(description='Delete all show episodes via its ID. Deleting an episode will mark it as wanted again',
+             parser=delete_parser)
     def delete(self, show_id, session):
-        """ Forgets all episodes of a show"""
+        """ Deletes all episodes of a show"""
         try:
             show = series.show_by_id(show_id, session=session)
         except NoResultFound:
             return {'status': 'error',
                     'message': 'Show with ID %s not found' % show_id
                     }, 404
-
-        for episode in show.episodes:
-            try:
-                series.forget_episodes_by_id(show.id, episode.id)
-            except ValueError as e:
-                return {'status': 'error',
-                        'message': e.args[0]
-                        }, 500
+        name = show.name
+        args = delete_parser.parse_args()
+        try:
+            series.remove_series(name, forget=args.get('forget'))
+        except ValueError as e:
+            return {'status': 'error',
+                    'message': e.args[0]
+                    }, 404
         return {}
-
-
-delete_parser = api.parser()
-delete_parser.add_argument('delete_seen', type=inputs.boolean, default=False,
-                           help="Enabling this will delete all the related releases from seen entries list as well, "
-                                "enabling to re-download them")
 
 
 @api.response(404, 'Show ID not found', default_error_schema)
@@ -685,11 +687,12 @@ class SeriesEpisodeAPI(APIResource):
                     'message': 'Episode with id %s does not belong to show %s' % (ep_id, show_id)}, 400
 
         args = delete_parser.parse_args()
-        if args.get('delete_seen'):
-            for release in episode.releases:
-                fire_event('forget', release.title)
-
-        series.forget_episodes_by_id(show_id, ep_id)
+        try:
+            series.remove_series_episode(show.name, episode.identifier, args.get('forget'))
+        except ValueError as e:
+            return {'status': 'error',
+                    'message': e.args[0]
+                    }, 404
         return {}
 
 
@@ -697,9 +700,9 @@ release_list_parser = api.parser()
 release_list_parser.add_argument('downloaded', type=inputs.boolean, help='Filter between release status')
 
 release_delete_parser = release_list_parser.copy()
-release_delete_parser.add_argument('delete_seen', type=inputs.boolean, default=False,
-                                   help="Enabling this will delete all the related releases from seen entries list as well, "
-                                        "enabling to re-download them")
+release_delete_parser.add_argument('forget', type=inputs.boolean, default=False,
+                                   help="Enabling this will for 'forget' event that will delete the downloaded"
+                                        " releases from the entire DB, enabling to re-download them")
 
 
 @api.response(404, 'Show ID not found', default_error_schema)

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -22,10 +22,10 @@ def do_cli(manager, options):
         display_summary(options)
     elif options.series_action == 'show':
         display_details(options.series_name)
-    elif options.series_action == 'delete':
-        forget(manager, options)
+    elif options.series_action == 'remove':
+        remove(manager, options)
     elif options.series_action == 'forget':
-        forget(manager, options, forget=True)
+        remove(manager, options, forget=True)
     elif options.series_action == 'begin':
         begin(manager, options)
 
@@ -121,7 +121,7 @@ def begin(manager, options):
         manager.config_changed()
 
 
-def forget(manager, options, forget=False):
+def remove(manager, options, forget=False):
     name = options.series_name
 
     if options.episode_id:

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -25,7 +25,7 @@ def do_cli(manager, options):
     elif options.series_action == 'delete':
         forget(manager, options)
     elif options.series_action == 'forget':
-        forget(manager, options, remove_from_seen=True)
+        forget(manager, options, global_forget=True)
     elif options.series_action == 'begin':
         begin(manager, options)
 
@@ -121,35 +121,30 @@ def begin(manager, options):
         manager.config_changed()
 
 
-def forget(manager, options, remove_from_seen=False):
+def forget(manager, options, global_forget=False):
     name = options.series_name
 
     if options.episode_id:
         # remove by id
         identifier = options.episode_id
         try:
-            forget_series_episode(name, identifier)
+            forget_series_episode(name, identifier, global_forget)
             console('Removed episode `%s` from series `%s`.' % (identifier, name.capitalize()))
         except ValueError:
             # Try upper casing identifier if we fail at first
             try:
-                forget_series_episode(name, identifier.upper())
+                forget_series_episode(name, identifier.upper(), global_forget)
                 console('Removed episode `%s` from series `%s`.' % (identifier, name.capitalize()))
             except ValueError as e:
                 console(e.message)
-        finally:
-            if remove_from_seen:
-                fire_event('forget', name + identifier)
+
     else:
         # remove whole series
         try:
-            forget_series(name)
+            forget_series(name, global_forget)
             console('Removed series `%s` from database.' % name.capitalize())
         except ValueError as e:
             console(e.message)
-        finally:
-            if remove_from_seen:
-                fire_event('forget', name)
 
     manager.config_changed()
 

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -4,7 +4,7 @@ import argparse
 from datetime import datetime, timedelta
 
 from flexget import options, plugin
-from flexget.event import event, fire_event
+from flexget.event import event
 from flexget.logger import console
 from flexget.manager import Session
 

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -22,7 +22,7 @@ def do_cli(manager, options):
         display_summary(options)
     elif options.series_action == 'show':
         display_details(options.series_name)
-    elif options.series_action == 'del':
+    elif options.series_action == 'delete':
         forget(manager, options)
     elif options.series_action == 'forget':
         forget(manager, options, remove_from_seen=True)

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -9,7 +9,7 @@ from flexget.logger import console
 from flexget.manager import Session
 
 try:
-    from flexget.plugins.filter.series import (Series, forget_series, forget_series_episode, set_series_begin,
+    from flexget.plugins.filter.series import (Series, remove_series, remove_series_episode, set_series_begin,
                                                normalize_series_name, new_eps_after, get_latest_release,
                                                get_series_summary, shows_by_name, show_episodes, shows_by_exact_name)
 except ImportError:
@@ -25,7 +25,7 @@ def do_cli(manager, options):
     elif options.series_action == 'delete':
         forget(manager, options)
     elif options.series_action == 'forget':
-        forget(manager, options, global_forget=True)
+        forget(manager, options, forget=True)
     elif options.series_action == 'begin':
         begin(manager, options)
 
@@ -121,30 +121,30 @@ def begin(manager, options):
         manager.config_changed()
 
 
-def forget(manager, options, global_forget=False):
+def forget(manager, options, forget=False):
     name = options.series_name
 
     if options.episode_id:
         # remove by id
         identifier = options.episode_id
         try:
-            forget_series_episode(name, identifier, global_forget)
+            remove_series_episode(name, identifier, forget)
             console('Removed episode `%s` from series `%s`.' % (identifier, name.capitalize()))
         except ValueError:
             # Try upper casing identifier if we fail at first
             try:
-                forget_series_episode(name, identifier.upper(), global_forget)
+                remove_series_episode(name, identifier.upper(), forget)
                 console('Removed episode `%s` from series `%s`.' % (identifier, name.capitalize()))
             except ValueError as e:
-                console(e.message)
+                console(e.args[0])
 
     else:
         # remove whole series
         try:
-            forget_series(name, global_forget)
+            remove_series(name, forget)
             console('Removed series `%s` from database.' % name.capitalize())
         except ValueError as e:
-            console(e.message)
+            console(e.args[0])
 
     manager.config_changed()
 
@@ -260,6 +260,6 @@ def register_parser_arguments():
                                           help='removes episodes or whole series from the entire database '
                                                '(including seen plugin)')
     forget_parser.add_argument('episode_id', nargs='?', default=None, help='episode ID to forget (optional)')
-    delete_parser = subparsers.add_parser('delete', parents=[series_parser],
+    delete_parser = subparsers.add_parser('remove', parents=[series_parser],
                                           help='removes episodes or whole series from the series database only')
     delete_parser.add_argument('episode_id', nargs='?', default=None, help='episode ID to forget (optional)')

--- a/flexget/plugins/filter/seen.py
+++ b/flexget/plugins/filter/seen.py
@@ -133,20 +133,20 @@ def forget(value):
     :return: count, field_count where count is number of entries removed and field_count number of fields
     """
     with Session() as session:
-        log.debug('forget called with %s' % value)
+        log.debug('forget called with %s', value)
         count = 0
         field_count = 0
         for se in session.query(SeenEntry).filter(or_(SeenEntry.title == value, SeenEntry.task == value)).all():
             field_count += len(se.fields)
             count += 1
-            log.debug('forgetting %s' % se)
+            log.debug('forgetting %s', se)
             session.delete(se)
 
         for sf in session.query(SeenField).filter(SeenField.value == value).all():
             se = session.query(SeenEntry).filter(SeenEntry.id == sf.seen_entry_id).first()
             field_count += len(se.fields)
             count += 1
-            log.debug('forgetting %s' % se)
+            log.debug('forgetting %s', se)
             session.delete(se)
     return count, field_count
 
@@ -338,7 +338,8 @@ def add(title, task_name, fields, reason=None, local=None, session=None):
 
 
 @with_session
-def search(value=None, status=None, start=None, stop=None, count=False, order_by='added', descending=False, session=None):
+def search(value=None, status=None, start=None, stop=None, count=False, order_by='added', descending=False,
+           session=None):
     query = session.query(SeenEntry)
     if descending:
         query = query.order_by(getattr(SeenEntry, order_by).desc())

--- a/flexget/plugins/filter/seen.py
+++ b/flexget/plugins/filter/seen.py
@@ -126,28 +126,28 @@ class SeenField(Base):
 
 
 @event('forget')
-@with_session
-def forget(value, session=None):
+def forget(value):
     """
     See module docstring
     :param string value: Can be task name, entry title or field value
     :return: count, field_count where count is number of entries removed and field_count number of fields
     """
-    log.debug('forget called with %s' % value)
-    count = 0
-    field_count = 0
-    for se in session.query(SeenEntry).filter(or_(SeenEntry.title == value, SeenEntry.task == value)).all():
-        field_count += len(se.fields)
-        count += 1
-        log.debug('forgetting %s' % se)
-        session.delete(se)
+    with Session() as session:
+        log.debug('forget called with %s' % value)
+        count = 0
+        field_count = 0
+        for se in session.query(SeenEntry).filter(or_(SeenEntry.title == value, SeenEntry.task == value)).all():
+            field_count += len(se.fields)
+            count += 1
+            log.debug('forgetting %s' % se)
+            session.delete(se)
 
-    for sf in session.query(SeenField).filter(SeenField.value == value).all():
-        se = session.query(SeenEntry).filter(SeenEntry.id == sf.seen_entry_id).first()
-        field_count += len(se.fields)
-        count += 1
-        log.debug('forgetting %s' % se)
-        session.delete(se)
+        for sf in session.query(SeenField).filter(SeenField.value == value).all():
+            se = session.query(SeenEntry).filter(SeenEntry.id == sf.seen_entry_id).first()
+            field_count += len(se.fields)
+            count += 1
+            log.debug('forgetting %s' % se)
+            session.delete(se)
     return count, field_count
 
 

--- a/flexget/plugins/filter/seen.py
+++ b/flexget/plugins/filter/seen.py
@@ -126,29 +126,29 @@ class SeenField(Base):
 
 
 @event('forget')
-def forget(value):
+@with_session
+def forget(value, session=None):
     """
     See module docstring
     :param string value: Can be task name, entry title or field value
     :return: count, field_count where count is number of entries removed and field_count number of fields
     """
     log.debug('forget called with %s' % value)
-    with Session() as session:
-        count = 0
-        field_count = 0
-        for se in session.query(SeenEntry).filter(or_(SeenEntry.title == value, SeenEntry.task == value)).all():
-            field_count += len(se.fields)
-            count += 1
-            log.debug('forgetting %s' % se)
-            session.delete(se)
+    count = 0
+    field_count = 0
+    for se in session.query(SeenEntry).filter(or_(SeenEntry.title == value, SeenEntry.task == value)).all():
+        field_count += len(se.fields)
+        count += 1
+        log.debug('forgetting %s' % se)
+        session.delete(se)
 
-        for sf in session.query(SeenField).filter(SeenField.value == value).all():
-            se = session.query(SeenEntry).filter(SeenEntry.id == sf.seen_entry_id).first()
-            field_count += len(se.fields)
-            count += 1
-            log.debug('forgetting %s' % se)
-            session.delete(se)
-        return count, field_count
+    for sf in session.query(SeenField).filter(SeenField.value == value).all():
+        se = session.query(SeenEntry).filter(SeenEntry.id == sf.seen_entry_id).first()
+        field_count += len(se.fields)
+        count += 1
+        log.debug('forgetting %s' % se)
+        session.delete(se)
+    return count, field_count
 
 
 @with_session

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -754,24 +754,6 @@ def remove_series_episode(name, identifier, forget=False, session=None):
         raise ValueError('Unknown series %s' % name)
 
 
-def forget_episodes_by_id(series_id, episode_id):
-    """ Removes a specific episode using `series_id` and `episode_id`."""
-    with Session() as session:
-        series = session.query(Series).filter(Series.id == series_id).first()
-        if series:
-            episode = session.query(Episode).filter(Episode.id == episode_id).first()
-            if episode:
-                if not series.begin:
-                    series.identified_by = ''  # reset identified_by flag so that it will be recalculated
-                session.delete(episode)
-                session.commit()
-                log.debug('Episode %s from series %s removed from database.', episode_id, series_id)
-            else:
-                raise ValueError('Unknown identifier %s for series %s' % (episode_id, series_id))
-        else:
-            raise ValueError('Unknown series %s' % series_id)
-
-
 def delete_release_by_id(release_id):
     with Session() as session:
         release = session.query(Release).filter(Release.id == release_id).first()

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -747,7 +747,6 @@ def remove_series_episode(name, identifier, forget=False, session=None):
                 for release in episode.downloaded_releases:
                     fire_event('forget', release.title)
             session.delete(episode)
-            session.commit()
             log.debug('Episode %s from series %s removed from database.', identifier, name)
         else:
             raise ValueError('Unknown identifier %s for series %s' % (identifier, name.capitalize()))

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -732,26 +732,23 @@ def forget_series(name):
         session.close()
 
 
-def forget_series_episode(name, identifier):
+@with_session
+def forget_series_episode(name, identifier, session=None):
     """Remove all episodes by `identifier` from series `name` from database."""
-    session = Session()
-    try:
-        series = session.query(Series).filter(Series.name == name).first()
-        if series:
-            episode = session.query(Episode).filter(Episode.identifier == identifier). \
-                filter(Episode.series_id == series.id).first()
-            if episode:
-                if not series.begin:
-                    series.identified_by = ''  # reset identified_by flag so that it will be recalculated
-                session.delete(episode)
-                session.commit()
-                log.debug('Episode %s from series %s removed from database.', identifier, name)
-            else:
-                raise ValueError('Unknown identifier %s for series %s' % (identifier, name.capitalize()))
+    series = session.query(Series).filter(Series.name == name).first()
+    if series:
+        episode = session.query(Episode).filter(Episode.identifier == identifier). \
+            filter(Episode.series_id == series.id).first()
+        if episode:
+            if not series.begin:
+                series.identified_by = ''  # reset identified_by flag so that it will be recalculated
+            session.delete(episode)
+            session.commit()
+            log.debug('Episode %s from series %s removed from database.', identifier, name)
         else:
-            raise ValueError('Unknown series %s' % name)
-    finally:
-        session.close()
+            raise ValueError('Unknown identifier %s for series %s' % (identifier, name.capitalize()))
+    else:
+        raise ValueError('Unknown series %s' % name)
 
 
 def forget_episodes_by_id(series_id, episode_id):

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -717,13 +717,13 @@ def set_series_begin(series, ep_id):
 
 
 @with_session
-def forget_series(name, session=None, global_forget=False):
+def remove_series(name, forget=False, session=None):
     """Remove a whole series `name` from database."""
     series = session.query(Series).filter(Series.name == name).all()
     if series:
         for s in series:
-            if global_forget:
-                for episode in series.episodes:
+            if forget:
+                for episode in s.episodes:
                     for release in episode.downloaded_releases:
                         fire_event('forget', release.title)
             session.delete(s)
@@ -734,7 +734,7 @@ def forget_series(name, session=None, global_forget=False):
 
 
 @with_session
-def forget_series_episode(name, identifier, session=None, global_forget=False):
+def remove_series_episode(name, identifier, forget=False, session=None):
     """Remove all episodes by `identifier` from series `name` from database."""
     series = session.query(Series).filter(Series.name == name).first()
     if series:
@@ -743,7 +743,7 @@ def forget_series_episode(name, identifier, session=None, global_forget=False):
         if episode:
             if not series.begin:
                 series.identified_by = ''  # reset identified_by flag so that it will be recalculated
-            if global_forget:
+            if forget:
                 for release in episode.downloaded_releases:
                     fire_event('forget', release.title)
             session.delete(episode)

--- a/flexget/plugins/output/series_forget.py
+++ b/flexget/plugins/output/series_forget.py
@@ -6,7 +6,7 @@ from flexget import plugin
 from flexget.event import event
 
 try:
-    from flexget.plugins.filter.series import forget_series_episode
+    from flexget.plugins.filter.series import remove_series_episode
 except ImportError:
     raise plugin.DependencyError(issued_by='series_forget', missing='series',
                                  message='series_forget plugin need series plugin to work')
@@ -23,7 +23,7 @@ class OutputSeriesForget(object):
         for entry in task.accepted:
             if 'series_name' in entry and 'series_id' in entry:
                 try:
-                    forget_series_episode(entry['series_name'], entry['series_id'])
+                    remove_series_episode(entry['series_name'], entry['series_id'])
                     log.info('Removed episode `%s` from series `%s` download history.' %
                              (entry['series_id'], entry['series_name']))
                 except ValueError:

--- a/flexget/plugins/output/series_forget.py
+++ b/flexget/plugins/output/series_forget.py
@@ -8,13 +8,13 @@ from flexget.event import event
 try:
     from flexget.plugins.filter.series import remove_series_episode
 except ImportError:
-    raise plugin.DependencyError(issued_by='series_forget', missing='series',
+    raise plugin.DependencyError(issued_by='series_remove', missing='series',
                                  message='series_forget plugin need series plugin to work')
 
 log = logging.getLogger('series_forget')
 
 
-class OutputSeriesForget(object):
+class OutputSeriesRemove(object):
     schema = {'type': 'boolean'}
 
     def on_task_output(self, task, config):
@@ -32,4 +32,4 @@ class OutputSeriesForget(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(OutputSeriesForget, 'series_forget', api_ver=2)
+    plugin.register(OutputSeriesRemove, 'series_remove', api_ver=2)

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -2008,7 +2008,7 @@ class TestCLI(object):
         assert all(any(line.lstrip().startswith(series) for line in lines) for series in ['Some Show', 'Other Show'])
 
 
-class TestSeriesForget(object):
+class TestSeriesRemove(object):
     config = """
         templates:
           global:
@@ -2022,23 +2022,23 @@ class TestSeriesForget(object):
             mock:
             - title: My Show S01E01 1080p
             - title: My Show S01E01 720p
-          forget_episode:
+          remove_episode:
             seen: no
             mock:
             - title: My Show S01E01
               series_name: My Show
               series_id: S01E01
             accept_all: yes
-            series_forget: yes
+            series_remove: yes
     """
 
-    def test_forget_episode(self, execute_task):
+    def test_remove_episode(self, execute_task):
         task = execute_task('get_episode')
         assert len(task.accepted) == 1
         first_rls = task.accepted[0]
         task = execute_task('get_episode')
         assert not task.accepted, 'series plugin duplicate blocking not working?'
-        task = execute_task('forget_episode')
+        task = execute_task('remove_episode')
         task = execute_task('get_episode')
         assert len(task.accepted) == 1, 'new release not accepted after forgetting ep'
         assert task.accepted[0] != first_rls, 'same release accepted on second run'

--- a/tests/test_series_api.py
+++ b/tests/test_series_api.py
@@ -33,12 +33,12 @@ class TestSeriesAPI(object):
 
         # Changed params
         rsp = api_client.get('/series/?status=new&max=10&days=4&sort_by=last_download_date&in_config=all'
-                       '&premieres=true&order=asc&page=2')
+                             '&premieres=true&order=asc&page=2')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
         # Negative test, invalid parameter
         rsp = api_client.get('/series/?status=bla&max=10&days=4&sort_by=last_download_date&in_config=all'
-                       '&premieres=true&order=asc&page=2')
+                             '&premieres=true&order=asc&page=2')
         assert rsp.status_code == 400, 'Response code is %s' % rsp.status_code
         assert mock_series_list.call_count == 6, 'Should have 3 calls, is actually %s' % mock_series_list.call_count
 
@@ -143,22 +143,19 @@ class TestSeriesAPI(object):
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
         assert mock_show_by_id.called
 
-    @patch.object(series, 'forget_episodes_by_id')
-    @patch.object(series, 'show_by_id')
-    def test_series_delete_episodes(self, mock_show_by_id, mock_forget_episodes_by_id, api_client):
-        show = series.Series()
-        episode = series.Episode()
-        release = series.Release()
-        release.downloaded = True
-        episode.releases.append(release)
-        show.episodes.append(episode)
+    def test_series_delete_episodes(self, api_client):
+        show = 'Test Show'
+        new_show = {
+            "series_name": show,
+            "episode_identifier": "s01e01",
+            "alternate_names": ['show1', 'show2']
+        }
 
-        mock_show_by_id.return_value = show
+        rsp = api_client.json_post(('/series/'), data=json.dumps(new_show))
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
         rsp = api_client.delete('/series/1/episodes')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
-        assert mock_show_by_id.called
-        assert mock_forget_episodes_by_id.called
 
     @patch.object(series, 'episode_in_show')
     @patch.object(series, 'episode_by_id')
@@ -176,12 +173,12 @@ class TestSeriesAPI(object):
         assert mock_episode_by_id.called
         assert mock_episode_in_show.called
 
-    @patch.object(series, 'forget_episodes_by_id')
+    @patch.object(series, 'remove_series_episode')
     @patch.object(series, 'episode_in_show')
     @patch.object(series, 'episode_by_id')
     @patch.object(series, 'show_by_id')
     def test_series_delete_episode(self, mock_show_by_id, mock_episode_by_id, mock_episode_in_show,
-                                   mock_forget_episodes_by_id, api_client):
+                                   mock_remove_series_episode, api_client):
         show = series.Series()
         episode = series.Episode()
 
@@ -193,7 +190,7 @@ class TestSeriesAPI(object):
         assert mock_show_by_id.called
         assert mock_episode_by_id.called
         assert mock_episode_in_show.called
-        assert mock_forget_episodes_by_id.called
+        assert mock_remove_series_episode.called
 
     @patch.object(series, 'episode_in_show')
     @patch.object(series, 'episode_by_id')

--- a/tests/test_series_api.py
+++ b/tests/test_series_api.py
@@ -83,7 +83,7 @@ class TestSeriesAPI(object):
         assert mock_new_eps_after.called
         assert mock_show_by_id.called
 
-    @patch.object(series, 'forget_series')
+    @patch.object(series, 'remove_series')
     @patch.object(series, 'show_by_id')
     def test_series_delete(self, mock_show_by_id, mock_forget_series, api_client):
         show = series.Series()


### PR DESCRIPTION
This will change the meaning of forget globally to mean that a `forget` event has been fired. It is currently being hooked only be `seen` plugin here:

## Changes:
- **Series CLI** - Changed `forget` action to implement new meaning, added `remove` command to do the same but without firing event.
- **Series API** - Changed `delete_seen` flag to `forget` in relevant place, added it to DELETE `/series/` method
- **`series_forget`** plugin changed to `series_remove`. Forget functionality was not added to it.

This will remove the requirement to manually delete from seen plugin as well, as that plugin hooks the forget event.

## Upgrade actions:
- `series_forget` renames to `series_remove`
- Changed the meaning of CLI `series forget ...`, replaced that with `series remove ...`