### PR TITLE
Added two new fields in Entry

### DIFF
--- a/flexget/plugins/input/plex.py
+++ b/flexget/plugins/input/plex.py
@@ -259,6 +259,8 @@ class InputPlex(object):
 
             e['plex_duration'] = node.getAttribute('duration')
             e['plex_summary'] = node.getAttribute('summary')
+            e['plex_userrating'] = node.getAttribute('userrating')
+            e['plex_key'] = node.getAttribute('ratingKey')
             count = node.getAttribute('viewCount')
             offset = node.getAttribute('viewOffset')
             if count:


### PR DESCRIPTION
### Motivation for changes:
I needed this two fields in order to be able to mark as seen and vote the episodes in tvshowtime and letterboxd websites automatically



plex_userrating: Rating given by the user. From 1 to 10
plex_key: Internal Plex identificator for the Media