### PR TITLE
Merged web qualities, closes #1218

### DIFF
--- a/flexget/plugins/api_t411.py
+++ b/flexget/plugins/api_t411.py
@@ -149,7 +149,7 @@ T411_VIDEO_QUALITY_MAP = {
     1174: qualities.get("webdl 1080p"),
     1182: qualities.get("webdl"),
     1175: qualities.get("webdl 720p"),
-    19: qualities.get("webrip")
+    19: qualities.get("webdl")
 }
 
 def auth_required(func):

--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -138,14 +138,13 @@ _sources = [
     QualityComponent('source', 90, 'tvrip', 'tv[\W_]?rip'),
     QualityComponent('source', 100, 'dsr', 'dsr|ds[\W_]?rip'),
     QualityComponent('source', 110, 'sdtv', '(?:[sp]dtv|dvb)(?:[\W_]?rip)?'),
-    QualityComponent('source', 120, 'webrip', 'web[\W_]?rip'),
-    QualityComponent('source', 130, 'dvdscr', '(?:(?:dvd|web)[\W_]?)?scr(?:eener)?', modifier=0),
-    QualityComponent('source', 140, 'bdscr', 'bdscr(?:eener)?'),
-    QualityComponent('source', 150, 'hdtv', 'a?hdtv(?:[\W_]?rip)?'),
-    QualityComponent('source', 160, 'webdl', 'web(?:[\W_]?(dl|hd))'),
-    QualityComponent('source', 170, 'dvdrip', 'dvd(?:[\W_]?rip)?'),
-    QualityComponent('source', 175, 'remux'),
-    QualityComponent('source', 180, 'bluray', '(?:b[dr][\W_]?rip|blu[\W_]?ray(?:[\W_]?rip)?)')
+    QualityComponent('source', 120, 'dvdscr', '(?:(?:dvd|web)[\W_]?)?scr(?:eener)?', modifier=0),
+    QualityComponent('source', 130, 'bdscr', 'bdscr(?:eener)?'),
+    QualityComponent('source', 140, 'hdtv', 'a?hdtv(?:[\W_]?rip)?'),
+    QualityComponent('source', 150, 'webdl', 'web|web(?:[\W_]?(dl|hd|rip))'),
+    QualityComponent('source', 160, 'dvdrip', 'dvd(?:[\W_]?rip)?'),
+    QualityComponent('source', 165, 'remux'),
+    QualityComponent('source', 170, 'bluray', '(?:b[dr][\W_]?rip|blu[\W_]?ray(?:[\W_]?rip)?)')
 ]
 _codecs = [
     QualityComponent('codec', 10, 'divx'),

--- a/tests/test_qualities.py
+++ b/tests/test_qualities.py
@@ -29,6 +29,7 @@ class TestQualityParser(object):
             return ParserGuessit
 
     @pytest.mark.parametrize("test_quality", [
+        ('Test.File 1080p.web', '1080p webdl'),
         ('Test.File 1080p.web-dl', '1080p webdl'),
         ('Test.File.web-dl.1080p', '1080p webdl'),
         ('Test.File.WebHD.720p', '720p webdl'),
@@ -48,6 +49,8 @@ class TestQualityParser(object):
         ('Test.File.1080p.10bit', '1080p 10bit'),
         ('Test.File.1080p.bluray.10bit', '1080p bluray 10bit'),
 
+        ('Test.File.720p.webrip', '720p webdl'),
+        ('Test.File.720p.web', '720p webdl'),
         ('Test.File.720p.webdl', '720p webdl'),
         ('Test.File.1280x720_web dl', '720p webdl'),
         ('Test.File.720p.h264.web.dl', '720p webdl h264'),


### PR DESCRIPTION
### Motivation for changes:
Webrip quality has improved greatly over the last few years to the point where it's even better than hdtv. Quality is known as `webrip` or `web` (scene), but some p2p groups also call it `web-dl` (although technically, `web-dl` refers to something like iTunes download).

Qualities is in need of an overhaul, but this small change would help immensely until then.


