### PR TITLE
Allow setting filename with config in download plugin

### DIFF
--- a/flexget/plugins/output/download.py
+++ b/flexget/plugins/output/download.py
@@ -64,7 +64,8 @@ class PluginDownload(object):
                     'path': {'type': 'string', 'format': 'path'},
                     'fail_html': {'type': 'boolean', 'default': True},
                     'overwrite': {'type': 'boolean', 'default': False},
-                    'temp': {'type': 'string', 'format': 'path'}
+                    'temp': {'type': 'string', 'format': 'path'},
+                    'filename': {'type': 'string'}
                 },
                 'additionalProperties': False
             },
@@ -426,8 +427,14 @@ class PluginDownload(object):
                 log.debug('entry: %s' % entry)
                 raise plugin.PluginWarning('Downloaded temp file `%s` doesn\'t exist!?' % entry['file'])
 
+            if config.get('filename'):
+                try:
+                    entry['filename'] = entry.render(config['filename'])
+                except RenderError as e:
+                    entry.fail('Could not set filename. Error during string replacement: %s' % e)
+                    return
             # if we still don't have a filename, try making one from title (last resort)
-            if not entry.get('filename'):
+            elif not entry.get('filename'):
                 entry['filename'] = entry['title']
                 log.debug('set filename from title %s' % entry['filename'])
                 if 'mime-type' not in entry:

--- a/flexget/plugins/output/download.py
+++ b/flexget/plugins/output/download.py
@@ -430,6 +430,7 @@ class PluginDownload(object):
             if config.get('filename'):
                 try:
                     entry['filename'] = entry.render(config['filename'])
+                    log.debug('set filename from config %s' % entry['filename'])
                 except RenderError as e:
                     entry.fail('Could not set filename. Error during string replacement: %s' % e)
                     return

--- a/flexget/plugins/output/download.py
+++ b/flexget/plugins/output/download.py
@@ -468,7 +468,7 @@ class PluginDownload(object):
                     log.debug("Overwriting already existing file %s", destfile)
                 else:
                     log.info('File `%s` already exists and is not identical, download failed.', destfile)
-                    entry.fail('File `%s` already exists and is not identical.', destfile)
+                    entry.fail('File `%s` already exists and is not identical.' % destfile)
                     return
             else:
                 # move temp file
@@ -480,7 +480,7 @@ class PluginDownload(object):
                     # ignore permission errors, see ticket #555
                     import errno
                     if not os.path.exists(destfile):
-                        raise plugin.PluginError('Unable to write %s', destfile)
+                        raise plugin.PluginError('Unable to write %s' % destfile)
                     if err.errno != errno.EPERM:
                         raise
 

--- a/flexget/plugins/output/download.py
+++ b/flexget/plugins/output/download.py
@@ -119,7 +119,7 @@ class PluginDownload(object):
             if url.startswith('magnet:'):
                 if handle_magnets:
                     # Set magnet link as main url, so a torrent client plugin can grab it
-                    log.debug('Accepting magnet url for %s' % entry['title'])
+                    log.debug('Accepting magnet url for %s', entry['title'])
                     entry['url'] = url
                     break
                 else:
@@ -128,7 +128,7 @@ class PluginDownload(object):
                     continue
             if require_path and 'path' not in entry:
                 # Don't fail here, there might be a magnet later in the list of urls
-                log.debug('Skipping url %s because there is no path for download' % url)
+                log.debug('Skipping url %s because there is no path for download', url)
                 continue
             error = self.process_entry(task, entry, url, tmp_path)
 
@@ -140,7 +140,7 @@ class PluginDownload(object):
 
             if not error:
                 # Set the main url, so we know where this file actually came from
-                log.debug('Successfully retrieved %s from %s' % (entry['title'], url))
+                log.debug('Successfully retrieved %s from %s', entry['title'], url)
                 entry['url'] = url
                 break
             else:
