### PR TITLE
DB API

### DIFF
--- a/flexget/plugins/api/database.py
+++ b/flexget/plugins/api/database.py
@@ -1,0 +1,79 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # pylint: disable=unused-import, redefined-builtin
+
+import logging
+
+from flask import request
+from flask_restplus import inputs
+
+from flexget.manager import Base
+from flexget.db_schema import reset_schema
+from flexget.api import api, APIResource, NotFoundError, ApiError
+
+log = logging.getLogger('database')
+
+db_api = api.namespace('database', description='Manage Flexget DB')
+
+
+@db_api.route('/cleanup/')
+@api.doc(description='Make all plugins clean un-needed data from the database')
+class DBCleanup(APIResource):
+    @api.response(200, 'DB Cleanup triggered')
+    def get(self, session=None):
+        self.manager.db_cleanup(force=True)
+        return {'status': 'success',
+                'message': 'DB Cleanup triggered'}, 200
+
+
+@db_api.route('/vacuum/')
+@api.doc(description='Running vacuum can increase performance and decrease database size')
+class DBCleanup(APIResource):
+    @api.response(200, 'DB VACUUM triggered')
+    def get(self, session=None):
+        session.execute('VACUUM')
+        session.commit()
+        return {'status': 'success',
+                'message': 'DB VACUUM triggered'}, 200
+
+
+reset_parser = api.parser()
+reset_parser.add_argument('sure', type=inputs.boolean, default='false', required=True,
+                          help='You must use this flag to indicate you REALLY want to do this')
+
+
+@db_api.route('/reset/')
+@api.doc(description='Reset the entire DB. BE CAREFUL WITH THIS. Also, this could take a while.')
+class DBCleanup(APIResource):
+    @api.response(200, 'DB reset triggered')
+    @api.response(400, '"sure" flag was not set to true')
+    @api.doc(parser=reset_parser)
+    def get(self, session=None):
+        args = reset_parser.parse_args()
+        if not args['sure']:
+            return {'status': 'error',
+                    'message': '"sure" flag was not set to true'}, 400
+        Base.metadata.drop_all(bind=self.manager.engine)
+        Base.metadata.create_all(bind=self.manager.engine)
+        return {'status': 'success',
+                'message': 'DB reset was successful'}, 200
+
+
+plugin_parser = api.parser()
+plugin_parser.add_argument('plugin_name', required=True, help='Name of plugin to reset')
+
+
+@db_api.route('/reset_plugin/')
+class DBCleanup(APIResource):
+    @api.response(200, 'Plugin DB reset triggered')
+    @api.response(500, 'The plugin has no stored schema to reset')
+    @api.doc(parser=plugin_parser)
+    def get(self, session=None):
+        args = plugin_parser.parse_args()
+        plugin = args['plugin_name']
+        try:
+            reset_schema(plugin)
+        except ValueError:
+            return {'status': 'error',
+                    'message': 'The plugin {} has no stored schema to reset'.format(plugin)}, 400
+        return {'status': 'success',
+                'message': 'Plugin {} DB reset was successful'.format(plugin)}, 200

--- a/flexget/plugins/api/database.py
+++ b/flexget/plugins/api/database.py
@@ -61,4 +61,4 @@ class DBPluginsSchemas(APIResource):
     @api.response(200, 'Successfully retrieved a list of plugin names to reset')
     def get(self, session=None):
         """ Get a list of plugin names available to reset """
-        return jsonify(plugin_schemas.keys())
+        return jsonify(plugin_schemas)

--- a/flexget/plugins/api/database.py
+++ b/flexget/plugins/api/database.py
@@ -63,6 +63,7 @@ class DBPluginReset(APIResource):
 
 @db_api.route('/plugins/')
 class DBPluginsSchemas(APIResource):
+    @api.response(200, 'Successfully retrieved a list of plugin names to reset')
     def get(self, session=None):
         """ Get a list of plugin names available to reset """
         return jsonify(plugin_schemas.keys())

--- a/flexget/plugins/api/database.py
+++ b/flexget/plugins/api/database.py
@@ -4,7 +4,6 @@ from builtins import *  # pylint: disable=unused-import, redefined-builtin
 import logging
 
 from flask import jsonify
-from flask_restplus import inputs
 
 from flexget.db_schema import reset_schema, plugin_schemas
 from flexget.api import api, APIResource
