### PR TITLE
Allow config changing plugins to operate while daemon is running

### DIFF
--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -226,7 +226,7 @@ class Manager(object):
     def should_reload(self):
         """ Add triggers to the list to trigger a config reload from memory. Needed for some options to work while
          daemon is running """
-        reload_triggers = ['cli_config']
+        reload_triggers = ['execute.cli_config']
         if any(getattr(self.options, trigger, False) for trigger in reload_triggers):
             return True
         return False

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -263,6 +263,7 @@ class Manager(object):
         # TODO: 1.2 This is a hack to make task priorities work still, not sure if it's the best one
         task_names = sorted(task_names, key=lambda t: self.config['tasks'][t].get('priority', 65535))
 
+        self.update_config(self.validate_config())
         finished_events = []
         for task_name in task_names:
             task = Task(self, task_name, options=options, output=output, loglevel=loglevel, priority=priority)
@@ -326,6 +327,7 @@ class Manager(object):
         """
         if not options:
             options = self.options
+        self.options = options
         command = options.cli_command
         command_options = getattr(options, command)
         # First check for built-in commands

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -226,8 +226,8 @@ class Manager(object):
     def should_reload(self):
         """ Add triggers to the list to trigger a config reload from memory. Needed for some options to work while
          daemon is running """
-        reload_triggers = [self.options.cli_config]
-        if any(trigger for trigger in reload_triggers):
+        reload_triggers = ['cli_config']
+        if any(getattr(self.options, trigger, False) for trigger in reload_triggers):
             return True
         return False
 


### PR DESCRIPTION
### Motivation for changes:
`cli_config` can't work when daemon is running since config isn't reloaded and manager doesn't add updated options to itself when firing event. This kinda fixes that in a hacky way. need some ideas how to do this better.
This should affect affect any config editing plugin, like `secrets` as well.

### Addressed issues:

- Fixes #1299



