### PR TITLE
Tasks with manual plugin enabled run even when not via manual run.

### DIFF
--- a/flexget/api/tasks.py
+++ b/flexget/api/tasks.py
@@ -330,7 +330,8 @@ class TaskExecutionAPI(APIResource):
 
         # This emulates the CLI command of using `--now` and `no-cache`
         options = {'interval_ignore': data.pop('now', None),
-                   'nocache': data.pop('no_cache', None)}
+                   'nocache': data.pop('no_cache', None),
+                   'allow_manual': True}
 
         for option, value in data.items():
             options[option] = value
@@ -359,7 +360,7 @@ class TaskExecutionAPI(APIResource):
                 entries.append(entry)
             options['inject'] = entries
 
-        executed_tasks = self.manager.execute(options=options, output=output, loglevel=loglevel, allow_manual=True)
+        executed_tasks = self.manager.execute(options=options, output=output, loglevel=loglevel)
 
         tasks_queued = []
 

--- a/flexget/api/tasks.py
+++ b/flexget/api/tasks.py
@@ -55,7 +55,6 @@ task_api_desc = 'Task config schema too large to display, you can view the schem
 @tasks_api.route('/')
 @api.doc(description=task_api_desc)
 class TasksAPI(APIResource):
-
     @api.response(200, model=tasks_list_api_schema)
     def get(self, session=None):
         """ List all tasks """
@@ -98,7 +97,6 @@ class TasksAPI(APIResource):
 @tasks_api.route('/<task>/')
 @api.doc(params={'task': 'task name'}, description=task_api_desc)
 class TaskAPI(APIResource):
-
     @api.response(200, model=task_api_schema)
     @api.response(NotFoundError, description='task not found')
     @api.response(ApiError, description='unable to read config')
@@ -271,7 +269,6 @@ task_execution_schema = api.schema('task_execution_input', task_execution_input)
 
 @tasks_api.route('/queue/')
 class TaskQueueAPI(APIResource):
-
     @api.response(200, model=task_api_queue_schema)
     def get(self, session=None):
         """ List task(s) in queue for execution """
@@ -314,7 +311,6 @@ inject_api = api.namespace('inject', description='Entry injection API')
 @tasks_api.route('/execute/')
 @api.doc(description=execution_doc)
 class TaskExecutionAPI(APIResource):
-
     @api.response(404, description='Task not found')
     @api.response(500, description='Could not resolve title from URL')
     @api.response(200, model=task_api_execute_schema)
@@ -363,7 +359,7 @@ class TaskExecutionAPI(APIResource):
                 entries.append(entry)
             options['inject'] = entries
 
-        executed_tasks = self.manager.execute(options=options, output=output, loglevel=loglevel)
+        executed_tasks = self.manager.execute(options=options, output=output, loglevel=loglevel, allow_manual=True)
 
         tasks_queued = []
 
@@ -415,7 +411,6 @@ def setup_params(mgr):
 
 
 class EntryDecoder(JSONEncoder):
-
     def default(self, o):
         if isinstance(o, LazyLookup):
             return '<LazyField>'

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -34,8 +34,7 @@ Session = sessionmaker(class_=ContextSession)
 from flexget import config_schema, db_schema, logger, plugin  # noqa
 from flexget.event import fire_event  # noqa
 from flexget.ipc import IPCClient, IPCServer  # noqa
-from flexget.options import CoreArgumentParser, get_parser, manager_parser, ParserError, unicode_argv, \
-    ScopedNamespace  # noqa
+from flexget.options import CoreArgumentParser, get_parser, manager_parser, ParserError, unicode_argv # noqa
 from flexget.task import Task  # noqa
 from flexget.task_queue import TaskQueue  # noqa
 from flexget.utils.tools import pid_exists, get_current_flexget_version  # noqa

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -222,7 +222,7 @@ class Manager(object):
     def has_lock(self):
         return self._has_lock
 