@@ -148,7 +148,7 @@ class PluginDownload(object):
         else:
             # check if entry must have a path (download: yes)
             if require_path and 'path' not in entry:
-                log.error('%s can\'t be downloaded, no path specified for entry' % entry['title'])
+                log.error('%s can\'t be downloaded, no path specified for entry', entry['title'])
                 entry.fail('no path specified for entry')
             else:
                 entry.fail(', '.join(errors))
@@ -158,7 +158,7 @@ class PluginDownload(object):
         if not os.path.isdir(received):
             os.makedirs(received)
         filename = os.path.join(received, '%s.error' % entry['title'].encode(sys.getfilesystemencoding(), 'replace'))
-        log.error('Error retrieving %s, the error page has been saved to %s' % (entry['title'], filename))
+        log.error('Error retrieving %s, the error page has been saved to %s', entry['title'], filename)
         with io.open(filename, 'wb') as outfile:
             outfile.write(page)
 
@@ -193,22 +193,22 @@ class PluginDownload(object):
         """
         try:
             if task.options.test:
-                log.info('Would download: %s' % entry['title'])
+                log.info('Would download: %s', entry['title'])
             else:
                 if not task.manager.unit_test:
-                    log.info('Downloading: %s' % entry['title'])
+                    log.info('Downloading: %s', entry['title'])
                 self.download_entry(task, entry, url, tmp_path)
         except RequestException as e:
-            log.warning('RequestException %s, while downloading %s' % (e, url))
+            log.warning('RequestException %s, while downloading %s', (e, url))
             return 'Network error during request: %s' % e
         except BadStatusLine as e:
-            log.warning('Failed to reach server. Reason: %s' % getattr(e, 'message', 'N/A'))
+            log.warning('Failed to reach server. Reason: %s', getattr(e, 'message', 'N/A'))
             return 'BadStatusLine'
         except IOError as e:
             if hasattr(e, 'reason'):
-                log.warning('Failed to reach server. Reason: %s' % e.reason)
+                log.warning('Failed to reach server. Reason: %s', e.reason)
             elif hasattr(e, 'code'):
-                log.warning('The server couldn\'t fulfill the request. Error code: %s' % e.code)
+                log.warning('The server couldn\'t fulfill the request. Error code: %s', e.code)
             log.debug('IOError', exc_info=True)
             return 'IOError'
         except ValueError as e:
@@ -225,21 +225,21 @@ class PluginDownload(object):
         :raises: PluginWarning
         """
 
-        log.debug('Downloading url \'%s\'' % url)
+        log.debug('Downloading url \'%s\'', url)
 
         # get content
         auth = None
         if 'download_auth' in entry:
             auth = entry['download_auth']
-            log.debug('Custom auth enabled for %s download: %s' % (entry['title'], entry['download_auth']))
+            log.debug('Custom auth enabled for %s download: %s', entry['title'], entry['download_auth'])
 
         try:
             response = task.requests.get(url, auth=auth, raise_status=False)
         except UnicodeError:
-            log.error('Unicode error while encoding url %s' % url)
+            log.error('Unicode error while encoding url %s', url)
             return
         if response.status_code != 200:
-            log.debug('Got %s response from server. Saving error page.' % response.status_code)
+            log.debug('Got %s response from server. Saving error page.', response.status_code)
             # Save the error page
             if response.content:
                 self.save_error_page(entry, task, response.content)
@@ -295,7 +295,7 @@ class PluginDownload(object):
             # store temp filename into entry so other plugins may read and modify content
             # temp file is moved into final destination at self.output
             entry['file'] = datafile
-            log.debug('%s field file set to: %s' % (entry['title'], entry['file']))
+            log.debug('%s field file set to: %s', entry['title'], entry['file'])
 
         if 'content-type' in response.headers:
             entry['mime-type'] = str(parse_header(response.headers['content-type'])[0])
@@ -312,14 +312,14 @@ class PluginDownload(object):
         if entry.get('content-disposition', True):
             self.filename_from_headers(entry, response)
         else:
