### PR TITLE
New list plugin: regexp_list

### DIFF
--- a/flexget/plugins/list/regexp_list.py
+++ b/flexget/plugins/list/regexp_list.py
@@ -1,0 +1,156 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *
+
+import logging
+import re
+from collections import MutableSet
+from datetime import datetime
+
+from sqlalchemy import Column, Unicode, Integer, ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+
+from flexget import plugin
+from flexget.db_schema import versioned_base, with_session
+from flexget.entry import Entry
+from flexget.event import event
+
+log = logging.getLogger('regexp_list')
+Base = versioned_base('regexp_list', 1)
+
+
+class RegexpListList(Base):
+    __tablename__ = 'regexp_list_lists'
+    id = Column(Integer, primary_key=True)
+    name = Column(Unicode, unique=True)
+    added = Column(DateTime, default=datetime.now)
+    regexps = relationship('RegexpListFile', backref='list', cascade='all, delete, delete-orphan', lazy='dynamic')
+
+    def __repr__(self):
+        return '<RegexpListList name=%s,id=%d>' % (self.name, self.id)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'name': self.name,
+            'added_on': self.added
+        }
+
+
+class RegexpListFile(Base):
+    __tablename__ = 'regexp_list_files'
+    id = Column(Integer, primary_key=True)
+    added = Column(DateTime, default=datetime.now)
+    regexp = Column(Unicode)
+    list_id = Column(Integer, ForeignKey(RegexpListList.id), nullable=False)
+
+    def __repr__(self):
+        return '<RegexpListFile regexp=%s,list_name=%s>' % (self.regexp, self.list.name)
+
+    def to_entry(self):
+        entry = Entry()
+        entry['title'] = entry['regexp'] = self.regexp
+        entry['url'] = 'mock://localhost/regexp_list/%d' % self.id
+        return entry
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'added_on': self.added,
+            'regexp': self.regexp
+        }
+
+
+class RegexpList(MutableSet):
+    schema = {'type': 'string'}
+
+    def _db_list(self, session):
+        return session.query(RegexpListList).filter(RegexpListList.name == self.config).first()
+
+    def _from_iterable(self, it):
+        # TODO: is this the right answer? the returned object won't have our custom __contains__ logic
+        return set(it)
+
+    @with_session
+    def __init__(self, config, session=None):
+        self.config = config
+        db_list = self._db_list(session)
+        if not db_list:
+            session.add(RegexpListList(name=self.config))
+
+    @with_session
+    def __iter__(self, session=None):
+        return iter([regexp.to_entry() for regexp in self._db_list(session).regexps])
+
+    @with_session
+    def __len__(self, session=None):
+        return self._db_list(session).regexps.count()
+
+    @with_session
+    def add(self, entry, session=None):
+        # Check if this is already in the list, refresh info if so
+        db_list = self._db_list(session=session)
+        db_file = self._find_entry(entry, session=session)
+        # Just delete and re-create to refresh
+        if db_file:
+            session.delete(db_file)
+        db_file = RegexpListFile()
+        db_file.regexp = entry['title']
+        db_list.regexps.append(db_file)
+        session.commit()
+        return db_file.to_entry()
+
+    @with_session
+    def discard(self, entry, session=None):
+        db_file = self._find_entry(entry, session=session)
+        if db_file:
+            log.debug('deleting file %s', db_file)
+            session.delete(db_file)
+
+    def __contains__(self, entry):
+        return self._find_entry(entry, match_regexp=True) is not None
+
+    @with_session
+    def _find_entry(self, entry, match_regexp=False, session=None):
+        """Finds `SubtitleListFile` corresponding to this entry, if it exists."""
+        res = None
+        if match_regexp:
+            for regexp in self._db_list(session).regexps:
+                if re.search(regexp.regexp, entry['title'], re.IGNORECASE):
+                    res = regexp
+        else:
+            res = self._db_list(session).regexps.filter(RegexpListFile.regexp == entry.get('regexp')).first()
+        return res
+
+    @property
+    def immutable(self):
+        return False
+
+    @property
+    def online(self):
+        """ Set the online status of the plugin, online plugin should be treated differently in certain situations,
+        like test mode"""
+        return False
+
+    @with_session
+    def get(self, entry, session):
+        match = self._find_entry(entry=entry, match_regexp=True, session=session)
+        return match.to_entry() if match else None
+
+
+class PluginRegexpList(object):
+    """Subtitle list"""
+    schema = RegexpList.schema
+
+    @staticmethod
+    def get_list(config):
+        return RegexpList(config)
+
+    def on_task_input(self, task, config):
+        regexp_list = RegexpList(config)
+
+        return list(regexp_list)
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(PluginRegexpList, 'regexp_list', api_ver=2, groups=['list'])

