### PR TITLE
bug fix for crash when letters are in SQLAlchemy version

### DIFF
--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -18,6 +18,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 
 import io
+import string
 
 import sqlalchemy
 import yaml
@@ -647,7 +648,7 @@ class Manager(object):
     def init_sqlalchemy(self):
         """Initialize SQLAlchemy"""
         try:
-            if [int(part) for part in sqlalchemy.__version__.split('.')] < [0, 7, 0]:
+            if [int(part) for part in sqlalchemy.__version__.translate(None, string.letters).split('.')] < [0, 7, 0]:
                 print('FATAL: SQLAlchemy 0.7.0 or newer required. Please upgrade your SQLAlchemy.', file=sys.stderr)
                 sys.exit(1)
         except ValueError as e:


### PR DESCRIPTION
### Motivation for changes:

Fix for error message "Failed to check SQLAlchemy version, you may need to upgrade it" for SQLAlchemy beta version (1.1.0b1).
### Detailed changes:

All letters are cutted out in version checker.
