### PR TITLE
[wip] Series list

### DIFF
--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -45,6 +45,8 @@ class objects_container(object):
 
     return_lists = {'type': 'array', 'items': list_object}
 
+
+
     return_series = {
         'type': 'object',
         'properties': {

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -129,10 +129,8 @@ class SeriesListListAPI(APIResource):
         session.delete(series_list)
         return {}
 
-choices = sorted([attribute for attribute in SERIES_ATTRIBUTES if attribute != 'set'])
-
 series_parser = api.parser()
-series_parser.add_argument('sort_by', choices=(choices), default='title',
+series_parser.add_argument('sort_by', choices=('title', 'added'), default='title',
                            help='Sort by attribute')
 series_parser.add_argument('order', choices=('desc', 'asc'), default='desc', help='Sorting order')
 series_parser.add_argument('page', type=int, default=1, help='Page number')

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -10,7 +10,7 @@ from flask import request
 from sqlalchemy.orm.exc import NoResultFound
 from flexget.plugins.filter.series import FilterSeriesBase
 from flexget.api import api, APIResource
-from flexget.plugins.list import movie_list as ml
+from flexget.plugins.list import series_list as sl
 from flexget.utils.tools import split_title_year
 
 SUPPORTED_IDS = FilterSeriesBase().supported_ids
@@ -21,11 +21,70 @@ log = logging.getLogger('series_list_api')
 
 series_list_api = api.namespace('series_list', description='Series List operations')
 
-default_error_schema = {
-    'type': 'object',
-    'properties': {
-        'status': {'type': 'string'},
-        'message': {'type': 'string'}
+
+class objects_container(object):
+    default_error_schema = {
+        'type': 'object',
+        'properties': {
+            'status': {'type': 'string'},
+            'message': {'type': 'string'}
+        }
     }
-}
+
+    list_object = {
+        'type': 'object',
+        'properties': {
+            'id': {'type': 'integer'},
+            'added_on': {'type': 'string'},
+            'name': {'type': 'string'}
+        }
+    }
+
+    list_input = copy.deepcopy(list_object)
+    del list_input['properties']['id']
+    del list_input['properties']['added_on']
+
+    return_lists = {'type': 'array', 'items': list_object}
+
+
 empty_response = api.schema('empty', {'type': 'object'})
+default_error_schema = api.schema('default_error_schema', objects_container.default_error_schema)
+return_lists_schema = api.schema('return_lists', objects_container.return_lists)
+new_list_schema = api.schema('new_list', objects_container.list_input)
+list_object_schema = api.schema('list_object', objects_container.list_object)
+
+series_list_parser = api.parser()
+series_list_parser.add_argument('name', help='Filter results by list name')
+
+
+@series_list_api.route('/')
+class SeriesListAPI(APIResource):
+    @api.response(200, model=return_lists_schema)
+    @api.doc(parser=series_list_parser)
+    def get(self, session=None):
+        """ Gets series lists """
+        args = series_list_parser.parse_args()
+        name = args.get('name')
+        series_lists = [series_list.to_dict() for series_list in sl.get_series_lists(name=name, session=session)]
+        return jsonify(series_lists)
+
+    @api.validate(new_list_schema)
+    @api.response(201, model=list_object_schema)
+    @api.response(500, description='List already exist', model=default_error_schema)
+    def post(self, session=None):
+        """ Create a new list """
+        data = request.json
+        name = data.get('name')
+        try:
+            series_list = sl.get_list_by_exact_name(name=name, session=session)
+        except NoResultFound:
+            series_list = None
+        if series_list:
+            return {'status': 'error',
+                    'message': "list with name '%s' already exists" % name}, 500
+        series_list = sl.SeriesListList(name=name)
+        session.add(series_list)
+        session.commit()
+        resp = jsonify(series_list.to_dict())
+        resp.status_code = 201
+        return resp

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -1,0 +1,31 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # pylint: disable=unused-import, redefined-builtin
+
+import copy
+import logging
+from math import ceil
+
+from flask import jsonify
+from flask import request
+from sqlalchemy.orm.exc import NoResultFound
+from flexget.plugins.filter.series import FilterSeriesBase
+from flexget.api import api, APIResource
+from flexget.plugins.list import movie_list as ml
+from flexget.utils.tools import split_title_year
+
+SUPPORTED_IDS = FilterSeriesBase().supported_ids
+SETTINGS_SCHEMA = FilterSeriesBase().settings_schema
+SERIES_ATTRIBUTES = SETTINGS_SCHEMA['properties']
+
+log = logging.getLogger('series_list_api')
+
+series_list_api = api.namespace('series_list', description='Series List operations')
+
+default_error_schema = {
+    'type': 'object',
+    'properties': {
+        'status': {'type': 'string'},
+        'message': {'type': 'string'}
+    }
+}
+empty_response = api.schema('empty', {'type': 'object'})

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm.exc import NoResultFound
 from flexget.plugins.filter.series import FilterSeriesBase
 from flexget.api import api, APIResource
 from flexget.plugins.list import series_list as sl
-from flexget.utils.tools import split_title_year
 
 SUPPORTED_IDS = FilterSeriesBase().supported_ids
 SETTINGS_SCHEMA = FilterSeriesBase().settings_schema
@@ -130,9 +129,10 @@ class SeriesListListAPI(APIResource):
         session.delete(series_list)
         return {}
 
+choices = sorted([attribute for attribute in SERIES_ATTRIBUTES if attribute != 'set'])
 
 series_parser = api.parser()
-series_parser.add_argument('sort_by', choices=('test'), default='title',
+series_parser.add_argument('sort_by', choices=(choices), default='title',
                            help='Sort by attribute')
 series_parser.add_argument('order', choices=('desc', 'asc'), default='desc', help='Sorting order')
 series_parser.add_argument('page', type=int, default=1, help='Page number')

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -952,7 +952,7 @@ class FilterSeriesBase(object):
     @property
     def supported_ids(self):
         # A list of supported series IDs to be used by various series plugins like configure_series, series_list, etc.
-        return ['tvdb_id', 'trakt_series_id', 'tvmaze_id']
+        return ['tvdb_id', 'trakt_show_id', 'tvmaze_id']
 
     def make_grouped_config(self, config):
         """Turns a simple series list into grouped format with a empty settings dict"""

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -949,6 +949,11 @@ class FilterSeriesBase(object):
             'additionalProperties': False
         }
 
+    @property
+    def supported_ids(self):
+        # A list of supported series IDs to be used by various series plugins like configure_series, series_list, etc.
+        return ['tvdb_id', 'trakt_series_id', 'tvmaze_id']
+
     def make_grouped_config(self, config):
         """Turns a simple series list into grouped format with a empty settings dict"""
         if not isinstance(config, dict):

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -290,3 +290,28 @@ def get_series_lists(name=None, session=None):
         log.debug('filtering by name %s', name)
         query = query.filter(SeriesListList.name == name)
     return query.all()
+
+
+@with_session
+def get_list_by_id(list_id, session=None):
+    log.debug('fetching list with id %d', list_id)
+    return session.query(SeriesListList).filter(SeriesListList.id == list_id).one()
+
+
+@with_session
+def get_series_by_list_id(list_id, count=False, start=None, stop=None, order_by='added', descending=False,
+                          session=None):
+    query = session.query(SeriesListSeries).filter(SeriesListSeries.list_id == list_id)
+    if count:
+        return query.count()
+    query = query.slice(start, stop).from_self()
+    if descending:
+        query = query.order_by(getattr(SeriesListSeries, order_by).desc())
+    else:
+        query = query.order_by(getattr(SeriesListSeries, order_by))
+    return query.all()
+
+@with_session
+def get_list_by_exact_name(name, session=None):
+    log.debug('returning list with name %s', name)
+    return session.query(SeriesListList).filter(func.lower(SeriesListList.name) == name.lower()).one()

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -1,0 +1,254 @@
+from __future__ import unicode_literals, division, absolute_import
+
+import logging
+from collections import MutableSet
+from datetime import datetime
+
+from builtins import *  # pylint: disable=unused-import, redefined-builtin
+from sqlalchemy import Column, Unicode, Integer, ForeignKey, Boolean, DateTime, String, func
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql.elements import and_
+
+from flexget import plugin
+from flexget.db_schema import versioned_base
+from flexget.utils.database import json_synonym, with_session
+from flexget.entry import Entry
+from flexget.event import event
+from flexget.utils.tools import split_title_year
+
+log = logging.getLogger('series_list')
+Base = versioned_base('series_list', 0)
+
+SUPPORTED_IDS = ['tvdb_id', 'trakt_series_id', 'tvmaze_id']
+
+
+class SeriesListList(Base):
+    __tablename__ = 'series_list_lists'
+    id = Column(Integer, primary_key=True)
+    name = Column(Unicode, unique=True)
+    added = Column(DateTime, default=datetime.now)
+    series = relationship('SeriesListSeries', backref='list', cascade='all, delete, delete-orphan', lazy='dynamic')
+
+    def __repr__(self):
+        return '<SeriesListList name=%d>' % (self.id)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'name': self.name,
+            'added_on': self.added
+        }
+
+
+class SeriesListSeries(Base):
+    __tablename__ = 'series_list_series'
+
+    id = Column(Integer, primary_key=True)
+    added = Column(DateTime, default=datetime.now)
+    title = Column(Unicode)
+
+    # Internal series attributes
+    path = Column(Unicode)
+    _alternate_names = Column('alternate_names', Unicode)
+    alternate_names = json_synonym('_alternate_names')
+    _name_regexp = Column('name_regexp', Unicode)
+    name_regexp = json_synonym('_name_regexp')
+    _ep_regexp = Column('ep_regexp', Unicode)
+    ep_regexp = json_synonym('_ep_regexp')
+    _date_regexp = Column('date_regexp', Unicode)
+    date_regexp = json_synonym('_date_regexp')
+    _sequence_regexp = Column('sequence_regexp', Unicode)
+    sequence_regexp = json_synonym('_sequence_regexp')
+    _id_regexp = Column('id_regexp', Unicode)
+    id_regexp = json_synonym('_id_regexp')
+    date_yearfirst = Column(Boolean)
+    date_dayfirst = Column(Boolean)
+    quality = Column(Unicode)  # Todo: enforce format
+    _qualities = Column('qualities', Unicode)
+    qualities = json_synonym('_qualities')  # Todo: enforce format
+    timeframe = Column(Unicode)  # Todo: enforce format
+    upgrade = Column(Boolean)
+    target = Column(Unicode)  # Todo: enforce format
+    specials = Column(Boolean)
+    propers = Column(Unicode)  # Todo: enforce format
+    identified_by = Column(String)
+    exact = Column(Boolean)
+    begin = Column(Unicode)  # Todo: enforce format
+    _from_group = Column('from_group', Unicode)
+    from_group = json_synonym('_from_group')
+    parse_only = Column(Boolean)
+    _special_ids = Column('special_ids', Unicode)
+    special_ids = json_synonym('_special_ids')
+    prefer_specials = Column(Boolean)
+    assume_special = Column(Boolean)
+    tracking = Column(Unicode)  # Todo: enforce format
+
+    list_id = Column(Integer, ForeignKey(SeriesListList.id), nullable=False)
+    ids = relationship('SeriesListID', backref='series', cascade='all, delete, delete-orphan')
+
+    def __repr__(self):
+        return '<SeriesListSeries title=%s,list_id=%d>' % (self.title, self.list_id)
+
+    @property
+    def attributes(self):
+        # This will build a list of attributes without the irrelevant class ones
+        return [a for a in dir(self) if not a.startswith('_') and a not in ['id', 'added', 'title']]
+
+    def to_entry(self, strip_year=False):
+        entry = Entry()
+        entry['title'] = entry['series_name'] = self.title
+        entry['url'] = 'mock://localhost/series_list/%d' % self.id
+        for attribute in self.attributes:
+            if getattr(self, attribute):
+                entry['configure_series_' + attribute] = getattr(self, attribute)
+        for series_list_id in self.ids:
+            entry[series_list_id.id_name] = series_list_id.id_value
+        return entry
+
+    def to_dict(self):
+        series_list_ids = [series_list_id.to_dict() for series_list_id in self.ids]
+        series_dict = {
+            'id': self.id,
+            'added_on': self.added,
+            'title': self.title,
+            'list_id': self.list_id,
+            'series_list_ids': series_list_ids
+        }
+        for attribute in self.attributes:
+            series_dict[attribute] = getattr(self, attribute) if getattr(self, attribute) else None
+        return series_dict
+
+
+class SeriesListID(Base):
+    __tablename__ = 'series_list_ids'
+    id = Column(Integer, primary_key=True)
+    added = Column(DateTime, default=datetime.now)
+    id_name = Column(Unicode)
+    id_value = Column(Unicode)
+    series_id = Column(Integer, ForeignKey(SeriesListSeries.id))
+
+    def __repr__(self):
+        return '<SeriesListID id_name=%s,id_value=%s,series_id=%d>' % (self.id_name, self.id_value, self.series_id)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'added_on': self.added,
+            'id_name': self.id_name,
+            'id_value': self.id_value,
+            'series_id': self.movie_id
+        }
+
+
+class SeriesList(MutableSet):
+    def _db_list(self, session):
+        return session.query(SeriesListList).filter(SeriesListList.name == self.list_name).first()
+
+    def _from_iterable(self, it):
+        # TODO: is this the right answer? the returned object won't have our custom __contains__ logic
+        return set(it)
+
+    @with_session
+    def __init__(self, config, session=None):
+        if not isinstance(config, dict):
+            config = {'list_name': config}
+        config.setdefault('strip_year', False)
+        self.list_name = config.get('list_name')
+        db_list = self._db_list(session)
+        if not db_list:
+            session.add(SeriesListList(name=self.list_name))
+
+    @with_session
+    def __iter__(self, session=None):
+        return iter([series.to_entry() for series in self._db_list(session).series])
+
+    @with_session
+    def __len__(self, session=None):
+        return len(self._db_list(session).series)
+
+    @with_session
+    def add(self, entry, session=None):
+        # Check if this is already in the list, refresh info if so
+        db_list = self._db_list(session=session)
+        db_series = self._find_entry(entry, session=session)
+        # Just delete and re-create to refresh
+        if db_series:
+            session.delete(db_series)
+        db_series = SeriesListSeries()
+        if 'series_name' in entry:
+            db_series.title = entry['series_name']
+        else:
+            db_series.title = entry['title']
+        for id_name in SUPPORTED_IDS:
+            if id_name in entry:
+                db_series.ids.append(SeriesListID(id_name=id_name, id_value=entry[id_name]))
+        log.debug('adding entry %s', entry)
+        db_list.series.append(db_series)
+        session.commit()
+        return db_series.to_entry()
+
+    @with_session
+    def discard(self, entry, session=None):
+        db_series = self._find_entry(entry, session=session)
+        if db_series:
+            log.debug('deleting series %s', db_series)
+            session.delete(db_series)
+
+    def __contains__(self, entry):
+        return self._find_entry(entry) is not None
+
+    @with_session
+    def _find_entry(self, entry, session=None):
+        """Finds `SeriesListSeries` corresponding to this entry, if it exists."""
+        for id_name in SUPPORTED_IDS:
+            if entry.get(id_name):
+                log.debug('trying to match series based off id %s: %s', id_name, entry[id_name])
+                res = (self._db_list(session).series.join(SeriesListSeries.ids).filter(
+                    and_(
+                        SeriesListID.id_name == id_name,
+                        SeriesListID.id_value == entry[id_name]))
+                       .first())
+                if res:
+                    log.debug('found series %s', res)
+                    return res
+        # Fall back to title
+        name = entry.get('series_name')
+        if not name:
+            log.verbose('no series name to match, skipping')
+            return
+        log.debug('trying to match series based of name: %s ', name)
+        res = (self._db_list(session).series.filter(SeriesListSeries.title == name.lower()).first())
+        if res:
+            log.debug('found series %s', res)
+        return res
+
+    @property
+    def immutable(self):
+        return False
+
+    @property
+    def online(self):
+        """ Set the online status of the plugin, online plugin should be treated differently in certain situations,
+        like test mode"""
+        return False
+
+    @with_session
+    def get(self, entry, session):
+        match = self._find_entry(entry=entry, session=session)
+        return match.to_entry() if match else None
+
+
+class PluginSeriesList(object):
+    schema = {'type': 'string'}
+
+    @staticmethod
+    def get_list(config):
+        return SeriesList(config)
+
+    def on_task_input(self, task, config):
+        return list(SeriesList(config))
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(PluginSeriesList, 'series_list', api_ver=2, groups=['list'])

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -226,7 +226,7 @@ class SeriesListIDRegexp(Base):
 
 
 class SeriesListQuality(Base):
-    __tablename__ = 'series_list_id_quality'
+    __tablename__ = 'series_list_quality'
 
     id = Column(Integer, primary_key=True)
     quality = Column(Unicode)
@@ -235,7 +235,7 @@ class SeriesListQuality(Base):
 
 
 class SeriesListQualities(Base):
-    __tablename__ = 'series_list_id_qualities'
+    __tablename__ = 'series_list_qualities'
 
     id = Column(Integer, primary_key=True)
     quality = Column(Unicode)

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -13,10 +13,9 @@ from sqlalchemy.sql.elements import and_
 from flexget.plugins.filter.series import FilterSeriesBase
 from flexget import plugin
 from flexget.db_schema import versioned_base
-from flexget.utils.database import json_synonym, with_session
+from flexget.utils.database import with_session
 from flexget.entry import Entry
 from flexget.event import event
-from flexget.utils.tools import split_title_year
 
 log = logging.getLogger('series_list')
 Base = versioned_base('series_list', 0)
@@ -34,7 +33,7 @@ class SeriesListList(Base):
     series = relationship('SeriesListSeries', backref='list', cascade='all, delete, delete-orphan', lazy='dynamic')
 
     def __repr__(self):
-        return '<SeriesListList name=%d>' % (self.id)
+        return '<SeriesListList name=%d>' % self.id
 
     def to_dict(self):
         return {

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -125,9 +125,10 @@ class SeriesListSeries(Base):
             # `set` is not a real series attribute and is just a way to pass IDs in task.
             if attribute == 'set':
                 continue
-            if getattr(self, attribute):
+            result = self.format_converter(attribute)
+            if result:
                 # Maintain support for configure_series plugin expected format
-                entry['configure_series_' + attribute] = entry[attribute] = self.format_converter(attribute)
+                entry['configure_series_' + attribute] = entry[attribute] = result
         for series_list_id in self.ids:
             entry[series_list_id.id_name] = series_list_id.id_value
             entry['set'].update({series_list_id.id_name: series_list_id.id_value})
@@ -142,6 +143,7 @@ class SeriesListSeries(Base):
             'series_list_ids': [series_list_id.to_dict() for series_list_id in self.ids]
         }
         for attribute in SETTINGS_SCHEMA['properties']:
+            # `set` is not a real series attribute and is just a way to pass IDs in task.
             if attribute == 'set':
                 continue
             series_dict[attribute] = self.format_converter(attribute)

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -167,7 +167,7 @@ class SeriesListID(Base):
             'added_on': self.added,
             'id_name': self.id_name,
             'id_value': self.id_value,
-            'series_id': self.movie_id
+            'series_id': self.series_id
         }
 
 
@@ -326,7 +326,7 @@ class SeriesList(MutableSet):
 
         # Get list of supported identifiers
         for id_name in SUPPORTED_IDS:
-            value = entry.get(id_name) or entry.get('set').get(id_name) if entry.get('set') else None
+            value = entry.get(id_name)
             if value:
                 log.debug('found supported ID %s with value %s in entry, adding to series', id_name, value)
                 db_series.ids.append(SeriesListID(id_name=id_name, id_value=value))
@@ -424,11 +424,11 @@ def get_series_by_list_id(list_id, count=False, start=None, stop=None, order_by=
     query = session.query(SeriesListSeries).filter(SeriesListSeries.list_id == list_id)
     if count:
         return query.count()
-    query = query.slice(start, stop).from_self()
     if descending:
         query = query.order_by(getattr(SeriesListSeries, order_by).desc())
     else:
         query = query.order_by(getattr(SeriesListSeries, order_by))
+    query = query.slice(start, stop)
     return query.all()
 
 

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -92,13 +92,6 @@ class SeriesListSeries(Base):
     def __repr__(self):
         return '<SeriesListSeries title=%s,list_id=%d>' % (self.title, self.list_id)
 
-    @property
-    def attributes(self):
-        # This will build a list of attributes without the irrelevant class ones
-        return [a for a in dir(self) if
-                not a.startswith('_') and a not in ['id', 'added', 'title', 'list_id', 'ids', 'list', 'attributes',
-                                                    'to_dict', 'to_entry', 'metadata']]
-
     def to_entry(self, strip_year=False):
         entry = Entry()
         entry['title'] = entry['series_name'] = self.title
@@ -119,7 +112,7 @@ class SeriesListSeries(Base):
             'list_id': self.list_id,
             'series_list_ids': series_list_ids
         }
-        for attribute in self.attributes:
+        for attribute in settings_schema['properties']:
             series_dict[attribute] = getattr(self, attribute) if getattr(self, attribute) else None
         return series_dict
 

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -132,6 +132,8 @@ class SeriesListSeries(Base):
             'series_list_ids': [series_list_id.to_dict() for series_list_id in self.ids]
         }
         for attribute in SETTINGS_SCHEMA['properties']:
+            if attribute == 'set':
+                continue
             series_dict[attribute] = getattr(self, attribute) if getattr(self, attribute) else None
         return series_dict
 
@@ -206,7 +208,7 @@ class SeriesList(MutableSet):
                 setattr(db_series, attribute, entry[attribute])
         # Get list of supported identifiers
         for id_name in SUPPORTED_IDS:
-            value = entry.get(id_name) or entry.get('set').get(id_name)
+            value = entry.get(id_name) or entry.get('set').get(id_name) if entry.get('set') else None
             if value:
                 log.debug('found supported ID %s with value %s in entry, adding to series', id_name, value)
                 db_series.ids.append(SeriesListID(id_name=id_name, id_value=value))

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -80,7 +80,7 @@ class SeriesListSeries(Base):
     tracking = Column(Unicode)  # Todo: enforce format
 
     list_id = Column(Integer, ForeignKey(SeriesListList.id), nullable=False)
-    ids = relationship('SeriesListID', backref='series', cascade='all, delete, delete-orphan')
+    ids = relationship('SeriesListSeriesExternalID', backref='series', cascade='all, delete, delete-orphan')
 
     def __init__(self, title):
         self.title = title
@@ -150,8 +150,8 @@ class SeriesListSeries(Base):
         return series_dict
 
 
