### PR TITLE
list_clear - new list plugin

### DIFF
--- a/flexget/plugins/modify/list_clear.py
+++ b/flexget/plugins/modify/list_clear.py
@@ -26,6 +26,7 @@ class ListClear(object):
         'required': ['what']
     }
 
+    @plugin.priority(255)
     def on_task_start(self, task, config):
         for item in config['what']:
             for plugin_name, plugin_config in item.items():

--- a/flexget/plugins/modify/list_clear.py
+++ b/flexget/plugins/modify/list_clear.py
@@ -21,13 +21,18 @@ class ListClear(object):
                      'error_maxProperties': 'Plugin options within list_clear plugin must be indented '
                                             '2 more spaces than the first letter of the plugin name.',
                      'minProperties': 1}]}},
-            'phase': {'type': 'string', 'enum': plugin.task_phases, 'default': 'exit'}
+            'phase': {'type': 'string', 'enum': plugin.task_phases, 'default': 'start'}
         },
         'required': ['what']
     }
 
+    def __getattr__(self, phase):
+        # enable plugin in regular task phases
+        if phase.replace('on_task_', '') in plugin.task_phases:
+            return self.clear
+
     @plugin.priority(255)
-    def on_task_start(self, task, config):
+    def clear(self, task, config):
         for item in config['what']:
             for plugin_name, plugin_config in item.items():
                 try:
@@ -42,15 +47,6 @@ class ListClear(object):
                         continue
                     log.verbose('clearing all items from %s - %s', plugin_name, plugin_config)
                     thelist.clear()
-
-    on_task_input = on_task_start
-    on_task_metainfo = on_task_start
-    on_task_filter = on_task_start
-    on_task_download = on_task_start
-    on_task_modify = on_task_start
-    on_task_output = on_task_start
-    on_task_learn = on_task_start
-    on_task_exit = on_task_start
 
 
 @event('plugin.register')

--- a/flexget/plugins/modify/list_clear.py
+++ b/flexget/plugins/modify/list_clear.py
@@ -37,7 +37,7 @@ class ListClear(object):
                 if thelist.immutable:
                     raise plugin.PluginError(thelist.immutable)
                 if config['phase'] == task.current_phase:
-                    if task.manager.options.test:
+                    if task.manager.options.test and thelist.online:
                         log.info('would have cleared all items from %s - %s', plugin_name, plugin_config)
                         continue
                     log.verbose('clearing all items from %s - %s', plugin_name, plugin_config)

--- a/flexget/plugins/modify/list_clear.py
+++ b/flexget/plugins/modify/list_clear.py
@@ -1,0 +1,57 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # pylint: disable=unused-import, redefined-builtin
+
+import logging
+
+from flexget import plugin
+from flexget.event import event
+from flexget.plugin import PluginError
+
+log = logging.getLogger('list_clear')
+
+
+class ListClear(object):
+    schema = {
+        'type': 'object',
+        'properties': {
+            'what': {'type': 'array', 'items':
+                {'allOf': [
+                    {'$ref': '/schema/plugins?group=list'},
+                    {'maxProperties': 1,
+                     'error_maxProperties': 'Plugin options within list_clear plugin must be indented '
+                                            '2 more spaces than the first letter of the plugin name.',
+                     'minProperties': 1}]}},
+            'phase': {'type': 'string', 'enum': plugin.task_phases, 'default': 'exit'}
+        },
+        'required': ['what']
+    }
+
+    def on_task_start(self, task, config):
+        for item in config['what']:
+            for plugin_name, plugin_config in item.items():
+                try:
+                    thelist = plugin.get_plugin_by_name(plugin_name).instance.get_list(plugin_config)
+                except AttributeError:
+                    raise PluginError('Plugin %s does not support list interface' % plugin_name)
+                if thelist.immutable:
+                    raise plugin.PluginError(thelist.immutable)
+                if config['phase'] == task.current_phase:
+                    if task.manager.options.test:
+                        log.info('would have cleared all items from %s - %s', plugin_name, plugin_config)
+                        continue
+                    log.verbose('clearing all items from %s - %s', plugin_name, plugin_config)
+                    thelist.clear()
+
+    on_task_input = on_task_start
+    on_task_metainfo = on_task_start
+    on_task_filter = on_task_start
+    on_task_download = on_task_start
+    on_task_modify = on_task_start
+    on_task_output = on_task_start
+    on_task_learn = on_task_start
+    on_task_exit = on_task_start
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(ListClear, 'list_clear', api_ver=2)

--- a/tests/test_list_interface.py
+++ b/tests/test_list_interface.py
@@ -138,6 +138,12 @@ class TestListInterface(object):
             list_clear:
               what:
                 - entry_list: test_list
+          test_list_clear_input:
+            entry_list: test_list
+            list_clear:
+              what:
+                - entry_list: test_list
+              phase: input
     """
 
     def test_list_add(self, execute_task):
@@ -281,4 +287,11 @@ class TestListInterface(object):
         assert len(task.entries) == 2
 
         task = execute_task('list_get')
+        assert len(task.entries) == 0
+
+    def test_list_clear_input(self, execute_task):
+        task = execute_task('test_list_add')
+        assert len(task.entries) == 2
+
+        task = execute_task('test_list_clear_input')
         assert len(task.entries) == 0

--- a/tests/test_list_interface.py
+++ b/tests/test_list_interface.py
@@ -132,12 +132,12 @@ class TestListInterface(object):
             list_clear:
               what:
                 - entry_list: test_list
-              phase: start
           test_list_clear_exit:
             entry_list: test_list
             list_clear:
               what:
                 - entry_list: test_list
+              phase: exit
           test_list_clear_input:
             entry_list: test_list
             list_clear:

--- a/tests/test_list_interface.py
+++ b/tests/test_list_interface.py
@@ -126,6 +126,18 @@ class TestListInterface(object):
 
           get_for_list_queue:
              movie_list: test_list_queue
+
+          test_list_clear_start:
+            entry_list: test_list
+            list_clear:
+              what:
+                - entry_list: test_list
+              phase: start
+          test_list_clear_exit:
+            entry_list: test_list
+            list_clear:
+              what:
+                - entry_list: test_list
     """
 
     def test_list_add(self, execute_task):
@@ -253,3 +265,20 @@ class TestListInterface(object):
 
         task = execute_task('get_for_list_queue')
         assert len(task.entries) == 1
+
+    def test_list_clear_start(self, execute_task):
+        task = execute_task('test_list_add')
+        assert len(task.entries) == 2
+
+        task = execute_task('test_list_clear_start')
+        assert len(task.entries) == 0
+
+    def test_list_clear_exit(self, execute_task):
+        task = execute_task('test_list_add')
+        assert len(task.entries) == 2
+
+        task = execute_task('test_list_clear_exit')
+        assert len(task.entries) == 2
+
+        task = execute_task('list_get')
+        assert len(task.entries) == 0


### PR DESCRIPTION
### Motivation for changes:
Wanted to be able to clear an entry_list before populating it eg. make entry_list mimick an RSS feed. It takes as input a `phase` param that specifies at which phase it should clear the list.
### Detailed changes:

- Added plugin
- Added three tests

### Config usage if relevant (new plugin or updated schema):
```
list_clear:
  what:
    - entry_list: whatever
  phase: start
```


