### PR TITLE
Miscellaneous Subliminal plugin improvements

### DIFF
--- a/flexget/plugins/output/subtitles_subliminal.py
+++ b/flexget/plugins/output/subtitles_subliminal.py
@@ -12,14 +12,17 @@ from flexget.event import event
 
 log = logging.getLogger('subtitles')
 
-PROVIDERS = [
-    'opensubtitles',
-    'thesubdb',
-    'podnapisi',
-    'addic7ed',
-    'tvsubtitles'
-]
-
+try:
+    from subliminal.extensions import provider_manager
+    PROVIDERS = provider_manager.names()
+except ImportError as e:
+    PROVIDERS = [
+        'opensubtitles',
+        'thesubdb',
+        'podnapisi',
+        'addic7ed',
+        'tvsubtitles'
+    ]
 
 class PluginSubliminal(object):
     """

--- a/flexget/plugins/output/subtitles_subliminal.py
+++ b/flexget/plugins/output/subtitles_subliminal.py
@@ -24,6 +24,8 @@ except ImportError as e:
         'tvsubtitles'
     ]
 
+AUTHENTICATION_SCHEMA = dict((provider, {'type': 'object'}) for provider in PROVIDERS)
+
 class PluginSubliminal(object):
     """
     Search and download subtitles using Subliminal by Antoine Bertin
@@ -47,6 +49,10 @@ class PluginSubliminal(object):
           providers: addic7ed, opensubtitles
           single: no
           directory: /disk/subtitles
+          authentication:
+            addic7ed:
+              username: myuser
+              passsword: mypassword
     """
 
     schema = {
@@ -58,6 +64,7 @@ class PluginSubliminal(object):
             'providers': {'type': 'array', 'items': {'type': 'string', 'enum': PROVIDERS}},
             'single': {'type': 'boolean', 'default': True},
             'directory': {'type:': 'string'},
+            'authentication': {'type': 'object', 'properties': AUTHENTICATION_SCHEMA},
         },
         'required': ['languages'],
         'additionalProperties': False
@@ -87,6 +94,9 @@ class PluginSubliminal(object):
                 providers: List of providers from where to download subtitles.
                 single: Download subtitles in single mode (no language code added to subtitle filename).
                 directory: Path to directory where to save the subtitles, default is next to the video.
+                authentication: >
+                  Dictionary of configuration options for different providers.
+                  Keys correspond to provider names, and values are dictionaries, usually specifying `username` and `password`.
         """
         if not task.accepted:
             log.debug('nothing accepted, aborting')
@@ -114,6 +124,7 @@ class PluginSubliminal(object):
         # keep all downloaded subtitles and save to disk when done (no need to write every time)
         downloaded_subtitles = collections.defaultdict(list)
         providers_list = config.get('providers', None)
+        provider_configs = config.get('authentication', None)
         # test if only one language was provided, if so we will download in single mode
         # (aka no language code added to subtitle filename)
         # unless we are forced not to by configuration
@@ -121,12 +132,18 @@ class PluginSubliminal(object):
         # we ignore the configuration and add the language code to the
         # potentially downloaded files
         single_mode = config.get('single', '') and len(languages | alternative_languages) <= 1
-        for entry in task.accepted:
-            if 'location' not in entry:
-                log.warning('Cannot act on entries that do not represent a local file.')
-            elif not os.path.exists(entry['location']):
-                entry.fail('file not found: %s' % entry['location'])
-            elif '$RECYCLE.BIN' not in entry['location']:  # ignore deleted files in Windows shares
+
+        with subliminal.core.ProviderPool(providers=providers_list, provider_configs=provider_configs) as provider_pool:
+            for entry in task.accepted:
+                if 'location' not in entry:
+                    log.warning('Cannot act on entries that do not represent a local file.')
+                    continue
+                if not os.path.exists(entry['location']):
+                    entry.fail('file not found: %s' % entry['location'])
+                    continue
+                if '$RECYCLE.BIN' in entry['location']:  # ignore deleted files in Windows shares
+                    continue
+
                 try:
                     entry_languages = set(entry.get('subtitle_languages', [])) or languages
 
@@ -149,23 +166,28 @@ class PluginSubliminal(object):
                         entry['subtitles_missing'] = set()
                         continue  # subs for preferred lang(s) already exists
                     else:
-                        subtitle = subliminal.download_best_subtitles({video}, entry_languages,
-                                                                      providers=providers_list, min_score=msc)
-                        if subtitle and any(subtitle.values()):
-                            downloaded_subtitles.update(subtitle)
+                        # Gather the subtitles for the alternative languages too, to avoid needing to search the sites
+                        # again. They'll just be ignored if the main languages are found.
+                        all_subtitles = provider_pool.list_subtitles(video, entry_languages | alternative_languages)
+
+                        subtitles = provider_pool.download_best_subtitles(all_subtitles, video, entry_languages,
+                                                                          min_score=msc)
+                        if subtitles:
+                            downloaded_subtitles[video].extend(subtitles)
                             log.info('Subtitles found for %s', entry['location'])
                         else:
                             # only try to download for alternatives that aren't alread downloaded
