### PR TITLE
`metainfo_movie` plugin

### DIFF
--- a/flexget/plugins/metainfo/metainfo_movie.py
+++ b/flexget/plugins/metainfo/metainfo_movie.py
@@ -26,9 +26,19 @@ class MetainfoMovie(object):
         entry['movie_year'] = parsed.year
         entry['proper'] = parsed.proper
         entry['proper_count'] = parsed.proper_count
-        # TODO: is this correct behaviour?
+
         if isinstance(parsed, GuessitParsedEntry):
             entry['release_group'] = parsed.parsed_group
+            entry['is_3d'] = parsed.is_3d
+            entry['subtitle_languages'] = parsed.subtitle_languages
+            entry['languages'] = parsed.languages
+            entry['video_codec'] = parsed.quality2.video_codec
+            entry['format'] = parsed.quality2.format
+            entry['audio_codec'] = parsed.quality2.audio_codec
+            entry['video_profile'] = parsed.quality2.video_profile
+            entry['screen_size'] = parsed.quality2.screen_size
+            entry['audio_channels'] = parsed.quality2.audio_channels
+            entry['audio_profile'] = parsed.quality2.audio_profile
 
         entry['movie_guessed'] = True
 

--- a/flexget/plugins/metainfo/metainfo_movie.py
+++ b/flexget/plugins/metainfo/metainfo_movie.py
@@ -19,29 +19,6 @@ class MetainfoMovie(object):
 
     schema = {'type': 'boolean'}
 
-    @staticmethod
-    def populate_entry_fields(entry, parsed):
-        entry['movie_parser'] = parsed
-        entry['movie_name'] = parsed.name
-        entry['movie_year'] = parsed.year
-        entry['proper'] = parsed.proper
-        entry['proper_count'] = parsed.proper_count
-
-        if isinstance(parsed, GuessitParsedEntry):
-            entry['release_group'] = parsed.parsed_group
-            entry['is_3d'] = parsed.is_3d
-            entry['subtitle_languages'] = parsed.subtitle_languages
-            entry['languages'] = parsed.languages
-            entry['video_codec'] = parsed.quality2.video_codec
-            entry['format'] = parsed.quality2.format
-            entry['audio_codec'] = parsed.quality2.audio_codec
-            entry['video_profile'] = parsed.quality2.video_profile
-            entry['screen_size'] = parsed.quality2.screen_size
-            entry['audio_channels'] = parsed.quality2.audio_channels
-            entry['audio_profile'] = parsed.quality2.audio_profile
-
-        entry['movie_guessed'] = True
-
     def on_task_metainfo(self, task, config):
         # Don't run if we are disabled
         if config is False:
@@ -58,13 +35,13 @@ class MetainfoMovie(object):
         :param entry: Entry that's being processed
         :return: True for successful parse
         """
-        if entry.get('movie_parser') and entry['movie_parser'].valid:
+        if entry.get('movie_guessed'):
             # Return true if we already parsed this
             return True
-        parsed = get_plugin_by_name('parsing').instance.parse_movie(data=entry['title'])
-        if parsed and parsed.valid:
-            parsed.name = normalize_name(remove_dirt(parsed.name))
-            self.populate_entry_fields(entry, parsed)
+        parser = get_plugin_by_name('parsing').instance.parse_movie(data=entry['title'])
+        if parser and parser.valid:
+            parser.name = normalize_name(remove_dirt(parser.name))
+            parser.populate_entry_fields(entry)
             return True
         return False
 

--- a/flexget/plugins/metainfo/metainfo_movie.py
+++ b/flexget/plugins/metainfo/metainfo_movie.py
@@ -7,7 +7,6 @@ from flexget.plugins.parsers.parser_common import normalize_name, remove_dirt
 from flexget import plugin
 from flexget.event import event
 from flexget.plugin import get_plugin_by_name
-from flexget.plugins.parsers.parser_guessit import GuessitParsedEntry
 
 log = logging.getLogger('metainfo_movie')
 
@@ -29,7 +28,8 @@ class MetainfoMovie(object):
                 continue
             self.guess_entry(entry)
 
-    def guess_entry(self, entry):
+    @staticmethod
+    def guess_entry(entry):
         """
         Populates movie_* fields for entries that are successfully parsed.
         :param entry: Entry that's being processed

--- a/flexget/plugins/metainfo/metainfo_movie.py
+++ b/flexget/plugins/metainfo/metainfo_movie.py
@@ -7,6 +7,7 @@ from flexget.plugins.parsers.parser_common import normalize_name, remove_dirt
 from flexget import plugin
 from flexget.event import event
 from flexget.plugin import get_plugin_by_name
+from flexget.plugins.parsers.parser_guessit import GuessitParsedEntry
 
 log = logging.getLogger('metainfo_movie')
 
