### PR TITLE
Fix scheduler issues with APScheduler 3.1+

### DIFF
--- a/flexget/plugins/daemon/scheduler.py
+++ b/flexget/plugins/daemon/scheduler.py
@@ -137,7 +137,7 @@ def setup_scheduler(manager):
     if not timezone:
         # The default sqlalchemy jobstore does not work when there isn't a name for the local timezone.
         # Just fall back to utc in this case
-        # FlexGet #2741, upstream ticket https://bitbucket.org/agronholm/apscheduler/issue/59
+        # FlexGet #2741, upstream ticket https://github.com/agronholm/apscheduler/issues/59
         log.info('Local timezone name could not be determined. Scheduler will display times in UTC for any log'
                  'messages. To resolve this set up /etc/timezone with correct time zone name.')
         timezone = pytz.utc
@@ -164,6 +164,9 @@ def setup_jobs(manager):
             log.info('Shutting down scheduler')
             scheduler.shutdown()
         return
+    if not scheduler.running:
+        log.info('Starting scheduler')
+        scheduler.start(paused=True)
     existing_job_ids = [job.id for job in scheduler.get_jobs()]
     configured_job_ids = []
     for job_config in config:
@@ -185,9 +188,7 @@ def setup_jobs(manager):
     for jid in existing_job_ids:
         if jid not in configured_job_ids:
             scheduler.remove_job(jid)
-    if not scheduler.running:
-        log.info('Starting scheduler')
-        scheduler.start()
+    scheduler.resume()
 
 
 @event('manager.shutdown_requested')

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,7 @@ jsonschema>=2.0
 path.py>=8.1.1
 pathlib>=1.0
 guessit<=2.0.4
-# Bug in apscheduler 3.1.0 https://github.com/agronholm/apscheduler/issues/121
-apscheduler>=3.0.3, !=3.1.0
+apscheduler>=3.2.0
 # WebUI Requirements
 cherrypy>=3.7.0
 flask>=0.7


### PR DESCRIPTION
### Motivation for changes:
Compatibility with APScheduler 3.2 and beyond
### Detailed changes:
The scheduler plugin was modified to start the scheduler in paused mode, then manipulate the jobs and only then start the job processing. The way FlexGet was doing it before only worked because of a programming oversight which was corrected in 3.1. The 3.1 version however lacked the means to provide comparable functionality. This shortcoming was just addressed in the 3.2 release.
- 

### Addressed issues:

- Fixes # .

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
========== 918 passed, 7 skipped, 1 xfailed, 3 xpassed, 1 pytest-warnings in 220.10 seconds ===========
paste output here
```


Job stores should not be accessed before they're started. The fact this was working in previous versions was an oversight. That said, APScheduler 3.1 lacked the ability to manipulate the jobs before the scheduler has been started, but 3.2 adds that feature.