-class SeriesListID(Base):
-    __tablename__ = 'series_list_ids'
+class SeriesListSeriesExternalID(Base):
+    __tablename__ = 'series_list_series_external_ids'
     id = Column(Integer, primary_key=True)
     added = Column(DateTime, default=datetime.now)
     id_name = Column(Unicode)
@@ -329,7 +329,7 @@ class SeriesList(MutableSet):
             value = entry.get(id_name)
             if value:
                 log.debug('found supported ID %s with value %s in entry, adding to series', id_name, value)
-                db_series.ids.append(SeriesListID(id_name=id_name, id_value=value))
+                db_series.ids.append(SeriesListSeriesExternalID(id_name=id_name, id_value=value))
         log.debug('adding entry %s', entry)
         db_list.series.append(db_series)
         session.commit()
@@ -353,8 +353,8 @@ class SeriesList(MutableSet):
                 log.debug('trying to match series based off id %s: %s', id_name, entry[id_name])
                 res = (self._db_list(session).series.join(SeriesListSeries.ids).filter(
                     and_(
-                        SeriesListID.id_name == id_name,
-                        SeriesListID.id_value == entry[id_name]))
+                        SeriesListSeriesExternalID.id_name == id_name,
+                        SeriesListSeriesExternalID.id_value == entry[id_name]))
                        .first())
                 if res:
                     log.debug('found series %s', res)

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -20,8 +20,8 @@ from flexget.utils.tools import split_title_year
 log = logging.getLogger('series_list')
 Base = versioned_base('series_list', 0)
 