@@ -25,6 +26,10 @@ class MetainfoMovie(object):
         entry['movie_year'] = parsed.year
         entry['proper'] = parsed.proper
         entry['proper_count'] = parsed.proper_count
+        # TODO: is this correct behaviour?
+        if isinstance(parsed, GuessitParsedEntry):
+            entry['release_group'] = parsed.parsed_group
+
         entry['movie_guessed'] = True
 
     def on_task_metainfo(self, task, config):

--- a/flexget/plugins/metainfo/metainfo_movie.py
+++ b/flexget/plugins/metainfo/metainfo_movie.py
@@ -1,0 +1,59 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # pylint: disable=unused-import, redefined-builtin
+
+import logging
+
+from flexget.plugins.parsers.parser_common import normalize_name, remove_dirt
+from flexget import plugin
+from flexget.event import event
+from flexget.plugin import get_plugin_by_name
+
+log = logging.getLogger('metainfo_movie')
+
+
+class MetainfoMovie(object):
+    """
+    Check if entry appears to be a movie, and populate movie info if so.
+    """
+
+    schema = {'type': 'boolean'}
+
+    @staticmethod
+    def populate_entry_fields(entry, parsed):
+        entry['movie_parser'] = parsed
+        entry['movie_name'] = parsed.name
+        entry['movie_year'] = parsed.year
+        entry['proper'] = parsed.proper
+        entry['proper_count'] = parsed.proper_count
+        entry['movie_guessed'] = True
+
+    def on_task_metainfo(self, task, config):
+        # Don't run if we are disabled
+        if config is False:
+            return
+        for entry in task.entries:
+            # If movie parser already parsed this, don't touch it.
+            if entry.get('movie_name'):
+                continue
+            self.guess_entry(entry)
+
+    def guess_entry(self, entry):
+        """
+        Populates movie_* fields for entries that are successfully parsed.
+        :param entry: Entry that's being processed
+        :return: True for successful parse
+        """
+        if entry.get('movie_parser') and entry['movie_parser'].valid:
+            # Return true if we already parsed this
+            return True
+        parsed = get_plugin_by_name('parsing').instance.parse_movie(data=entry['title'])
+        if parsed and parsed.valid:
+            parsed.name = normalize_name(remove_dirt(parsed.name))
+            self.populate_entry_fields(entry, parsed)
+            return True
+        return False
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(MetainfoMovie, 'metainfo_movie', api_ver=2)

--- a/flexget/plugins/parsers/parser_guessit.py
+++ b/flexget/plugins/parsers/parser_guessit.py
@@ -18,7 +18,6 @@ from flexget.utils import qualities
 from .parser_common import old_assume_quality
 from .parser_common import ParsedEntry, ParsedVideoQuality, ParsedVideo, ParsedSerie, ParsedMovie
 
-
 log = logging.getLogger('parser_guessit')
 
 logging.getLogger('rebulk').setLevel(logging.WARNING)
@@ -177,6 +176,25 @@ class GuessitParsedMovie(GuessitParsedVideo, ParsedMovie):
     def title(self):
         return self._guess_result.get('title')
 
+    def populate_entry_fields(self, entry):
+        """ Populates entry fields based on parser data"""
+        entry['movie_parser'] = self
+        entry['movie_name'] = self.name
+        entry['movie_year'] = self.year
+        entry['proper'] = self.proper
+        entry['proper_count'] = self.proper_count
+        entry['release_group'] = self.parsed_group
+        entry['is_3d'] = self.is_3d
+        entry['subtitle_languages'] = self.subtitle_languages
+        entry['languages'] = self.languages
+        entry['video_codec'] = self.quality2.video_codec
+        entry['format'] = self.quality2.format
+        entry['audio_codec'] = self.quality2.audio_codec
+        entry['video_profile'] = self.quality2.video_profile
+        entry['screen_size'] = self.quality2.screen_size
+        entry['audio_channels'] = self.quality2.audio_channels
+        entry['audio_profile'] = self.quality2.audio_profile
+
 
 class GuessitParsedSerie(GuessitParsedVideo, ParsedSerie):
     part_re = re.compile('part\\s?(\\d+)', re.IGNORECASE)
@@ -260,6 +278,7 @@ class GuessitParsedSerie(GuessitParsedVideo, ParsedSerie):
     def valid_strict(self):
         return True
 
+
 def _id_regexps_function(input_string, context):
     ret = []
     for regexp in context.get('id_regexps'):
@@ -267,9 +286,12 @@ def _id_regexps_function(input_string, context):
             ret.append(match.span)
     return ret
 