@@ -35,10 +34,6 @@ class DBVacuum(APIResource):
                 'message': 'DB VACUUM triggered'}, 200
 
 
-reset_parser = api.parser()
-reset_parser.add_argument('sure', type=inputs.boolean, default='false', required=True,
-                          help='You must use this flag to indicate you REALLY want to do this')
-
 plugin_parser = api.parser()
 plugin_parser.add_argument('plugin_name', required=True, help='Name of plugin to reset')
 
@@ -46,7 +41,7 @@ plugin_parser.add_argument('plugin_name', required=True, help='Name of plugin to
 @db_api.route('/reset_plugin/')
 class DBPluginReset(APIResource):
     @api.response(200, 'Plugin DB reset triggered')
-    @api.response(500, 'The plugin has no stored schema to reset')
+    @api.response(400, 'The plugin has no stored schema to reset')
     @api.doc(parser=plugin_parser)
     def get(self, session=None):
         """ Reset the DB of a specific plugin """

--- a/flexget/plugins/api/database.py
+++ b/flexget/plugins/api/database.py
@@ -27,7 +27,7 @@ class DBCleanup(APIResource):
 
 @db_api.route('/vacuum/')
 @api.doc(description='Running vacuum can increase performance and decrease database size')
-class DBCleanup(APIResource):
+class DBVacuum(APIResource):
     @api.response(200, 'DB VACUUM triggered')
     def get(self, session=None):
         session.execute('VACUUM')
@@ -40,30 +40,12 @@ reset_parser = api.parser()
 reset_parser.add_argument('sure', type=inputs.boolean, default='false', required=True,
                           help='You must use this flag to indicate you REALLY want to do this')
 
-
-@db_api.route('/reset/')
-@api.doc(description='Reset the entire DB. BE CAREFUL WITH THIS. Also, this could take a while.')
-class DBCleanup(APIResource):
-    @api.response(200, 'DB reset triggered')
-    @api.response(400, '"sure" flag was not set to true')
-    @api.doc(parser=reset_parser)
-    def get(self, session=None):
-        args = reset_parser.parse_args()
-        if not args['sure']:
-            return {'status': 'error',
-                    'message': '"sure" flag was not set to true'}, 400
-        Base.metadata.drop_all(bind=self.manager.engine)
-        Base.metadata.create_all(bind=self.manager.engine)
-        return {'status': 'success',
-                'message': 'DB reset was successful'}, 200
-
-
 plugin_parser = api.parser()
 plugin_parser.add_argument('plugin_name', required=True, help='Name of plugin to reset')
 
 
 @db_api.route('/reset_plugin/')
-class DBCleanup(APIResource):
+class DBPluginReset(APIResource):
     @api.response(200, 'Plugin DB reset triggered')
     @api.response(500, 'The plugin has no stored schema to reset')
     @api.doc(parser=plugin_parser)

--- a/tests/test_database_api.py
+++ b/tests/test_database_api.py
@@ -1,0 +1,25 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # pylint: disable=unused-import, redefined-builtin
+
+
+class TestDatabaseAPI(object):
+    config = 'tasks: {}'
+
+    def test_database_methods(self, api_client):
+        rsp = api_client.get('/database/cleanup/')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+
+        rsp = api_client.get('/database/vacuum/')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+
+        rsp = api_client.get('/database/reset_plugin/')
+        assert rsp.status_code == 400, 'Response code is %s' % rsp.status_code
+
+        rsp = api_client.get('/database/reset_plugin/?plugin_name=bla')
+        assert rsp.status_code == 400, 'Response code is %s' % rsp.status_code
+
+        rsp = api_client.get('/database/reset_plugin/?plugin_name=tvmaze')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+
+        rsp = api_client.get('/database/plugins/')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code


### PR DESCRIPTION
### Motivation for changes:
Manage DB via API
### Detailed changes:

- `/cleanup/` endpoint triggers DB cleanup. 
- `/vacuum/` endpoint triggers DB VACUUM. 
- ~~`/reset/` endpoint resets entire DB. Must be supplied with `sure` param set to true. ~~ Removed, too risky and not useful.
- `/reset_plugin/` endpoint takes `plugin` param and tries to reset its DB. 
- `/plugins/` endpoint return list of plugin names that can be reset.


#### To Do

- [x] `/plugins/` endpoint that will return relevant plugin names that can be reset. 
- [x] Tests. 

