### PR TITLE
[change] move/copy/delete 'along' now supports subdirs

### DIFF
--- a/flexget/plugins/output/move.py
+++ b/flexget/plugins/output/move.py
@@ -104,11 +104,13 @@ class BaseFileOps(object):
                 if not src_isdir and 'along' in config:
                     parent = os.path.dirname(src)
                     filename_no_ext = os.path.splitext(os.path.basename(src))[0]
-                    for ext in config['along']['files']:
-                        siblings.update(get_siblings(ext, src, filename_no_ext, parent))
-                    for subdir in config['along'].get('subdirs', []):
-                        # use glob to get a list of matching dirs
-                        abs_subdirs = glob.glob(os.path.join(parent, os.path.normpath(subdir)))
+                    subdirs = [parent] + config['along'].get('subdirs', [])
+                    for subdir in subdirs:
+                        if subdir == parent:
+                            abs_subdirs = [subdir]
+                        else:
+                            # use glob to get a list of matching dirs
+                            abs_subdirs = glob.glob(os.path.join(parent, os.path.normpath(subdir)))
                         # iterate over every dir returned by glob looking for matching ext
                         for abs_subdir in abs_subdirs:
                             if os.path.isdir(abs_subdir):

--- a/flexget/plugins/output/move.py
+++ b/flexget/plugins/output/move.py
@@ -280,7 +280,16 @@ class CopyFiles(TransformingOps):
                     'allow_dir': {'type': 'boolean'},
                     'unpack_safety': {'type': 'boolean'},
                     'keep_extension': {'type': 'boolean'},
-                    'along': {'type': 'array', 'items': {'type': 'string'}}
+                    'along': {'type': 'array', 'items':
+                        {
+                            'oneOf': [
+                                {
+                                    'type': 'object',
+                                    'additionalProperties': one_or_more({'type': 'string'})
+                                },
+                                {'type': 'string'}
+                            ]
+                        }},
                 },
                 'additionalProperties': False
             }

--- a/flexget/plugins/output/move.py
+++ b/flexget/plugins/output/move.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # pylint: disable=unused-import, redefined-builtin
 
 import os
+import re
 import glob
 import shutil
 import logging
@@ -31,6 +32,39 @@ def make_ext(ext):
     return ('.' + ext).replace('..', '.')
 
 
+def escape(pathname):
+    """Escape all special characters. Taken from glob in py3.4+"""
+    # Escaping is done by wrapping any of "*?[" between square brackets.
+    # Metacharacters do not work in the drive part and shouldn't be escaped.
+
+    magic_check = re.compile('([*?[])')
+    magic_check_bytes = re.compile(b'([*?[])')
+    drive, pathname = os.path.splitdrive(pathname)
+    if isinstance(pathname, bytes):
+        pathname = magic_check_bytes.sub(br'[\1]', pathname)
+    else:
+        pathname = magic_check.sub(r'[\1]', pathname)
+    return drive + pathname
+
+
+def get_siblings(ext, main_file_path, main_file_no_ext, abs_path):
+    siblings = {}
+    normalized_ext = make_ext(ext)
+    # escape the filename to avoid special characters in main file confusing glob
+    escaped_filename = escape(main_file_no_ext)
+    # use glob to get a list of matching files
+    files = glob.glob(os.path.join(abs_path, escaped_filename + normalized_ext))
+
+    for f in files:
+        # we have to use the length of the main file (no ext) to extract the real
+        # extension of the sibling file because of language codes etc.
+        filename = os.path.basename(f)
+        glob_ext = filename[len(main_file_no_ext):]
+        if f != main_file_path and os.path.exists(f):
+            siblings[f] = glob_ext
+    return siblings
+
+
 class BaseFileOps(object):
     # Defined by subclasses
     log = None
@@ -38,12 +72,10 @@ class BaseFileOps(object):
         'type': 'object',
         'properties': {
             'files': one_or_more({'type': 'string'}),
-            'subdirs': {
-                'type': 'object',
-                'additionalProperties': one_or_more({'type': 'string'})
-            }
+            'subdirs': one_or_more({'type': 'string'})
         },
-        'additionalProperties': False
+        'additionalProperties': False,
+        'required': ['files']
     }
 
     def on_task_output(self, task, config):
@@ -71,32 +103,18 @@ class BaseFileOps(object):
                 siblings = {}  # dict of (path=ext) pairs
                 if not src_isdir and 'along' in config:
                     parent = os.path.dirname(src)
-                    src_file, src_ext = os.path.splitext(src)
                     filename_no_ext = os.path.splitext(os.path.basename(src))[0]
-                    for ext in config['along'].get('files', {}):
-                        normalized_ext = make_ext(ext)
-                        sibling = os.path.join(src_file, normalized_ext)
-                        if os.path.exists(sibling):
-                            siblings[sibling] = normalized_ext
-                    for subdir, exts in config['along'].get('subdirs', {}).items():
+                    for ext in config['along']['files']:
+                        siblings.update(get_siblings(ext, src, filename_no_ext, parent))
+                    for subdir in config['along'].get('subdirs', []):
                         # use glob to get a list of matching dirs
                         abs_subdirs = glob.glob(os.path.join(parent, os.path.normpath(subdir)))
-                        if not isinstance(exts, list):
-                            exts = [exts]
                         # iterate over every dir returned by glob looking for matching ext
                         for abs_subdir in abs_subdirs:
                             if os.path.isdir(abs_subdir):
-                                for ext in exts:
-                                    normalized_ext = make_ext(ext)
-                                    # use glob to get a list of matching files
-                                    files = glob.glob(os.path.join(abs_subdir, filename_no_ext + normalized_ext))
-                                    for file in files:
-                                        # we have to use the length of the main file (no ext) to extract the real
-                                        # extension of the sibling file because of language codes etc.
-                                        filename = os.path.basename(file)
-                                        glob_ext = filename[len(filename_no_ext):]
-                                        if os.path.exists(file):
-                                            siblings[file] = glob_ext
+                                for ext in config['along']['files']:
+                                    siblings.update(get_siblings(ext, src, filename_no_ext, abs_subdir))
+
                 # execute action in subclasses
                 self.handle_entry(task, config, entry, siblings)
             except OSError as err:


### PR DESCRIPTION
### Motivation for changes:
Sometimes subtitles are in a subdir called `Subs`. One would expect `along` to support this already, but it doesn't. This change is mostly relevant for `copy` and `move`.
### Detailed changes:

- `along` takes a string (as now) or an object that is `subdir_name: one_or_more(string)`.
- Changed it to use `glob` to allow wildcards etc.

### Config usage if relevant (new plugin or updated schema):
```
  move_my_stuff:
    filesystem:
      path: /my/storage
      regexp: '.*\.mkv'
      retrieve: files
    move:
      to: /my/media
      along:
        files:
          - nfo
        subdirs:
          subs: 
            - *.srt
    accept_all: yes
```