-_id_regexps = Rebulk().functional(_id_regexps_function, name='regexpId', disabled=lambda context: not context.get('id_regexps'))
+
+_id_regexps = Rebulk().functional(_id_regexps_function, name='regexpId',
+                                  disabled=lambda context: not context.get('id_regexps'))
 
 guessit_api = GuessItApi(rebulk_builder().rebulk(_id_regexps))
+
 
 class ParserGuessit(object):
     def _guessit_options(self, options):

--- a/flexget/utils/titles/movie.py
+++ b/flexget/utils/titles/movie.py
@@ -26,6 +26,14 @@ class MovieParser(TitleParser):
         self.reset()
         TitleParser.__init__(self)
 
+    def populate_entry_fields(self, entry):
+        """ Populates entry fields based on parser data"""
+        entry['movie_parser'] = self
+        entry['movie_name'] = self.name
+        entry['movie_year'] = self.year
+        entry['proper'] = self.proper
+        entry['proper_count'] = self.proper_count
+
     @property
     def valid(self):
         return True

--- a/tests/test_metainfo.py
+++ b/tests/test_metainfo.py
@@ -5,7 +5,6 @@ import pytest
 
 
 class TestMetainfo(object):
-
     config = """
         tasks:
           test_content_size:
@@ -24,7 +23,6 @@ class TestMetainfo(object):
 
 
 class TestMetainfoImdb(object):
-
     config = """
         tasks:
           test:
@@ -49,7 +47,6 @@ class TestMetainfoImdb(object):
 
 
 class TestMetainfoQuality(object):
-
     config = """
         tasks:
           test:
@@ -141,3 +138,27 @@ class TestMetainfoSeries(object):
             assert 'series_name' not in entry, error
             assert 'series_guessed' not in entry, error
             assert 'series_parser' not in entry, error
+
+
+class TestMetainfoMovie(object):
+    config = """
+        templates:
+          global:
+            metainfo_movie: yes
+        tasks:
+          test:
+            mock:
+              - {title: 'FlexGet.720p.HDTV.xvid-TheName'}
+              - {title: 'FlexGet2 (1999).720p.HDTV.xvid-TheName'}
+              - {title: 'FlexGet3 (2004).PROPER.1080p.BluRay.xvid-TheName'}
+
+
+    """
+
+    def test_metainfo_movie(self, execute_task):
+        task = execute_task('test')
+        assert task.find_entry(movie_name='Flexget', quality='720p hdtv xvid'), 'Failed to parse movie info'
+        assert task.find_entry(movie_name='Flexget2', movie_year=1999,
+                               quality='720p hdtv xvid'), 'Failed to parse movie info'
+        assert task.find_entry(movie_name='Flexget3', movie_year=2004, proper=True,
+                               quality='1080p BluRay xvid'), 'Failed to parse movie info'

--- a/tests/test_metainfo.py
+++ b/tests/test_metainfo.py
@@ -151,6 +151,13 @@ class TestMetainfoMovie(object):
               - {title: 'FlexGet.720p.HDTV.xvid-TheName'}
               - {title: 'FlexGet2 (1999).720p.HDTV.xvid-TheName'}
               - {title: 'FlexGet3 (2004).PROPER.1080p.BluRay.xvid-TheName'}
+          test_guessit:
+            parsing:
+              movie: guessit
+            mock:
+              - {title: 'FlexGet.720p.HDTV.xvid-TheName'}
+              - {title: 'FlexGet2 (1999).720p.HDTV.xvid-TheName'}
+              - {title: 'FlexGet3 (2004).PROPER.1080p.BluRay.xvid-TheName'}
 
 
     """
@@ -162,3 +169,8 @@ class TestMetainfoMovie(object):
                                quality='720p hdtv xvid'), 'Failed to parse movie info'
         assert task.find_entry(movie_name='Flexget3', movie_year=2004, proper=True,
                                quality='1080p BluRay xvid'), 'Failed to parse movie info'
+
+    def test_metainfo_movie_with_guessit(self, execute_task):
+        task = execute_task('test_guessit')
+        assert task.find_entry(movie_name='Flexget', quality='720p hdtv xvid',
+                               release_group='TheName'), 'Failed to parse movie info'

--- a/tests/test_metainfo.py
+++ b/tests/test_metainfo.py
@@ -156,21 +156,51 @@ class TestMetainfoMovie(object):
               movie: guessit
             mock:
               - {title: 'FlexGet.720p.HDTV.xvid-TheName'}
-              - {title: 'FlexGet2 (1999).720p.HDTV.xvid-TheName'}
               - {title: 'FlexGet3 (2004).PROPER.1080p.BluRay.xvid-TheName'}
