### PR TITLE
Allow the sending of the prowl url parameter

### DIFF
--- a/flexget/plugins/output/prowl.py
+++ b/flexget/plugins/output/prowl.py
@@ -34,7 +34,8 @@ class OutputProwl(object):
             'application': {'type': 'string', 'default': 'FlexGet'},
             'event': {'type': 'string', 'default': 'New Release'},
             'priority': {'type': 'integer', 'default': 0},
-            'description': {'type': 'string'}
+            'description': {'type': 'string'},
+            'url': {'type': 'string'}
         },
         'required': ['apikey'],
         'additionalProperties': False
@@ -51,6 +52,7 @@ class OutputProwl(object):
             event = entry.get('event', config['event'])
             priority = entry.get('priority', config['priority'])
             description = config.get('description', entry['title'])
+            message_url = config.get('url')
 
             # If event has jinja template, render it
             try:
@@ -65,9 +67,15 @@ class OutputProwl(object):
                 description = entry['title']
                 log.error('Error rendering jinja description: %s' % e)
 
+            # If url has jinja template, render it
+            try:
+                message_url = entry.render(message_url)
+            except RenderError as e:
+                log.error('Error rendering jinja url: %s' % e)
+
             url = 'https://api.prowlapp.com/publicapi/add'
             data = {'priority': priority, 'application': application, 'apikey': apikey,
-                    'event': event.encode('utf-8'), 'description': description}
+                    'event': event.encode('utf-8'), 'description': description, 'url': message_url}
 
             if task.options.test:
                 log.info('Would send prowl message about: %s', entry['title'])

--- a/flexget/plugins/output/prowl.py
+++ b/flexget/plugins/output/prowl.py
@@ -52,7 +52,7 @@ class OutputProwl(object):
             event = entry.get('event', config['event'])
             priority = entry.get('priority', config['priority'])
             description = config.get('description', entry['title'])
-            message_url = config.get('url')
+            message_url = config.get('url', '')
 
             # If event has jinja template, render it
             try:

--- a/flexget/plugins/output/prowl.py
+++ b/flexget/plugins/output/prowl.py
@@ -71,6 +71,7 @@ class OutputProwl(object):
             try:
                 message_url = entry.render(message_url)
             except RenderError as e:
+                message_url = ''
                 log.error('Error rendering jinja url: %s' % e)
 
             url = 'https://api.prowlapp.com/publicapi/add'


### PR DESCRIPTION
### Motivation for changes:
Allow the sending of the url parameter in prowl notifications
### Detailed changes:
This alteration allows the prowl message to link to a user defined url
Such as the imdb page for a movie
```
    prowl:
      apikey: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
      event: 'New movie'
      description: '{{title}}'
      url: '{{imdb_url}}'
```

Or for the more tech savy a custom page that deals with the torrent
```
    prowl:
      apikey: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
      event: 'New movie'
      description: '{{title}}'
      url: 'https://myserver.com/ctrl/{{torrent_info_hash}}'
```

### Addressed issues:

n/a

### Config usage if relevant (new plugin or updated schema):
```
    prowl:
      apikey: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
      event: 'New movie'
      description: '{{title}}'
      url: '{{imdb_url}}'
```
### Log and/or tests output (preferably both):
```
paste output here
```