-SUPPORTED_IDS = ['tvdb_id', 'trakt_series_id', 'tvmaze_id']
-settings_schema = FilterSeriesBase().settings_schema
+SUPPORTED_IDS = FilterSeriesBase().supported_ids
+SETTINGS_SCHEMA = FilterSeriesBase().settings_schema
 
 
 class SeriesListList(Base):
@@ -96,7 +96,7 @@ class SeriesListSeries(Base):
         entry = Entry()
         entry['title'] = entry['series_name'] = self.title
         entry['url'] = 'mock://localhost/series_list/%d' % self.id
-        for attribute in settings_schema['properties']:
+        for attribute in SETTINGS_SCHEMA['properties']:
             if getattr(self, attribute):
                 entry['configure_series_' + attribute] = getattr(self, attribute)
         for series_list_id in self.ids:
@@ -112,7 +112,7 @@ class SeriesListSeries(Base):
             'list_id': self.list_id,
             'series_list_ids': series_list_ids
         }
-        for attribute in settings_schema['properties']:
+        for attribute in SETTINGS_SCHEMA['properties']:
             series_dict[attribute] = getattr(self, attribute) if getattr(self, attribute) else None
         return series_dict
 

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -271,3 +271,13 @@ class PluginSeriesList(object):
 @event('plugin.register')
 def register_plugin():
     plugin.register(PluginSeriesList, 'series_list', api_ver=2, groups=['list'])
