### PR TITLE
Unified naming

### DIFF
--- a/flexget/plugins/modify/path_by_space.py
+++ b/flexget/plugins/modify/path_by_space.py
@@ -12,7 +12,7 @@ from flexget.event import event
 from flexget.config_schema import parse_size, parse_percent
 from flexget.config_schema import one_or_more
 
-log = logging.getLogger('path_select')
+log = logging.getLogger('path_by_space')
 
 
 disk_stats_tuple = namedtuple(
@@ -42,7 +42,6 @@ def os_disk_stats(folder):
 
 
 def disk_stats(folder):
-
     free_bytes, total_bytes = os_disk_stats(folder)
     used_bytes = total_bytes - free_bytes
     free_percent = 0.0 if total_bytes == 0 else 100 * free_bytes / total_bytes
@@ -92,14 +91,14 @@ selector_map = {
 }
 
 
-class PluginPathSelect(object):
+class PluginPathBySpace(object):
     """Allows setting a field to a folder based on it's space
 
     Path will be selected at random if multiple paths match the within
 
     Example:
 
-    path_select:
+    path_by_space:
       select: most_free_percent # or most_free, most_used, most_used_percent, has_free
       within: 9000 # within in MB or percent.
       paths:
@@ -127,7 +126,6 @@ class PluginPathSelect(object):
 
     @plugin.priority(250)  # run before other plugins
     def on_task_metainfo(self, task, config):
-
         selector = selector_map[config['select']]
 
         # Convert within to bytes (int) or percent (float)
@@ -151,4 +149,4 @@ class PluginPathSelect(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginPathSelect, 'path_select', api_ver=2)
+    plugin.register(PluginPathBySpace, 'path_by_space', api_ver=2)

--- a/flexget/plugins/output/telegram.py
+++ b/flexget/plugins/output/telegram.py
@@ -22,7 +22,7 @@ except ImportError:
 
 _MIN_TELEGRAM_VER = '3.4'
 
-_PLUGIN_NAME = 'send_telegram'
+_PLUGIN_NAME = 'telegram'
 
 _PARSERS = ['markdown', 'html']
 
@@ -77,7 +77,7 @@ class SendTelegram(object):
     Configuration example::
 
     my-task:
-      send_telegram:
+      telegram:
         bot_token: token
         template: {{title}}
         use_markdown: no
@@ -91,9 +91,9 @@ class SendTelegram(object):
 
     Bootstrapping and testing the bot::
 
-    * Execute: `flexget send_telegram bootstrap`.
+    * Execute: `flexget telegram bootstrap`.
       Look at the console output and make sure that the operation was successful.
-    * Execute: `flexget send_telegram test-msg`.
+    * Execute: `flexget telegram test-msg`.
       This will send a test message for every recipient you've configured.
 
 

--- a/tests/test_path_by_space.py
+++ b/tests/test_path_by_space.py
@@ -20,7 +20,7 @@ def mock_os_disk_stats(folder):
     return free_bytes, total_bytes
 
 
-@mock.patch('flexget.plugins.modify.path_select.os_disk_stats', side_effect=mock_os_disk_stats)
+@mock.patch('flexget.plugins.modify.path_by_space.os_disk_stats', side_effect=mock_os_disk_stats)
 class TestPathSelect(object):
 
     config = """
@@ -28,7 +28,7 @@ class TestPathSelect(object):
           test_most_free:
             mock:
               - {title: 'Existence.2012'}
-            path_select:
+            path_by_space:
               to_field: path
               within: 0G
               select: most_free
@@ -39,7 +39,7 @@ class TestPathSelect(object):
           test_most_free_within:
             mock:
               - {title: 'Existence.2012'}
-            path_select:
+            path_by_space:
               to_field: path
               within: 1G
               select: most_free
@@ -52,7 +52,7 @@ class TestPathSelect(object):
           test_most_used:
             mock:
               - {title: 'Existence.2012'}
-            path_select:
+            path_by_space:
               to_field: path
               within: 1G
               select: most_used
@@ -64,7 +64,7 @@ class TestPathSelect(object):
           test_most_free_percent:
             mock:
               - {title: 'Existence.2012'}
-            path_select:
+            path_by_space:
               to_field: path
               within: 2%
               select: most_free_percent
@@ -76,7 +76,7 @@ class TestPathSelect(object):
           test_most_free_percent_within:
             mock:
               - {title: 'Existence.2012'}
-            path_select:
+            path_by_space:
               to_field: path
               within: 2%
               select: most_free_percent
@@ -89,7 +89,7 @@ class TestPathSelect(object):
           test_most_used_percent:
             mock:
               - {title: 'Existence.2012'}
-            path_select:
+            path_by_space:
               to_field: path
               within: 2%
               select: most_used_percent


### PR DESCRIPTION
### Motivation for changes:

Consistent naming convention

### Detailed changes:

- Renamed send_telegram to telegram
- Renamed path_select to path_by_space