-                            subtitle = subliminal.download_best_subtitles({video}, alternative_languages,
-                                                                          providers=providers_list, min_score=msc)
+                            subtitles = provider_pool.download_best_subtitles(all_subtitles, video, alternative_languages,
+                                                                              min_score=msc)
 
-                            if subtitle and any(subtitle.values()):
-                                downloaded_subtitles.update(subtitle)
+                            if subtitles:
+                                downloaded_subtitles[video].extend(subtitles)
                                 entry.fail('subtitles found for a second-choice language.')
                             else:
                                 entry.fail('cannot find any subtitles for now.')
+
                         downloaded_languages = set([Language.fromietf(str(l.language))
-                                                    for l in subtitle[video]])
+                                                    for l in subtitles])
                         if entry_languages:
                             entry['subtitles_missing'] = entry_languages - downloaded_languages
                             if len(entry['subtitles_missing']) > 0:

--- a/flexget/plugins/output/subtitles_subliminal.py
+++ b/flexget/plugins/output/subtitles_subliminal.py
@@ -117,7 +117,13 @@ class PluginSubliminal(object):
                                         })
         except RegionAlreadyConfigured:
             pass
-        logging.getLogger("subliminal").setLevel(logging.CRITICAL)
+
+        # Let subliminal be more verbose if our logger is set to DEBUG
+        if log.isEnabledFor(logging.DEBUG):
+            logging.getLogger("subliminal").setLevel(logging.INFO)
+        else:
+            logging.getLogger("subliminal").setLevel(logging.CRITICAL)
+
         logging.getLogger("dogpile").setLevel(logging.CRITICAL)
         logging.getLogger("enzyme").setLevel(logging.WARNING)
         try:

--- a/flexget/plugins/output/subtitles_subliminal.py
+++ b/flexget/plugins/output/subtitles_subliminal.py
@@ -15,7 +15,7 @@ log = logging.getLogger('subtitles')
 try:
     from subliminal.extensions import provider_manager
     PROVIDERS = provider_manager.names()
-except ImportError as e:
+except ImportError:
     PROVIDERS = [
         'opensubtitles',
         'thesubdb',
@@ -99,7 +99,8 @@ class PluginSubliminal(object):
                 hearing_impaired: Prefer subtitles for the hearing impaired when available
                 authentication: >
                   Dictionary of configuration options for different providers.
-                  Keys correspond to provider names, and values are dictionaries, usually specifying `username` and `password`.
+                  Keys correspond to provider names, and values are dictionaries, usually specifying `username` and
+                  `password`.
         """
         if not task.accepted:
             log.debug('nothing accepted, aborting')
@@ -189,8 +190,8 @@ class PluginSubliminal(object):
                             log.info('Subtitles found for %s', entry['location'])
                         else:
                             # only try to download for alternatives that aren't alread downloaded
-                            subtitles = provider_pool.download_best_subtitles(all_subtitles, video, alternative_languages,
-                                                                              min_score=msc,
+                            subtitles = provider_pool.download_best_subtitles(all_subtitles, video,
+                                                                              alternative_languages, min_score=msc,
                                                                               hearing_impaired=hearing_impaired)
 
                             if subtitles:

--- a/flexget/plugins/output/subtitles_subliminal.py
+++ b/flexget/plugins/output/subtitles_subliminal.py
@@ -118,6 +118,7 @@ class PluginSubliminal(object):
         except RegionAlreadyConfigured:
             pass
         logging.getLogger("subliminal").setLevel(logging.CRITICAL)
+        logging.getLogger("dogpile").setLevel(logging.CRITICAL)
         logging.getLogger("enzyme").setLevel(logging.WARNING)
         try:
             languages = set([Language.fromietf(s) for s in config.get('languages', [])])


### PR DESCRIPTION
### Motivation/Detailed changes:

- Use the effective list of providers to validate configuration when possible. Avoids needing to manually update the list to follow upstream.
- Make it possible to use providers that require login by adding the `provider_configs` option.
- Add `hearing_impaired` option.
- Make debugging easier by silencing useless spam, and un-silencing subliminal itself.

### Config usage if relevant (new plugin or updated schema):

#### Add `provider_configs` option
```yaml
subliminal:
  provider_configs:
    legendastv:
      username: myuser
      password: mypassword
```
#### Add `hearing_impaired` option
```yaml
subliminal:
  hearing_impaired: yes
``` 