+
+
+@with_session
+def get_series_lists(name=None, session=None):
+    log.debug('retrieving series lists')
+    query = session.query(SeriesListList)
+    if name:
+        log.debug('filtering by name %s', name)
+        query = query.filter(SeriesListList.name == name)
+    return query.all()

--- a/flexget/plugins/plugin_configure_series.py
+++ b/flexget/plugins/plugin_configure_series.py
@@ -26,7 +26,6 @@ class LastHash(Base):
 
 
 class ConfigureSeries(FilterSeriesBase):
-
     """Generates series configuration from any input (supporting API version 2, soon all)
 
     Configuration::
@@ -78,8 +77,9 @@ class ConfigureSeries(FilterSeriesBase):
 
             for entry in result:
                 s = series.setdefault(entry['title'], {})
-                if entry.get('tvdb_id'):
-                    s['set'] = {'tvdb_id': entry['tvdb_id']}
+                for supported_id in FilterSeriesBase().supported_ids:
+                    if entry.get(supported_id):
+                        s['set'] = {supported_id: entry[supported_id]}
 
                 # Allow configure_series to set anything available to series
                 for key, schema in self.settings_schema['properties'].items():

--- a/flexget/utils/json.py
+++ b/flexget/utils/json.py
@@ -106,6 +106,8 @@ def loads(*args, **kwargs):
     :param bool decode_datetime: If `True`, dates in ISO8601 format will be deserialized to :class:`datetime.datetime`
       objects.
     """