-    def execute(self, options=None, output=None, loglevel=None, priority=1, allow_manual=False):
+    def execute(self, options=None, output=None, loglevel=None, priority=1):
         """
         Run all (can be limited with options) tasks from the config.
 
@@ -231,8 +231,7 @@ class Manager(object):
             written to it.
         :param priority: If there are other executions waiting to be run, they will be run in priority order,
             lowest first.
-        :param allow_manual: A flag whether to allow execution of tasks that have enabled manual plugin
-        :returns: a list of :class:`threading.Event` instances which will be
+         :returns: a list of :class:`threading.Event` instances which will be
             set when each respective task has finished running
         """
         if options is None:
@@ -266,8 +265,7 @@ class Manager(object):
 
         finished_events = []
         for task_name in task_names:
-            task = Task(self, task_name, options=options, output=output, loglevel=loglevel, priority=priority,
-                        allow_manual=allow_manual)
+            task = Task(self, task_name, options=options, output=output, loglevel=loglevel, priority=priority)
             self.task_queue.put(task)
             finished_events.append((task.id, task.name, task.finished_event))
         return finished_events
@@ -367,7 +365,7 @@ class Manager(object):
         else:
             self.task_queue.start()
             self.ipc_server.start()
-            self.execute(options, allow_manual=True)
+            self.execute(options)
             self.shutdown(finish_queue=True)
             self.task_queue.wait()
         fire_event('manager.execute.completed', self, options)

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -34,7 +34,7 @@ Session = sessionmaker(class_=ContextSession)
 from flexget import config_schema, db_schema, logger, plugin  # noqa
 from flexget.event import fire_event  # noqa
 from flexget.ipc import IPCClient, IPCServer  # noqa
-from flexget.options import CoreArgumentParser, get_parser, manager_parser, ParserError, unicode_argv # noqa
+from flexget.options import CoreArgumentParser, get_parser, manager_parser, ParserError, unicode_argv  # noqa
 from flexget.task import Task  # noqa
 from flexget.task_queue import TaskQueue  # noqa
 from flexget.utils.tools import pid_exists, get_current_flexget_version  # noqa
@@ -242,7 +242,6 @@ class Manager(object):
             options_namespace.__dict__.update(options)
             options = options_namespace
         task_names = self.tasks
-        setattr(options, 'allow_manual', allow_manual)
         # Handle --tasks
         if options.tasks:
             # Consider * the same as not specifying tasks at all (makes sure manual plugin still works)
@@ -267,7 +266,8 @@ class Manager(object):
 
         finished_events = []
         for task_name in task_names:
-            task = Task(self, task_name, options=options, output=output, loglevel=loglevel, priority=priority)
+            task = Task(self, task_name, options=options, output=output, loglevel=loglevel, priority=priority,
+                        allow_manual=allow_manual)
             self.task_queue.put(task)
             finished_events.append((task.id, task.name, task.finished_event))
         return finished_events

--- a/flexget/options.py
+++ b/flexget/options.py
@@ -470,4 +470,6 @@ class CoreArgumentParser(ArgumentParser):
             if hasattr(result, 'execute'):
                 exec_options.__dict__.update(result.execute.__dict__)
             result.execute = exec_options
+        # Set the 'allow_manual' flag to True for any usage of the CLI
+        setattr(result, 'allow_manual', True)
         return result

--- a/flexget/plugins/daemon/irc.py
+++ b/flexget/plugins/daemon/irc.py
@@ -138,7 +138,6 @@ class MissingConfigOption(Exception):
 
 
 class IRCConnection(irc_bot.IRCBot):
-
     def __init__(self, config, config_name):
         self.config = config
         self.connection_name = config_name
@@ -313,7 +312,8 @@ class IRCConnection(irc_bot.IRCBot):
             if isinstance(tasks, basestring):
                 tasks = [tasks]
             log.info('Injecting %d entries into tasks %s', len(self.entry_queue), ', '.join(tasks))
