### PR TITLE
added some requested features to subtitle_list, closes #1224

### DIFF
--- a/flexget/plugins/list/subtitle_list.py
+++ b/flexget/plugins/list/subtitle_list.py
@@ -305,8 +305,6 @@ class PluginSubtitleList(object):
                 if number_of_files == 0:
                     subtitle_list.discard(item)
 
-        for item in subtitle_list:
-            log.error(item)
         return list((set(subtitle_list) | temp_items_from_dir) - temp_discarded_items)
 
     @classmethod

--- a/flexget/plugins/output/subtitles_subliminal.py
+++ b/flexget/plugins/output/subtitles_subliminal.py
@@ -138,7 +138,7 @@ class PluginSubliminal(object):
                         hash_scores = movie_scores['hash']
                     log.info('Name computed for %s was %s', entry['location'], title)
                     msc = hash_scores if config['exact_match'] else 0
-                    if entry_languages & existing_subtitles:
+                    if entry_languages == existing_subtitles:
                         log.debug('All preferred languages already exist for "%s"', entry['title'])
                         entry['subtitles_missing'] = set()
                         continue  # subs for preferred lang(s) already exists

--- a/tests/test_subtitle_list.py
+++ b/tests/test_subtitle_list.py
@@ -120,6 +120,69 @@ class TestSubtitleList(object):
                - subtitle_list:
                    list: test
                    remove_after: 7 days