+    if args[0] is None:
+        return
     if kwargs.pop('decode_datetime', False):
         kwargs['object_hook'] = _datetime_decoder
         kwargs['cls'] = DTDecoder

--- a/flexget/utils/json.py
+++ b/flexget/utils/json.py
@@ -23,7 +23,6 @@ except ImportError:
         except ImportError:
             raise DependencyError(missing='simplejson')
 
-
 DATE_FMT = '%Y-%m-%d'
 ISO8601_FMT = '%Y-%m-%dT%H:%M:%SZ'
 
@@ -32,6 +31,9 @@ class DTDecoder(json.JSONDecoder):
     def decode(self, obj, **kwargs):
         # The built-in `json` library will `unicode` strings, except for empty strings. patch this for
         # consistency so that `unicode` is always returned.
+        if obj is None:
+            return
+
         if obj == b'':
             return ''
 

--- a/tests/test_series_list.py
+++ b/tests/test_series_list.py
@@ -49,7 +49,7 @@ class TestSeriesList(object):
 
     def test_base_series_list(self, execute_task):
         task = execute_task('test_list_add')
-        assert len(task.entries) == 1
+        assert len(task.accepted) == 1
 
         task = execute_task('list_get')
         assert len(task.entries) == 1
@@ -57,15 +57,15 @@ class TestSeriesList(object):
 
     def test_base_configure_series_with_list(self, execute_task):
         task = execute_task('test_list_add')