-            manager.execute(options={'tasks': tasks, 'cron': True, 'inject': self.entry_queue}, priority=5)
+            manager.execute(options={'tasks': tasks, 'cron': True, 'inject': self.entry_queue}, priority=5,
+                            allow_manual=True)
 
         if tasks_re:
             tasks_entry_map = {}
@@ -681,7 +681,6 @@ def irc_update_config(manager):
 
 
 class IRCConnectionManager(object):
-
     def __init__(self, config):
         self.config = config
         self.shutdown_event = threading.Event()

--- a/flexget/plugins/daemon/irc.py
+++ b/flexget/plugins/daemon/irc.py
@@ -312,8 +312,8 @@ class IRCConnection(irc_bot.IRCBot):
             if isinstance(tasks, basestring):
                 tasks = [tasks]
             log.info('Injecting %d entries into tasks %s', len(self.entry_queue), ', '.join(tasks))
-            manager.execute(options={'tasks': tasks, 'cron': True, 'inject': self.entry_queue}, priority=5,
-                            allow_manual=True)
+            manager.execute(options={'tasks': tasks, 'cron': True, 'inject': self.entry_queue, 'allow_manual': True},
+                            priority=5)
 
         if tasks_re:
             tasks_entry_map = {}
@@ -333,7 +333,8 @@ class IRCConnection(irc_bot.IRCBot):
 
             for task, entries in tasks_entry_map.items():
                 log.info('Injecting %d entries into task "%s"', len(entries), task)
-                manager.execute(options={'tasks': [task], 'cron': True, 'inject': entries}, priority=5)
+                manager.execute(options={'tasks': [task], 'cron': True, 'inject': entries, 'allow_manual': True},
+                                priority=5)
 
         self.entry_queue = []
 

--- a/flexget/plugins/daemon/scheduler.py
+++ b/flexget/plugins/daemon/scheduler.py
@@ -106,7 +106,7 @@ def job_id(conf):
 def run_job(tasks):
     """Add the execution to the queue and waits until it is finished"""
     log.debug('executing tasks: %s', tasks)
-    finished_events = manager.execute(options={'tasks': tasks, 'cron': True}, priority=5)
+    finished_events = manager.execute(options={'tasks': tasks, 'cron': True, 'allow_manual': False}, priority=5)
     for _, task_name, event in finished_events:
         log.debug('task finished executing: %s', task_name)
         event.wait()

--- a/flexget/plugins/operate/manual.py
+++ b/flexget/plugins/operate/manual.py
@@ -20,8 +20,8 @@ class ManualTask(object):
         if not config:
             return
         # If --task hasn't been specified disable this plugin
-        if not task.options.tasks or task.name not in task.options.tasks:
-            log.debug('Disabling task %s' % task.name)
+        if not task.options.tasks or task.name not in task.options.tasks or not task.options.allow_manual:
+            log.debug('Disabling task %s, task can only run in manual mode (via API/CLI)' % task.name)
             task.abort('manual task not specified in --tasks', silent=True)
 
 

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -182,8 +182,7 @@ class Task(object):
     # Used to determine task order, when priority is the same
     _counter = itertools.count()
 
