### PR TITLE
Plugins API

### DIFF
--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -57,11 +57,10 @@ class DependencyError(Exception):
 
     def __str__(self):
         return '<DependencyError(issued_by=%r,missing=%r,message=%r,silent=%r)>' % \
-            (self.issued_by, self.missing, self.message, self.silent)
+               (self.issued_by, self.missing, self.message, self.silent)
 
 
 class RegisterException(Exception):
-
     def __init__(self, value):
         super(RegisterException, self).__init__()
         self.value = value
@@ -72,7 +71,6 @@ class RegisterException(Exception):
 
 @python_2_unicode_compatible
 class PluginWarning(Warning):
-
     def __init__(self, value, logger=log, **kwargs):
         super(PluginWarning, self).__init__()
         self.value = value
@@ -85,7 +83,6 @@ class PluginWarning(Warning):
 
 @python_2_unicode_compatible
 class PluginError(Exception):
-
     def __init__(self, value, logger=log, **kwargs):
         super(PluginError, self).__init__()
         # Value is expected to be a string
@@ -139,6 +136,7 @@ class internet(object):
                 elif hasattr(e, 'code'):
                     raise PluginError('The server couldn\'t fulfill the request. Error code: %s' % e.code, self.log)
                 raise PluginError('IOError when connecting to server: %s' % e, self.log)
+
         return wrapped_func
 
 
@@ -148,7 +146,9 @@ def priority(value):
     def decorator(target):
         target.priority = value
         return target
+
     return decorator
+
 
 DEFAULT_PRIORITY = 128
 
@@ -332,17 +332,30 @@ class PluginInfo(dict):
 
     def __str__(self):
         return '<PluginInfo(name=%s)>' % self.name
-        
+
     def _is_valid_operand(self, other):
         return hasattr(other, 'name')
 
     def __eq__(self, other):
         return self.name == other.name
-    
+
     def __lt__(self, other):
         return self.name < other.name
 
     __repr__ = __str__
+
+    def to_dict(self):
+        return {
+            'name': self.name,
+            'api_ver': self.api_ver,
+            'builtin': self.builtin,
+            'category': self.category,
+            'contexts': self.contexts,
+            'debug': self.debug,
+            'groups': self.groups,
+            'phase_handlers': [dict(phase=handler, priority=event.priority) for handler, event in
+                               self.phase_handlers.items()]
+        }
 
 
 register = PluginInfo
