### PR TITLE
Fix cfscraper plugin, fixes #1037

### DIFF
--- a/flexget/plugins/operate/cfscraper.py
+++ b/flexget/plugins/operate/cfscraper.py
@@ -31,11 +31,8 @@ class CFScraper(object):
 
         class CFScrapeWrapper(Session, cfscrape.CloudflareScraper):
             """
-            Wrapper class to strip unwanted input args from the Flexget requests class
+            This class allows the FlexGet session to inherit from CFScraper instead of the requests.Session directly.
             """
-
-            def request(self, method, url, *args, **kwargs):
-                return super(CFScrapeWrapper, self).request(method, url, *args, **kwargs)
 
         if config is True:
             task.requests = CFScrapeWrapper.create_scraper(task.requests)

--- a/flexget/plugins/operate/cfscraper.py
+++ b/flexget/plugins/operate/cfscraper.py
@@ -6,7 +6,6 @@ import logging
 from flexget import plugin, validator
 from flexget.event import event
 from flexget.utils.requests import Session
-
  
 log = logging.getLogger('cfscraper')
 
@@ -30,18 +29,13 @@ class CFScraper(object):
             log.debug('Error importing cfscrape: %s' % e)
             raise plugin.DependencyError('cfscraper', 'cfscrape', 'cfscrape module required. ImportError: %s' % e)
 
-        class CFScrapeWrapper(cfscrape.CloudflareScraper, Session):
+        class CFScrapeWrapper(Session, cfscrape.CloudflareScraper):
             """
             Wrapper class to strip unwanted input args from the Flexget requests class
             """
 
             def request(self, method, url, *args, **kwargs):
-                raise_status = kwargs.pop('raise_status', False)
-                resp = super(CFScrapeWrapper, self).request(method, url, *args, **kwargs)
-
-                if raise_status:
-                    resp.raise_for_status()
-                return resp
+                return super(CFScrapeWrapper, self).request(method, url, *args, **kwargs)
 
         if config is True:
             task.requests = CFScrapeWrapper.create_scraper(task.requests)

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -231,7 +231,7 @@ class Session(requests.Session):
 
         try:
             log.debug('Fetching %s' % url)
-            result = requests.Session.request(self, method, url, *args, **kwargs)
+            result = super(Session, self).request(method, url, *args, **kwargs)
         except requests.Timeout:
             # Mark this site in known unresponsive list
             set_unresponsive(url)

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -167,9 +167,9 @@ class Session(requests.Session):
 
     """
 
-    def __init__(self, timeout=30, max_retries=1):
+    def __init__(self, timeout=30, max_retries=1, *args, **kwargs):
         """Set some defaults for our session if not explicitly defined."""
-        requests.Session.__init__(self)
+        super(Session, self).__init__(*args, **kwargs)
         self.timeout = timeout
         self.stream = True
         self.adapters['http://'].max_retries = max_retries


### PR DESCRIPTION
Created a wrapper for the CloudflareScraper class such that we can strip out some of the kwargs.

Shouldn't be merged until https://github.com/Anorov/cloudflare-scrape/pull/52 is merged upstream. Currently, he made the class such that the helper functions that make it easy to create a Session are static methods. My PR on his branch will make them class methods instead, which enables us to extend the class ad nauseam.