-        assert len(task.entries) == 1
+        assert len(task.accepted) == 1
 
         task = execute_task('test_basic_configure_series')
-        assert len(task.entries) == 1
-        assert task.find_entry(series_name='series 1')
+        assert len(task.accepted) == 1
+        assert task.find_entry(category='accepted', series_name='series 1')
 
     def test_series_list_with_attributes(self, execute_task):
         task = execute_task('test_add_with_attributes')
-        assert len(task.entries) == 1
+        assert len(task.accepted) == 1
 
         task = execute_task('list_get')
         assert len(task.entries) == 1

--- a/tests/test_series_list.py
+++ b/tests/test_series_list.py
@@ -30,13 +30,17 @@ class TestSeriesList(object):
             mock:
               - {title: 'series 1',
                  url: "http://mock.url/file1.torrent",
+                 set: {tvdb_id: "1234", tvmaze_id: "1234", not_valid_id: "1234"},
                  alternate_name: [SER1, SER2],
+                 name_regexp: ["^ser", "^series 1$"],
                  qualities: [720p, 1080p],
                  timeframe: '2 days',
                  upgrade: yes,
                  propers: yes,
+                 specials: yes,
                  not_a_real_attribute: yes,
-                 tracking: 'backfill'}
+                 tracking: 'backfill',
+                 identified_by: "ep"}
             accept_all: yes
             list_add:
               - series_list: test_list
@@ -66,10 +70,14 @@ class TestSeriesList(object):
         task = execute_task('list_get')
         assert len(task.entries) == 1
         assert task.find_entry(title='series 1')
+        assert task.find_entry(set={'tvdb_id': '1234', 'tvmaze_id': '1234'})
         assert task.find_entry(alternate_name=['SER1', 'SER2'])
+        assert task.find_entry(name_regexp=["^ser", "^series 1$"])
         assert task.find_entry(qualities=['720p', '1080p'])
         assert task.find_entry(timeframe='2 days')
         assert task.find_entry(upgrade=True)
         assert task.find_entry(propers=True)
+        assert task.find_entry(specials=True)
         assert task.find_entry(tracking='backfill')
+        assert task.find_entry(identified_by='ep')
         assert not task.find_entry(not_a_real_attribute=True)

--- a/tests/test_series_list.py
+++ b/tests/test_series_list.py
@@ -18,6 +18,14 @@ class TestSeriesList(object):
             accept_all: yes
             list_add:
               - series_list: test_list
+
+          test_basic_configure_series:
+            mock:
+              - {title: 'series 1.s01e01.720p.HDTV-flexget', url: "http://mock.url/file1.torrent"}
+            configure_series:
+              from:
+                series_list: test_list
+
     """
 
     def test_base_series_list(self, execute_task):
@@ -27,3 +35,13 @@ class TestSeriesList(object):
         task = execute_task('list_get')
         assert len(task.entries) == 1
         assert task.find_entry(title='series 1')
+
+    def test_base_configure_series_with_list(self, execute_task):
+        task = execute_task('test_list_add')
+        assert len(task.entries) == 1
+
+        task = execute_task('test_basic_configure_series')
+        assert len(task.entries) == 1
+        assert task.find_entry(series_name='series 1')
+
+

--- a/tests/test_series_list.py
+++ b/tests/test_series_list.py
@@ -73,5 +73,3 @@ class TestSeriesList(object):
         assert task.find_entry(propers=True)
         assert task.find_entry(tracking='backfill')
         assert not task.find_entry(not_a_real_attribute=True)
-
-

--- a/tests/test_series_list.py
+++ b/tests/test_series_list.py
@@ -26,6 +26,21 @@ class TestSeriesList(object):
               from:
                 series_list: test_list
 
+          test_add_with_attributes:
+            mock:
+              - {title: 'series 1',
+                 url: "http://mock.url/file1.torrent",
+                 alternate_name: [SER1, SER2],
+                 qualities: [720p, 1080p],
+                 timeframe: '2 days',
+                 upgrade: yes,
+                 propers: yes,
+                 not_a_real_attribute: yes,
+                 tracking: 'backfill'}
+            accept_all: yes
+            list_add:
+              - series_list: test_list
+
     """
 
     def test_base_series_list(self, execute_task):