-            log.info('Content-disposition disabled for %s' % entry['title'])
+            log.info('Content-disposition disabled for %s', entry['title'])
         self.filename_ext_from_mime(entry)
 
         if not entry.get('filename'):
             filename = unquote(url.rsplit('/', 1)[1])
-            log.debug('No filename - setting from url: %s' % filename)
+            log.debug('No filename - setting from url: %s', filename)
             entry['filename'] = filename
-        log.debug('Finishing download_entry() with filename %s' % entry.get('filename'))
+        log.debug('Finishing download_entry() with filename %s', entry.get('filename'))
 
     def filename_from_headers(self, entry, response):
         """Checks entry filename if it's found from content-disposition"""
@@ -340,27 +340,27 @@ class PluginDownload(object):
                 except UnicodeError:
                     pass
             filename = decode_html(filename)
-            log.debug('Found filename from headers: %s' % filename)
+            log.debug('Found filename from headers: %s', filename)
             if 'filename' in entry:
-                log.debug('Overriding filename %s with %s from content-disposition' % (entry['filename'], filename))
+                log.debug('Overriding filename %s with %s from content-disposition', entry['filename'], filename)
             entry['filename'] = filename
 
     def filename_ext_from_mime(self, entry):
         """Tries to set filename extension from mime-type"""
         extensions = mimetypes.guess_all_extensions(entry['mime-type'], strict=False)
         if extensions:
-            log.debug('Mimetype guess for %s is %s ' % (entry['mime-type'], extensions))
+            log.debug('Mimetype guess for %s is %s ', (entry['mime-type'], extensions))
             if entry.get('filename'):
                 if any(entry['filename'].endswith(extension) for extension in extensions):
-                    log.debug('Filename %s extension matches to mime-type' % entry['filename'])
+                    log.debug('Filename %s extension matches to mime-type', entry['filename'])
                 else:
                     # mimetypes library has no concept of a 'prefered' extension when there are multiple possibilites
                     # this causes the first to be used which is not always desirable, e.g. 'ksh' for 'text/plain'
                     extension = mimetypes.guess_extension(entry['mime-type'], strict=False)
-                    log.debug('Adding mime-type extension %s to %s' % (extension, entry['filename']))
+                    log.debug('Adding mime-type extension %s to %s', (extension, entry['filename']))
                     entry['filename'] = entry['filename'] + extension
         else:
-            log.debug('Python doesn\'t know extension for mime-type: %s' % entry['mime-type'])
+            log.debug('Python doesn\'t know extension for mime-type: %s', entry['mime-type'])
 
     def on_task_output(self, task, config):
         """Move downloaded content from temp folder to final destination"""
@@ -370,10 +370,10 @@ class PluginDownload(object):
                 self.output(task, entry, config)
             except plugin.PluginWarning as e:
                 entry.fail()
-                log.error('Plugin error while writing: %s' % e)
+                log.error('Plugin error while writing: %s', e)
             except Exception as e:
                 entry.fail()
-                log.exception('Exception while writing: %s' % e)
+                log.exception('Exception while writing: %s', e)
 
     def output(self, task, entry, config):
         """Moves temp-file into final destination
@@ -383,7 +383,7 @@ class PluginDownload(object):
         """
 
         if 'file' not in entry and not task.options.test:
-            log.debug('file missing, entry: %s' % entry)
+            log.debug('file missing, entry: %s', entry)
             raise plugin.PluginError('Entry `%s` has no temp file associated with' % entry['title'])
 
         try:
@@ -408,7 +408,7 @@ class PluginDownload(object):
 
             # If we are in test mode, report and return
             if task.options.test:
-                log.info('Would write `%s` to `%s`' % (entry['title'], path))
+                log.info('Would write `%s` to `%s`', entry['title'], path)
                 # Set a fake location, so the exec plugin can do string replacement during --test #1015
                 entry['output'] = os.path.join(path, 'TEST_MODE_NO_OUTPUT')  # backwards compatibility
                 entry['location'] = os.path.join(path, 'TEST_MODE_NO_OUTPUT')
