### PR TITLE
IPTorrents - Only parse search results

### DIFF
--- a/flexget/plugins/urlrewrite_iptorrents.py
+++ b/flexget/plugins/urlrewrite_iptorrents.py
@@ -136,8 +136,9 @@ class UrlRewriteIPTorrents(object):
                 raise plugin.PluginError("Invalid cookies (user not logged in)...")
 
             soup = get_soup(req.content, parser="html.parser")
+            torrents = soup.find('table', {'class': 'torrents'})
 
-            for torrent in soup.findAll('a', href=re.compile('\.torrent$')):
+            for torrent in torrents.findAll('a', href=re.compile('\.torrent$')):
                 entry = Entry()
                 entry['url'] = "{base}{link}?torrent_pass={key}".format(
                     base=BASE_URL, link=torrent['href'], key=config.get('rss_key'))

--- a/flexget/plugins/urlrewrite_iptorrents.py
+++ b/flexget/plugins/urlrewrite_iptorrents.py
@@ -151,8 +151,8 @@ class UrlRewriteIPTorrents(object):
                 entry['search_sort'] = torrent_availability(entry['torrent_seeds'],
                                                             entry['torrent_leeches'])
 
-                size = torrent.findNext("td", text=re.compile('([\.\d]+) ([GMK]?)B')).text
-                size = re.search('([\.\d]+) ([GMK]?)B', size)
+                size = torrent.findNext(text=re.compile('^([\.\d]+) ([GMK]?)B$'))
+                size = re.search('^([\.\d]+) ([GMK]?)B$', size)
                 if size:
                     if size.group(2) == 'G':
                         entry['content_size'] = int(float(size.group(1)) * 1000 ** 3 / 1024 ** 2)


### PR DESCRIPTION
The IPTorrents plugin attempts to parse any link ending in ".torrent", which causes it to go through the "Recommended" and "Top" torrents section at the top of the page. This isn't desirable behavior, and causes a crash when those links don't include the attributes it expects. This change will make it specifically parse the search results table on the page.