### PR TITLE
Allow IPTorrents to accept UID as a string

### DIFF
--- a/flexget/plugins/urlrewrite/iptorrents.py
+++ b/flexget/plugins/urlrewrite/iptorrents.py
@@ -72,7 +72,10 @@ class UrlRewriteIPTorrents(object):
         'type': 'object',
         'properties': {
             'rss_key': {'type': 'string'},
-            'uid': {'type': 'integer'},
+            'uid': {'oneOf': [ 
+                {'type': 'integer'}, 
+                {'type': 'string'} 
+            ]},
             'password': {'type': 'string'},
             'category': one_or_more({
                 'oneOf': [


### PR DESCRIPTION
### Motivation for changes:
Currently you can't use IPTorrets with the `secrets` plugin because it requires that UID be provided as an integer. UID is always cast as a string, so this should be a safe change.

### Detailed changes:

- Change schema to accept either an integer or a string

### Addressed issues:

N/A

### Config usage if relevant (new plugin or updated schema):
```
    discover:
      what:
        - emit_series: yes
      from:
        - iptorrents: 
            rss_key: '{{ secrets.iptorrents.rss_key }}'
            uid: '{{ secrets.iptorrents.uid }}'
            password: '{{secrets.iptorrents.password}}'
            category: 
              - TV-x264
```
### Log and/or tests output (preferably both):
```
2016-05-30 13:26 VERBOSE  discover      series-discover Searching for `The Venture Bros. S07E01` with plugin `iptorrents` (1 of 3)
2016-05-30 13:26 DEBUG    iptorrents    series-discover searching with url: https://www.iptorrents.com/t?5=&q=The+Venture+Bros.+S07E01&qf=
2016-05-30 13:26 DEBUG    utils.requests series-discover Fetching https://www.iptorrents.com/t?5=&q=The+Venture+Bros.+S07E01&qf=
2016-05-30 13:26 DEBUG    iptorrents    series-discover searching with url: https://www.iptorrents.com/t?5=&q=The+Venture+Bros.+7x01&qf=
2016-05-30 13:26 DEBUG    utils.requests series-discover Fetching https://www.iptorrents.com/t?5=&q=The+Venture+Bros.+7x01&qf=
```