@@ -43,5 +58,20 @@ class TestSeriesList(object):
         task = execute_task('test_basic_configure_series')
         assert len(task.entries) == 1
         assert task.find_entry(series_name='series 1')
+
+    def test_series_list_with_attributes(self, execute_task):
+        task = execute_task('test_add_with_attributes')
+        assert len(task.entries) == 1
+
+        task = execute_task('list_get')
+        assert len(task.entries) == 1
+        assert task.find_entry(title='series 1')
+        assert task.find_entry(alternate_name=['SER1', 'SER2'])
+        assert task.find_entry(qualities=['720p', '1080p'])
+        assert task.find_entry(timeframe='2 days')
+        assert task.find_entry(upgrade=True)
+        assert task.find_entry(propers=True)
+        assert task.find_entry(tracking='backfill')
+        assert not task.find_entry(not_a_real_attribute=True)
 
 

--- a/tests/test_series_list.py
+++ b/tests/test_series_list.py
@@ -30,9 +30,13 @@ class TestSeriesList(object):
             mock:
               - {title: 'series 1',
                  url: "http://mock.url/file1.torrent",
-                 set: {tvdb_id: "1234", tvmaze_id: "1234", not_valid_id: "1234"},
+                 tvdb_id: "1234",
+                 tvmaze_id: "1234",
+                 not_valid_id: "1234",
+                 trakt_show_id: "1234",
                  alternate_name: [SER1, SER2],
                  name_regexp: ["^ser", "^series 1$"],
+                 quality: 720p,
                  qualities: [720p, 1080p],
                  timeframe: '2 days',
                  upgrade: yes,
@@ -70,7 +74,10 @@ class TestSeriesList(object):
         task = execute_task('list_get')
         assert len(task.entries) == 1
         assert task.find_entry(title='series 1')
-        assert task.find_entry(set={'tvdb_id': '1234', 'tvmaze_id': '1234'})
+        assert task.find_entry(tvdb_id='1234')
+        assert task.find_entry(tvmaze_id='1234')
+        assert task.find_entry(trakt_show_id='1234')
+        assert task.find_entry(quality='720p')
         assert task.find_entry(alternate_name=['SER1', 'SER2'])
         assert task.find_entry(name_regexp=["^ser", "^series 1$"])
         assert task.find_entry(qualities=['720p', '1080p'])

--- a/tests/test_series_list.py
+++ b/tests/test_series_list.py
@@ -1,0 +1,29 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # pylint: disable=unused-import, redefined-builtin
+
+
+class TestSeriesList(object):
+    config = """
+        templates:
+          global:
+            disable: [seen]
+
+        tasks:
+          list_get:
+            series_list: test_list
+
+          test_list_add:
+            mock:
+              - {title: 'series 1', url: "http://mock.url/file1.torrent"}
+            accept_all: yes
+            list_add:
+              - series_list: test_list
+    """
+
+    def test_base_series_list(self, execute_task):
+        task = execute_task('test_list_add')
+        assert len(task.entries) == 1
+
+        task = execute_task('list_get')
+        assert len(task.entries) == 1
+        assert task.find_entry(title='series 1')


### PR DESCRIPTION
### Motivation for changes:
A manged list for series, enabling using `series` plugin without the need to explicitly edit config file or use 3rd party service.
This will also allows using multiple lists for multiple purposes.

Note: This does not affect series tracking in any way, this just represents an input to which `configure_series` plugin can be used with (among others things).
### Detailed changes:

- New managed list type, `series_list`
- Manageable via API and CLI
- Had to add a small change to JSON decoder to support trying to decode None values.
- Added a global supported series IDs list to be shared between `configure_series` and `series_list` (and any other plugin that this can relate too, need to look into other `series` related plugins).

### Config usage if relevant (new plugin or updated schema):
```
tasks:
  series_with_list:
    configure_series:
      from:
        series_list: main_shows
    rss: http://url.com/links
    download: /path/to/downloads
```
### Log and/or tests output (preferably both):
Tests included.

#### To Do:
- [ ] CLI
- [ ] API and tests

