### PR TITLE
Fixed Trakt adding episodes to list

### DIFF
--- a/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode
+++ b/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode
@@ -1,0 +1,158 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Authorization: [!!python/unicode Bearer 00b06077e9946af0a268e6e17e62f7a6982c43fad93cc04c407d1d05ca6565be]
+      Content-Type: [!!python/unicode application/json]
+      trakt-api-key: [!!python/unicode 57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+      trakt-api-version: [2]
+    method: GET
+    uri: https://api-v2launch.trakt.tv/users/me/watchlist/episodes
+  response:
+    body: {string: !!python/unicode '[{"rank":1,"listed_at":"2016-07-17T20:16:45.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
+        of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
+        of Thrones","year":2011,"ids":{"trakt":1390,"slug":"game-of-thrones","tvdb":121361,"imdb":"tt0944947","tmdb":1399,"tvrage":24493}}}]'}
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      cf-ray: [2c438ab7485234d6-LHR]
+      connection: [keep-alive]
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 18 Jul 2016 05:30:28 GMT']
+      etag: [W/"11830cf37ca448e4ce5cc37e78b03f35"]
+      last-modified: ['Mon, 18 Jul 2016 05:30:34 GMT']
+      server: [cloudflare-nginx]
+      set-cookie: ['__cfduid=dd60fb727ccb9a4b11f27db411b135c511468819828; expires=Tue,
+          18-Jul-17 05:30:28 GMT; path=/; domain=.trakt.tv; HttpOnly']
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-frame-options: [SAMEORIGIN]
+      x-private-user: ['false']
+      x-request-id: [473ce928-412f-4bad-9090-4acdaf03d586]
+      x-runtime: ['0.032650']
+      x-sort-by: [rank]
+      x-sort-how: [asc]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"episodes": [{"ids": {"tvdb": 121361, "tvrage": 24493,
+      "imdb": "tt0944947", "trakt": 73674}}]}'
+    headers:
+      Authorization: [!!python/unicode Bearer 00b06077e9946af0a268e6e17e62f7a6982c43fad93cc04c407d1d05ca6565be]
+      Content-Length: ['95']
+      Content-Type: [!!python/unicode application/json]
+      Cookie: [__cfduid=dd60fb727ccb9a4b11f27db411b135c511468819828]
+      trakt-api-key: [!!python/unicode 57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+      trakt-api-version: [2]
+    method: POST
+    uri: https://api-v2launch.trakt.tv/sync/watchlist/remove
+  response:
+    body: {string: !!python/unicode '{"deleted":{"movies":0,"shows":0,"seasons":0,"episodes":1},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      cf-ray: [2c438ac218d934d6-LHR]
+      connection: [keep-alive]
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 18 Jul 2016 05:30:30 GMT']
+      etag: [W/"395f41838a26aa40f95625e4dc214057"]
+      server: [cloudflare-nginx]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-frame-options: [SAMEORIGIN]
+      x-request-id: [877c3dd0-b258-40bb-8e2e-61e1370810ad]
+      x-runtime: ['0.024214']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: [!!python/unicode Bearer 00b06077e9946af0a268e6e17e62f7a6982c43fad93cc04c407d1d05ca6565be]
+      Content-Type: [!!python/unicode application/json]
+      Cookie: [__cfduid=dd60fb727ccb9a4b11f27db411b135c511468819828]
+      trakt-api-key: [!!python/unicode 57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+      trakt-api-version: [2]
+    method: GET
+    uri: https://api-v2launch.trakt.tv/users/me/watchlist/episodes
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      cf-ray: [2c438acea99234d6-LHR]
+      connection: [keep-alive]
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 18 Jul 2016 05:30:32 GMT']
+      etag: [W/"893a838c5aae4fabb49e5e11a24c7b20"]
+      last-modified: ['Mon, 18 Jul 2016 05:30:25 GMT']
+      server: [cloudflare-nginx]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-frame-options: [SAMEORIGIN]
+      x-private-user: ['false']
+      x-request-id: [3d1bdbfb-4ed8-469b-894b-1b409f05baa2]
+      x-runtime: ['0.032633']
+      x-sort-by: [rank]
+      x-sort-how: [asc]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"episodes": [{"ids": {"tvdb": 121361, "tvrage": 24493,
+      "imdb": "tt0944947", "trakt": 73674}}]}'
+    headers:
+      Authorization: [!!python/unicode Bearer 00b06077e9946af0a268e6e17e62f7a6982c43fad93cc04c407d1d05ca6565be]
+      Content-Length: ['95']
+      Content-Type: [!!python/unicode application/json]
+      Cookie: [__cfduid=dd60fb727ccb9a4b11f27db411b135c511468819828]
+      trakt-api-key: [!!python/unicode 57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+      trakt-api-version: [2]
+    method: POST
+    uri: https://api-v2launch.trakt.tv/sync/watchlist
+  response:
+    body: {string: !!python/unicode '{"added":{"movies":0,"shows":0,"seasons":0,"episodes":1},"existing":{"movies":0,"shows":0,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      cf-ray: [2c438adb1a1334d6-LHR]
+      connection: [keep-alive]
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 18 Jul 2016 05:30:34 GMT']
+      etag: [W/"47bbbe533aa38ab81d69a3be78d7523e"]
+      server: [cloudflare-nginx]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-frame-options: [SAMEORIGIN]
+      x-request-id: [1b6f6949-84d8-43cf-bc6c-20a440734c44]
+      x-runtime: ['0.030050']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Authorization: [!!python/unicode Bearer 00b06077e9946af0a268e6e17e62f7a6982c43fad93cc04c407d1d05ca6565be]
+      Content-Type: [!!python/unicode application/json]
+      Cookie: [__cfduid=dd60fb727ccb9a4b11f27db411b135c511468819828]
+      trakt-api-key: [!!python/unicode 57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+      trakt-api-version: [2]
+    method: GET
+    uri: https://api-v2launch.trakt.tv/users/me/watchlist/episodes
+  response:
+    body: {string: !!python/unicode '[{"rank":1,"listed_at":"2016-07-18T05:30:38.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
+        of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
+        of Thrones","year":2011,"ids":{"trakt":1390,"slug":"game-of-thrones","tvdb":121361,"imdb":"tt0944947","tmdb":1399,"tvrage":24493}}}]'}
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      cf-ray: [2c438ae79aa734d6-LHR]
+      connection: [keep-alive]
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 18 Jul 2016 05:30:36 GMT']
+      etag: [W/"95ada048e42db452d2f12bf99201202d"]
+      last-modified: ['Mon, 18 Jul 2016 05:30:40 GMT']
+      server: [cloudflare-nginx]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-frame-options: [SAMEORIGIN]
+      x-private-user: ['false']
+      x-request-id: [308dccd3-9a27-44db-9a00-c8acabba10bd]
+      x-runtime: ['0.030845']
+      x-sort-by: [rank]
+      x-sort-how: [asc]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_trakt_list_interface.py
+++ b/tests/test_trakt_list_interface.py
@@ -93,8 +93,8 @@ class TestTraktList(object):
         assert set(titles) == set(('The Walking Dead', 'Deadpool', 'Castle S08E15 Fidelis Ad Mortem'))
 
     def test_trakt_add(self):
-        trakt_set = TraktSet(self.trakt_config)
         # Initialize trakt set
+        trakt_set = TraktSet(self.trakt_config)
         trakt_set.clear()
 
         entry = Entry(title='White collar', series_name='White Collar (2009)')
@@ -103,6 +103,21 @@ class TestTraktList(object):
 
         trakt_set.add(entry)
         assert entry in trakt_set
+
+    def test_trakt_add_episode(self):
+        episode_config = self.trakt_config.copy()
+        episode_config['type'] = 'episodes'
+        trakt_set = TraktSet(episode_config)
+        # Initialize trakt set
+        trakt_set.clear()
+
+        entry = Entry(**{u'trakt_show_slug': u'game-of-thrones', u'original_url': u'http://trakt.tv/shows/game-of-thrones/seasons/4/episodes/5', u'url': u'http://trakt.tv/shows/game-of-thrones/seasons/4/episodes/5', u'series_season': 4, u'tvdb_id': 121361, u'series_name': u'Game of Thrones (2011)', u'imdb_id': u'tt0944947', u'series_id': u'S04E05', u'series_episode': 5, u'trakt_episode_id': 73674, u'title': u'Game of Thrones (2011) S04E05 First of His Name', u'trakt_show_id': 1390, u'trakt_ep_name': u'First of His Name', u'tvrage_id': 24493})
+
+        assert entry not in trakt_set
+
+        trakt_set.add(entry)
+        assert entry in trakt_set
+
 
     def test_trakt_remove(self):
         trakt_set = TraktSet(self.trakt_config)


### PR DESCRIPTION
### Motivation for changes:
Reporting to trakt about collected episodes was broken. Their documentation suggested a completely different method, which I implemented. Now works.
### Detailed changes:

- Adding episodes to lists is now done via "episodes" and not via "shows", while specifying all known episode ids (trakt, imdb etc)