### PR TITLE
Populate series info for Plex episodes

### DIFF
--- a/flexget/plugins/input/plex.py
+++ b/flexget/plugins/input/plex.py
@@ -235,14 +235,21 @@ class InputPlex(object):
             if viewgroup == "episode":
                 e['plex_thumb'] = "http://%s:%d%s%s" % (
                     config['server'], config['port'], node.getAttribute('thumb'), urlappend)
+                e['series_name'] = title
                 season = int(node.getAttribute('parentIndex'))
                 if node.getAttribute('parentIndex') == node.getAttribute('year'):
                     season = node.getAttribute('originallyAvailableAt')
                     filenamemap = "%s_%s%s_%s_%s_%s.%s"
                     episode = ""
+                    e['series_id_type'] = 'date'
+                    e['series_date'] = season
                 elif node.getAttribute('index'):
                     episode = int(node.getAttribute('index'))
                     filenamemap = "%s_%02dx%02d_%s_%s_%s.%s"
+                    e['series_season'] = season
+                    e['series_episode'] = episode
+                    e['series_id_type'] = 'ep'
+                    e['series_id'] = 'S%02dE%02d' % (season, episode)
                 else:
                     log.debug("Could not get episode number for '%s' (Hint, ratingKey: %s)"
                               % (title, node.getAttribute('ratingKey')))


### PR DESCRIPTION
### Motivation for changes:

Sometimes I download episodes into my Plex server through channels other than Flexget.  I would like to mark these episodes as seen/downloaded in Flexget.  Currently the series plugin cannot be used with Plex episode entries because the necessary field are not set, although the information is available.  These changes set the relevant fields so Flexget can get metainfo about Plex episodes.

### Detailed changes:

Added the fields `series_name`, `series_season`, `series_episode`, `series_id_type`, and `series_id` for Plex episode entires.  The necessary info was already used in Flexget for setting other fields, so my changes are entirely setting these fields.


