### PR TITLE
Fix py3 crash

### DIFF
--- a/flexget/task.py
+++ b/flexget/task.py
@@ -526,7 +526,7 @@ class Task(object):
                 if isinstance(templates, basestring) or isinstance(templates, list) and template in templates:
                     task_templates.update({template: value})
             hashable_config = list(self.config.items()) + list(task_templates.items())
-            config_hash = hashlib.md5(str(sorted(hashable_config)).encode('utf-8')).hexdigest()
+            config_hash = hashlib.md5(str(sorted(hashable_config, key=lambda x: x[0])).encode('utf-8')).hexdigest()
             last_hash = session.query(TaskConfigHash).filter(TaskConfigHash.task == self.name).first()
             if self.is_rerun:
                 # Restore the config to state right after start phase


### PR DESCRIPTION
### Motivation for changes:
Fixes a crash that can occur on py3.5 on a specifc discover task when it is re-run. Just switched to py3.5 on main machine
```
templates:
  trakt_shows:
    configure_series:
      from:
        trakt_list:
          username: '{{ secrets.credentials.trakt.username }}'
          account: '{{ secrets.credentials.trakt.account }}'
          list: '{{ secrets.credentials.trakt.list }}'
          type: '{{ secrets.credentials.trakt.type }}'
          strip_dates: yes
      settings:
        quality: 720p hdtv h264 !aac
        identified_by: ep
        upgrade: yes
        propers: yes
    trakt_lookup:
      username: '{{ secrets.credentials.trakt.username }}'
      account: '{{ secrets.credentials.trakt.account }}'
    tvmaze_lookup: yes

tasks:
  download_from_trakt_list:
    discover:
      what:
        - next_series_episodes: yes
      from:
        - torrentleech: 
            rss_key: '{{secrets.credentials.torrentleech.rsskey}}'
            username: '{{secrets.credentials.torrentleech.username}}'
            password: '{{secrets.credentials.torrentleech.password}}'
            category: HD
        - kat:
            category: tv
            verified: yes
    template:
      - trakt_shows
      - deluge
      - telegram
```



### Detailed changes:
Add a key to `config_hash` sorting.

### Addressed issues:
```
2016-06-27 15:58 VERBOSE  input_cache   download_from_trakt_list Restored 3 entries from db cache
2016-06-27 15:58 VERBOSE  discover      download_from_trakt_list Discovering 3 titles ...
2016-06-27 15:58 INFO     task          download_from_trakt_list Plugin next_series_episodes has requested task to be ran again after execution has completed. Reason: Look for next season
2016-06-27 15:58 VERBOSE  discover      download_from_trakt_list Discover interval of 5 hours not met for 3 entries. Use --discover-now to override.
2016-06-27 15:58 VERBOSE  details       download_from_trakt_list Task didn't produce any entries.
2016-06-27 15:58 VERBOSE  details       download_from_trakt_list Summary - Accepted: 0 (Rejected: 0 Undecided: 0 Failed: 0)
2016-06-27 15:58 INFO     task          download_from_trakt_list Rerunning the task in case better resolution can be achieved.
2016-06-27 15:58 CRITICAL task_queue                    BUG: Unhandled exception during task queue run loop.
Traceback (most recent call last):
  File "c:\python35\lib\site-packages\flexget\task_queue.py", line 47, in run
    self.current_task.execute()
  File "c:\python35\lib\site-packages\flexget\task.py", line 71, in wrapper
    return func(self, *args, **kw)
  File "c:\python35\lib\site-packages\flexget\task.py", line 598, in execute
    self._execute()
  File "c:\python35\lib\site-packages\flexget\task.py", line 529, in _execute
    config_hash = hashlib.md5(str(sorted(hashable_config)).encode('utf-8')).hexdigest()
TypeError: unorderable types: dict() < dict()
```

I am not entirely sure why this doesn't happen for all tasks, something to do with rerun probably.


