### PR TITLE
List interface: improve logging

### DIFF
--- a/flexget/plugins/filter/list_accept.py
+++ b/flexget/plugins/filter/list_accept.py
@@ -67,7 +67,10 @@ class ListAccept(object):
                     log.info('`%s` is marked as online, would remove accepted items outside of --test mode.',
                              plugin_name)
                     continue
-                log.verbose('removing accepted entries from %s - %s', plugin_name, plugin_config)
+
+                for entry in task.accepted:
+                    log.verbose('Removing %s from list %s', entry.get('title', 'entry'), plugin_name)
+
                 thelist -= task.accepted
 
 

--- a/flexget/plugins/output/list_add.py
+++ b/flexget/plugins/output/list_add.py
@@ -44,7 +44,10 @@ class ListAdd(object):
                     log.info('`%s` is marked as an online plugin, would add accepted items outside of --test mode. '
                              'Skipping', plugin_name)
                     continue
-                log.verbose('adding accepted entries into %s - %s', plugin_name, plugin_config)
+
+                for entry in task.accepted:
+                    log.verbose('Adding %s to list %s', entry.get('title', 'entry'), plugin_name)
+
                 thelist |= task.accepted
 
 

--- a/flexget/plugins/output/list_remove.py
+++ b/flexget/plugins/output/list_remove.py
@@ -37,7 +37,10 @@ class ListRemove(object):
                     log.info('`%s` is marked as online, would remove accepted items outside of --test mode.',
                              plugin_name)
                     continue
-                log.verbose('removing accepted entries from %s - %s', plugin_name, plugin_config)
+
+                for entry in task.accepted:
+                    log.verbose('Removing %s from list %s', entry.get('title', 'entry'), plugin_name)
+
                 thelist -= task.accepted
 
 


### PR DESCRIPTION
Before the generic list interface was introduced, each entry that was added to the movie queue was logged. This helped tremendously to see what was happening in a task.

I've restored this logging in list_add/remove/accept.