### PR TITLE
Series list

### DIFF
--- a/docs/develop/list_interface.rst
+++ b/docs/develop/list_interface.rst
@@ -175,7 +175,7 @@ and avoid acceptance duplication during filter phase.
 
     @with_session
     def get(self, entry, session):
-        match = self._find_entry(entry=entry, session=session)
+        match = self.find_entry(entry=entry, session=session)
         return match.to_entry() if match else None
 
 

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -41,7 +41,12 @@ class objects_container(object):
     del list_input['properties']['id']
     del list_input['properties']['added_on']
 
-    return_lists = {'type': 'array', 'items': list_object}
+    return_lists = {
+        'type': 'object',
+        'properties': {
+            'series_lists': {'type': 'array', 'items': list_object}
+        }
+    }
 
     input_series_list_id_object = {
         'type': 'array',
@@ -156,7 +161,7 @@ class SeriesListAPI(APIResource):
         name = args.get('name')
         series_lists = [series_list.to_dict() for series_list in
                         sl.SeriesListDBContainer.get_series_lists(name=name, session=session)]
-        return jsonify(series_lists)
+        return jsonify({'series_lists': series_lists})
 
     @api.validate(new_list_schema)
     @api.response(201, model=list_object_schema)

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -45,6 +45,8 @@ class objects_container(object):
 
     return_lists = {'type': 'array', 'items': list_object}
 
+
+
     return_series = {
         'type': 'object',
         'properties': {

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -62,59 +62,12 @@ class objects_container(object):
             'added_on': {'type': 'string'},
             'series_id': {'type': 'integer'}
         }})
+    input_series_object = FilterSeriesBase().settings_schema
+    input_series_object['properties'].update({'title': {'type': 'string'}})
+    input_series_object['required'] = ['title']
+    input_series_object['additionalProperties'] = True
 
-    input_series_object = {
-        'type': 'object',
-        'properties': {
-            'title': {'type': 'string'},
-            'path': {'type': 'string'},
-            'alternate_name': {'type': 'array', 'items': {'type': 'string', 'format': 'regex'}},
-            'name_regexp': {'type': 'array', 'items': {'type': 'string', 'format': 'regex'}},
-            'ep_regexp': {'type': 'array', 'items': {'type': 'string', 'format': 'regex'}},
-            'date_regexp': {'type': 'array', 'items': {'type': 'string', 'format': 'regex'}},
-            'sequence_regexp': {'type': 'array', 'items': {'type': 'string', 'format': 'regex'}},
-            'id_regexp': {'type': 'array', 'items': {'type': 'string', 'format': 'regex'}},
-            'date_yearfirst': {'type': 'boolean'},
-            'date_dayfirst': {'type': 'boolean'},
-            'quality': {'type': 'string', 'format': 'quality_requirements'},
-            'qualities': {'type': 'array', 'items': {'type': 'string', 'format': 'quality_requirements'}},
-            'timeframe': {'type': 'string', 'format': 'interval'},
-            'upgrade': {'type': 'boolean'},
-            'target': {'type': 'string', 'format': 'quality_requirements'},
-            # Specials
-            'specials': {'type': 'boolean'},
-            # Propers (can be boolean, or an interval string)
-            'propers': {'type': ['boolean', 'string'], 'format': 'interval'},
-            # Identified by
-            'identified_by': {
-                'type': 'string', 'enum': ['ep', 'date', 'sequence', 'id', 'auto']
-            },
-            # Strict naming
-            'exact': {'type': 'boolean'},
-            # Begin takes an ep, sequence or date identifier
-            'begin': {
-                'oneOf': [
-                    {'name': 'ep identifier', 'type': 'string', 'pattern': r'(?i)^S\d{2,4}E\d{2,3}$',
-                     'error_pattern': 'episode identifiers should be in the form `SxxEyy`'},
-                    {'name': 'date identifier', 'type': 'string', 'pattern': r'^\d{4}-\d{2}-\d{2}$',
-                     'error_pattern': 'date identifiers must be in the form `YYYY-MM-DD`'},
-                    {'name': 'sequence identifier', 'type': 'integer', 'minimum': 0}
-                ]
-            },
-            'from_group': {'type': 'array', 'items': {'type': 'string'}},
-            'parse_only': {'type': 'boolean'},
-            'special_ids': {'type': 'array', 'items': {'type': 'string'}},
-            'prefer_specials': {'type': 'boolean'},
-            'assume_special': {'type': 'boolean'},
-            'tracking': {'type': ['boolean', 'string'], 'enum': [True, False, 'backfill']}
-        },
-        'required': ['title'],
-        'additionalProperties': True
-    }
-
-    edit_series_object = copy.deepcopy(input_series_object)
-    del edit_series_object['properties']['title']
-    del edit_series_object['required']
+    edit_series_object = FilterSeriesBase().settings_schema
 
     return_series_object = copy.deepcopy(input_series_object)
     return_series_object['properties']['series_list_identifiers'] = {'type': 'array',

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -111,7 +111,7 @@ class SeriesListAPI(APIResource):
         args = series_list_parser.parse_args()
         name = args.get('name')
         series_lists = [series_list.to_dict() for series_list in
-                        sl.SeriesListDBContainer.get_series_lists(name=name, session=session)]
+                        sl.SeriesListDB.get_series_lists(name=name, session=session)]
         return jsonify({'series_lists': series_lists})
 
     @api.validate(new_list_schema)
@@ -122,7 +122,7 @@ class SeriesListAPI(APIResource):
         data = request.json
         name = data.get('name')
         try:
-            series_list = sl.SeriesListDBContainer.get_list_by_exact_name(name=name, session=session)
+            series_list = sl.SeriesListDB.get_list_by_exact_name(name=name, session=session)
         except NoResultFound:
             series_list = None
         if series_list:
@@ -144,7 +144,7 @@ class SeriesListListAPI(APIResource):
     def get(self, list_id, session=None):
         """ Get list by ID """
         try:
-            series_list = sl.SeriesListDBContainer.get_list_by_id(list_id=list_id, session=session)
+            series_list = sl.SeriesListDB.get_list_by_id(list_id=list_id, session=session)
         except NoResultFound:
             return {'status': 'error',
                     'message': 'list_id %d does not exist' % list_id}, 404
@@ -155,7 +155,7 @@ class SeriesListListAPI(APIResource):
     def delete(self, list_id, session=None):
         """ Delete list by ID """
         try:
-            series_list = sl.SeriesListDBContainer.get_list_by_id(list_id=list_id, session=session)
+            series_list = sl.SeriesListDB.get_list_by_id(list_id=list_id, session=session)
         except NoResultFound:
             return {'status': 'error',
                     'message': 'list_id %d does not exist' % list_id}, 404
@@ -202,12 +202,12 @@ class SeriesListSeriesAPI(APIResource):
             'session': session
         }
         try:
-            sl.SeriesListDBContainer.get_list_by_id(list_id=list_id, session=session)
+            sl.SeriesListDB.get_list_by_id(list_id=list_id, session=session)
         except NoResultFound:
             return {'status': 'error',
                     'message': 'list_id %d does not exist' % list_id}, 404
-        count = sl.SeriesListDBContainer.get_series_by_list_id(count=True, **kwargs)
-        series = [series.to_dict() for series in sl.SeriesListDBContainer.get_series_by_list_id(**kwargs)]
+        count = sl.SeriesListDB.get_series_by_list_id(count=True, **kwargs)
+        series = [series.to_dict() for series in sl.SeriesListDB.get_series_by_list_id(**kwargs)]
         pages = int(ceil(count / float(page_size)))
 
         number_of_series = min(page_size, count)
@@ -225,13 +225,13 @@ class SeriesListSeriesAPI(APIResource):
     def post(self, list_id, session=None):
         """ Add series to list by ID """
         try:
-            series_list = sl.SeriesListDBContainer.get_list_by_id(list_id=list_id, session=session)
+            series_list = sl.SeriesListDB.get_list_by_id(list_id=list_id, session=session)
         except NoResultFound:
             return {'status': 'error',
                     'message': 'list_id %d does not exist' % list_id}, 404
         data = request.json
         title = data.get('title')
-        series = sl.SeriesListDBContainer.get_series_by_title(list_id=list_id, title=title, session=session)
+        series = sl.SeriesListDB.get_series_by_title(list_id=list_id, title=title, session=session)
         if series:
             return {'status': 'error',
                     'message': 'series with name "%s" already exist in list %d' % (title, list_id)}, 500
@@ -251,7 +251,7 @@ class SeriesListSeriesAPI(APIResource):
     def get(self, list_id, series_id, session=None):
         """ Get a series by list ID and series ID """
         try:
-            series = sl.SeriesListDBContainer.get_series_by_id(list_id=list_id, series_id=series_id, session=session)
+            series = sl.SeriesListDB.get_series_by_id(list_id=list_id, series_id=series_id, session=session)
         except NoResultFound:
             return {'status': 'error',
                     'message': 'could not find series with id %d in list %d' % (series_id, list_id)}, 404
@@ -261,7 +261,7 @@ class SeriesListSeriesAPI(APIResource):
     def delete(self, list_id, series_id, session=None):
         """ Delete a series by list ID and series ID """
         try:
-            series = sl.SeriesListDBContainer.get_series_by_id(list_id=list_id, series_id=series_id, session=session)
+            series = sl.SeriesListDB.get_series_by_id(list_id=list_id, series_id=series_id, session=session)
         except NoResultFound:
             return {'status': 'error',
                     'message': 'could not find series with id %d in list %d' % (series_id, list_id)}, 404
@@ -275,7 +275,7 @@ class SeriesListSeriesAPI(APIResource):
     def put(self, list_id, series_id, session=None):
         """ Edit series data """
         try:
-            series = sl.SeriesListDBContainer.get_series_by_id(list_id=list_id, series_id=series_id, session=session)
+            series = sl.SeriesListDB.get_series_by_id(list_id=list_id, series_id=series_id, session=session)
         except NoResultFound:
             return {'status': 'error',
                     'message': 'could not find series with id %d in list %d' % (series_id, list_id)}, 404

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -103,11 +103,10 @@ class objects_container(object):
             'special_ids': {'type': 'array', 'items': {'type': 'string'}},
             'prefer_specials': {'type': 'boolean'},
             'assume_special': {'type': 'boolean'},
-            'tracking': {'type': ['boolean', 'string'], 'enum': [True, False, 'backfill']},
-            'series_list_identifiers': input_series_list_id_object
+            'tracking': {'type': ['boolean', 'string'], 'enum': [True, False, 'backfill']}
         },
         'required': ['title'],
-        'additionalProperties': False
+        'additionalProperties': True
     }
 
     edit_series_object = copy.deepcopy(input_series_object)
@@ -215,8 +214,8 @@ series_parser.add_argument('order', choices=('desc', 'asc'), default='desc', hel
 series_parser.add_argument('page', type=int, default=1, help='Page number')
 series_parser.add_argument('page_size', type=int, default=10, help='Number of series per page')
 
-series_identifiers_doc = "Use series identifier using the following format:\n[{'ID_NAME: 'ID_VALUE'}]." \
-                         " Has to be one of %s" % " ,".join(supported_ids)
+series_identifiers_doc = "Any recognized series identifiers that are part of the payload will be added ot series. Add" \
+                         "them to the root of the payload."
 
 
 @series_list_api.route('/<int:list_id>/series/')

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -235,7 +235,7 @@ class SeriesListSeriesAPI(APIResource):
         if series:
             return {'status': 'error',
                     'message': 'series with name "%s" already exist in list %d' % (title, list_id)}, 500
-        db_series = sl.get_db_series(data)
+        db_series = sl.SeriesListDB.get_db_series(data)
         series_list.series.append(db_series)
         session.commit()
         response = jsonify(db_series.to_dict())
@@ -282,6 +282,6 @@ class SeriesListSeriesAPI(APIResource):
         title = series.title
         data = request.json
         data.update({'title': title})
-        series = sl.get_db_series(data, series)
+        series = sl.SeriesListDB.get_db_series(data, series)
         session.commit()
         return jsonify(series.to_dict())

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -155,7 +155,8 @@ class SeriesListAPI(APIResource):
         """ Gets series lists """
         args = series_list_parser.parse_args()
         name = args.get('name')
-        series_lists = [series_list.to_dict() for series_list in sl.get_series_lists(name=name, session=session)]
+        series_lists = [series_list.to_dict() for series_list in
+                        sl.SeriesListDBContainer.get_series_lists(name=name, session=session)]
         return jsonify(series_lists)
 
     @api.validate(new_list_schema)
@@ -166,7 +167,7 @@ class SeriesListAPI(APIResource):
         data = request.json
         name = data.get('name')
         try:
-            series_list = sl.get_list_by_exact_name(name=name, session=session)
+            series_list = sl.SeriesListDBContainer.get_list_by_exact_name(name=name, session=session)
         except NoResultFound:
             series_list = None
         if series_list:
@@ -188,7 +189,7 @@ class SeriesListListAPI(APIResource):
     def get(self, list_id, session=None):
         """ Get list by ID """
         try:
-            series_list = sl.get_list_by_id(list_id=list_id, session=session)
+            series_list = sl.SeriesListDBContainer.get_list_by_id(list_id=list_id, session=session)
         except NoResultFound:
             return {'status': 'error',
                     'message': 'list_id %d does not exist' % list_id}, 404
@@ -199,7 +200,7 @@ class SeriesListListAPI(APIResource):
     def delete(self, list_id, session=None):
         """ Delete list by ID """
         try:
-            series_list = sl.get_list_by_id(list_id=list_id, session=session)
+            series_list = sl.SeriesListDBContainer.get_list_by_id(list_id=list_id, session=session)
         except NoResultFound:
             return {'status': 'error',
                     'message': 'list_id %d does not exist' % list_id}, 404
@@ -246,12 +247,12 @@ class SeriesListSeriesAPI(APIResource):
             'session': session
         }
         try:
-            sl.get_list_by_id(list_id=list_id, session=session)
+            sl.SeriesListDBContainer.get_list_by_id(list_id=list_id, session=session)
         except NoResultFound:
             return {'status': 'error',
                     'message': 'list_id %d does not exist' % list_id}, 404
-        count = sl.get_series_by_list_id(count=True, **kwargs)
-        series = [series.to_dict() for series in sl.get_series_by_list_id(**kwargs)]
+        count = sl.SeriesListDBContainer.get_series_by_list_id(count=True, **kwargs)
+        series = [series.to_dict() for series in sl.SeriesListDBContainer.get_series_by_list_id(**kwargs)]
         pages = int(ceil(count / float(page_size)))
 
         number_of_series = min(page_size, count)
@@ -269,13 +270,13 @@ class SeriesListSeriesAPI(APIResource):
     def post(self, list_id, session=None):
         """ Add series to list by ID """
         try:
-            series_list = sl.get_list_by_id(list_id=list_id, session=session)
+            series_list = sl.SeriesListDBContainer.get_list_by_id(list_id=list_id, session=session)
         except NoResultFound:
             return {'status': 'error',
                     'message': 'list_id %d does not exist' % list_id}, 404
         data = request.json
         title = data.get('title')
-        series = sl.get_series_by_title(list_id=list_id, title=title, session=session)
+        series = sl.SeriesListDBContainer.get_series_by_title(list_id=list_id, title=title, session=session)
         if series:
             return {'status': 'error',
                     'message': 'series with name "%s" already exist in list %d' % (title, list_id)}, 500
@@ -295,7 +296,7 @@ class SeriesListSeriesAPI(APIResource):
     def get(self, list_id, series_id, session=None):
         """ Get a series by list ID and series ID """
         try:
-            series = sl.get_series_by_id(list_id=list_id, series_id=series_id, session=session)
+            series = sl.SeriesListDBContainer.get_series_by_id(list_id=list_id, series_id=series_id, session=session)
         except NoResultFound:
             return {'status': 'error',
                     'message': 'could not find series with id %d in list %d' % (series_id, list_id)}, 404
@@ -305,7 +306,7 @@ class SeriesListSeriesAPI(APIResource):
     def delete(self, list_id, series_id, session=None):
         """ Delete a series by list ID and series ID """
         try:
-            series = sl.get_series_by_id(list_id=list_id, series_id=series_id, session=session)
+            series = sl.SeriesListDBContainer.get_series_by_id(list_id=list_id, series_id=series_id, session=session)
         except NoResultFound:
             return {'status': 'error',
                     'message': 'could not find series with id %d in list %d' % (series_id, list_id)}, 404
@@ -319,7 +320,7 @@ class SeriesListSeriesAPI(APIResource):
     def put(self, list_id, series_id, session=None):
         """ Edit series data """
         try:
-            series = sl.get_series_by_id(list_id=list_id, series_id=series_id, session=session)
+            series = sl.SeriesListDBContainer.get_series_by_id(list_id=list_id, series_id=series_id, session=session)
         except NoResultFound:
             return {'status': 'error',
                     'message': 'could not find series with id %d in list %d' % (series_id, list_id)}, 404

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -283,7 +283,7 @@ class SeriesListSeriesAPI(APIResource):
         db_series = sl.get_db_series(data)
         series_list.series.append(db_series)
         session.commit()
-        response = jsonify({'series': db_series.to_dict()})
+        response = jsonify(db_series.to_dict())
         response.status_code = 201
         return response
 

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -173,7 +173,7 @@ class SeriesListListAPI(APIResource):
     @api.response(200, model=list_object_schema)
     @api.validate(edit_global_series_schema)
     def put(self, list_id, session=None):
-        """ Delete list by ID """
+        """ Edit list by ID """
         data = request.json
         updated_series_list = []
         try:

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -331,6 +331,6 @@ class SeriesListSeriesAPI(APIResource):
         title = series.title
         data = request.json
         data.update({'title': title})
-        series = sl.get_db_series(data)
+        series = sl.get_db_series(data, series)
         session.commit()
         return jsonify(series.to_dict())

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -12,8 +12,6 @@ from flexget.plugins.filter.series import FilterSeriesBase
 from flexget.api import api, APIResource
 from flexget.plugins.list import series_list as sl
 
