### PR TITLE
Change qBittorrent plugin to use multipart request for adding torrents

### DIFF
--- a/flexget/plugins/output/qbittorrent.py
+++ b/flexget/plugins/output/qbittorrent.py
@@ -61,7 +61,8 @@ class OutputQBitTorrent(object):
     def add_torrent(self, data):
         if not self.connected:
             raise plugin.PluginError('Not connected.')
-        self.session.post(self.url + '/command/download', data=data)
+        multipart_data = {k: (None, v) for k, v in data.items()}
+        self.session.post(self.url + '/command/download', files=multipart_data)
         log.debug('Added task to qBittorrent')
 
     def prepare_config(self, config):
@@ -96,7 +97,7 @@ class OutputQBitTorrent(object):
             data = {}
             data['savepath'] = entry.get('path', config.get('path'))
             data['label'] = entry.get('label', config['label']).lower()
-            data['urls'] = [entry.get('url')]
+            data['urls'] = entry.get('url')
             if task.manager.options.test:
                 log.info('Test mode.')
                 log.info('Would add torrent to qBittorrent with:')


### PR DESCRIPTION
qBittorrent's API specifies using a multipart request to add torrents, so each piece is encoded as plain text rather than form encoded. This should fix issues like [this](https://github.com/Flexget/Flexget/issues/1013).