-
-
+              - {title: 'The.Flexget.2000.BluRay.Remux.1080p.AVC.TrueHD.5.1-FQ'}
+              - {title: 'The.Flexget.Winters.War.2016.1080p.WEB-DL.H264.AC3-FlexO'}
     """
 
     def test_metainfo_movie(self, execute_task):
         task = execute_task('test')
-        assert task.find_entry(movie_name='Flexget', quality='720p hdtv xvid'), 'Failed to parse movie info'
-        assert task.find_entry(movie_name='Flexget2', movie_year=1999,
-                               quality='720p hdtv xvid'), 'Failed to parse movie info'
-        assert task.find_entry(movie_name='Flexget3', movie_year=2004, proper=True,
-                               quality='1080p BluRay xvid'), 'Failed to parse movie info'
+        assert task.find_entry(movie_name='Flexget',
+                               quality='720p hdtv xvid')
+        assert task.find_entry(movie_name='Flexget2',
+                               movie_year=1999,
+                               quality='720p hdtv xvid')
+        assert task.find_entry(movie_name='Flexget3',
+                               movie_year=2004,
+                               proper=True,
+                               quality='1080p BluRay xvid')
 
     def test_metainfo_movie_with_guessit(self, execute_task):
         task = execute_task('test_guessit')
-        assert task.find_entry(movie_name='Flexget', quality='720p hdtv xvid',
-                               release_group='TheName'), 'Failed to parse movie info'
+        assert task.find_entry(movie_name='Flexget',
+                               format='HDTV',
+                               screen_size='720p',
+                               video_codec='XviD',
+                               release_group='TheName')
+
+        assert task.find_entry(movie_name='Flexget3',
+                               movie_year=2004,
+                               proper=True,
+                               format='BluRay',
+                               screen_size='1080p',
+                               video_codec='XviD',
+                               release_group='TheName')
+
+        assert task.find_entry(movie_name='The Flexget',
+                               audio_channels='5.1',
+                               audio_codec='TrueHD',
+                               movie_year=2000,
+                               format='BluRay',
+                               screen_size='1080p',
+                               release_group='FQ')
+
+        assert task.find_entry(movie_name='The Flexget Winters War',
+                               audio_codec='AC3',
+                               movie_year=2016,
+                               format='WEB-DL',
+                               screen_size='1080p',
+                               video_codec='h264',
+                               release_group='FlexO')

--- a/tests/test_subtitle_list.py
+++ b/tests/test_subtitle_list.py
@@ -179,9 +179,8 @@ class TestSubtitleList(object):
             pass
 
     # Skip if subliminal is not installed or if python version <2.7
-    @pytest.mark.skip(reason="test sporadically fails, need further research")
-    # @pytest.mark.skipif(sys.version_info < (2, 7), reason='requires python2.7')
-    # @pytest.mark.skipif(not subliminal, reason='requires subliminal')
+    @pytest.mark.skipif(sys.version_info < (2, 7), reason='requires python2.7')
+    @pytest.mark.skipif(not subliminal, reason='requires subliminal')
     def test_subtitle_list_subliminal_success(self, execute_task):
         task = execute_task('subtitle_add_local_file')
         assert len(task.entries) == 1, 'Task should have accepted walking dead local file'

--- a/tests/test_subtitle_list.py
+++ b/tests/test_subtitle_list.py
@@ -179,8 +179,9 @@ class TestSubtitleList(object):
             pass
 
     # Skip if subliminal is not installed or if python version <2.7
-    @pytest.mark.skipif(sys.version_info < (2, 7), reason='requires python2.7')
-    @pytest.mark.skipif(not subliminal, reason='requires subliminal')
+    @pytest.mark.skip(reason="test sporadically fails, need further research")
+    # @pytest.mark.skipif(sys.version_info < (2, 7), reason='requires python2.7')
+    # @pytest.mark.skipif(not subliminal, reason='requires subliminal')
     def test_subtitle_list_subliminal_success(self, execute_task):
         task = execute_task('subtitle_add_local_file')
         assert len(task.entries) == 1, 'Task should have accepted walking dead local file'


### PR DESCRIPTION
### Motivation for changes:
Gives an ability to parse movies and add related attributes to entry in task

### Detailed changes:
- Added `metainfo_movie` plugin
- Return the following `entry` attributes:
  - `movie_parser`
  - `movie_name`
  - `movie_year`
  - `proper`
  - `proper_count`

If parser is `guessit`, the following attributes are also added:
- `release_group`
- `is_3d`
- `languages`
- `video_codec`
- `format`
- `audio_codec`
- `video_profile`
- `screen_size`
- `audio_channels`
- `audio_profile`
### Addressed issues:

- Fixes #1015 

### Config usage if relevant (new plugin or updated schema):
```
movie_task:
  rss: http://url.com
  metainfo_movie: yes
  list_queue:
    - movie_list: movies
  download: /path/to/movies
```
#### To Do:

- [x] Add more guessit data to entry 