-supported_ids = FilterSeriesBase().supported_ids()
-
 log = logging.getLogger('series_list_api')
 
 series_list_api = api.namespace('series_list', description='Series List operations')

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -8,25 +8,15 @@ from math import ceil
 from flask import jsonify
 from flask import request
 from sqlalchemy.orm.exc import NoResultFound
-from flexget import plugin
 from flexget.plugins.filter.series import FilterSeriesBase
 from flexget.api import api, APIResource
 from flexget.plugins.list import series_list as sl
 
-
-SETTINGS_SCHEMA = FilterSeriesBase().settings_schema
-SERIES_ATTRIBUTES = SETTINGS_SCHEMA['properties']
+supported_ids = FilterSeriesBase().supported_ids()
 
 log = logging.getLogger('series_list_api')
 
 series_list_api = api.namespace('series_list', description='Series List operations')
-
-def supported_ids():
-    # Return a list of supported series identifier as registered via their plugins
-    ids = []
-    for plugin_ in plugin.get_plugins(group='series_metainfo'):
-        ids.append(plugin_.instance.series_identifier())
-    return ids
 
 
 class objects_container(object):
@@ -225,7 +215,7 @@ series_parser.add_argument('page', type=int, default=1, help='Page number')
 series_parser.add_argument('page_size', type=int, default=10, help='Number of series per page')
 
 series_identifiers_doc = "Use series identifier using the following format:\n[{'ID_NAME: 'ID_VALUE'}]." \
-                         " Has to be one of %s" % " ,".join(supported_ids())
+                         " Has to be one of %s" % " ,".join(supported_ids)
 
 
 @series_list_api.route('/<int:list_id>/series/')

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -129,10 +129,8 @@ class SeriesListListAPI(APIResource):
         session.delete(series_list)
         return {}
 
-choices = sorted([attribute for attribute in SERIES_ATTRIBUTES if attribute != 'set'])
-
 series_parser = api.parser()
