### PR TITLE
Fix invalid search string generation, update base_url to use HTTPS

### DIFF
--- a/flexget/plugins/urlrewrite/iptorrents.py
+++ b/flexget/plugins/urlrewrite/iptorrents.py
@@ -46,7 +46,7 @@ CATEGORIES = {
     'TV-Web-DL': 22
 }
 
-BASE_URL = 'http://iptorrents.com'
+BASE_URL = 'https://iptorrents.com'
 
 
 class UrlRewriteIPTorrents(object):
@@ -121,7 +121,7 @@ class UrlRewriteIPTorrents(object):
         # If there are any text categories, turn them into their id number
         categories = [c if isinstance(c, int) else CATEGORIES[c]
                       for c in categories]
-        filter_url = '&'.join(('l' + str(c) + '=') for c in categories)
+        filter_url = '&'.join((str(c) + '=') for c in categories)
 
         entries = set()
 


### PR DESCRIPTION
### Motivation for changes:
IPTorrents search plugin was generating invalid search strings. Also, upon further inspection, it was connecting via plaintext HTTP.

### Detailed changes:

- Update search string generator code to no longer prepend "l" to each category number
- Use HTTPS instead of HTTP

### Addressed issues:

- N/A

### Config usage if relevant (new plugin or updated schema):

N/A

### Log and/or tests output (preferably both):
```
016-05-29 22:36 VERBOSE  discover      download-movies Searching for `The Martian (2015)` with plugin `iptorrents` (1 of 1)
2016-05-29 22:36 DEBUG    iptorrents    download-movies searching with url: https://iptorrents.com/t?90=&89=&q=The+Martian+%282015%29&qf=
2016-05-29 22:36 DEBUG    utils.requests download-movies Fetching https://iptorrents.com/t?90=&89=&q=The+Martian+%282015%29&qf=
2016-05-29 22:36 DEBUG    discover      download-movies Discovered 8 entries from iptorrents
2016-05-29 22:36 DEBUG    backlog       download-movies 0 entries purged from backlog
2016-05-29 22:36 VERBOSE  details       download-movies Produced 8 entries.
```


