### PR TITLE
change download and move to set 'location' instead of 'output'

### DIFF
--- a/flexget/plugins/output/download.py
+++ b/flexget/plugins/output/download.py
@@ -409,7 +409,6 @@ class PluginDownload(object):
             if task.options.test:
                 log.info('Would write `%s` to `%s`' % (entry['title'], path))
                 # Set a fake location, so the exec plugin can do string replacement during --test #1015
-                entry['old_location'] = entry['location']
                 entry['location'] = os.path.join(path, 'TEST_MODE_NO_OUTPUT')
                 return
 
@@ -477,7 +476,6 @@ class PluginDownload(object):
                         raise
 
             # store final destination as output key
-            entry['old_location'] = entry['location']
             entry['location'] = destfile
 
         finally:

--- a/flexget/plugins/output/download.py
+++ b/flexget/plugins/output/download.py
@@ -409,7 +409,8 @@ class PluginDownload(object):
             if task.options.test:
                 log.info('Would write `%s` to `%s`' % (entry['title'], path))
                 # Set a fake location, so the exec plugin can do string replacement during --test #1015
-                entry['output'] = os.path.join(path, 'TEST_MODE_NO_OUTPUT')
+                entry['old_location'] = entry['location']
+                entry['location'] = os.path.join(path, 'TEST_MODE_NO_OUTPUT')
                 return
 
             # make path
@@ -476,7 +477,8 @@ class PluginDownload(object):
                         raise
 
             # store final destination as output key
-            entry['output'] = destfile
+            entry['old_location'] = entry['location']
+            entry['location'] = destfile
 
         finally:
             self.cleanup_temp_file(entry)

--- a/flexget/plugins/output/download.py
+++ b/flexget/plugins/output/download.py
@@ -409,6 +409,7 @@ class PluginDownload(object):
             if task.options.test:
                 log.info('Would write `%s` to `%s`' % (entry['title'], path))
                 # Set a fake location, so the exec plugin can do string replacement during --test #1015
+                entry['output'] = os.path.join(path, 'TEST_MODE_NO_OUTPUT')  # backwards compatibility
                 entry['location'] = os.path.join(path, 'TEST_MODE_NO_OUTPUT')
                 return
 
@@ -476,6 +477,7 @@ class PluginDownload(object):
                         raise
 
             # store final destination as output key
+            entry['output'] = destfile  # backwards compatibility
             entry['location'] = destfile
 
         finally:

--- a/flexget/plugins/output/move.py
+++ b/flexget/plugins/output/move.py
@@ -243,6 +243,7 @@ class TransformingOps(BaseFileOps):
                     self.log.info('`%s` has been %s to `%s` as well.' % (s, funct_done, d))
                 except Exception as err:
                     self.log.warning(str(err))
+        entry['output'] = dst
         entry['old_location'] = entry['location']
         entry['location'] = dst
         if self.move and not src_isdir:

--- a/flexget/plugins/output/move.py
+++ b/flexget/plugins/output/move.py
@@ -243,7 +243,8 @@ class TransformingOps(BaseFileOps):
                     self.log.info('`%s` has been %s to `%s` as well.' % (s, funct_done, d))
                 except Exception as err:
                     self.log.warning(str(err))
-        entry['output'] = dst
+        entry['old_location'] = entry['location']
+        entry['location'] = dst
         if self.move and not src_isdir:
             self.clean_source(task, config, entry)
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -140,8 +140,8 @@ class TestDownload(object):
         tmp_umask = os.umask(curr_umask)
         # executes task and downloads the file
         task = execute_task('test')
-        assert task.entries[0]['output'], 'output missing?'
-        testfile = task.entries[0]['output']
+        assert task.entries[0]['location'], 'location missing?'
+        testfile = task.entries[0]['location']
         assert os.path.exists(testfile), 'download file does not exists'
         testfile_stat = os.stat(testfile)
         modes_equal = 0o666 - curr_umask == stat.S_IMODE(testfile_stat.st_mode)


### PR DESCRIPTION
### Motivation for changes:
It makes more sense that `location` always contains the _current_ location of the file.
### Detailed changes:

- Simply changed `output` to `location` and added `old_location` field.