-series_parser.add_argument('sort_by', choices=(choices), default='title',
+series_parser.add_argument('sort_by', choices=('title', 'added'), default='title',
                            help='Sort by attribute')
 series_parser.add_argument('order', choices=('desc', 'asc'), default='desc', help='Sorting order')
 series_parser.add_argument('page', type=int, default=1, help='Page number')

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -10,7 +10,7 @@ from flask import request
 from sqlalchemy.orm.exc import NoResultFound
 from flexget.plugins.filter.series import FilterSeriesBase
 from flexget.api import api, APIResource
-from flexget.plugins.list import movie_list as ml
+from flexget.plugins.list import series_list as sl
 from flexget.utils.tools import split_title_year
 
 SUPPORTED_IDS = FilterSeriesBase().supported_ids
@@ -21,11 +21,70 @@ log = logging.getLogger('series_list_api')
 
 series_list_api = api.namespace('series_list', description='Series List operations')
 
-default_error_schema = {
-    'type': 'object',
-    'properties': {
-        'status': {'type': 'string'},
-        'message': {'type': 'string'}
+
+class objects_container(object):
+    default_error_schema = {
+        'type': 'object',
+        'properties': {
+            'status': {'type': 'string'},
+            'message': {'type': 'string'}
+        }
     }
-}
+
+    list_object = {
+        'type': 'object',
+        'properties': {
+            'id': {'type': 'integer'},
+            'added_on': {'type': 'string'},
+            'name': {'type': 'string'}
+        }
+    }
+
+    list_input = copy.deepcopy(list_object)
+    del list_input['properties']['id']
+    del list_input['properties']['added_on']
+
+    return_lists = {'type': 'array', 'items': list_object}
+
+
 empty_response = api.schema('empty', {'type': 'object'})
+default_error_schema = api.schema('default_error_schema', objects_container.default_error_schema)
+return_lists_schema = api.schema('return_lists', objects_container.return_lists)
+new_list_schema = api.schema('new_list', objects_container.list_input)
+list_object_schema = api.schema('list_object', objects_container.list_object)
+
+series_list_parser = api.parser()
+series_list_parser.add_argument('name', help='Filter results by list name')
+
+
+@series_list_api.route('/')
+class SeriesListAPI(APIResource):
+    @api.response(200, model=return_lists_schema)
+    @api.doc(parser=series_list_parser)
+    def get(self, session=None):
+        """ Gets series lists """
+        args = series_list_parser.parse_args()
+        name = args.get('name')
+        series_lists = [series_list.to_dict() for series_list in sl.get_series_lists(name=name, session=session)]
+        return jsonify(series_lists)
+
+    @api.validate(new_list_schema)
+    @api.response(201, model=list_object_schema)
+    @api.response(500, description='List already exist', model=default_error_schema)
+    def post(self, session=None):
+        """ Create a new list """
+        data = request.json
+        name = data.get('name')
+        try:
+            series_list = sl.get_list_by_exact_name(name=name, session=session)
+        except NoResultFound:
+            series_list = None
+        if series_list:
+            return {'status': 'error',
+                    'message': "list with name '%s' already exists" % name}, 500
+        series_list = sl.SeriesListList(name=name)
+        session.add(series_list)
+        session.commit()
+        resp = jsonify(series_list.to_dict())
+        resp.status_code = 201
+        return resp

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -1,0 +1,31 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # pylint: disable=unused-import, redefined-builtin
+
+import copy
+import logging
+from math import ceil
+
+from flask import jsonify
+from flask import request
+from sqlalchemy.orm.exc import NoResultFound
+from flexget.plugins.filter.series import FilterSeriesBase
+from flexget.api import api, APIResource
+from flexget.plugins.list import movie_list as ml
+from flexget.utils.tools import split_title_year
+
+SUPPORTED_IDS = FilterSeriesBase().supported_ids
+SETTINGS_SCHEMA = FilterSeriesBase().settings_schema
+SERIES_ATTRIBUTES = SETTINGS_SCHEMA['properties']
+
+log = logging.getLogger('series_list_api')
+
+series_list_api = api.namespace('series_list', description='Series List operations')
+
+default_error_schema = {
+    'type': 'object',
+    'properties': {
+        'status': {'type': 'string'},
+        'message': {'type': 'string'}
+    }
+}
+empty_response = api.schema('empty', {'type': 'object'})

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -175,17 +175,17 @@ class SeriesListListAPI(APIResource):
     def put(self, list_id, session=None):
         """ Delete list by ID """
         data = request.json
-        updates_series = []
+        updated_series_list = []
         try:
             series_list = sl.SeriesListDB.get_list_by_id(list_id=list_id, session=session)
         except NoResultFound:
             return {'status': 'error',
                     'message': 'list_id %d does not exist' % list_id}, 404
         for series in series_list.series:
-            updates_series.append(sl.SeriesListDB.get_db_series(data, series))
-        series_list.series = updates_series
+            updated_series_list.append(sl.SeriesListDB.get_db_series(data, series))
+        series_list.series = updated_series_list
         session.commit()
-        return jsonify({'series': [series.to_dict() for series in updates_series]})
+        return jsonify({'series': [series.to_dict() for series in updated_series_list]})
 
 
 series_parser = api.parser()

--- a/flexget/plugins/api/series_list.py
+++ b/flexget/plugins/api/series_list.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm.exc import NoResultFound
 from flexget.plugins.filter.series import FilterSeriesBase
 from flexget.api import api, APIResource
 from flexget.plugins.list import series_list as sl
-from flexget.utils.tools import split_title_year
 
 SUPPORTED_IDS = FilterSeriesBase().supported_ids
 SETTINGS_SCHEMA = FilterSeriesBase().settings_schema
@@ -130,9 +129,10 @@ class SeriesListListAPI(APIResource):
         session.delete(series_list)
         return {}
 
+choices = sorted([attribute for attribute in SERIES_ATTRIBUTES if attribute != 'set'])
 
 series_parser = api.parser()
-series_parser.add_argument('sort_by', choices=('test'), default='title',
+series_parser.add_argument('sort_by', choices=(choices), default='title',
                            help='Sort by attribute')
 series_parser.add_argument('order', choices=('desc', 'asc'), default='desc', help='Sorting order')
 series_parser.add_argument('page', type=int, default=1, help='Page number')

--- a/flexget/plugins/cli/series_list.py
+++ b/flexget/plugins/cli/series_list.py
@@ -29,6 +29,7 @@ def supported_ids():
 class SeriesListType(object):
     """ Container class that hold several custom argparse types"""
 
+    @staticmethod
     def regex_type(value):
         """ Custom argparse type that validates regex"""
         try:
@@ -37,6 +38,7 @@ class SeriesListType(object):
             raise ArgumentTypeError('value {} is not a valid regexp'.format(value))
         return value
 
+    @staticmethod
     def quality_req_type(value):
         """ Custom argparse type that validates Quality"""
         try:
@@ -45,6 +47,7 @@ class SeriesListType(object):
             raise ArgumentTypeError(e)
         return value
 
+    @staticmethod
     def interval_type(value):
         """ Custom argparse type that validates Interval"""
         try:
@@ -53,18 +56,21 @@ class SeriesListType(object):
             raise ArgumentTypeError(e)
         return value
 
+    @staticmethod
     def episode_identifier(value):
         result = re.match(r'(?i)^S\d{2,4}E\d{2,3}$', value)
         if not result:
             raise ArgumentTypeError('Value {} does not match identifier format of `SxxEyy`'.format(value))
         return value
 
+    @staticmethod
     def date_identifier(value):
         result = re.match(r'^\d{4}-\d{2}-\d{2}$', value)
         if not result:
             raise ArgumentTypeError('Value {} does not match identifier format of `YYYY-MM-DD`'.format(value))
         return value
 
+    @staticmethod
     def sequence_identifier(value):
         try:
             if int(value) < 0:
@@ -73,6 +79,7 @@ class SeriesListType(object):
             raise ArgumentTypeError('Value {} must be an integer higher than 0'.format(value))
         return value
 
+    @staticmethod
     def series_list_keyword_type(identifier):
         if identifier.count('=') != 1:
             raise ArgumentTypeError('Received identifier in wrong format: %s, '
@@ -86,7 +93,7 @@ class SeriesListType(object):
 
 def build_data_dict(options):
     """ Converts options to a recognizable data type for series adding/matching"""
-    data = {'title': options.series_title}
+    data = {'series_name': options.series_title}
     for attribute in SERIES_ATTRIBUTES:
         if attribute == 'set':
             continue
@@ -152,10 +159,11 @@ def series_list_add(options):
         data = build_data_dict(options)
         series = SeriesList(options.list_name, session=session).find_entry(data, session=session)
         if series:
-            console('Series with title {} already exist, creating'.format(options.series_title))
+            console('Series with title {} already exist'.format(options.series_title))
             return
         series = get_db_series(data)
-        series_list.series.append(series)
+        series.list_id = series_list.id
+        session.add(series)
         console('Successfully added series {} to list {}'.format(series.title, series_list.name))
 
 

--- a/flexget/plugins/cli/series_list.py
+++ b/flexget/plugins/cli/series_list.py
@@ -132,6 +132,10 @@ def do_cli(manager, options):
         series_list_del(options)
         return
 
+    if options.list_action == 'purge':
+        series_list_purge(options)
+        return
+
 
 def series_list_lists(options):
     """ Show all series lists """
@@ -269,6 +273,17 @@ def series_list_del(options):
         console('Successfully deleted series {} from series list {}'.format(options.series_title, options.list_name))
 
 
+def series_list_purge(options):
+    with Session() as session:
+        try:
+            series_list = slDb.get_list_by_exact_name(options.list_name)
+        except NoResultFound:
+            console('Could not find series list with name {}'.format(options.list_name))
+            return
+        console('Deleting list %s' % options.list_name)
+        session.delete(series_list)
+
+
 @event('options.register')
 def register_parser_arguments():
     series_parser = ArgumentParser(add_help=False)
@@ -368,3 +383,4 @@ def register_parser_arguments():
     update_parser.add_argument('--clear', nargs='+', type=SeriesListType.exiting_attribute,
                                help="Clears a series attribute")
     subparsers.add_parser('delete', parents=[list_name_parser, series_id_parser], help='Delete series from series list')
+    subparsers.add_parser('purge', parents=[list_name_parser], help='Removes an entire series list. Use with caution.')

--- a/flexget/plugins/cli/series_list.py
+++ b/flexget/plugins/cli/series_list.py
@@ -177,74 +177,80 @@ def register_parser_arguments():
     list_name_parser.add_argument('list_name', nargs='?', default='series',
                                   help='Name of series list to operate on. Default is `series`')
 
+    series_attributes_parser = ArgumentParser(add_help=False)
+    series_attributes_parser.add_argument('--path', help='Set path field for this series')
+    series_attributes_parser.add_argument('--alternate-name', nargs='+', help='Alternate series name(s)')
+    series_attributes_parser.add_argument('--name-regexp', nargs='+', type=SeriesListType.regex_type,
+                                          help='Manually specify regexp(s) that matches to series name')
+    series_attributes_parser.add_argument('--ep-regexp', nargs='+', type=SeriesListType.regex_type,
+                                          help='Manually specify regexp(s) that matches to episode, season numbering')
+    series_attributes_parser.add_argument('--date-regexp', nargs='+', type=SeriesListType.regex_type,
+                                          help='Date regexp')
+    series_attributes_parser.add_argument('--sequence-regexp', nargs='+', type=SeriesListType.regex_type,
+                                          help='Sequence regexp')
+    series_attributes_parser.add_argument('--id-regexp', nargs='+', type=SeriesListType.regex_type,
+                                          help='Manually specify regexp(s) that matches to series identifier '
+                                               '(numbering)')
+    series_attributes_parser.add_argument('--date-yearfirst', type=bool, help='Parse year first')
+    series_attributes_parser.add_argument('--date-dayfirst', type=bool, help='Parse date first')
+    series_attributes_parser.add_argument('--quality', type=SeriesListType.quality_req_type, help='Required quality')
+    series_attributes_parser.add_argument('--qualities', type=SeriesListType.quality_req_type, nargs='+',
+                                          help='Download all listed qualities when they become available')
+    series_attributes_parser.add_argument('--timeframe', type=SeriesListType.interval_type,
+                                          help='Wait given amount of time for specified quality to become available, '
+                                               'after that fall back to best so far')
+    series_attributes_parser.add_argument('--upgrade', type=bool,
+                                          help='Keeps getting the better qualities as they become available.')
+    series_attributes_parser.add_argument('--target', type=SeriesListType.quality_req_type,
+                                          help='The target quality that should be downloaded without waiting'
+                                               ' for `timeframe` to complete')
+    series_attributes_parser.add_argument('--specials', type=bool,
+                                          help='Turn off specials support for series. On by default',
+                                          default=True)
+    series_attributes_parser.add_argument('--no-propers', dest="propers", action='store_false',
+                                          help='Turn off propers for the series')
+    series_attributes_parser.add_argument('--allow-propers', dest="propers", action='store_true',
+                                          help='Turn on propers for the series')
+    series_attributes_parser.add_argument('--propers-interval', dest="propers", type=SeriesListType.interval_type,
+                                          help='Set propers interval.')
+    series_attributes_parser.add_argument('--identified-by', choices=('ep', 'date', 'sequence', 'id', 'auto'),
+                                          help='Configure how episode numbering is detected. Uses `auto` mode as '
+                                               'default', default='auto')
+    series_attributes_parser.add_argument('--exact', type=bool, help='Enable strict name matching')
+    series_attributes_parser.add_argument('--begin-ep', type=SeriesListType.episode_identifier, dest="begin",
+                                          help='Manually specify first episode to start series on. Should conform to '
+                                               '`SxxEyy` format')
+    series_attributes_parser.add_argument('--begin-date', type=SeriesListType.date_identifier, dest="begin",
+                                          help='Manually specify first episode to start series on. Should conform to '
+                                               '`YYYY-MM-DD` format')
+    series_attributes_parser.add_argument('--begin-sequence', type=SeriesListType.sequence_identifier, dest="begin",
+                                          help='Manually specify first episode to start series on. Should be higher an'
+                                               ' integer than 0')
+    series_attributes_parser.add_argument('--from-group', nargs='+', help='Accept series only from given groups')
+    series_attributes_parser.add_argument('--parse-only', type=bool,
+                                          help='Series plugin will not accept or reject any entries, merely fill in all'
+                                               ' metadata fields.')
+    series_attributes_parser.add_argument('--special-ids', nargs='+',
+                                          help='Defines other IDs which will cause entries to be flagged as specials')
+    series_attributes_parser.add_argument('--prefer-specials', type=bool,
+                                          help='Flag entries matching both special and a normal ID type as specials')
+    series_attributes_parser.add_argument('--assume-special', type=bool,
+                                          help='Assume any entry with no series numbering detected is a special and '
+                                               'treat it accordingly')
+    series_attributes_parser.add_argument('--no-tracking', dest="tracking", action='store_false',
+                                          help='Turn off tracking for the series')
+    series_attributes_parser.add_argument('--allow-tracking', dest="tracking", action='store_true',
+                                          help='Turn on tracking for the series')
+    series_attributes_parser.add_argument('--tracking', choices=('backfill',), help='Put into backfill mode')
+    series_attributes_parser.add_argument('-i', '--identifiers', metavar='<identifiers>', nargs='+',
+                                          type=SeriesListType.series_list_keyword_type,
+                                          help='Can be a string or a list of string with the format tvdb_id=XXX,'
+                                               ' trakt_show_id=XXX, etc')
+
     parser = options.register_command('series-list', do_cli, help='View and manage series lists')
     # Set up our subparsers
     subparsers = parser.add_subparsers(title='actions', metavar='<action>', dest='list_action')
     subparsers.add_parser('all', help='Shows all existing series lists')
     subparsers.add_parser('list', parents=[list_name_parser], help='List movies from a list')
-    add_subparser = subparsers.add_parser('add', parents=[list_name_parser, series_parser],
-                                          help='Add a series to a list')
-    add_subparser.add_argument('--path', help='Set path field for this series')
-    add_subparser.add_argument('--alternate-name', nargs='+', help='Alternate series name(s)')
-    add_subparser.add_argument('--name-regexp', nargs='+', type=SeriesListType.regex_type,
-                               help='Manually specify regexp(s) that matches to series name')
-    add_subparser.add_argument('--ep-regexp', nargs='+', type=SeriesListType.regex_type,
-                               help='Manually specify regexp(s) that matches to episode, season numbering')
-    add_subparser.add_argument('--date-regexp', nargs='+', type=SeriesListType.regex_type, help='Date regexp')
-    add_subparser.add_argument('--sequence-regexp', nargs='+', type=SeriesListType.regex_type, help='Sequence regexp')
-    add_subparser.add_argument('--id-regexp', nargs='+', type=SeriesListType.regex_type,
-                               help='Manually specify regexp(s) that matches to series identifier (numbering)')
-    add_subparser.add_argument('--date-yearfirst', type=bool, help='Parse year first')
-    add_subparser.add_argument('--date-dayfirst', type=bool, help='Parse date first')
-    add_subparser.add_argument('--quality', type=SeriesListType.quality_req_type, help='Required quality')
-    add_subparser.add_argument('--qualities', type=SeriesListType.quality_req_type, nargs='+',
-                               help='Download all listed qualities when they become available')
-    add_subparser.add_argument('--timeframe', type=SeriesListType.interval_type,
-                               help='Wait given amount of time for specified quality to become available, '
-                                    'after that fall back to best so far')
-    add_subparser.add_argument('--upgrade', type=bool,
-                               help='Keeps getting the better qualities as they become available.')
-    add_subparser.add_argument('--target', type=SeriesListType.quality_req_type,
-                               help='The target quality that should be downloaded without waiting for `timeframe` '
-                                    'to complete')
-    add_subparser.add_argument('--specials', type=bool, help='Turn off specials support for series. On by default',
-                               default=True)
-    add_subparser.add_argument('--no-propers', dest="propers", action='store_false',
-                               help='Turn off propers for the series')
-    add_subparser.add_argument('--allow-propers', dest="propers", action='store_true',
-                               help='Turn on propers for the series')
-    add_subparser.add_argument('--propers-interval', dest="propers", type=SeriesListType.interval_type,
-                               help='Set propers interval.')
-    add_subparser.add_argument('--identified-by', choices=('ep', 'date', 'sequence', 'id', 'auto'),
-                               help='Configure how episode numbering is detected. Uses `auto` mode as default',
-                               default='auto')
-    add_subparser.add_argument('--exact', type=bool, help='Enable strict name matching')
-    add_subparser.add_argument('--begin-ep', type=SeriesListType.episode_identifier, dest="begin",
-                               help='Manually specify first episode to start series on. Should conform to '
-                                    '`SxxEyy` format')
-    add_subparser.add_argument('--begin-date', type=SeriesListType.date_identifier, dest="begin",
-                               help='Manually specify first episode to start series on. Should conform to '
-                                    '`YYYY-MM-DD` format')
-    add_subparser.add_argument('--begin-sequence', type=SeriesListType.sequence_identifier, dest="begin",
-                               help='Manually specify first episode to start series on. Should be higher an'
-                                    ' integer than 0')
-    add_subparser.add_argument('--from-group', nargs='+', help='Accept series only from given groups')
-    add_subparser.add_argument('--parse-only', type=bool,
-                               help='Series plugin will not accept or reject any entries, merely fill in all'
-                                    ' metadata fields.')
-    add_subparser.add_argument('--special-ids', nargs='+',
-                               help='Defines other IDs which will cause entries to be flagged as specials')
-    add_subparser.add_argument('--prefer-specials', type=bool,
-                               help='Flag entries matching both special and a normal ID type as specials')
-    add_subparser.add_argument('--assume-special', type=bool,
-                               help='Assume any entry with no series numbering detected is a special and treat it'
-                                    ' accordingly')
-    add_subparser.add_argument('--no-tracking', dest="tracking", action='store_false',
-                               help='Turn off tracking for the series')
-    add_subparser.add_argument('--allow-tracking', dest="tracking", action='store_true',
-                               help='Turn on tracking for the series')
-    add_subparser.add_argument('--tracking', choices=('backfill',), help='Put into backfill mode')
-    add_subparser.add_argument('-i', '--identifiers', metavar='<identifiers>', nargs='+',
-                               type=SeriesListType.series_list_keyword_type,
-                               help='Can be a string or a list of string with the format tvdb_id=XXX,'
-                                    ' trakt_show_id=XXX, etc')
+    subparsers.add_parser('add', parents=[list_name_parser, series_parser, series_attributes_parser],
+                          help='Add a series to a list')

--- a/flexget/plugins/cli/series_list.py
+++ b/flexget/plugins/cli/series_list.py
@@ -185,13 +185,13 @@ def series_list_show(options):
             return
 
         try:
-            series = slDb.get_series_by_id(series_list.id, int(options.series), session=session)
+            series = slDb.get_series_by_id(series_list.id, int(options.series_title), session=session)
         except NoResultFound:
             console(
-                'Could not find matching series with ID {} in list `{}`'.format(int(options.series), options.list_name))
+                'Could not find matching series with ID {} in list `{}`'.format(int(options.series_title), options.list_name))
             return
         except ValueError:
-            series = slDb.get_series_by_title(series_list.id, options.series, session=session)
+            series = slDb.get_series_by_title(series_list.id, options.series_title, session=session)
             if not series:
                 console(
                     'Could not find matching series with title `{}` in list `{}`'.format(options.series,
@@ -214,16 +214,16 @@ def series_list_update(options):
             return
 
         try:
-            series = slDb.get_series_by_id(series_list.id, int(options.series), session=session)
+            series = slDb.get_series_by_id(series_list.id, int(options.series_title), session=session)
         except NoResultFound:
             console(
-                'Could not find matching series with ID {} in list `{}`'.format(int(options.series), options.list_name))
+                'Could not find matching series with ID {} in list `{}`'.format(int(options.series_title), options.list_name))
             return
         except ValueError:
-            series = slDb.get_series_by_title(series_list.id, options.series, session=session)
+            series = slDb.get_series_by_title(series_list.id, options.series_title, session=session)
             if not series:
                 console(
-                    'Could not find matching series with title `{}` in list `{}`'.format(options.series,
+                    'Could not find matching series with title `{}` in list `{}`'.format(options.series_title,
                                                                                          options.list_name))
 
         console('Updating series #{}: {}'.format(series.id, series.title))
@@ -235,7 +235,7 @@ def series_list_update(options):
         data = build_data_dict(options)
         series = get_db_series(data, series)
         session.commit()
-        console('Successfully updated series  #{}: {}'.format(series.id, series.title))
+        console('Successfully updated series #{}: {}'.format(series.id, series.title))
 
 
 @event('options.register')
@@ -244,12 +244,13 @@ def register_parser_arguments():
     series_parser.add_argument('series_title', metavar='series-title',
                                help="Title of the series. Should include country code if relevant")
 
+    # This parser will be used when series ID can be used
+    series_id_parser = ArgumentParser(add_help=False)
+    series_id_parser.add_argument('series_title', metavar='series-title', help="Series title or ID")
+
     list_name_parser = ArgumentParser(add_help=False)
     list_name_parser.add_argument('list_name', nargs='?', default='series',
                                   help='Name of series list to operate on. Default is `series`')
-
-    series_id_parser = ArgumentParser(add_help=False)
-    series_id_parser.add_argument('series', help="Series title or ID")
 
     series_attributes_parser = ArgumentParser(add_help=False)
     series_attributes_parser.add_argument('--path', help='Set path field for this series')

--- a/flexget/plugins/cli/series_list.py
+++ b/flexget/plugins/cli/series_list.py
@@ -108,8 +108,6 @@ class SeriesListType(object):
 
 
 def tracking_attributes(attributes_list):
-    del attributes_list['path']
-    del attributes_list['set']
     del attributes_list['alternate_name']
     del attributes_list['name_regexp']
     del attributes_list['ep_regexp']

--- a/flexget/plugins/cli/series_list.py
+++ b/flexget/plugins/cli/series_list.py
@@ -1,0 +1,32 @@
+from __future__ import unicode_literals, division, absolute_import
+
+from argparse import ArgumentParser, ArgumentTypeError
+
+from flexget import options
+from flexget.event import event
+from flexget.logger import console
+from flexget.plugins.list.series_list import SeriesListDBContainer as slDb
+
+
+def do_cli(manager, options):
+    """Handle series-list subcommand"""
+    if options.list_action == 'all':
+        series_list_lists(options)
+        return
+
+
+def series_list_lists(options):
+    """ Show all movie lists """
+    lists = slDb.get_series_lists()
+    console('Existing series lists:')
+    console('-' * 20)
+    for series_list in lists:
+        console(series_list.name)
+
+
+@event('options.register')
+def register_parser_arguments():
+    parser = options.register_command('series-list', do_cli, help='view and manage series lists')
+    # Set up our subparsers
+    subparsers = parser.add_subparsers(title='actions', metavar='<action>', dest='list_action')
+    subparsers.add_parser('all', help='shows all existing series lists')

--- a/flexget/plugins/cli/series_list.py
+++ b/flexget/plugins/cli/series_list.py
@@ -137,7 +137,7 @@ def series_list_add(options):
 @event('options.register')
 def register_parser_arguments():
     series_parser = ArgumentParser(add_help=False)
-    series_parser.add_argument('series_title', help="Title of the series. Should include country code if relevant")
+    series_parser.add_argument('series-title', help="Title of the series. Should include country code if relevant")
 
     list_name_parser = ArgumentParser(add_help=False)
     list_name_parser.add_argument('list_name', nargs='?', default='series',

--- a/flexget/plugins/cli/series_list.py
+++ b/flexget/plugins/cli/series_list.py
@@ -14,8 +14,7 @@ from flexget.config_schema import parse_interval
 from flexget.plugins.list.series_list import SeriesListList, SeriesListDB as slDb, SeriesList
 from flexget.plugins.filter.series import FilterSeriesBase
 
-SETTINGS_SCHEMA = FilterSeriesBase().settings_schema
-SERIES_ATTRIBUTES = SETTINGS_SCHEMA['properties']
+SERIES_ATTRIBUTES = FilterSeriesBase().settings_schema['properties']
 
 
 class SeriesListType(object):

--- a/flexget/plugins/cli/series_list.py
+++ b/flexget/plugins/cli/series_list.py
@@ -141,6 +141,7 @@ def series_list_list(options):
 
 
 def series_list_add(options):
+    """ Add series to the series list """
     with Session() as session:
         try:
             series_list = slDb.get_list_by_exact_name(options.list_name)
@@ -210,13 +211,13 @@ def register_parser_arguments():
                                help='Configure how episode numbering is detected. Uses `auto` mode as default',
                                default='auto')
     add_subparser.add_argument('--exact', type=bool, help='Enable strict name matching')
-    add_subparser.add_argument('--begin-ep-identifier', type=SeriesListType.episode_identifier, dest="begin",
+    add_subparser.add_argument('--begin-ep', type=SeriesListType.episode_identifier, dest="begin",
                                help='Manually specify first episode to start series on. Should conform to '
                                     '`SxxEyy` format')
-    add_subparser.add_argument('--begin-date-identifier', type=SeriesListType.date_identifier, dest="begin",
+    add_subparser.add_argument('--begin-date', type=SeriesListType.date_identifier, dest="begin",
                                help='Manually specify first episode to start series on. Should conform to '
                                     '`YYYY-MM-DD` format')
-    add_subparser.add_argument('--begin-sequence-identifier', type=SeriesListType.sequence_identifier, dest="begin",
+    add_subparser.add_argument('--begin-sequence', type=SeriesListType.sequence_identifier, dest="begin",
                                help='Manually specify first episode to start series on. Should be higher an'
                                     ' integer than 0')
     add_subparser.add_argument('--from-group', nargs='+', help='Accept series only from given groups')

--- a/flexget/plugins/cli/series_list.py
+++ b/flexget/plugins/cli/series_list.py
@@ -18,14 +18,6 @@ SETTINGS_SCHEMA = FilterSeriesBase().settings_schema
 SERIES_ATTRIBUTES = SETTINGS_SCHEMA['properties']
 
 
-def supported_ids():
-    # Return a list of supported series identifier as registered via their plugins
-    ids = []
-    for p in plugin.get_plugins(group='series_metainfo'):
-        ids.append(p.instance.series_identifier())
-    return ids
-
-
 class SeriesListType(object):
     """ Container class that hold several custom argparse types"""
 
@@ -85,10 +77,11 @@ class SeriesListType(object):
             raise ArgumentTypeError('Received identifier in wrong format: %s, '
                                     ' should be in keyword format like `tvdb_id=1234567`'.format(identifier))
         name, value = identifier.split('=', 2)
-        if name not in supported_ids():
+        if name not in FilterSeriesBase().supported_ids():
             raise ArgumentTypeError(
                 'Received unsupported identifier ID %s. Should be one of %s'.format(identifier,
-                                                                                    ' ,'.join(supported_ids())))
+                                                                                    ' ,'.join(
+                                                                                        FilterSeriesBase().supported_ids())))
         return {name: value}
 
     @staticmethod
@@ -107,7 +100,7 @@ def build_data_dict(options):
         data[attribute] = getattr(options, attribute)
     if options.identifiers:
         for identifier in options.identifiers:
-            if identifier in supported_ids():
+            if identifier in FilterSeriesBase().supported_ids():
                 for k, v in identifier.items():
                     data[k] = v
     return data

--- a/flexget/plugins/cli/series_list.py
+++ b/flexget/plugins/cli/series_list.py
@@ -2,9 +2,12 @@ from __future__ import unicode_literals, division, absolute_import
 
 from argparse import ArgumentParser, ArgumentTypeError
 
+from sqlalchemy.orm.exc import NoResultFound
+
 from flexget import options
 from flexget.event import event
 from flexget.logger import console
+from flexget.manager import Session
 from flexget.plugins.list.series_list import SeriesListDBContainer as slDb
 
 
@@ -14,14 +17,35 @@ def do_cli(manager, options):
         series_list_lists(options)
         return
 
+    if options.list_action == 'list':
+        series_list_list(options)
+        return
+
 
 def series_list_lists(options):
-    """ Show all movie lists """
+    """ Show all series lists """
     lists = slDb.get_series_lists()
     console('Existing series lists:')
     console('-' * 20)
     for series_list in lists:
         console(series_list.name)
+
+
+def series_list_list(options):
+    """List series list"""
+    with Session() as session:
+        try:
+            series_list = slDb.get_list_by_exact_name(options.list_name)
+        except NoResultFound:
+            console('Could not find series list with name {}'.format(options.list_name))
+            return
+        console('Series for list {}:'.format(options.list_name))
+        console('-' * 79)
+        for series in slDb.get_series_by_list_id(series_list.id, descending=True, session=session):
+            title_string = '{} '.format(series.title)
+            identifiers = '[' + ', '.join(
+                '{}={}'.format(identifier.id_name, identifier.id_value) for identifier in series.ids) + ']'
+            console(title_string + identifiers)
 
 
 @event('options.register')
@@ -30,3 +54,7 @@ def register_parser_arguments():
     # Set up our subparsers
     subparsers = parser.add_subparsers(title='actions', metavar='<action>', dest='list_action')
     subparsers.add_parser('all', help='shows all existing series lists')
+
+    list_name_parser = ArgumentParser(add_help=False)
+    list_name_parser.add_argument('list_name', nargs='?', default='series', help='Name of series list to operate on')
+    subparsers.add_parser('list', parents=[list_name_parser], help='list movies from a list')

--- a/flexget/plugins/cli/series_list.py
+++ b/flexget/plugins/cli/series_list.py
@@ -74,12 +74,12 @@ class SeriesListType(object):
     @staticmethod
     def series_list_keyword_type(identifier):
         if identifier.count('=') != 1:
-            raise ArgumentTypeError('Received identifier in wrong format: %s, '
-                                    ' should be in keyword format like `tvdb_id=1234567`'.format(identifier))
+            raise ArgumentTypeError('Received identifier in wrong format: {}, '
+                                    'should be in keyword format like `tvdb_id=1234567`'.format(identifier))
         name, value = identifier.split('=', 2)
         if name not in FilterSeriesBase().supported_ids():
             raise ArgumentTypeError(
-                'Received unsupported identifier ID %s. Should be one of %s'.format(identifier,
+                'Received unsupported identifier ID {}. Should be one of {}'.format(identifier,
                                                                                     ' ,'.join(
                                                                                         FilterSeriesBase().supported_ids())))
         return {name: value}
@@ -87,8 +87,8 @@ class SeriesListType(object):
     @staticmethod
     def keyword_type(identifier):
         if identifier.count('=') != 1:
-            raise ArgumentTypeError('Received identifier in wrong format: %s, '
-                                    ' should be in keyword format like `movedone=/a/random/path`'.format(identifier))
+            raise ArgumentTypeError('Received identifier in wrong format: {}, '
+                                    'should be in keyword format like `movedone=/a/random/path`'.format(identifier))
         name, value = identifier.split('=', 2)
         return {name: value}
 
@@ -285,7 +285,7 @@ def series_list_purge(options):
         except NoResultFound:
             console('Could not find series list with name {}'.format(options.list_name))
             return
-        console('Deleting list %s' % options.list_name)
+        console('Deleting list {}'.format(options.list_name))
         session.delete(series_list)
 
 

--- a/flexget/plugins/cli/series_list.py
+++ b/flexget/plugins/cli/series_list.py
@@ -1,14 +1,86 @@
 from __future__ import unicode_literals, division, absolute_import
 
+import re
 from argparse import ArgumentParser, ArgumentTypeError
 
 from sqlalchemy.orm.exc import NoResultFound
 
-from flexget import options
+from flexget import options, plugin
 from flexget.event import event
 from flexget.logger import console
 from flexget.manager import Session
-from flexget.plugins.list.series_list import SeriesListDBContainer as slDb
+from flexget.utils import qualities
+from flexget.config_schema import parse_interval
+from flexget.plugins.list.series_list import SeriesListList, SeriesListDBContainer as slDb
+
+
+def supported_ids():
+    # Return a list of supported series identifier as registered via their plugins
+    ids = []
+    for p in plugin.get_plugins(group='series_metainfo'):
+        ids.append(p.instance.series_identifier())
+    return ids
+
+
+def regex_type(value):
+    """ Custom argparse type that validates regex"""
+    try:
+        re.compile(value)
+    except re.error:
+        raise ArgumentTypeError('value {} is not a valid regexp'.format(value))
+    return value
+
+
+def quality_req_type(value):
+    """ Custom argparse type that validates Quality"""
+    try:
+        qualities.Requirements(value)
+    except ValueError as e:
+        raise ArgumentTypeError(e)
+    return value
+
+
+def interval_type(value):
+    """ Custom argparse type that validates Interval"""
+    try:
+        parse_interval(value)
+    except (ValueError, TypeError) as e:
+        raise ArgumentTypeError(e)
+    return value
+
+
+def episode_identifier(value):
+    result = re.match(r'(?i)^S\d{2,4}E\d{2,3}$', value)
+    if not result:
+        raise ArgumentTypeError('Value {} does not match identifier format of `SxxEyy`'.format(value))
+    return value
+
+
+def date_identifier(value):
+    result = re.match(r'^\d{4}-\d{2}-\d{2}$', value)
+    if not result:
+        raise ArgumentTypeError('Value {} does not match identifier format of `YYYY-MM-DD`'.format(value))
+    return value
+
+
+def sequence_identifier(value):
+    try:
+        if int(value) < 0:
+            ArgumentTypeError('Value {} must be an integer higher than 0'.format(value))
+    except ValueError:
+        raise ArgumentTypeError('Value {} must be an integer higher than 0'.format(value))
+    return value
+
+
+def series_list_keyword_type(identifier):
+    if identifier.count('=') != 1:
+        raise ArgumentTypeError('Received identifier in wrong format: %s, '
+                                ' should be in keyword format like `tvdb_id=1234567`' % identifier)
+    name, value = identifier.split('=', 2)
+    if name not in supported_ids():
+        raise ArgumentTypeError(
+            'Received unsupported identifier ID %s. Should be one of %s' % (identifier, ' ,'.join(supported_ids())))
+    return {name: value}
 
 
 def do_cli(manager, options):
@@ -19,6 +91,10 @@ def do_cli(manager, options):
 
     if options.list_action == 'list':
         series_list_list(options)
+        return
+
+    if options.list_action == 'add':
+        series_list_add(options)
         return
 
 
@@ -48,13 +124,88 @@ def series_list_list(options):
             console(title_string + identifiers)
 
 
+def series_list_add(options):
+    with Session() as session:
+        try:
+            series_list = slDb.get_list_by_exact_name(options.list_name)
+        except NoResultFound:
+            console('Could not find series list with name {}, creating'.format(options.list_name))
+            series_list = SeriesListList(name=options.list_name)
+        session.merge(series_list)
+
+
 @event('options.register')
 def register_parser_arguments():
-    parser = options.register_command('series-list', do_cli, help='view and manage series lists')
-    # Set up our subparsers
-    subparsers = parser.add_subparsers(title='actions', metavar='<action>', dest='list_action')
-    subparsers.add_parser('all', help='shows all existing series lists')
+    series_parser = ArgumentParser(add_help=False)
+    series_parser.add_argument('series_title', help="Title of the series. Should include country code if relevant")
 
     list_name_parser = ArgumentParser(add_help=False)
-    list_name_parser.add_argument('list_name', nargs='?', default='series', help='Name of series list to operate on')
-    subparsers.add_parser('list', parents=[list_name_parser], help='list movies from a list')
+    list_name_parser.add_argument('list_name', nargs='?', default='series',
+                                  help='Name of series list to operate on. Default is `series`')
+
+    parser = options.register_command('series-list', do_cli, help='View and manage series lists')
+    # Set up our subparsers
+    subparsers = parser.add_subparsers(title='actions', metavar='<action>', dest='list_action')
+    subparsers.add_parser('all', help='Shows all existing series lists')
+    subparsers.add_parser('list', parents=[list_name_parser], help='List movies from a list')
+    add_subparser = subparsers.add_parser('add', parents=[list_name_parser, series_parser],
+                                          help='Add a series to a list')
+    add_subparser.add_argument('--alternate-name', nargs='+', help='Alternate series name(s)')
+    add_subparser.add_argument('--name-regexp', nargs='+', type=regex_type,
+                               help='Manually specify regexp(s) that matches to series name.')
+    add_subparser.add_argument('--ep-regexp', nargs='+', type=regex_type,
+                               help='Manually specify regexp(s) that matches to episode, season numbering.')
+    add_subparser.add_argument('--date-regexp', nargs='+', type=regex_type, help='Date regexp')
+    add_subparser.add_argument('--sequence-regexp', nargs='+', type=regex_type, help='Sequence regexp')
+    add_subparser.add_argument('--id-regexp', nargs='+', type=regex_type,
+                               help='Manually specify regexp(s) that matches to series identifier (numbering).')
+    add_subparser.add_argument('--date-yearfirst', type=bool, help='Parse year first')
+    add_subparser.add_argument('--date-dayfirst', type=bool, help='Parse date first')
+    add_subparser.add_argument('--quality', type=quality_req_type, help='Required quality')
+    add_subparser.add_argument('--qualities', type=quality_req_type, nargs='+',
+                               help='Download all listed qualities when they become available.')
+    add_subparser.add_argument('--upgrade', type=bool,
+                               help='Keeps getting the better qualities as they become available.')
+    add_subparser.add_argument('--target', type=quality_req_type,
+                               help='The target quality that should be downloaded without waiting for `timeframe` '
+                                    'to complete.')
+    add_subparser.add_argument('--specials', type=bool, help='Turn off specials support for series. On by default',
+                               default=True)
+    add_subparser.add_argument('--no-propers', dest="propers", action='store_false',
+                               help='Turn off propers for the series.')
+    add_subparser.add_argument('--allow-propers', dest="propers", action='store_true',
+                               help='Turn on propers for the series.')
+    add_subparser.add_argument('--propers-interval', dest="propers", type=interval_type, help='Set propers interval.')
+    add_subparser.add_argument('--identified-by', choices=('ep', 'date', 'sequence', 'id', 'auto'),
+                               help='Configure how episode numbering is detected. Uses `auto` mode as default',
+                               default='auto')
+    add_subparser.add_argument('--exact', type=bool, help='Enable strict name matching')
+    add_subparser.add_argument('--begin-ep-identifier', type=episode_identifier, dest="begin",
+                               help='Manually specify first episode to start series on. Should conform to '
+                                    '`SxxEyy` format')
+    add_subparser.add_argument('--begin-date-identifier', type=date_identifier, dest="begin",
+                               help='Manually specify first episode to start series on. Should conform to '
+                                    '`YYYY-MM-DD` format')
+    add_subparser.add_argument('--begin-sequence-identifier', type=sequence_identifier, dest="begin",
+                               help='Manually specify first episode to start series on. Should be higher an'
+                                    ' integer than 0')
+    add_subparser.add_argument('--from-group', nargs='+', help='Accept series only from given groups')
+    add_subparser.add_argument('--parse-only', type=bool,
+                               help='Series plugin will not accept or reject any entries, merely fill in all'
+                                    ' metadata fields.')
+    add_subparser.add_argument('--specials-ids', nargs='+',
+                               help='Defines other IDs which will cause entries to be flagged as specials')
+    add_subparser.add_argument('--prefer-specials', type=bool,
+                               help='Flag entries matching both special and a normal ID type as specials')
+    add_subparser.add_argument('--assume-special', type=bool,
+                               help='Assume any entry with no series numbering detected is a special and treat it'
+                                    ' accordingly')
+    add_subparser.add_argument('--no-tracking', dest="tracking", action='store_false',
+                               help='Turn off tracking for the series.')
+    add_subparser.add_argument('--allow-tracking', dest="tracking", action='store_true',
+                               help='Turn on tracking for the series.')
+    add_subparser.add_argument('--tracking', choices=('backfill',), help='Put into backfill mode')
+    add_subparser.add_argument('-i', '--identifiers', metavar='<identifiers>', nargs='+',
+                               type=series_list_keyword_type,
+                               help='Can be a string or a list of string with the format tvdb_id=XXX,'
+                                    ' trakt_show_id=XXX, etc')

--- a/flexget/plugins/cli/series_list.py
+++ b/flexget/plugins/cli/series_list.py
@@ -11,7 +11,7 @@ from flexget.logger import console
 from flexget.manager import Session
 from flexget.utils import qualities
 from flexget.config_schema import parse_interval
-from flexget.plugins.list.series_list import SeriesListList, SeriesListDB as slDb, SeriesList, get_db_series
+from flexget.plugins.list.series_list import SeriesListList, SeriesListDB as slDb, SeriesList
 from flexget.plugins.filter.series import FilterSeriesBase
 
 SETTINGS_SCHEMA = FilterSeriesBase().settings_schema
@@ -184,7 +184,7 @@ def series_list_add(options):
         if series:
             console('Series with title {} already exist'.format(options.series_title))
             return
-        series = get_db_series(data)
+        series = slDb.get_db_series(data)
         series.list_id = series_list.id
         session.add(series)
         console('Successfully added series {} to list {}'.format(series.title, series_list.name))
@@ -248,7 +248,7 @@ def series_list_update(options):
                 setattr(series, attribute, None)
             return
         data = build_data_dict(options)
-        series = get_db_series(data, series)
+        series = slDb.get_db_series(data, series)
         session.commit()
         console('Successfully updated series #{}: {}'.format(series.id, series.title))
 

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -949,10 +949,13 @@ class FilterSeriesBase(object):
             'additionalProperties': False
         }
 
-    @property
-    def supported_ids(self):
-        # A list of supported series IDs to be used by various series plugins like configure_series, series_list, etc.
-        return ['tvdb_id', 'trakt_show_id', 'tvmaze_id']
+    @staticmethod
+    def supported_ids():
+        # Return a list of supported series identifier as registered via their plugins
+        ids = []
+        for p in plugin.get_plugins(group='series_metainfo'):
+            ids.append(p.instance.series_identifier())
+        return ids
 
     def make_grouped_config(self, config):
         """Turns a simple series list into grouped format with a empty settings dict"""

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -952,7 +952,7 @@ class FilterSeriesBase(object):
     @property
     def supported_ids(self):
         # A list of supported series IDs to be used by various series plugins like configure_series, series_list, etc.
-        return ['tvdb_id', 'trakt_series_id', 'tvmaze_id']
+        return ['tvdb_id', 'trakt_show_id', 'tvmaze_id']
 
     def make_grouped_config(self, config):
         """Turns a simple series list into grouped format with a empty settings dict"""

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -40,7 +40,7 @@ class SeriesListList(Base):
     series = relationship('SeriesListSeries', backref='list', cascade='all, delete, delete-orphan', lazy='dynamic')
 
     def __repr__(self):
-        return '<SeriesListList name=%d>' % self.id
+        return '<SeriesListList id=%d,name=%s>' % (self.id, self.name)
 
     def to_dict(self):
         return {
@@ -330,6 +330,7 @@ class SeriesList(MutableSet):
         self.list_name = config.get('list_name')
         db_list = self._db_list(session)
         if not db_list:
+            log.debug('series list with name %s not found, adding', self.list_name)
             session.add(SeriesListList(name=self.list_name))
 
     @with_session

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -13,7 +13,7 @@ from sqlalchemy.sql.elements import and_
 from flexget.plugins.filter.series import FilterSeriesBase
 from flexget import plugin
 from flexget.db_schema import versioned_base
-from flexget.utils.database import with_session
+from flexget.utils.database import with_session, json_synonym
 from flexget.entry import Entry
 from flexget.event import event
 
@@ -50,6 +50,8 @@ class SeriesListSeries(Base):
     title = Column(Unicode)
 
     # Internal series attributes
+    _set = Column('set', Unicode)
+    set = json_synonym('_set')
     path = Column(Unicode)
     alternate_name = relationship('SeriesListAlternateName', backref='series', cascade='all, delete, delete-orphan')
     name_regexp = relationship('SeriesListNameRegexp', backref='series', cascade='all, delete, delete-orphan')
@@ -119,9 +121,6 @@ class SeriesListSeries(Base):
         entry['set'] = {}
 
         for attribute in SERIES_ATTRIBUTES:
-            # `set` is not a real series attribute and is just a way to pass IDs in task.
-            if attribute == 'set':
-                continue
             result = self.format_converter(attribute)
             if result:
                 # Maintain support for configure_series plugin expected format
@@ -140,9 +139,6 @@ class SeriesListSeries(Base):
             'series_list_identifiers': [series_list_id.to_dict() for series_list_id in self.ids]
         }
         for attribute in SETTINGS_SCHEMA['properties']:
-            # `set` is not a real series attribute and is just a way to pass IDs in task.
-            if attribute == 'set':
-                continue
             series_dict[attribute] = self.format_converter(attribute)
         return series_dict
 

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -22,7 +22,14 @@ Base = versioned_base('series_list', 0)
 
 SETTINGS_SCHEMA = FilterSeriesBase().settings_schema
 SERIES_ATTRIBUTES = SETTINGS_SCHEMA['properties']
-supported_ids = FilterSeriesBase().supported_ids()
+
+
+def supported_ids():
+    # Return a list of supported series identifier as registered via their plugins
+    ids = []
+    for p in plugin.get_plugins(group='series_metainfo'):
+        ids.append(p.instance.series_identifier())
+    return ids
 
 
 class SeriesListList(Base):
@@ -292,7 +299,7 @@ def get_db_series(entry):
         db_series.special_ids = [SeriesListSpecialID(id_name=name) for name in entry.get('special_ids')]
 
     # Get list of supported identifiers
-    for id_name in supported_ids:
+    for id_name in supported_ids():
         value = entry.get(id_name)
         if value:
             log.debug('found supported ID %s with value %s in entry, adding to series', id_name, value)
@@ -352,7 +359,7 @@ class SeriesList(MutableSet):
     @with_session
     def _find_entry(self, entry, session=None):
         """Finds `SeriesListSeries` corresponding to this entry, if it exists."""
-        for id_name in supported_ids:
+        for id_name in supported_ids():
             if entry.get(id_name):
                 log.debug('trying to match series based off id %s: %s', id_name, entry[id_name])
                 res = (self._db_list(session).series.join(SeriesListSeries.ids).filter(

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -290,3 +290,28 @@ def get_series_lists(name=None, session=None):
         log.debug('filtering by name %s', name)
         query = query.filter(SeriesListList.name == name)
     return query.all()
+
+
+@with_session
+def get_list_by_id(list_id, session=None):
+    log.debug('fetching list with id %d', list_id)
+    return session.query(SeriesListList).filter(SeriesListList.id == list_id).one()
+
+
+@with_session
+def get_series_by_list_id(list_id, count=False, start=None, stop=None, order_by='added', descending=False,
+                          session=None):
+    query = session.query(SeriesListSeries).filter(SeriesListSeries.list_id == list_id)
+    if count:
+        return query.count()
+    query = query.slice(start, stop).from_self()
+    if descending:
+        query = query.order_by(getattr(SeriesListSeries, order_by).desc())
+    else:
+        query = query.order_by(getattr(SeriesListSeries, order_by))
+    return query.all()
+
+@with_session
+def get_list_by_exact_name(name, session=None):
+    log.debug('returning list with name %s', name)
+    return session.query(SeriesListList).filter(func.lower(SeriesListList.name) == name.lower()).one()

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -22,14 +22,7 @@ Base = versioned_base('series_list', 0)
 
 SETTINGS_SCHEMA = FilterSeriesBase().settings_schema
 SERIES_ATTRIBUTES = SETTINGS_SCHEMA['properties']
-
-
-def supported_ids():
-    # Return a list of supported series identifier as registered via their plugins
-    ids = []
-    for plugin_ in plugin.get_plugins(group='series_metainfo'):
-        ids.append(plugin_.instance.series_identifier())
-    return ids
+supported_ids = FilterSeriesBase().supported_ids()
 
 
 class SeriesListList(Base):
@@ -321,7 +314,7 @@ def get_db_series(entry):
         db_series.tracking = entry.get('tracking')
 
     # Get list of supported identifiers
-    for id_name in supported_ids():
+    for id_name in supported_ids:
         value = entry.get(id_name)
         if value:
             log.debug('found supported ID %s with value %s in entry, adding to series', id_name, value)
@@ -381,7 +374,7 @@ class SeriesList(MutableSet):
     @with_session
     def _find_entry(self, entry, session=None):
         """Finds `SeriesListSeries` corresponding to this entry, if it exists."""
-        for id_name in supported_ids():
+        for id_name in supported_ids:
             if entry.get(id_name):
                 log.debug('trying to match series based off id %s: %s', id_name, entry[id_name])
                 res = (self._db_list(session).series.join(SeriesListSeries.ids).filter(

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -69,21 +69,21 @@ class SeriesListSeries(Base):
     date_dayfirst = Column(Boolean)
     quality = relationship('SeriesListQuality', uselist=False, backref='series', cascade='all, delete, delete-orphan')
     qualities = relationship('SeriesListQualities', backref='series',
-                             cascade='all, delete, delete-orphan')  # Todo: enforce format
-    timeframe = Column(Unicode)  # Todo: enforce format
+                             cascade='all, delete, delete-orphan')
+    timeframe = Column(Unicode)
     upgrade = Column(Boolean)
-    target = Column(Unicode)  # Todo: enforce format
+    target = Column(Unicode)
     specials = Column(Boolean)
-    propers = Column(Unicode)  # Todo: enforce format
+    propers = Column(Unicode)
     identified_by = Column(String)
     exact = Column(Boolean)
-    begin = Column(Unicode)  # Todo: enforce format
+    begin = Column(Unicode)
     from_group = relationship('SeriesListFromGroup', backref='series', cascade='all, delete, delete-orphan')
     parse_only = Column(Boolean)
     special_ids = relationship('SeriesListSpecialID', backref='series', cascade='all, delete, delete-orphan')
     prefer_specials = Column(Boolean)
     assume_special = Column(Boolean)
-    tracking = Column(Unicode)  # Todo: enforce format
+    tracking = Column(Unicode)
 
     list_id = Column(Integer, ForeignKey(SeriesListList.id), nullable=False)
     ids = relationship('SeriesListSeriesExternalID', backref='series', cascade='all, delete, delete-orphan')
@@ -270,32 +270,55 @@ class SeriesListSpecialID(Base):
 def get_db_series(entry):
     title = entry.get('series_name') or entry['title']
     db_series = SeriesListSeries(title)
-    # Setting series attributes
-    db_series.alternate_name = [SeriesListAlternateName(name=name) for name in entry.get('alternate_name', [])]
-    db_series.name_regexp = [SeriesListNameRegexp(regexp=regexp) for regexp in entry.get('name_regexp', [])]
-    db_series.ep_regexp = [SeriesListEpRegexp(regexp=regexp) for regexp in entry.get('ep_regexp', [])]
-    db_series.date_regexp = [SeriesListDateRegexp(regexp=regexp) for regexp in entry.get('date_regexp', [])]
-    db_series.sequence_regexp = [SeriesListSequenceRegexp(regexp=regexp) for regexp in
-                                 entry.get('sequence_regexp', [])]
-    db_series.id_regexp = [SeriesListIDRegexp(regexp=regexp) for regexp in entry.get('id_regexp', [])]
-    db_series.date_dayfirst = entry.get('date_dayfirst')
-    db_series.date_dayfirst = entry.get('date_dayfirst')
-    db_series.quality = SeriesListQuality(quality=entry.get('quality')) if entry.get('quality') else None
-    db_series.qualities = [SeriesListQualities(quality=quality) for quality in entry.get('qualities', [])]
-    db_series.timeframe = entry.get('timeframe')
-    db_series.upgrade = entry.get('upgrade')
-    db_series.target = entry.get('target')
-    db_series.specials = entry.get('specials')
-    db_series.propers = entry.get('propers')
-    db_series.identified_by = entry.get('identified_by')
-    db_series.exact = entry.get('exact')
-    db_series.begin = entry.get('begin')
-    db_series.from_group = [SeriesListFromGroup(group_name=name) for name in entry.get('from_group', [])]
-    db_series.parse_only = entry.get('parse_only')
-    db_series.special_ids = [SeriesListSpecialID(id_name=name) for name in entry.get('special_ids', [])]
-    db_series.prefer_specials = entry.get('prefer_specials')
-    db_series.assume_special = entry.get('assume_special')
-    db_series.tracking = entry.get('tracking')
+    # Setting series attributes only for received data
+    if entry.get('alternate_name'):
+        db_series.alternate_name = [SeriesListAlternateName(name=name) for name in entry.get('alternate_name')]
+    if entry.get('name_regexp'):
+        db_series.name_regexp = [SeriesListNameRegexp(regexp=regexp) for regexp in entry.get('name_regexp')]
+    if entry.get('ep_regexp'):
+        db_series.ep_regexp = [SeriesListEpRegexp(regexp=regexp) for regexp in entry.get('ep_regexp')]
+    if entry.get('date_regexp'):
+        db_series.date_regexp = [SeriesListDateRegexp(regexp=regexp) for regexp in entry.get('date_regexp')]
+    if entry.get('sequence_regexp'):
+        db_series.sequence_regexp = [SeriesListSequenceRegexp(regexp=regexp) for regexp in entry.get('sequence_regexp')]
+    if entry.get('id_regexp'):
+        db_series.id_regexp = [SeriesListIDRegexp(regexp=regexp) for regexp in entry.get('id_regexp')]
+    if entry.get('date_dayfirst'):
+        db_series.date_dayfirst = entry.get('date_dayfirst')
+    if entry.get('date_dayfirst'):
+        db_series.date_dayfirst = entry.get('date_dayfirst')
+    if entry.get('quality'):
+        db_series.quality = SeriesListQuality(quality=entry.get('quality'))
+    if entry.get('qualities'):
+        db_series.qualities = [SeriesListQualities(quality=quality) for quality in entry.get('qualities')]
+    if entry.get('timeframe'):
+        db_series.timeframe = entry.get('timeframe')
+    if entry.get('upgrade'):
+        db_series.upgrade = entry.get('upgrade')
+    if entry.get('target'):
+        db_series.target = entry.get('target')
+    if entry.get('specials'):
+        db_series.specials = entry.get('specials')
+    if entry.get('propers'):
+        db_series.propers = entry.get('propers')
+    if entry.get('identified_by'):
+        db_series.identified_by = entry.get('identified_by')
+    if entry.get('exact'):
+        db_series.exact = entry.get('exact')
+    if entry.get('begin'):
+        db_series.begin = entry.get('begin')
+    if entry.get('from_group'):
+        db_series.from_group = [SeriesListFromGroup(group_name=name) for name in entry.get('from_group')]
+    if entry.get('parse_only'):
+        db_series.parse_only = entry.get('parse_only')
+    if entry.get('special_ids'):
+        db_series.special_ids = [SeriesListSpecialID(id_name=name) for name in entry.get('special_ids')]
+    if entry.get('prefer_specials'):
+        db_series.prefer_specials = entry.get('prefer_specials')
+    if entry.get('assume_special'):
+        db_series.assume_special = entry.get('assume_special')
+    if entry.get('tracking'):
+        db_series.tracking = entry.get('tracking')
 
     # Get list of supported identifiers
     for id_name in supported_ids():
@@ -458,3 +481,10 @@ def get_series_by_title(list_id, title, session=None):
                 func.lower(SeriesListSeries.title) == title.lower(),
                 SeriesListSeries.list_id == list_id)
         ).first()
+
+
+@with_session
+def get_series_by_id(list_id, series_id, session=None):
+    log.debug('fetching series with id %d from list id %d', series_id, list_id)
+    return session.query(SeriesListSeries).filter(
+        and_(SeriesListSeries.id == series_id, SeriesListSeries.list_id == list_id)).one()

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -226,7 +226,7 @@ class SeriesListIDRegexp(Base):
 
 
 class SeriesListQuality(Base):
-    __tablename__ = 'series_list_id_quality'
+    __tablename__ = 'series_list_quality'
 
     id = Column(Integer, primary_key=True)
     quality = Column(Unicode)
@@ -235,7 +235,7 @@ class SeriesListQuality(Base):
 
 
 class SeriesListQualities(Base):
-    __tablename__ = 'series_list_id_qualities'
+    __tablename__ = 'series_list_qualities'
 
     id = Column(Integer, primary_key=True)
     quality = Column(Unicode)

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -13,10 +13,9 @@ from sqlalchemy.sql.elements import and_
 from flexget.plugins.filter.series import FilterSeriesBase
 from flexget import plugin
 from flexget.db_schema import versioned_base
-from flexget.utils.database import json_synonym, with_session
+from flexget.utils.database import with_session
 from flexget.entry import Entry
 from flexget.event import event
-from flexget.utils.tools import split_title_year
 
 log = logging.getLogger('series_list')
 Base = versioned_base('series_list', 0)
@@ -34,7 +33,7 @@ class SeriesListList(Base):
     series = relationship('SeriesListSeries', backref='list', cascade='all, delete, delete-orphan', lazy='dynamic')
 
     def __repr__(self):
-        return '<SeriesListList name=%d>' % (self.id)
+        return '<SeriesListList name=%d>' % self.id
 
     def to_dict(self):
         return {

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -407,7 +407,7 @@ class PluginSeriesList(object):
         return list(SeriesList(config))
 
 
-class SeriesListDBContainer(object):
+class SeriesListDB(object):
     """ A container class to hold DB methods for this plugin"""
 
     @staticmethod
@@ -449,7 +449,7 @@ class SeriesListDBContainer(object):
     @staticmethod
     @with_session
     def get_series_by_title(list_id, title, session=None):
-        series_list = SeriesListDBContainer.get_list_by_id(list_id=list_id, session=session)
+        series_list = SeriesListDB.get_list_by_id(list_id=list_id, session=session)
         if series_list:
             log.debug('searching for series %s in list %d', title, list_id)
             return session.query(SeriesListSeries).filter(

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -264,6 +264,12 @@ def get_db_series(entry):
     title = entry.get('series_name') or entry['title']
     db_series = SeriesListSeries(title)
     # Setting series attributes only for received data
+    single_attributes = ['date_dayfirst', 'date_yearfirst', 'timeframe', 'upgrade', 'target', 'specials', 'propers',
+                         'identified_by', 'exact', 'begin', 'parse_only', 'prefer_specials', 'assume_special',
+                         'tracking']
+    for attribute in single_attributes:
+        if entry.get(attribute):
+            setattr(db_series, attribute, entry.get(attribute))
     if entry.get('alternate_name'):
         db_series.alternate_name = [SeriesListAlternateName(name=name) for name in entry.get('alternate_name')]
     if entry.get('name_regexp'):
@@ -276,42 +282,14 @@ def get_db_series(entry):
         db_series.sequence_regexp = [SeriesListSequenceRegexp(regexp=regexp) for regexp in entry.get('sequence_regexp')]
     if entry.get('id_regexp'):
         db_series.id_regexp = [SeriesListIDRegexp(regexp=regexp) for regexp in entry.get('id_regexp')]
-    if entry.get('date_dayfirst'):
-        db_series.date_dayfirst = entry.get('date_dayfirst')
-    if entry.get('date_dayfirst'):
-        db_series.date_dayfirst = entry.get('date_dayfirst')
     if entry.get('quality'):
         db_series.quality = SeriesListQuality(quality=entry.get('quality'))
     if entry.get('qualities'):
         db_series.qualities = [SeriesListQualities(quality=quality) for quality in entry.get('qualities')]
-    if entry.get('timeframe'):
-        db_series.timeframe = entry.get('timeframe')
-    if entry.get('upgrade'):
-        db_series.upgrade = entry.get('upgrade')
-    if entry.get('target'):
-        db_series.target = entry.get('target')
-    if entry.get('specials'):
-        db_series.specials = entry.get('specials')
-    if entry.get('propers'):
-        db_series.propers = entry.get('propers')
-    if entry.get('identified_by'):
-        db_series.identified_by = entry.get('identified_by')
-    if entry.get('exact'):
-        db_series.exact = entry.get('exact')
-    if entry.get('begin'):
-        db_series.begin = entry.get('begin')
     if entry.get('from_group'):
         db_series.from_group = [SeriesListFromGroup(group_name=name) for name in entry.get('from_group')]
-    if entry.get('parse_only'):
-        db_series.parse_only = entry.get('parse_only')
     if entry.get('special_ids'):
         db_series.special_ids = [SeriesListSpecialID(id_name=name) for name in entry.get('special_ids')]
-    if entry.get('prefer_specials'):
-        db_series.prefer_specials = entry.get('prefer_specials')
-    if entry.get('assume_special'):
-        db_series.assume_special = entry.get('assume_special')
-    if entry.get('tracking'):
-        db_series.tracking = entry.get('tracking')
 
     # Get list of supported identifiers
     for id_name in supported_ids:

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -125,9 +125,10 @@ class SeriesListSeries(Base):
             # `set` is not a real series attribute and is just a way to pass IDs in task.
             if attribute == 'set':
                 continue
-            if getattr(self, attribute):
+            result = self.format_converter(attribute)
+            if result:
                 # Maintain support for configure_series plugin expected format
-                entry['configure_series_' + attribute] = entry[attribute] = self.format_converter(attribute)
+                entry['configure_series_' + attribute] = entry[attribute] = result
         for series_list_id in self.ids:
             entry[series_list_id.id_name] = series_list_id.id_value
             entry['set'].update({series_list_id.id_name: series_list_id.id_value})
@@ -142,6 +143,7 @@ class SeriesListSeries(Base):
             'series_list_ids': [series_list_id.to_dict() for series_list_id in self.ids]
         }
         for attribute in SETTINGS_SCHEMA['properties']:
+            # `set` is not a real series attribute and is just a way to pass IDs in task.
             if attribute == 'set':
                 continue
             series_dict[attribute] = self.format_converter(attribute)

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -24,14 +24,6 @@ SETTINGS_SCHEMA = FilterSeriesBase().settings_schema
 SERIES_ATTRIBUTES = SETTINGS_SCHEMA['properties']
 
 
-def supported_ids():
-    # Return a list of supported series identifier as registered via their plugins
-    ids = []
-    for p in plugin.get_plugins(group='series_metainfo'):
-        ids.append(p.instance.series_identifier())
-    return ids
-
-
 class SeriesListList(Base):
     __tablename__ = 'series_list_lists'
     id = Column(Integer, primary_key=True)
@@ -306,7 +298,7 @@ def get_db_series(data, db_series=None):
         db_series.special_ids = [SeriesListSpecialID(id_name=name) for name in data.get('special_ids')]
 
     # Get list of supported identifiers
-    for id_name in supported_ids():
+    for id_name in FilterSeriesBase().supported_ids():
         value = data.get(id_name)
         if value:
             log.debug('found supported ID %s with value %s in entry, adding to series', id_name, value)
@@ -367,7 +359,7 @@ class SeriesList(MutableSet):
     @with_session
     def find_entry(self, entry, session=None):
         """Finds `SeriesListSeries` corresponding to this entry, if it exists."""
-        for id_name in supported_ids():
+        for id_name in FilterSeriesBase().supported_ids():
             if entry.get(id_name):
                 log.debug('trying to match series based off id %s: %s', id_name, entry[id_name])
                 res = (self._db_list(session).series.join(SeriesListSeries.ids).filter(

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -344,7 +344,7 @@ class SeriesList(MutableSet):
     def add(self, entry, session=None):
         # Check if this is already in the list, refresh info if so
         db_list = self._db_list(session=session)
-        db_series = self._find_entry(entry, session=session)
+        db_series = self.find_entry(entry, session=session)
         # Just delete and re-create to refresh
         if db_series:
             session.delete(db_series)
@@ -355,16 +355,16 @@ class SeriesList(MutableSet):
 
     @with_session
     def discard(self, entry, session=None):
-        db_series = self._find_entry(entry, session=session)
+        db_series = self.find_entry(entry, session=session)
         if db_series:
             log.debug('deleting series %s', db_series)
             session.delete(db_series)
 
     def __contains__(self, entry):
-        return self._find_entry(entry) is not None
+        return self.find_entry(entry) is not None
 
     @with_session
-    def _find_entry(self, entry, session=None):
+    def find_entry(self, entry, session=None):
         """Finds `SeriesListSeries` corresponding to this entry, if it exists."""
         for id_name in supported_ids():
             if entry.get(id_name):
@@ -400,7 +400,7 @@ class SeriesList(MutableSet):
 
     @with_session
     def get(self, entry, session):
-        match = self._find_entry(entry=entry, session=session)
+        match = self.find_entry(entry=entry, session=session)
         return match.to_entry() if match else None
 
 

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -115,8 +115,7 @@ class SeriesListSeries(Base):
                 return [special_id.id_name for special_id in value]
         if attribute in ['propers', 'tracking']:
             # Value can be either bool or unicode
-            if value in ['0', '1']:
-                return bool(int(value))
+            return bool(int(value)) if value in ['0', '1'] else value
         if attribute == 'quality':
             return value.quality
         return value

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -167,7 +167,7 @@ class SeriesListID(Base):
             'added_on': self.added,
             'id_name': self.id_name,
             'id_value': self.id_value,
-            'series_id': self.movie_id
+            'series_id': self.series_id
         }
 
 
@@ -326,7 +326,7 @@ class SeriesList(MutableSet):
 
         # Get list of supported identifiers
         for id_name in SUPPORTED_IDS:
-            value = entry.get(id_name) or entry.get('set').get(id_name) if entry.get('set') else None
+            value = entry.get(id_name)
             if value:
                 log.debug('found supported ID %s with value %s in entry, adding to series', id_name, value)
                 db_series.ids.append(SeriesListID(id_name=id_name, id_value=value))
@@ -424,11 +424,11 @@ def get_series_by_list_id(list_id, count=False, start=None, stop=None, order_by=
     query = session.query(SeriesListSeries).filter(SeriesListSeries.list_id == list_id)
     if count:
         return query.count()
-    query = query.slice(start, stop).from_self()
     if descending:
         query = query.order_by(getattr(SeriesListSeries, order_by).desc())
     else:
         query = query.order_by(getattr(SeriesListSeries, order_by))
+    query = query.slice(start, stop)
     return query.all()
 
 

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -20,9 +20,16 @@ from flexget.event import event
 log = logging.getLogger('series_list')
 Base = versioned_base('series_list', 0)
 
-SUPPORTED_IDS = FilterSeriesBase().supported_ids
 SETTINGS_SCHEMA = FilterSeriesBase().settings_schema
 SERIES_ATTRIBUTES = SETTINGS_SCHEMA['properties']
+
+
+def supported_ids():
+    # Return a list of supported series identifier as registered via their plugins
+    ids = []
+    for plugin_ in plugin.get_plugins(group='series_metainfo'):
+        ids.append(plugin_.instance.series_identifier())
+    return ids
 
 
 class SeriesListList(Base):
@@ -291,7 +298,7 @@ def get_db_series(entry):
     db_series.tracking = entry.get('tracking')
 
     # Get list of supported identifiers
-    for id_name in SUPPORTED_IDS:
+    for id_name in supported_ids():
         value = entry.get(id_name)
         if value:
             log.debug('found supported ID %s with value %s in entry, adding to series', id_name, value)
@@ -351,7 +358,7 @@ class SeriesList(MutableSet):
     @with_session
     def _find_entry(self, entry, session=None):
         """Finds `SeriesListSeries` corresponding to this entry, if it exists."""
-        for id_name in SUPPORTED_IDS:
+        for id_name in supported_ids():
             if entry.get(id_name):
                 log.debug('trying to match series based off id %s: %s', id_name, entry[id_name])
                 res = (self._db_list(session).series.join(SeriesListSeries.ids).filter(

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -258,53 +258,6 @@ class SeriesListSpecialID(Base):
     series_id = Column(Integer, ForeignKey(SeriesListSeries.id))
 
 
-def get_db_series(data, db_series=None):
-    """
-    This method creates of edits a db SeriesListSeries object based on passed data
-    :param data: Dict or entry with the relevant data
-    :param db_series: If passed, this method will update the given attributes of a series object.
-    :return: A SeriesListSeries object
-    """
-    if not db_series:
-        title = data.get('series_name') or data['title']
-        db_series = SeriesListSeries(title)
-    # Setting series attributes only for received data
-    single_attributes = ['date_dayfirst', 'date_yearfirst', 'timeframe', 'upgrade', 'target', 'specials', 'propers',
-                         'identified_by', 'exact', 'begin', 'parse_only', 'prefer_specials', 'assume_special',
-                         'tracking', 'set']
-    for attribute in single_attributes:
-        if data.get(attribute) is not None:
-            setattr(db_series, attribute, data[attribute])
-    if data.get('alternate_name'):
-        db_series.alternate_name = [SeriesListAlternateName(name=name) for name in data.get('alternate_name')]
-    if data.get('name_regexp'):
-        db_series.name_regexp = [SeriesListNameRegexp(regexp=regexp) for regexp in data.get('name_regexp')]
-    if data.get('ep_regexp'):
-        db_series.ep_regexp = [SeriesListEpRegexp(regexp=regexp) for regexp in data.get('ep_regexp')]
-    if data.get('date_regexp'):
-        db_series.date_regexp = [SeriesListDateRegexp(regexp=regexp) for regexp in data.get('date_regexp')]
-    if data.get('sequence_regexp'):
-        db_series.sequence_regexp = [SeriesListSequenceRegexp(regexp=regexp) for regexp in data.get('sequence_regexp')]
-    if data.get('id_regexp'):
-        db_series.id_regexp = [SeriesListIDRegexp(regexp=regexp) for regexp in data.get('id_regexp')]
-    if data.get('quality'):
-        db_series.quality = SeriesListQuality(quality=data.get('quality'))
-    if data.get('qualities'):
-        db_series.qualities = [SeriesListQualities(quality=quality) for quality in data.get('qualities')]
-    if data.get('from_group'):
-        db_series.from_group = [SeriesListFromGroup(group_name=name) for name in data.get('from_group')]
-    if data.get('special_ids'):
-        db_series.special_ids = [SeriesListSpecialID(id_name=name) for name in data.get('special_ids')]
-
-    # Get list of supported identifiers
-    for id_name in FilterSeriesBase().supported_ids():
-        value = data.get(id_name)
-        if value:
-            log.debug('found supported ID %s with value %s in entry, adding to series', id_name, value)
-            db_series.ids.append(SeriesListSeriesExternalID(id_name=id_name, id_value=value))
-    return db_series
-
-
 class SeriesList(MutableSet):
     def _db_list(self, session):
         return session.query(SeriesListList).filter(SeriesListList.name == self.list_name).first()
@@ -340,7 +293,7 @@ class SeriesList(MutableSet):
         # Just delete and re-create to refresh
         if db_series:
             session.delete(db_series)
-        db_series = get_db_series(entry)
+        db_series = SeriesListDB.get_db_series(entry)
         db_list.series.append(db_series)
         session.commit()
         return db_series.to_entry()
@@ -464,6 +417,54 @@ class SeriesListDB(object):
         log.debug('fetching series with id %d from list id %d', series_id, list_id)
         return session.query(SeriesListSeries).filter(
             and_(SeriesListSeries.id == series_id, SeriesListSeries.list_id == list_id)).one()
+
+    @staticmethod
+    def get_db_series(data, db_series=None):
+        """
+        This method creates of edits a db SeriesListSeries object based on passed data
+        :param data: Dict or entry with the relevant data
+        :param db_series: If passed, this method will update the given attributes of a series object.
+        :return: A SeriesListSeries object
+        """
+        if not db_series:
+            title = data.get('series_name') or data['title']
+            db_series = SeriesListSeries(title)
+        # Setting series attributes only for received data
+        single_attributes = ['date_dayfirst', 'date_yearfirst', 'timeframe', 'upgrade', 'target', 'specials', 'propers',
+                             'identified_by', 'exact', 'begin', 'parse_only', 'prefer_specials', 'assume_special',
+                             'tracking', 'set']
+        for attribute in single_attributes:
+            if data.get(attribute) is not None:
+                setattr(db_series, attribute, data[attribute])
+        if data.get('alternate_name'):
+            db_series.alternate_name = [SeriesListAlternateName(name=name) for name in data.get('alternate_name')]
+        if data.get('name_regexp'):
+            db_series.name_regexp = [SeriesListNameRegexp(regexp=regexp) for regexp in data.get('name_regexp')]
+        if data.get('ep_regexp'):
+            db_series.ep_regexp = [SeriesListEpRegexp(regexp=regexp) for regexp in data.get('ep_regexp')]
+        if data.get('date_regexp'):
+            db_series.date_regexp = [SeriesListDateRegexp(regexp=regexp) for regexp in data.get('date_regexp')]
+        if data.get('sequence_regexp'):
+            db_series.sequence_regexp = [SeriesListSequenceRegexp(regexp=regexp) for regexp in
+                                         data.get('sequence_regexp')]
+        if data.get('id_regexp'):
+            db_series.id_regexp = [SeriesListIDRegexp(regexp=regexp) for regexp in data.get('id_regexp')]
+        if data.get('quality'):
+            db_series.quality = SeriesListQuality(quality=data.get('quality'))
+        if data.get('qualities'):
+            db_series.qualities = [SeriesListQualities(quality=quality) for quality in data.get('qualities')]
+        if data.get('from_group'):
+            db_series.from_group = [SeriesListFromGroup(group_name=name) for name in data.get('from_group')]
+        if data.get('special_ids'):
+            db_series.special_ids = [SeriesListSpecialID(id_name=name) for name in data.get('special_ids')]
+
+        # Get list of supported identifiers
+        for id_name in FilterSeriesBase().supported_ids():
+            value = data.get(id_name)
+            if value:
+                log.debug('found supported ID %s with value %s in entry, adding to series', id_name, value)
+                db_series.ids.append(SeriesListSeriesExternalID(id_name=id_name, id_value=value))
+        return db_series
 
 
 @event('plugin.register')

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -123,8 +123,11 @@ class SeriesListSeries(Base):
         for attribute in SERIES_ATTRIBUTES:
             result = self.format_converter(attribute)
             if result:
-                # Maintain support for configure_series plugin expected format
-                entry['configure_series_' + attribute] = entry[attribute] = result
+                if attribute == 'set':
+                    entry['set'].update(result)
+                else:
+                    # Maintain support for configure_series plugin expected format
+                    entry['configure_series_' + attribute] = entry[attribute] = result
         for series_list_id in self.ids:
             entry[series_list_id.id_name] = series_list_id.id_value
             entry['set'].update({series_list_id.id_name: series_list_id.id_value})
@@ -268,7 +271,7 @@ def get_db_series(data, db_series=None):
     # Setting series attributes only for received data
     single_attributes = ['date_dayfirst', 'date_yearfirst', 'timeframe', 'upgrade', 'target', 'specials', 'propers',
                          'identified_by', 'exact', 'begin', 'parse_only', 'prefer_specials', 'assume_special',
-                         'tracking']
+                         'tracking', 'set']
     for attribute in single_attributes:
         if data.get(attribute) is not None:
             setattr(db_series, attribute, data[attribute])

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -423,7 +423,7 @@ class SeriesListDBContainer(object):
 
     @staticmethod
     @with_session
-    def get_list_by_id(self, list_id, session=None):
+    def get_list_by_id(list_id, session=None):
         log.debug('fetching list with id %d', list_id)
         return session.query(SeriesListList).filter(SeriesListList.id == list_id).one()
 

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -132,6 +132,8 @@ class SeriesListSeries(Base):
             'series_list_ids': [series_list_id.to_dict() for series_list_id in self.ids]
         }
         for attribute in SETTINGS_SCHEMA['properties']:
+            if attribute == 'set':
+                continue
             series_dict[attribute] = getattr(self, attribute) if getattr(self, attribute) else None
         return series_dict
 
@@ -206,7 +208,7 @@ class SeriesList(MutableSet):
                 setattr(db_series, attribute, entry[attribute])
         # Get list of supported identifiers
         for id_name in SUPPORTED_IDS:
-            value = entry.get(id_name) or entry.get('set').get(id_name)
+            value = entry.get(id_name) or entry.get('set').get(id_name) if entry.get('set') else None
             if value:
                 log.debug('found supported ID %s with value %s in entry, adding to series', id_name, value)
                 db_series.ids.append(SeriesListID(id_name=id_name, id_value=value))

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -100,7 +100,7 @@ class SeriesListSeries(Base):
         type schema formats, and convert instrumented lists on the fly
         """
         value = getattr(self, attribute)
-        if not value:
+        if value is None:
             return
         if isinstance(value, InstrumentedList):
             if attribute.endswith('regexp'):
@@ -275,8 +275,8 @@ def get_db_series(entry):
                          'identified_by', 'exact', 'begin', 'parse_only', 'prefer_specials', 'assume_special',
                          'tracking']
     for attribute in single_attributes:
-        if entry.get(attribute):
-            setattr(db_series, attribute, entry.get(attribute))
+        if entry.get(attribute) is not None:
+            setattr(db_series, attribute, entry[attribute])
     if entry.get('alternate_name'):
         db_series.alternate_name = [SeriesListAlternateName(name=name) for name in entry.get('alternate_name')]
     if entry.get('name_regexp'):

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -80,7 +80,7 @@ class SeriesListSeries(Base):
     tracking = Column(Unicode)  # Todo: enforce format
 
     list_id = Column(Integer, ForeignKey(SeriesListList.id), nullable=False)
-    ids = relationship('SeriesListID', backref='series', cascade='all, delete, delete-orphan')
+    ids = relationship('SeriesListSeriesExternalID', backref='series', cascade='all, delete, delete-orphan')
 
     def __init__(self, title):
         self.title = title
@@ -150,8 +150,8 @@ class SeriesListSeries(Base):
         return series_dict
 
 
-class SeriesListID(Base):
-    __tablename__ = 'series_list_ids'
+class SeriesListSeriesExternalID(Base):
+    __tablename__ = 'series_list_series_external_ids'
     id = Column(Integer, primary_key=True)
     added = Column(DateTime, default=datetime.now)
     id_name = Column(Unicode)
@@ -329,7 +329,7 @@ class SeriesList(MutableSet):
             value = entry.get(id_name)
             if value:
                 log.debug('found supported ID %s with value %s in entry, adding to series', id_name, value)
-                db_series.ids.append(SeriesListID(id_name=id_name, id_value=value))
+                db_series.ids.append(SeriesListSeriesExternalID(id_name=id_name, id_value=value))
         log.debug('adding entry %s', entry)
         db_list.series.append(db_series)
         session.commit()
@@ -353,8 +353,8 @@ class SeriesList(MutableSet):
                 log.debug('trying to match series based off id %s: %s', id_name, entry[id_name])
                 res = (self._db_list(session).series.join(SeriesListSeries.ids).filter(
                     and_(
-                        SeriesListID.id_name == id_name,
-                        SeriesListID.id_value == entry[id_name]))
+                        SeriesListSeriesExternalID.id_name == id_name,
+                        SeriesListSeriesExternalID.id_value == entry[id_name]))
                        .first())
                 if res:
                     log.debug('found series %s', res)

--- a/flexget/plugins/list/series_list.py
+++ b/flexget/plugins/list/series_list.py
@@ -271,3 +271,13 @@ class PluginSeriesList(object):
 @event('plugin.register')
 def register_plugin():
     plugin.register(PluginSeriesList, 'series_list', api_ver=2, groups=['list'])
+
+
+@with_session
+def get_series_lists(name=None, session=None):
+    log.debug('retrieving series lists')
+    query = session.query(SeriesListList)
+    if name:
+        log.debug('filtering by name %s', name)
+        query = query.filter(SeriesListList.name == name)
+    return query.all()

--- a/flexget/plugins/list/trakt_list.py
+++ b/flexget/plugins/list/trakt_list.py
@@ -321,11 +321,6 @@ class TraktList(object):
     def on_task_input(self, task, config):
         return list(TraktSet(config))
 
-    @staticmethod
-    def series_identifier():
-        """Returns the plugin main identifier type"""
-        return 'trakt_show_id'
-
 
 class TraktAdd(object):
     """Add all accepted elements in your trakt.tv watchlist/library/seen or custom list."""
@@ -355,6 +350,6 @@ class TraktRemove(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(TraktList, 'trakt_list', api_ver=2, groups=['list', 'series_metainfo'])
+    plugin.register(TraktList, 'trakt_list', api_ver=2, groups=['list'])
     plugin.register(TraktAdd, 'trakt_add', api_ver=2)
     plugin.register(TraktRemove, 'trakt_remove', api_ver=2)

--- a/flexget/plugins/list/trakt_list.py
+++ b/flexget/plugins/list/trakt_list.py
@@ -321,6 +321,11 @@ class TraktList(object):
     def on_task_input(self, task, config):
         return list(TraktSet(config))
 
+    @staticmethod
+    def series_identifier():
+        """Returns the plugin main identifier type"""
+        return 'trakt_show_id'
+
 
 class TraktAdd(object):
     """Add all accepted elements in your trakt.tv watchlist/library/seen or custom list."""
@@ -350,6 +355,6 @@ class TraktRemove(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(TraktList, 'trakt_list', api_ver=2, groups=['list'])
+    plugin.register(TraktList, 'trakt_list', api_ver=2, groups=['list', 'series_metainfo'])
     plugin.register(TraktAdd, 'trakt_add', api_ver=2)
     plugin.register(TraktRemove, 'trakt_remove', api_ver=2)

--- a/flexget/plugins/metainfo/thetvdb_lookup.py
+++ b/flexget/plugins/metainfo/thetvdb_lookup.py
@@ -164,7 +164,12 @@ class PluginThetvdbLookup(object):
                 if entry.get('series_id_type') in ('ep', 'sequence', 'date'):
                     entry.register_lazy_func(self.lazy_episode_lookup, self.episode_map)
 
+    @staticmethod
+    def series_identifier():
+        """Returns the plugin main identifier type"""
+        return 'tvdb_id'
+
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginThetvdbLookup, 'thetvdb_lookup', api_ver=2)
+    plugin.register(PluginThetvdbLookup, 'thetvdb_lookup', api_ver=2, groups=['series_metainfo'])

--- a/flexget/plugins/metainfo/trakt_lookup.py
+++ b/flexget/plugins/metainfo/trakt_lookup.py
@@ -361,7 +361,12 @@ class PluginTraktLookup(object):
                     entry.register_lazy_func(collected_lookup, ['trakt_collected'])
                     entry.register_lazy_func(watched_lookup, ['trakt_watched'])
 
+    @staticmethod
+    def series_identifier():
+        """Returns the plugin main identifier type"""
+        return 'trakt_id'
+
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginTraktLookup, 'trakt_lookup', api_ver=3)
+    plugin.register(PluginTraktLookup, 'trakt_lookup', api_ver=3, groups=['series_metainfo'])

--- a/flexget/plugins/metainfo/trakt_lookup.py
+++ b/flexget/plugins/metainfo/trakt_lookup.py
@@ -76,7 +76,7 @@ class PluginTraktLookup(object):
         'imdb_id': 'imdb_id',
         'tvdb_id': 'tvdb_id',
         'tmdb_id': 'tmdb_id',
-        'trakt_id': 'id',
+        'trakt_show_id': 'id',
         'trakt_slug': 'slug',
         'tvrage_id': 'tvrage_id',
         'trakt_trailer': 'trailer',
@@ -132,7 +132,7 @@ class PluginTraktLookup(object):
         'movie_year': 'year',
         'trakt_name': 'title',
         'trakt_year': 'year',
-        'trakt_id': 'id',
+        'trakt_movie_id': 'id',
         'trakt_slug': 'slug',
         'imdb_id': 'imdb_id',
         'tmdb_id': 'tmdb_id',
@@ -364,7 +364,7 @@ class PluginTraktLookup(object):
     @staticmethod
     def series_identifier():
         """Returns the plugin main identifier type"""
-        return 'trakt_id'
+        return 'trakt_show_id'
 
 
 @event('plugin.register')

--- a/flexget/plugins/metainfo/trakt_lookup.py
+++ b/flexget/plugins/metainfo/trakt_lookup.py
@@ -284,10 +284,10 @@ class PluginTraktLookup(object):
         """Does the lookup for this entry and populates the entry fields."""
         if style == 'show' or style == 'episode':
             lookup = lookup_series
-            trakt_id = entry.get('trakt_id', eval_lazy=True)
+            trakt_id = entry.get('trakt_show_id', eval_lazy=True)
         else:
             lookup = lookup_movie
-            trakt_id = entry.get('trakt_id', eval_lazy=True)
+            trakt_id = entry.get('trakt_movie_id', eval_lazy=True)
         with Session() as session:
             lookupargs = {'trakt_id': trakt_id,
                           'session': session}
@@ -307,10 +307,10 @@ class PluginTraktLookup(object):
         """Does the lookup for this entry and populates the entry fields."""
         if style == 'show' or style == 'episode':
             lookup = lookup_series
-            trakt_id = entry.get('trakt_id', eval_lazy=True)
+            trakt_id = entry.get('trakt_show_id', eval_lazy=True)
         else:
             lookup = lookup_movie
-            trakt_id = entry.get('trakt_id', eval_lazy=True)
+            trakt_id = entry.get('trakt_movie_id', eval_lazy=True)
         with Session() as session:
             lookupargs = {'trakt_id': trakt_id,
                           'session': session}

--- a/flexget/plugins/metainfo/tvmaze_lookup.py
+++ b/flexget/plugins/metainfo/tvmaze_lookup.py
@@ -168,7 +168,12 @@ class PluginTVMazeLookup(object):
                 if ('series_season' in entry and 'series_episode' in entry) or ('series_date' in entry):
                     entry.register_lazy_func(self.lazy_episode_lookup, self.episode_map)
 
+    @staticmethod
+    def series_identifier():
+        """Returns the plugin main identifier type"""
+        return 'tvmaze_id'
+
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginTVMazeLookup, 'tvmaze_lookup', api_ver=3)
+    plugin.register(PluginTVMazeLookup, 'tvmaze_lookup', api_ver=3, groups=['series_metainfo'])

--- a/flexget/plugins/plugin_configure_series.py
+++ b/flexget/plugins/plugin_configure_series.py
@@ -17,6 +17,14 @@ log = logging.getLogger('configure_series')
 Base = db_schema.versioned_base('import_series', 0)
 
 
+def supported_ids():
+    # Return a list of supported series identifier as registered via their plugins
+    ids = []
+    for plugin_ in plugin.get_plugins(group='series_metainfo'):
+        ids.append(plugin_.instance.series_identifier())
+    return ids
+
+
 class LastHash(Base):
     __tablename__ = 'import_series_last_hash'
 
@@ -77,7 +85,7 @@ class ConfigureSeries(FilterSeriesBase):
 
             for entry in result:
                 s = series.setdefault(entry['title'], {})
-                for supported_id in FilterSeriesBase().supported_ids:
+                for supported_id in supported_ids():
                     if entry.get(supported_id):
                         s['set'] = {supported_id: entry[supported_id]}
 

--- a/flexget/plugins/plugin_configure_series.py
+++ b/flexget/plugins/plugin_configure_series.py
@@ -16,8 +16,6 @@ from flexget.plugins.filter.series import FilterSeriesBase
 log = logging.getLogger('configure_series')
 Base = db_schema.versioned_base('import_series', 0)
 
-supported_ids = FilterSeriesBase().supported_ids()
-
 
 class LastHash(Base):
     __tablename__ = 'import_series_last_hash'
@@ -79,7 +77,7 @@ class ConfigureSeries(FilterSeriesBase):
 
             for entry in result:
                 s = series.setdefault(entry['title'], {})
-                for supported_id in supported_ids:
+                for supported_id in FilterSeriesBase().supported_ids():
                     if entry.get(supported_id):
                         s['set'] = {supported_id: entry[supported_id]}
 

--- a/flexget/plugins/plugin_configure_series.py
+++ b/flexget/plugins/plugin_configure_series.py
@@ -16,13 +16,7 @@ from flexget.plugins.filter.series import FilterSeriesBase
 log = logging.getLogger('configure_series')
 Base = db_schema.versioned_base('import_series', 0)
 
-
-def supported_ids():
-    # Return a list of supported series identifier as registered via their plugins
-    ids = []
-    for plugin_ in plugin.get_plugins(group='series_metainfo'):
-        ids.append(plugin_.instance.series_identifier())
-    return ids
+supported_ids = FilterSeriesBase().supported_ids()
 
 
 class LastHash(Base):
@@ -85,7 +79,7 @@ class ConfigureSeries(FilterSeriesBase):
 
             for entry in result:
                 s = series.setdefault(entry['title'], {})
-                for supported_id in supported_ids():
+                for supported_id in supported_ids:
                     if entry.get(supported_id):
                         s['set'] = {supported_id: entry[supported_id]}
 

--- a/flexget/utils/json.py
+++ b/flexget/utils/json.py
@@ -31,9 +31,6 @@ class DTDecoder(json.JSONDecoder):
     def decode(self, obj, **kwargs):
         # The built-in `json` library will `unicode` strings, except for empty strings. patch this for
         # consistency so that `unicode` is always returned.
-        if obj is None:
-            return
-
         if obj == b'':
             return ''
 
@@ -106,8 +103,6 @@ def loads(*args, **kwargs):
     :param bool decode_datetime: If `True`, dates in ISO8601 format will be deserialized to :class:`datetime.datetime`
       objects.
     """
-    if args[0] is None:
-        return
     if kwargs.pop('decode_datetime', False):
         kwargs['object_hook'] = _datetime_decoder
         kwargs['cls'] = DTDecoder

--- a/flexget/utils/json.py
+++ b/flexget/utils/json.py
@@ -106,6 +106,8 @@ def loads(*args, **kwargs):
     :param bool decode_datetime: If `True`, dates in ISO8601 format will be deserialized to :class:`datetime.datetime`
       objects.
     """
+    if args[0] is None:
+        return
     if kwargs.pop('decode_datetime', False):
         kwargs['object_hook'] = _datetime_decoder
         kwargs['cls'] = DTDecoder

--- a/flexget/utils/json.py
+++ b/flexget/utils/json.py
@@ -31,6 +31,9 @@ class DTDecoder(json.JSONDecoder):
     def decode(self, obj, **kwargs):
         # The built-in `json` library will `unicode` strings, except for empty strings. patch this for
         # consistency so that `unicode` is always returned.
+        if obj is None:
+            return
+
         if obj == b'':
             return ''
 
@@ -103,6 +106,9 @@ def loads(*args, **kwargs):
     :param bool decode_datetime: If `True`, dates in ISO8601 format will be deserialized to :class:`datetime.datetime`
       objects.
     """
+    if args[0] is None:
+        return
+
     if kwargs.pop('decode_datetime', False):
         kwargs['object_hook'] = _datetime_decoder
         kwargs['cls'] = DTDecoder

--- a/tests/test_series_list.py
+++ b/tests/test_series_list.py
@@ -49,7 +49,7 @@ class TestSeriesList(object):
 
     def test_base_series_list(self, execute_task):
         task = execute_task('test_list_add')
-        assert len(task.entries) == 1
+        assert len(task.accepted) == 1
 
         task = execute_task('list_get')
         assert len(task.entries) == 1
@@ -57,15 +57,15 @@ class TestSeriesList(object):
 
     def test_base_configure_series_with_list(self, execute_task):
         task = execute_task('test_list_add')
-        assert len(task.entries) == 1
+        assert len(task.accepted) == 1
 
         task = execute_task('test_basic_configure_series')
-        assert len(task.entries) == 1
-        assert task.find_entry(series_name='series 1')
+        assert len(task.accepted) == 1
+        assert task.find_entry(category='accepted', series_name='series 1')
 
     def test_series_list_with_attributes(self, execute_task):
         task = execute_task('test_add_with_attributes')
-        assert len(task.entries) == 1
+        assert len(task.accepted) == 1
 
         task = execute_task('list_get')
         assert len(task.entries) == 1

--- a/tests/test_series_list.py
+++ b/tests/test_series_list.py
@@ -30,13 +30,17 @@ class TestSeriesList(object):
             mock:
               - {title: 'series 1',
                  url: "http://mock.url/file1.torrent",
+                 set: {tvdb_id: "1234", tvmaze_id: "1234", not_valid_id: "1234"},
                  alternate_name: [SER1, SER2],
+                 name_regexp: ["^ser", "^series 1$"],
                  qualities: [720p, 1080p],
                  timeframe: '2 days',
                  upgrade: yes,
                  propers: yes,
+                 specials: yes,
                  not_a_real_attribute: yes,
-                 tracking: 'backfill'}
+                 tracking: 'backfill',
+                 identified_by: "ep"}
             accept_all: yes
             list_add:
               - series_list: test_list
@@ -66,10 +70,14 @@ class TestSeriesList(object):
         task = execute_task('list_get')
         assert len(task.entries) == 1
         assert task.find_entry(title='series 1')
+        assert task.find_entry(set={'tvdb_id': '1234', 'tvmaze_id': '1234'})
         assert task.find_entry(alternate_name=['SER1', 'SER2'])
+        assert task.find_entry(name_regexp=["^ser", "^series 1$"])
         assert task.find_entry(qualities=['720p', '1080p'])
         assert task.find_entry(timeframe='2 days')
         assert task.find_entry(upgrade=True)
         assert task.find_entry(propers=True)
+        assert task.find_entry(specials=True)
         assert task.find_entry(tracking='backfill')
+        assert task.find_entry(identified_by='ep')
         assert not task.find_entry(not_a_real_attribute=True)

--- a/tests/test_series_list.py
+++ b/tests/test_series_list.py
@@ -73,5 +73,3 @@ class TestSeriesList(object):
         assert task.find_entry(propers=True)
         assert task.find_entry(tracking='backfill')
         assert not task.find_entry(not_a_real_attribute=True)
-
-

--- a/tests/test_series_list.py
+++ b/tests/test_series_list.py
@@ -12,6 +12,9 @@ class TestSeriesList(object):
           list_get:
             series_list: test_list
 
+          list_get_2:
+            series_list: test_list 2
+
           test_list_add:
             mock:
               - {title: 'series 1', url: "http://mock.url/file1.torrent"}
@@ -54,8 +57,23 @@ class TestSeriesList(object):
             mock:
               - {title: 'series 1.s01e01.720p.HDTV-flexget', url: "http://mock.url/file1.torrent"}
             accept_all: yes
+            metainfo_series: yes
             list_accept:
               - series_list: test_list
+
+          test_list_remove:
+            mock:
+              - {title: 'series 1.s01e01.720p.HDTV-flexget', url: "http://mock.url/file1.torrent"}
+            accept_all: yes
+            metainfo_series: yes
+            list_remove:
+              - series_list: test_list
+
+          test_list_to_list:
+            series_list: test_list
+            accept_all: yes
+            list_add:
+              - series_list: test_list 2
 
     """
 
@@ -109,3 +127,27 @@ class TestSeriesList(object):
 
         task = execute_task('list_get')
         assert len(task.entries) == 0
+
+    def test_list_remove(self, execute_task):
+        task = execute_task('test_list_add')
+        assert len(task.accepted) == 1
+
+        task = execute_task('test_list_remove')
+        assert len(task.accepted) == 1
+
+        task = execute_task('list_get')
+        assert len(task.entries) == 0
+
+    def test_list_to_list(self, execute_task):
+        task = execute_task('test_list_add')
+        assert len(task.accepted) == 1
+
+        task = execute_task('test_list_to_list')
+        assert len(task.accepted) == 1
+
+        task1 = execute_task('list_get')
+        task_1_entries = task1.entries
+
+        task2 = execute_task('list_get_2')
+        task_2_entries = task2.entries
+        assert len(task_1_entries) == len(task_2_entries) == 1

--- a/tests/test_series_list.py
+++ b/tests/test_series_list.py
@@ -29,6 +29,7 @@ class TestSeriesList(object):
           test_add_with_attributes:
             mock:
               - {title: 'series 1',
+                 set: {movedone: "/random/path"},
                  url: "http://mock.url/file1.torrent",
                  tvdb_id: "1234",
                  tvmaze_id: "1234",
@@ -74,6 +75,7 @@ class TestSeriesList(object):
         task = execute_task('list_get')
         assert len(task.entries) == 1
         assert task.find_entry(title='series 1')
+        assert task.find_entry(set={'movedone': "/random/path"})
         assert task.find_entry(tvdb_id='1234')
         assert task.find_entry(tvmaze_id='1234')
         assert task.find_entry(trakt_show_id='1234')

--- a/tests/test_series_list.py
+++ b/tests/test_series_list.py
@@ -26,6 +26,21 @@ class TestSeriesList(object):
               from:
                 series_list: test_list
 
+          test_add_with_attributes:
+            mock:
+              - {title: 'series 1',
+                 url: "http://mock.url/file1.torrent",
+                 alternate_name: [SER1, SER2],
+                 qualities: [720p, 1080p],
+                 timeframe: '2 days',
+                 upgrade: yes,
+                 propers: yes,
+                 not_a_real_attribute: yes,
+                 tracking: 'backfill'}
+            accept_all: yes
+            list_add:
+              - series_list: test_list
+
     """
 
     def test_base_series_list(self, execute_task):
@@ -43,5 +58,20 @@ class TestSeriesList(object):
         task = execute_task('test_basic_configure_series')
         assert len(task.entries) == 1
         assert task.find_entry(series_name='series 1')
+
+    def test_series_list_with_attributes(self, execute_task):
+        task = execute_task('test_add_with_attributes')
+        assert len(task.entries) == 1
+
+        task = execute_task('list_get')
+        assert len(task.entries) == 1
+        assert task.find_entry(title='series 1')
+        assert task.find_entry(alternate_name=['SER1', 'SER2'])
+        assert task.find_entry(qualities=['720p', '1080p'])
+        assert task.find_entry(timeframe='2 days')
+        assert task.find_entry(upgrade=True)
+        assert task.find_entry(propers=True)
+        assert task.find_entry(tracking='backfill')
+        assert not task.find_entry(not_a_real_attribute=True)
 
 

--- a/tests/test_series_list.py
+++ b/tests/test_series_list.py
@@ -81,14 +81,14 @@ class TestSeriesList(object):
         assert entry['set']['tvdb_id'] == '1234'
         assert entry['set']['tvmaze_id'] == '1234'
         assert entry['set']['trakt_show_id'] == '1234'
-        assert entry['quality'] == '720p'
-        assert entry['alternate_name'] == ['SER1', 'SER2']
-        assert entry['name_regexp'] == ["^ser", "^series 1$"]
-        assert entry['qualities'] == ['720p', '1080p']
-        assert entry['timeframe'] == '2 days'
-        assert entry['upgrade'] == True
-        assert entry['propers'] == True
-        assert entry['specials'] == True
-        assert entry['tracking'] == 'backfill'
-        assert entry['identified_by'] == 'ep'
+        assert entry['configure_series_quality'] == entry['quality'] == '720p'
+        assert entry['configure_series_alternate_name'] == entry['alternate_name'] == ['SER1', 'SER2']
+        assert entry['configure_series_name_regexp'] == entry['name_regexp'] == ["^ser", "^series 1$"]
+        assert entry['configure_series_qualities'] == entry['qualities'] == ['720p', '1080p']
+        assert entry['configure_series_timeframe'] == entry['timeframe'] == '2 days'
+        assert entry['configure_series_upgrade'] == entry['upgrade'] == True
+        assert entry['configure_series_propers'] == entry['propers'] == True
+        assert entry['configure_series_specials'] == entry['specials'] == True
+        assert entry['configure_series_tracking'] == entry['tracking'] == 'backfill'
+        assert entry['configure_series_identified_by'] == entry['identified_by'] == 'ep'
         assert not entry.get('not_a_real_attribute')

--- a/tests/test_series_list.py
+++ b/tests/test_series_list.py
@@ -30,9 +30,13 @@ class TestSeriesList(object):
             mock:
               - {title: 'series 1',
                  url: "http://mock.url/file1.torrent",
-                 set: {tvdb_id: "1234", tvmaze_id: "1234", not_valid_id: "1234"},
+                 tvdb_id: "1234",
+                 tvmaze_id: "1234",
+                 not_valid_id: "1234",
+                 trakt_show_id: "1234",
                  alternate_name: [SER1, SER2],
                  name_regexp: ["^ser", "^series 1$"],
+                 quality: 720p,
                  qualities: [720p, 1080p],
                  timeframe: '2 days',
                  upgrade: yes,
@@ -70,7 +74,10 @@ class TestSeriesList(object):
         task = execute_task('list_get')
         assert len(task.entries) == 1
         assert task.find_entry(title='series 1')
-        assert task.find_entry(set={'tvdb_id': '1234', 'tvmaze_id': '1234'})
+        assert task.find_entry(tvdb_id='1234')
+        assert task.find_entry(tvmaze_id='1234')
+        assert task.find_entry(trakt_show_id='1234')
+        assert task.find_entry(quality='720p')
         assert task.find_entry(alternate_name=['SER1', 'SER2'])
         assert task.find_entry(name_regexp=["^ser", "^series 1$"])
         assert task.find_entry(qualities=['720p', '1080p'])

--- a/tests/test_series_list.py
+++ b/tests/test_series_list.py
@@ -74,19 +74,21 @@ class TestSeriesList(object):
 
         task = execute_task('list_get')
         assert len(task.entries) == 1
-        assert task.find_entry(title='series 1')
-        assert task.find_entry(set={'movedone': "/random/path"})
-        assert task.find_entry(tvdb_id='1234')
-        assert task.find_entry(tvmaze_id='1234')
-        assert task.find_entry(trakt_show_id='1234')
-        assert task.find_entry(quality='720p')
-        assert task.find_entry(alternate_name=['SER1', 'SER2'])
-        assert task.find_entry(name_regexp=["^ser", "^series 1$"])
-        assert task.find_entry(qualities=['720p', '1080p'])
-        assert task.find_entry(timeframe='2 days')
-        assert task.find_entry(upgrade=True)
-        assert task.find_entry(propers=True)
-        assert task.find_entry(specials=True)
-        assert task.find_entry(tracking='backfill')
-        assert task.find_entry(identified_by='ep')
-        assert not task.find_entry(not_a_real_attribute=True)
+        entry = task.find_entry(title='series 1')
+        assert entry
+
+        assert entry['set']['movedone'] == '/random/path'
+        assert entry['set']['tvdb_id'] == '1234'
+        assert entry['set']['tvmaze_id'] == '1234'
+        assert entry['set']['trakt_show_id'] == '1234'
+        assert entry['quality'] == '720p'
+        assert entry['alternate_name'] == ['SER1', 'SER2']
+        assert entry['name_regexp'] == ["^ser", "^series 1$"]
+        assert entry['qualities'] == ['720p', '1080p']
+        assert entry['timeframe'] == '2 days'
+        assert entry['upgrade'] == True
+        assert entry['propers'] == True
+        assert entry['specials'] == True
+        assert entry['tracking'] == 'backfill'
+        assert entry['identified_by'] == 'ep'
+        assert not entry.get('not_a_real_attribute')

--- a/tests/test_series_list.py
+++ b/tests/test_series_list.py
@@ -50,6 +50,13 @@ class TestSeriesList(object):
             list_add:
               - series_list: test_list
 
+          test_list_accept:
+            mock:
+              - {title: 'series 1.s01e01.720p.HDTV-flexget', url: "http://mock.url/file1.torrent"}
+            accept_all: yes
+            list_accept:
+              - series_list: test_list
+
     """
 
     def test_base_series_list(self, execute_task):
@@ -92,3 +99,13 @@ class TestSeriesList(object):
         assert entry['configure_series_tracking'] == entry['tracking'] == 'backfill'
         assert entry['configure_series_identified_by'] == entry['identified_by'] == 'ep'
         assert not entry.get('not_a_real_attribute')
+
+    def test_list_accept(self, execute_task):
+        task = execute_task('test_list_add')
+        assert len(task.accepted) == 1
+
+        task = execute_task('test_list_accept')
+        assert len(task.accepted) == 1
+
+        task = execute_task('list_get')
+        assert len(task.entries) == 0

--- a/tests/test_series_list_api.py
+++ b/tests/test_series_list_api.py
@@ -229,7 +229,6 @@ class TestSeriesListAPI(object):
                     'propers': True,
                     'specials': True,
                     'tracking': False,
-                    'identified_by': "ep",
                     'exact': True,
                     'begin': 's01e01',
                     'from_group': ['group1', 'group2'],

--- a/tests/test_series_list_api.py
+++ b/tests/test_series_list_api.py
@@ -152,3 +152,51 @@ class TestSeriesListAPI(object):
 
         rsp = api_client.get('/series_list/1/series/1/')
         assert rsp.status_code == 404, 'Response code is %s' % rsp.status_code
+
+    def test_series_list_edit_series_id(self, api_client):
+        payload = {'name': 'name'}
+
+        # Create list
+        rsp = api_client.json_post('/series_list/', data=json.dumps(payload))
+        assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
+
+        series = {'title': 'test_series'}
+
+        # Add series to list
+        rsp = api_client.json_post('/series_list/1/series/', data=json.dumps(series))
+        assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
+        assert json.loads(rsp.get_data(as_text=True)).get('title') == 'test_series'
+
+        new_data = {'alternate_name': ['SER1', 'SER2'],
+                    'name_regexp': ["^ser", "^series 1$"],
+                    'ep_regexp': ["^ser", "^series 1$"],
+                    'date_regexp': ["^ser", "^series 1$"],
+                    'sequence_regexp': ["^ser", "^series 1$"],
+                    'id_regexp': ["^ser", "^series 1$"],
+                    'date_yearfirst': True,
+                    'date_dayfirst': True,
+                    'quality': '720p',
+                    'qualities': ['720p', '1080p'],
+                    'timeframe': '2 days',
+                    'upgrade': True,
+                    'target': '1080p',
+                    'propers': True,
+                    'specials': True,
+                    'tracking': False,
+                    'identified_by': "ep",
+                    'exact': True,
+                    'begin': 's01e01',
+                    'from_group': ['group1', 'group2'],
+                    'parse_only': True}
+
+        rsp = api_client.json_put('/series_list/1/series/1/', data=json.dumps(new_data))
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+        response1 = json.loads(rsp.get_data(as_text=True))
+        assert response1.get('title') == 'title'
+        for attribute in new_data:
+            assert new_data[attribute] == response1[attribute]
+
+            # rsp = api_client.get('/series_list/1/series/1/')
+            # assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+            # response2 = json.loads(rsp.get_data(as_text=True))
+            # assert response1 == response2

--- a/tests/test_series_list_api.py
+++ b/tests/test_series_list_api.py
@@ -192,11 +192,11 @@ class TestSeriesListAPI(object):
         rsp = api_client.json_put('/series_list/1/series/1/', data=json.dumps(new_data))
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
         response1 = json.loads(rsp.get_data(as_text=True))
-        assert response1.get('title') == 'title'
+        assert response1.get('title') == 'test_series'
         for attribute in new_data:
             assert new_data[attribute] == response1[attribute]
 
-            # rsp = api_client.get('/series_list/1/series/1/')
-            # assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
-            # response2 = json.loads(rsp.get_data(as_text=True))
-            # assert response1 == response2
+        rsp = api_client.get('/series_list/1/series/1/')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+        response2 = json.loads(rsp.get_data(as_text=True))
+        assert response1 == response2

--- a/tests/test_series_list_api.py
+++ b/tests/test_series_list_api.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, division, absolute_import
+
+from builtins import *  # pylint: disable=unused-import, redefined-builtin
+import pytest
+
+from flexget.utils import json
+
+
+class TestSeriesListAPI(object):
+    config = 'tasks: {}'
+
+    def test_series_list_list(self, api_client):
+        rsp = api_client.get('/series_list/')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+
+        # Named param
+        rsp = api_client.get('/series_list/?name=name')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+
+        data = {'name': 'test'}
+
+        # Create list
+        rsp = api_client.json_post('/series_list/', data=json.dumps(data))
+        assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
+
+    def test_series_list_list_id(self, api_client):
+        payload = {'name': 'name'}
+
+        # Create list
+        rsp = api_client.json_post('/series_list/', data=json.dumps(payload))
+        assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
+
+        # Get list
+        rsp = api_client.get('/series_list/1/')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+
+        # Delete list
+        rsp = api_client.delete('/series_list/1/')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+
+    def test_series_list_series(self, api_client):
+        # Get non existent list
+        rsp = api_client.get('/series_list/1/series/')
+        assert rsp.status_code == 404, 'Response code is %s' % rsp.status_code
+
+        payload = {'name': 'name'}
+
+        # Create list
+        rsp = api_client.json_post('/series_list/', data=json.dumps(payload))
+        assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
+
+        series = {'title': 'title'}
+
+        # Add series to list
+        rsp = api_client.json_post('/series_list/1/series/', data=json.dumps(series))
+        assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
+        assert json.loads(rsp.get_data(as_text=True)).get('title') == 'title'

--- a/tests/test_series_list_api.py
+++ b/tests/test_series_list_api.py
@@ -10,7 +10,7 @@ from flexget.utils import json
 class TestSeriesListAPI(object):
     config = 'tasks: {}'
 
-    def test_series_list_list(self, api_client):
+    def test_series_list_lists(self, api_client):
         rsp = api_client.get('/series_list/')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
@@ -18,11 +18,21 @@ class TestSeriesListAPI(object):
         rsp = api_client.get('/series_list/?name=name')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
-        data = {'name': 'test'}
+        test1 = {'name': 'test1'}
+        test2 = {'name': 'test2'}
 
         # Create list
-        rsp = api_client.json_post('/series_list/', data=json.dumps(data))
+        rsp = api_client.json_post('/series_list/', data=json.dumps(test1))
         assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
+        assert json.loads(rsp.get_data(as_text=True)).get('name') == 'test1'
+
+        rsp = api_client.json_post('/series_list/', data=json.dumps(test2))
+        assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
+        assert json.loads(rsp.get_data(as_text=True)).get('name') == 'test2'
+
+        rsp = api_client.get('/series_list/')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+        assert len(json.loads(rsp.get_data(as_text=True)).get('series_lists')) == 2
 
     def test_series_list_list_id(self, api_client):
         payload = {'name': 'name'}

--- a/tests/test_series_list_api.py
+++ b/tests/test_series_list_api.py
@@ -69,6 +69,7 @@ class TestSeriesListAPI(object):
         assert json.loads(rsp.get_data(as_text=True)).get('title') == 'title'
 
         series = {'title': 'series 1',
+                  'set': {'movedone': '/a/random/path'},
                   'alternate_name': ['SER1', 'SER2'],
                   'name_regexp': ["^ser", "^series 1$"],
                   'ep_regexp': ["^ser", "^series 1$"],

--- a/tests/test_series_list_api.py
+++ b/tests/test_series_list_api.py
@@ -50,15 +50,16 @@ class TestSeriesListAPI(object):
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
     def test_series_list_series(self, api_client):
-        # Get non existent list
-        rsp = api_client.get('/series_list/1/series/')
-        assert rsp.status_code == 404, 'Response code is %s' % rsp.status_code
-
+        # Create list
         payload = {'name': 'name'}
 
-        # Create list
         rsp = api_client.json_post('/series_list/', data=json.dumps(payload))
         assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
+
+        # Get non existent list
+        rsp = api_client.get('/series_list/1/series/')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+        assert json.loads(rsp.get_data(as_text=True)).get('series') == []
 
         series = {'title': 'title'}
 
@@ -96,6 +97,10 @@ class TestSeriesListAPI(object):
         for attribute in series:
             assert series[attribute] == response[attribute]
 
+        rsp = api_client.get('/series_list/1/series/')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+        assert len(json.loads(rsp.get_data(as_text=True)).get('series')) == 2
+
     def test_series_list_series_with_identifiers(self, api_client):
         # Get non existent list
         rsp = api_client.get('/series_list/1/series/')
@@ -121,3 +126,29 @@ class TestSeriesListAPI(object):
             # Only recognized series identifiers will be added
             assert not identifier['id_name'] == 'unknown'
             assert series[identifier['id_name']] == identifier['id_value']
+
+    def test_series_list_series_id(self, api_client):
+        payload = {'name': 'name'}
+
+        # Create list
+        rsp = api_client.json_post('/series_list/', data=json.dumps(payload))
+        assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
+
+        rsp = api_client.get('/series_list/1/series/1/')
+        assert rsp.status_code == 404, 'Response code is %s' % rsp.status_code
+
+        series = {'title': 'title'}
+
+        # Add series to list
+        rsp = api_client.json_post('/series_list/1/series/', data=json.dumps(series))
+        assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
+        assert json.loads(rsp.get_data(as_text=True)).get('title') == 'title'
+
+        rsp = api_client.get('/series_list/1/series/1/')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+
+        rsp = api_client.delete('/series_list/1/series/1/')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+
+        rsp = api_client.get('/series_list/1/series/1/')
+        assert rsp.status_code == 404, 'Response code is %s' % rsp.status_code

--- a/tests/test_series_list_api.py
+++ b/tests/test_series_list_api.py
@@ -85,3 +85,29 @@ class TestSeriesListAPI(object):
         response = json.loads(rsp.get_data(as_text=True))
         for attribute in series:
             assert series[attribute] == response[attribute]
+
+    def test_series_list_series_with_identifiers(self, api_client):
+        # Get non existent list
+        rsp = api_client.get('/series_list/1/series/')
+        assert rsp.status_code == 404, 'Response code is %s' % rsp.status_code
+
+        payload = {'name': 'name'}
+
+        # Create list
+        rsp = api_client.json_post('/series_list/', data=json.dumps(payload))
+        assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
+
+        series = {'title': 'title',
+                  'tvmaze_id': 1234,
+                  'trakt_show_id': 555,
+                  'tvdb_id': 666,
+                  'unknown': 999}
+
+        # Add series to list
+        rsp = api_client.json_post('/series_list/1/series/', data=json.dumps(series))
+        assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
+        response = json.loads(rsp.get_data(as_text=True))
+        for identifier in response.get('series_list_identifiers'):
+            # Only recognized series identifiers will be added
+            assert not identifier['id_name'] == 'unknown'
+            assert series[identifier['id_name']] == identifier['id_value']

--- a/tests/test_series_list_api.py
+++ b/tests/test_series_list_api.py
@@ -201,3 +201,48 @@ class TestSeriesListAPI(object):
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
         response2 = json.loads(rsp.get_data(as_text=True))
         assert response1 == response2
+
+    def test_global_list_settings(self, api_client):
+        payload = {'name': 'test_list'}
+
+        # Create list
+        rsp = api_client.json_post('/series_list/', data=json.dumps(payload))
+        assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
+
+        series_1 = {'title': 'test_series_1'}
+        series_2 = {'title': 'test_series_2'}
+
+        # Add series to list
+        rsp = api_client.json_post('/series_list/1/series/', data=json.dumps(series_1))
+        assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
+        assert json.loads(rsp.get_data(as_text=True)).get('title') == 'test_series_1'
+
+        rsp = api_client.json_post('/series_list/1/series/', data=json.dumps(series_2))
+        assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
+        assert json.loads(rsp.get_data(as_text=True)).get('title') == 'test_series_2'
+
+        new_data = {'quality': '720p',
+                    'qualities': ['720p', '1080p'],
+                    'timeframe': '2 days',
+                    'upgrade': True,
+                    'target': '1080p',
+                    'propers': True,
+                    'specials': True,
+                    'tracking': False,
+                    'identified_by': "ep",
+                    'exact': True,
+                    'begin': 's01e01',
+                    'from_group': ['group1', 'group2'],
+                    'parse_only': True}
+
+        rsp = api_client.json_put('/series_list/1/', data=json.dumps(new_data))
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+
+        rsp = api_client.get('/series_list/1/series/')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+        response = json.loads(rsp.get_data(as_text=True))
+        assert len(response.get('series')) == 2
+
+        for series in response.get('series'):
+            for attribute in new_data:
+                assert series[attribute] == new_data[attribute]

--- a/tests/test_series_list_api.py
+++ b/tests/test_series_list_api.py
@@ -56,3 +56,32 @@ class TestSeriesListAPI(object):
         rsp = api_client.json_post('/series_list/1/series/', data=json.dumps(series))
         assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
         assert json.loads(rsp.get_data(as_text=True)).get('title') == 'title'
+
+        series = {'title': 'series 1',
+                  'alternate_name': ['SER1', 'SER2'],
+                  'name_regexp': ["^ser", "^series 1$"],
+                  'ep_regexp': ["^ser", "^series 1$"],
+                  'date_regexp': ["^ser", "^series 1$"],
+                  'sequence_regexp': ["^ser", "^series 1$"],
+                  'id_regexp': ["^ser", "^series 1$"],
+                  'date_yearfirst': True,
+                  'date_dayfirst': True,
+                  'quality': '720p',
+                  'qualities': ['720p', '1080p'],
+                  'timeframe': '2 days',
+                  'upgrade': True,
+                  'target': '1080p',
+                  'propers': True,
+                  'specials': True,
+                  'tracking': False,
+                  'identified_by': "ep",
+                  'exact': True,
+                  'begin': 's01e01',
+                  'from_group': ['group1', 'group2'],
+                  'parse_only': True}
+
+        rsp = api_client.json_post('/series_list/1/series/', data=json.dumps(series))
+        assert rsp.status_code == 201, 'Response code is %s' % rsp.status_code
+        response = json.loads(rsp.get_data(as_text=True))
+        for attribute in series:
+            assert series[attribute] == response[attribute]

--- a/tests/test_trakt.py
+++ b/tests/test_trakt.py
@@ -71,7 +71,7 @@ class TestTraktShowLookup(object):
         """trakt: Test Lookup (ONLINE)"""
         task = execute_task('test')
         entry = task.find_entry(title='House.S01E02.HDTV.XViD-FlexGet')
-        assert entry['trakt_id'] == 1399, \
+        assert entry['trakt_show_id'] == 1399, \
             'Trakt_ID should be 1339 is %s for %s' % (entry['trakt_show_id'], entry['series_name'])
         assert entry['trakt_series_status'] == 'ended', 'Series Status should be "ENDED" returned %s' \
                                                         % (entry['trakt_series_status'])
@@ -116,19 +116,19 @@ class TestTraktShowLookup(object):
             series = ApiTrakt.lookup_series(**lookupargs)
 
             assert series.tvdb_id == entry['tvdb_id'], 'tvdb id should be the same as the first entry'
-            assert series.id == entry['trakt_id'], 'trakt id should be the same as the first entry'
+            assert series.id == entry['trakt_show_id'], 'trakt id should be the same as the first entry'
             assert series.title.lower() == entry['trakt_series_name'].lower(), 'series name should match first entry'
 
     def test_search_success(self, execute_task):
         task = execute_task('test_search_success')
         entry = task.find_entry('accepted', title='11-22-63.S01E01.HDTV.XViD-FlexGet')
-        assert entry.get('trakt_id') == 102771, 'Should have returned the correct trakt id'
+        assert entry.get('trakt_show_id') == 102771, 'Should have returned the correct trakt id'
 
     def test_date(self, execute_task):
         task = execute_task('test_date')
         entry = task.find_entry(title='the daily show 2012-6-6')
         # Make sure show data got populated
-        assert entry.get('trakt_id') == 2211, 'should have populated trakt show data'
+        assert entry.get('trakt_show_id') == 2211, 'should have populated trakt show data'
         # We don't support lookup by date at the moment, make sure there isn't a false positive
         if entry.get('trakt_episode_id') == 173423:
             assert False, 'We support trakt episode lookup by date now? Great! Change this test.'
@@ -140,9 +140,9 @@ class TestTraktShowLookup(object):
         task = execute_task('test_absolute')
         entry = task.find_entry(title='naruto 128')
         # Make sure show data got populated
-        assert entry.get('trakt_id') == 46003, 'should have populated trakt show data'
+        assert entry.get('trakt_show_id') == 46003, 'should have populated trakt show data'
         # We don't support lookup by absolute number at the moment, make sure there isn't a false positive
-        if entry.get('trakt_id') == 916040:
+        if entry.get('trakt_show_id') == 916040:
             assert False, 'We support trakt episode lookup by absolute number now? Great! Change this test.'
         else:
             assert entry.get('trakt_episode_id') is None, 'false positive for episode match, we don\'t ' \


### PR DESCRIPTION
### Motivation for changes:
A manged list for series, enabling using `series` plugin without the need to explicitly edit config file or use 3rd party service.
This will also allows using multiple lists for multiple purposes.

Note: This does not affect series tracking in any way, this just represents an input to which `configure_series` plugin can be used with (among others things).
### Detailed changes:

- New managed list type, `series_list`
- Manageable via API and CLI
- Had to add a small change to JSON decoder to support trying to decode None values.
- Added a global supported series IDs list to be shared between `configure_series` and `series_list` (and any other plugin that this can relate too, need to look into other `series` related plugins).

### Config usage if relevant (new plugin or updated schema):
```
tasks:
  series_with_list:
    configure_series:
      from:
        series_list: main_shows
    rss: http://url.com/links
    download: /path/to/downloads
```
### Log and/or tests output (preferably both):
Tests included.

#### To Do:
- [x] CLI
- [x] API and tests
- [x] Create a method in lookup providers that will register valid series identifiers instead of using hard coded list
- [x] Change API input payload to directly inherit from `series` schema
- [x] Readd `set` attribute as it was wrong not to use it in the first place