--- a/flexget/plugins/list/regexp_list.py
+++ b/flexget/plugins/list/regexp_list.py
@@ -23,7 +23,7 @@ class RegexpListList(Base):
     id = Column(Integer, primary_key=True)
     name = Column(Unicode, unique=True)
     added = Column(DateTime, default=datetime.now)
-    regexps = relationship('RegexpListFile', backref='list', cascade='all, delete, delete-orphan', lazy='dynamic')
+    regexps = relationship('RegexListRegexp', backref='list', cascade='all, delete, delete-orphan', lazy='dynamic')
 
     def __repr__(self):
         return '<RegexpListList name=%s,id=%d>' % (self.name, self.id)
@@ -36,15 +36,15 @@ class RegexpListList(Base):
         }
 
 
-class RegexpListFile(Base):
-    __tablename__ = 'regexp_list_files'
+class RegexListRegexp(Base):
+    __tablename__ = 'regexp_list_regexps'
     id = Column(Integer, primary_key=True)
     added = Column(DateTime, default=datetime.now)
     regexp = Column(Unicode)
     list_id = Column(Integer, ForeignKey(RegexpListList.id), nullable=False)
 
     def __repr__(self):
-        return '<RegexpListFile regexp=%s,list_name=%s>' % (self.regexp, self.list.name)
+        return '<RegexListRegexp regexp=%s,list_name=%s>' % (self.regexp, self.list.name)
 
     def to_entry(self):
         entry = Entry()
@@ -93,7 +93,7 @@ class RegexpList(MutableSet):
         # Just delete and re-create to refresh
         if db_regexp:
             session.delete(db_regexp)
-        db_regexp = RegexpListFile()
+        db_regexp = RegexListRegexp()
         db_regexp.regexp = entry['title']
         db_list.regexps.append(db_regexp)
         session.commit()
@@ -118,7 +118,7 @@ class RegexpList(MutableSet):
                 if re.search(regexp.regexp, entry['title'], re.IGNORECASE):
                     res = regexp
         else:
-            res = self._db_list(session).regexps.filter(RegexpListFile.regexp ==
+            res = self._db_list(session).regexps.filter(RegexListRegexp.regexp ==
                                                         entry.get('regexp', entry['title'])).first()
         return res
 

--- a/flexget/plugins/list/regexp_list.py
+++ b/flexget/plugins/list/regexp_list.py
@@ -94,7 +94,7 @@ class RegexpList(MutableSet):
         if db_regexp:
             session.delete(db_regexp)
         db_regexp = RegexListRegexp()
-        db_regexp.regexp = entry['title']
+        db_regexp.regexp = entry.get('regexp', entry['title'])
         db_list.regexps.append(db_regexp)
         session.commit()
         return db_regexp.to_entry()

--- a/flexget/plugins/list/regexp_list.py
+++ b/flexget/plugins/list/regexp_list.py
@@ -89,22 +89,22 @@ class RegexpList(MutableSet):
     def add(self, entry, session=None):
         # Check if this is already in the list, refresh info if so
         db_list = self._db_list(session=session)
-        db_file = self._find_entry(entry, session=session)
+        db_regexp = self._find_entry(entry, session=session)
         # Just delete and re-create to refresh
-        if db_file:
-            session.delete(db_file)
-        db_file = RegexpListFile()
-        db_file.regexp = entry['title']
-        db_list.regexps.append(db_file)
+        if db_regexp:
+            session.delete(db_regexp)
+        db_regexp = RegexpListFile()
+        db_regexp.regexp = entry['title']
+        db_list.regexps.append(db_regexp)
         session.commit()
-        return db_file.to_entry()
+        return db_regexp.to_entry()
 
     @with_session
     def discard(self, entry, session=None):
-        db_file = self._find_entry(entry, session=session)
-        if db_file:
-            log.debug('deleting file %s', db_file)
-            session.delete(db_file)
+        db_regexp = self._find_entry(entry, session=session)
+        if db_regexp:
+            log.debug('deleting file %s', db_regexp)
+            session.delete(db_regexp)
 
     def __contains__(self, entry):
         return self._find_entry(entry, match_regexp=True) is not None
@@ -118,7 +118,8 @@ class RegexpList(MutableSet):
                 if re.search(regexp.regexp, entry['title'], re.IGNORECASE):
                     res = regexp
         else:
-            res = self._db_list(session).regexps.filter(RegexpListFile.regexp == entry.get('regexp')).first()
+            res = self._db_list(session).regexps.filter(RegexpListFile.regexp ==
+                                                        entry.get('regexp', entry['title'])).first()
         return res
 
     @property

--- a/tests/test_regexp_list.py
+++ b/tests/test_regexp_list.py
@@ -1,0 +1,50 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # pylint: disable=unused-import, redefined-builtin
+
+
+class TestRegexpList(object):
+    config = """
+        tasks:
+          regexp_list_add:
+            mock:
+              - {title: 'game.of.thrones.s\d{2}e\d{2}'}
+            list_add:
+              - regexp_list: test 1
+            accept_all: yes
+          regexp_list_match:
+            mock:
+              - {title: 'Game of Thrones S01E01 720p HDTV-FlexGet'}
+            list_match:
+              from:
+                - regexp_list: test 1
+              remove_on_match: no
+          regexp_list_add_advanced:
+            mock:
+              - {title: 'Game of Thrones'}
+            manipulate:
+              - title:
+                  replace:
+                    regexp: '$'
+                    format: ' s\d{2}e\d{2}'
+              - title:
+                  replace:
+                    regexp: ' '
+                    format: '.'
+            list_add:
+              - regexp_list: test 1
+            accept_all: yes
+    """
+
+    def test_regexp_list_simple_match(self, execute_task):
+        task = execute_task('regexp_list_add')
+        assert len(task.accepted) == 1
+
+        task = execute_task('regexp_list_match')
+        assert len(task.accepted) == 1
+
+    def test_regexp_list_advanced_match(self, execute_task):
+        task = execute_task('regexp_list_add_advanced')
+        assert len(task.accepted) == 1
+
+        task = execute_task('regexp_list_match')
+        assert len(task.accepted) == 1


### PR DESCRIPTION
### Motivation for changes:
I'm greedy and want to match a list of automatically generated regexes (from trakt_list etc.) on rss feeds.

It contains a list of regular expressions that it uses to match entries.
### Detailed changes:

- added

### Config usage if relevant (new plugin or updated schema):
```
  regexp_list_add:
    trakt_list:
      account: '{{ secrets.trakt.usr }}'
      list: my_shows
      type: shows
      strip_dates: yes
    list_add:
      - regexp_list: test
    manipulate:  # example result: game.*of.*thrones.*s\d{2}e\d{2}
      - title:
          replace:
            regexp: '$'
            format: 's\d{2}e\d{2}'
      - title:
          replace:
            regexp: ' '
            format: '.*'
    accept_all: yes
  regexp_list_download:
    rss: https://some_url.com/rss
    list_match:
      from:
        - regexp_list: test
      remove_on_match: no
      single_match: no
    download: /home/derp/watch_dir
```

### TODO
 - [x] tests