+           subtitle_add_local_dir:
+             disable: builtins
+             template: no_global
+             mock:
+               - {title: "My Videos", location: "subtitle_list_test_dir"}
+             list_add:
+               - subtitle_list:
+                   list: test
+                   allow_dir: yes
+                   languages: ['ja']
+             accept_all: yes
+           subtitle_emit_dir:
+             disable: builtins
+             template: no_global
+             subtitle_list:
+               list: test
+               allow_dir: yes
+               languages: [en]
+           subtitle_simulate_success_no_check:
+             template: no_global
+             subtitle_list:
+               list: test
+               allow_dir: yes
+               check_subtitles: no
+             subliminal:
+               languages: [ja]
+               exact_match: no
+               providers:
+                 - opensubtitles
+             list_queue:
+               - subtitle_list:
+                   list: test
+                   allow_dir: yes
+           subtitle_add_force_file:
+             disable: builtins
+             template: no_global
+             mock:
+               - {title: "The.Walking.Dead.S06E09-FlexGet",
+                  location: "subtitle_list_test_dir/The.Walking.Dead.S06E09-FlexGet.mp4"}
+             list_add:
+               - subtitle_list:
+                   list: test
+                   allow_dir: yes
+                   languages: ['ja']
+             accept_all: yes
+           subtitle_add_force_file_no:
+             disable: builtins
+             template: no_global
+             mock:
+               - {title: "The.Walking.Dead.S06E09-FlexGet",
+                  location: "subtitle_list_test_dir/The.Walking.Dead.S06E09-FlexGet.mp4"}
+             list_add:
+               - subtitle_list:
+                   list: test
+                   languages: ['ja']
+                   force_file_existence: no
+             accept_all: yes
+           subtitle_emit_force_no:
+             disable: builtins
+             template: no_global
+             subtitle_list:
+               list: test
+               force_file_existence: no
     """
 
     def test_subtitle_list_del(self, execute_task):
@@ -225,3 +288,103 @@ class TestSubtitleList(object):
 
         task = execute_task('subtitle_emit')
         assert len(task.entries) == 2, 'Big Bang Theory already has a local subtitle and should have been removed.'
+
+    def test_subtitle_list_local_dir(self, execute_task):
+        task = execute_task('subtitle_add_local_dir')
+
+        with Session() as session:
+            s = session.query(SubtitleListFile).first()
+            assert s.title == 'My Videos', 'Should have added the dir with title "My Videos" to the list'
+
+        task = execute_task('subtitle_emit_dir')
+
+        assert len(task.entries) == 3, 'Should have found 3 video files and the containing dir should not be included.'
+
+    def test_subtitle_list_local_disallow_dir(self, execute_task):
+        task = execute_task('subtitle_add_local_dir')
+
+        task = execute_task('subtitle_emit')
+
+        assert len(task.entries) == 0, 'Dirs are not allowed'
+
+    # Skip if subliminal is not installed or if python version <2.7
+    @pytest.mark.skipif(sys.version_info < (2, 7), reason='requires python2.7')
+    @pytest.mark.skipif(not subliminal, reason='requires subliminal')
+    def test_subtitle_list_subliminal_dir_success(self, execute_task):
+        task = execute_task('subtitle_add_local_dir')
+
+        with open('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.ja.srt', 'a'):
+            os.utime('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.ja.srt', None)
+
+        with open('subtitle_list_test_dir/Marvels.Jessica.Jones.S01E02-FlexGet.ja.srt', 'a'):
+            os.utime('subtitle_list_test_dir/Marvels.Jessica.Jones.S01E02-FlexGet.ja.srt', None)
+
+        with open('subtitle_list_test_dir/The.Big.Bang.Theory.S09E09-FlexGet.ja.srt', 'a'):
+            os.utime('subtitle_list_test_dir/The.Big.Bang.Theory.S09E09-FlexGet.ja.srt', None)
+
+        task = execute_task('subtitle_simulate_success_no_check')
+        assert len(task.accepted) == 1, 'All files have subtitles, but list_queue can only accept one'
+
+        with Session() as session:
+            s = session.query(SubtitleListFile).first()
+            assert s is None, '"My Videos" should have been deleted from the list'
+
+        try:
+            os.remove('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.ja.srt')
+        except OSError:
+            pass
+        try:
+            os.remove('subtitle_list_test_dir/Marvels.Jessica.Jones.S01E02-FlexGet.ja.srt')
+        except OSError:
+            pass
+        try:
+            os.remove('subtitle_list_test_dir/The.Big.Bang.Theory.S09E09-FlexGet.ja.srt')
+        except OSError:
+            pass
+
+    def test_subtitle_list_force_file_existence_no(self, execute_task):
+        task = execute_task('subtitle_add_force_file_no')
+
+        assert not os.path.exists(task.entries[0]['location']), 'File should not exist.'
+
+        with Session() as session:
+            s = session.query(SubtitleListFile).first()
+            assert s, 'The file should have been added to the list even though it does not exist'
+
+        task = execute_task('subtitle_emit_force_no')
+
+        assert len(task.entries) == 0, 'List should not be empty, but since file does not exist it isn\' returned'
+
+        with Session() as session:
+            s = session.query(SubtitleListFile).first()
+            assert s, 'The file should still be in the list'
+
+    def test_subtitle_list_force_file_existence_yes(self, execute_task):
+        task = execute_task('subtitle_add_force_file')
+
+        assert not os.path.exists(task.entries[0]['location']), 'File should not exist.'
+
+        with Session() as session:
+            s = session.query(SubtitleListFile).first()
+            assert s is None, 'The file should not have been added to the list as it does not exist'
+
+        task = execute_task('subtitle_emit')
+
+        assert len(task.entries) == 0, 'List should be empty'
+
+    def test_subtitle_list_force_file_existence_yes_input(self, execute_task):
+        task = execute_task('subtitle_add_force_file_no')
+
+        assert not os.path.exists(task.entries[0]['location']), 'File should not exist.'
+
+        with Session() as session:
+            s = session.query(SubtitleListFile).first()
+            assert s, 'The file should have been added to the list even though it does not exist'
+
+        task = execute_task('subtitle_emit')
+
+        assert len(task.entries) == 0, 'No input should be returned as the file does not exist'
+
+        with Session() as session:
+            s = session.query(SubtitleListFile).first()
+            assert s is None, 'The file should have been removed from the list since it does not exist'

--- a/tests/test_subtitle_list.py
+++ b/tests/test_subtitle_list.py
@@ -57,7 +57,7 @@ class TestSubtitleList(object):
                - subtitle_list:
                    list: test
              rerun: 0
-           subtitle_success:
+           subtitle_simulate_success:
              template: no_global
              subtitle_list:
                list: test
@@ -188,7 +188,16 @@ class TestSubtitleList(object):
         task = execute_task('subtitle_add_another_local_file')
         assert len(task.entries) == 1, 'Task should have accepted jessica jones file'
 
-        task = execute_task('subtitle_success')
+        with open('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.en.srt', 'a'):
+            os.utime('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.en.srt', None)
+
+        with open('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.ja.srt', 'a'):
+            os.utime('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.ja.srt', None)
+
+        with open('subtitle_list_test_dir/Marvels.Jessica.Jones.S01E02-FlexGet.en.srt', 'a'):
+            os.utime('subtitle_list_test_dir/Marvels.Jessica.Jones.S01E02-FlexGet.en.srt', None)
+
+        task = execute_task('subtitle_simulate_success')
         assert len(task.failed) == 1, 'Should have found both languages for walking dead but not for jessica jones'
 
         task = execute_task('subtitle_emit')


### PR DESCRIPTION
### Motivation for changes:
Someone asked for this feature, which was already in the now deprecated subtitle_queue. It's a slippery slope though as it can get very messy very fast. Torrent support has been dropped as it is too complex to handle all cases eg. single file torrents are not always placed in a folder.

### Detailed changes:

- Added `path` config option
- Added `check_file_existence` (should probably be renamed as this option is deleting from the list if file doesn't exist)
- Added `allow_dir` option, which allows dirs to be put in the list

### Addressed issues:

- Fixes #1224

### Config usage if relevant (new plugin or updated schema):
```
subtitle_list:
  path:
    from_field: output
  allow_dir: yes
  check_file_existence: no
  list: subtitle_queue
```
### TODO
- [x] tests