@@ -454,6 +467,7 @@ def get_plugins(phase=None, group=None, context=None, category=None, name=None, 
     :return: List of PluginInfo instances.
     :rtype: list
     """
+
     def matches(plugin):
         if phase is not None and phase not in phase_methods:
             raise ValueError('Unknown phase %s' % phase)
@@ -470,6 +484,7 @@ def get_plugins(phase=None, group=None, context=None, category=None, name=None, 
         if min_api is not None and plugin.api_ver < min_api:
             return False
         return True
+
     return filter(matches, iter(plugins.values()))
 
 

--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -344,19 +344,6 @@ class PluginInfo(dict):
 
     __repr__ = __str__
 
-    def to_dict(self):
-        return {
-            'name': self.name,
-            'api_ver': self.api_ver,
-            'builtin': self.builtin,
-            'category': self.category,
-            'contexts': self.contexts,
-            'debug': self.debug,
-            'groups': self.groups,
-            'phase_handlers': [dict(phase=handler, priority=event.priority) for handler, event in
-                               self.phase_handlers.items()]
-        }
-
 
 register = PluginInfo
 

--- a/flexget/plugins/api/plugins.py
+++ b/flexget/plugins/api/plugins.py
@@ -1,0 +1,49 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # pylint: disable=unused-import, redefined-builtin
+
+import logging
+
+from flask import jsonify
+from flask_restplus import inputs
+
+from flexget.plugin import get_plugins
+from flexget.api import api, APIResource, ApiError
+
+log = logging.getLogger('plugins')
+
+plugins_api = api.namespace('plugins', description='Get Flexget plugins')
+
+plugins_parser = api.parser()
+plugins_parser.add_argument('group', help='Show plugins belonging to this group')
+plugins_parser.add_argument('phase', help='Show plugins that act on this phase')
+plugins_parser.add_argument('include_schema', type=inputs.boolean, default=False,
+                            help='Include plugin schema. This will increase response size')
+
+
+@plugins_api.route('/')
+class PluginsAPI(APIResource):
+    @api.response(200, 'Successfully retrieved plugin list')
+    @api.response(500, 'Unknown phase')
+    @api.doc(parser=plugins_parser)
+    def get(self, session=None):
+        """ Get list of plugins """
+        args = plugins_parser.parse_args()
+        plugin_list = []
+        try:
+            for plugin in get_plugins(phase=args['phase'], group=args['group']):
+                p = {'name': plugin.name,
+                     'api_ver': plugin.api_ver,
+                     'builtin': plugin.builtin,
+                     'category': plugin.category,
+                     'contexts': plugin.contexts,
+                     'debug': plugin.debug,
+                     'groups': plugin.groups}
+                p['phase_handlers'] = [dict(phase=handler, priority=event.priority) for handler, event in
+                                       plugin.phase_handlers.items()]
+
+                if args['include_schema']:
+                    p['schema'] = plugin.schema
+                plugin_list.append(p)
+        except ValueError as e:
+            raise ApiError(str(e))
+        return jsonify(plugin_list)

--- a/flexget/plugins/api/plugins.py
+++ b/flexget/plugins/api/plugins.py
@@ -5,7 +5,7 @@ import logging
 
 from flask_restplus import inputs
 
-from flexget.plugin import get_plugins
+from flexget.plugin import get_plugins, get_plugin_by_name
 from flexget.api import api, APIResource, ApiError
 
 log = logging.getLogger('plugins')
@@ -41,7 +41,7 @@ plugin_list_reply = {
         'number_of_plugins': {'type': 'integer'}
     }
 }
-
+plugin_schema = api.schema('plugin_object', plugin_object)
 plugin_list_reply_schema = api.schema('plugin_list_reply', plugin_list_reply)
 
 plugins_parser = api.parser()
@@ -62,16 +62,7 @@ class PluginsAPI(APIResource):
         plugin_list = []
         try:
             for plugin in get_plugins(phase=args['phase'], group=args['group']):
-                p = {'name': plugin.name,
-                     'api_ver': plugin.api_ver,
-                     'builtin': plugin.builtin,
-                     'category': plugin.category,
-                     'contexts': plugin.contexts,
-                     'debug': plugin.debug,
-                     'groups': plugin.groups}
-                p['phase_handlers'] = [dict(phase=handler, priority=event.priority) for handler, event in
-                                       plugin.phase_handlers.items()]
-
+                p = plugin.to_dict()
                 if args['include_schema']:
                     p['schema'] = plugin.schema
                 plugin_list.append(p)
@@ -79,3 +70,9 @@ class PluginsAPI(APIResource):
             raise ApiError(str(e))
         return {'plugin_list': plugin_list,
                 'number_of_plugins': len(plugin_list)}
+
+
+# @plugins_api.route('/<string:plugin_name>/')
+# class PluginAPI(APIResource):
+#     def get(self, plugin_name, session=None):
+#         """ Return plugin data by name"""

--- a/tests/test_plugins_api.py
+++ b/tests/test_plugins_api.py
@@ -1,0 +1,34 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # pylint: disable=unused-import, redefined-builtin
+
+from flexget.utils import json
+
+
+class TestPluginsAPI(object):
+    config = 'tasks: {}'
+
+    def test_plugins_api(self, api_client):
+        rsp = api_client.get('/plugins/')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+
+        rsp = api_client.get('/plugins/?include_schema=true')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+
+        rsp = api_client.get('/plugins/?group=search')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+
+        rsp = api_client.get('/plugins/?group=fgfg')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+        assert json.loads(rsp.get_data(as_text=True))['plugin_list'] == []
+
+        rsp = api_client.get('/plugins/?phase=fgfg')
+        assert rsp.status_code == 400, 'Response code is %s' % rsp.status_code
+
+        rsp = api_client.get('/plugins/?phase=input')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+
+        rsp = api_client.get('/plugins/bla/')
+        assert rsp.status_code == 400, 'Response code is %s' % rsp.status_code
+
+        rsp = api_client.get('/plugins/seen/')
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code


### PR DESCRIPTION
### Motivation for changes:
View registered plugins
### Detailed changes:

- `/plugins/` endpoint will return plugin list. `group` and `phase` can be added as params. `include_schema` is also a param which is `false` by default since the response is very big with all the schema.

- `/plugins/<plugin_name>/` will retrieve a single plugin info. `include_schema` param is also relevant here.

- ~~Added `to_dict()` method for `PluginInfo`~~ Created method in API module

### Log and/or tests output (preferably both):
Example output for `http://127.0.0.1:5050/api/plugins/seen/?include_schema=true`:
```
{
  "api_ver": 2,
  "builtin": true,
  "category": "filter",
  "contexts": [
    "task"
  ],
  "debug": false,
  "groups": [],
  "name": "seen",
  "phase_handlers": [
    {
      "phase": "filter",
      "priority": 255
    },
    {
      "phase": "learn",
      "priority": 128
    }
  ],
  "schema": {
    "id": "/schema/plugin/seen",
    "oneOf": [
      {
        "type": "boolean"
      },
      {
        "enum": [
          "global",
          "local"
        ],
        "type": "string"
      },
      {
        "properties": {
          "fields": {
            "items": {
              "type": "string"
            },
            "minItems": 1,
            "type": "array",
            "uniqueItems": true
          },
          "local": {
            "type": "boolean"
          }
        },
        "type": "object"
      }
    ]
  }
}
```