-    def __init__(self, manager, name, config=None, options=None, output=None, loglevel=None, priority=None,
-                 allow_manual=False):
+    def __init__(self, manager, name, config=None, options=None, output=None, loglevel=None, priority=None):
         """
         :param Manager manager: Manager instance.
         :param string name: Name of the task.
@@ -208,7 +207,8 @@ class Task(object):
             options_namespace = copy.copy(self.manager.options.execute)
             options_namespace.__dict__.update(options)
             options = options_namespace
-        setattr(options, 'allow_manual', allow_manual)
+        if not hasattr(options, 'allow_manual'):
+          setattr(options, 'allow_manual', False)
         self.options = options
         self.output = output
         self.loglevel = loglevel

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -207,6 +207,7 @@ class Task(object):
             options_namespace = copy.copy(self.manager.options.execute)
             options_namespace.__dict__.update(options)
             options = options_namespace
+        # If execution hasn't specifically set the `allow_manual` flag, set it to False by default
         if not hasattr(options, 'allow_manual'):
           setattr(options, 'allow_manual', False)
         self.options = options

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -138,7 +138,6 @@ class EntryContainer(list):
 
 
 class TaskAbort(Exception):
-
     def __init__(self, reason, silent=False):
         self.reason = reason
         self.silent = silent
@@ -183,7 +182,8 @@ class Task(object):
     # Used to determine task order, when priority is the same
     _counter = itertools.count()
 
-    def __init__(self, manager, name, config=None, options=None, output=None, loglevel=None, priority=None):
+    def __init__(self, manager, name, config=None, options=None, output=None, loglevel=None, priority=None,
+                 allow_manual=False):
         """
         :param Manager manager: Manager instance.
         :param string name: Name of the task.
@@ -208,6 +208,7 @@ class Task(object):
             options_namespace = copy.copy(self.manager.options.execute)
             options_namespace.__dict__.update(options)
             options = options_namespace
+        setattr(options, 'allow_manual', allow_manual)
         self.options = options
         self.output = output
         self.loglevel = loglevel

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,7 @@ def execute_task(manager):
     A function that can be used to execute and return a named task in `config` argument.
     """
 
-    def execute(task_name, abort=False, options=None):
+    def execute(task_name, abort=False, options=None, allow_manual=None):
         """
         Use to execute one test task from config.
 
@@ -84,7 +84,7 @@ def execute_task(manager):
         """
         log.info('********** Running task: %s ********** ' % task_name)
         config = manager.config['tasks'][task_name]
-        task = Task(manager, task_name, config=config, options=options)
+        task = Task(manager, task_name, config=config, options=options, allow_manual=allow_manual)
 
         try:
             if abort:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,7 @@ def execute_task(manager):
     A function that can be used to execute and return a named task in `config` argument.
     """
 
-    def execute(task_name, abort=False, options=None, allow_manual=None):
+    def execute(task_name, abort=False, options=None):
         """
         Use to execute one test task from config.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,7 +84,7 @@ def execute_task(manager):
         """
         log.info('********** Running task: %s ********** ' % task_name)
         config = manager.config['tasks'][task_name]
-        task = Task(manager, task_name, config=config, options=options, allow_manual=allow_manual)
+        task = Task(manager, task_name, config=config, options=options)
 
         try:
             if abort:

--- a/tests/test_feed_control.py
+++ b/tests/test_feed_control.py
@@ -64,5 +64,5 @@ class TestManualOnlytask(object):
 
     def test_manual_with_onlytask(self, execute_task):
         # Pretend we have been run with --task test2
-        task = execute_task('test2', options=dict(tasks=['test2']), allow_manual=True)
+        task = execute_task('test2', options=dict(tasks=['test2'], allow_manual=True))
         assert task.find_entry(title='download'), 'Manual tasks failed to download on manual run'

--- a/tests/test_feed_control.py
+++ b/tests/test_feed_control.py
@@ -64,5 +64,5 @@ class TestManualOnlytask(object):
 
     def test_manual_with_onlytask(self, execute_task):
         # Pretend we have been run with --task test2
-        task = execute_task('test2', options=dict(tasks=['test2']))
+        task = execute_task('test2', options=dict(tasks=['test2']), allow_manual=True)
         assert task.find_entry(title='download'), 'Manual tasks failed to download on manual run'


### PR DESCRIPTION
### Motivation for changes:
`manual` plugin doesn't work, because the condition that it checks can never be True. 

### Detailed changes:

- Added a `allow_manual` flag to `Manager.execute()` and set it to True when calling it from CLI/API and IRC plugin.
- If a task is triggered by schedule plugin and has `manual: yes` set, it will be aborted.

### Addressed issues:

- Fixes #1291 




