### PR TITLE
Fix JSON serialization bug in transmission plugin

### DIFF
--- a/flexget/plugins/plugin_transmission.py
+++ b/flexget/plugins/plugin_transmission.py
@@ -546,7 +546,7 @@ class PluginTransmission(TransmissionBase):
                                 try:
                                     cli.rename_torrent_path(r.id, fl[r.id][index]['name'],
                                                             os.path.basename(
-                                                                pathscrub(filename + file_ext)).encode('utf-8')
+                                                                pathscrub(filename + file_ext))
                                                             )
                                 except TransmissionError:
                                     log.error('content_filename only supported with transmission 2.8+')


### PR DESCRIPTION
### Motivation for changes:

Fix a bug in transmission plugin that causes a fatal exception when using `content_filename` that a binary string cannot be serialized to JSON.
### Detailed changes:

Remove a call to `.encode('utf-8')` on the filename to keep the filename as a proper 'str' object.
### Addressed issues:

No separate issue reported.
### Config usage if relevant (new plugin or updated schema):

```
templates:
  webdl:
    configure_series:
      settings:
        quality: 720p !h265
        set:
          path: /media/data/TV Shows/{{series_name}}
          main_file_only: yes
          content_filename: "{{ series_name|replace(' ','.') }} - {% if series_id_type == 'ep' %}{{ series_season }}x{{ series_episode|pad(2) }}{% else %}{{series_id}}{% endif %} - {{ quality|upper }}{% if proper %} - PROPER{% endif %}"
          magnetization_timeout: 300
        upgrade: yes
        tracking: no
      from:
        filesystem:
          - /media/data/TV Shows/
    transmission:
      host: localhost
      port: 9091

tasks:
  kickass:
    priority: 10
    inputs:
      - rss: https://kat.cr/tv/?rss=1&page=1
    template: webdl
```
### Log and/or tests output (preferably both):

```
2016-06-23 23:17 DEBUG    manager                       Figuring out config load paths
2016-06-23 23:17 DEBUG    manager                       Found config: /home/xbmc/.flexget/config.yml
2016-06-23 23:17 DEBUG    manager                       Config file /home/xbmc/.flexget/config.yml selected
2016-06-23 23:17 INFO     download      kickass         Downloading: Aquarius 2x04 (720p-HDTV-x264-PROPER-FLEET)[VTV]
2016-06-23 23:17 INFO     transmission  kickass         "Aquarius 2x04 (720p-HDTV-x264-PROPER-FLEET)[VTV]" torrent added to transmission
2016-06-23 23:17 CRITICAL task          kickass         BUG: Unhandled error in plugin transmission: b'Aquarius - 2x4 - 720P HDTV H264 [PROPER].mkv' is not JSON serializable
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/flexget/task.py", line 443, in __run_plugin
    return method(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/flexget/event.py", line 23, in __call__
    return self.func(*args, **kwargs)
```

This change removes code that converted a `str` to a `list<byte>` when using `content_filename`.

The `.encode('utf-8')` call was returning a byte array that caused a JSON serialization error.  By removing this call, a regular UTF-8 `str` object is returned, which can be properly serialized.