@@ -416,7 +416,7 @@ class PluginDownload(object):
 
             # make path
             if not os.path.isdir(path):
-                log.debug('Creating directory %s' % path)
+                log.debug('Creating directory %s', path)
                 try:
                     os.makedirs(path)
                 except:
@@ -424,7 +424,7 @@ class PluginDownload(object):
 
             # check that temp file is present
             if not os.path.exists(entry['file']):
-                log.debug('entry: %s' % entry)
+                log.debug('entry: %s', entry)
                 raise plugin.PluginWarning('Downloaded temp file `%s` doesn\'t exist!?' % entry['file'])
 
             if config.get('filename'):
@@ -437,13 +437,13 @@ class PluginDownload(object):
             # if we still don't have a filename, try making one from title (last resort)
             elif not entry.get('filename'):
                 entry['filename'] = entry['title']
-                log.debug('set filename from title %s' % entry['filename'])
+                log.debug('set filename from title %s', entry['filename'])
                 if 'mime-type' not in entry:
-                    log.warning('Unable to figure proper filename for %s. Using title.' % entry['title'])
+                    log.warning('Unable to figure proper filename for %s. Using title.', entry['title'])
                 else:
                     guess = mimetypes.guess_extension(entry['mime-type'])
                     if not guess:
-                        log.warning('Unable to guess extension with mime-type %s' % guess)
+                        log.warning('Unable to guess extension with mime-type %s', guess)
                     else:
                         self.filename_ext_from_mime(entry)
 
@@ -458,21 +458,21 @@ class PluginDownload(object):
             name = ' '.join(name.split())
             # combine to full path + filename
             destfile = os.path.join(path, name)
-            log.debug('destfile: %s' % destfile)
+            log.debug('destfile: %s', destfile)
 
             if os.path.exists(destfile):
                 import filecmp
                 if filecmp.cmp(entry['file'], destfile):
                     log.debug("Identical destination file '%s' already exists", destfile)
                 elif config.get('overwrite'):
-                    log.debug("Overwriting already existing file %s" % destfile)
+                    log.debug("Overwriting already existing file %s", destfile)
                 else:
-                    log.info('File `%s` already exists and is not identical, download failed.' % destfile)
-                    entry.fail('File `%s` already exists and is not identical.' % destfile)
+                    log.info('File `%s` already exists and is not identical, download failed.', destfile)
+                    entry.fail('File `%s` already exists and is not identical.', destfile)
                     return
             else:
                 # move temp file
-                log.debug('moving %s to %s' % (entry['file'], destfile))
+                log.debug('moving %s to %s', entry['file'], destfile)
 
                 try:
                     shutil.move(entry['file'], destfile)
@@ -480,7 +480,7 @@ class PluginDownload(object):
                     # ignore permission errors, see ticket #555
                     import errno
                     if not os.path.exists(destfile):
-                        raise plugin.PluginError('Unable to write %s' % destfile)
+                        raise plugin.PluginError('Unable to write %s', destfile)
                     if err.errno != errno.EPERM:
                         raise
 
@@ -502,7 +502,7 @@ class PluginDownload(object):
     def cleanup_temp_file(self, entry):
         if 'file' in entry:
             if os.path.exists(entry['file']):
-                log.debug('removing temp file %s from %s' % (entry['file'], entry['title']))
+                log.debug('removing temp file %s from %s', entry['file'], entry['title'])
                 os.remove(entry['file'])
             shutil.rmtree(os.path.dirname(entry['file']))
             del(entry['file'])


### PR DESCRIPTION
### Motivation for changes:
request on IRC/Gitter

### Config usage if relevant (new plugin or updated schema):
Allows doing something like this:
```
  my_task:
    plugin_priority:
      download: 256  # run download before builtin torrent plugin
    download:
      path: /my/path
      filename: "{{ torrent_info_hash }}.torrent"
```

