### PR TITLE
Parse magnet uri as bytes

### DIFF
--- a/flexget/plugins/plugin_rtorrent.py
+++ b/flexget/plugins/plugin_rtorrent.py
@@ -542,6 +542,7 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
 
         if entry['url'].startswith('magnet:'):
             torrent_raw = 'd10:magnet-uri%d:%se' % (len(entry['url']), entry['url'])
+            torrent_raw = str.encode(torrent_raw)
         else:
             # Check that file is downloaded
             if 'file' not in entry:


### PR DESCRIPTION
### Motivation for changes:
when adding torrents from magnet they need to be bytes. 
now they do
### Detailed changes:

just added one line
torrent_raw = str.encode(torrent_raw)


### Addressed issues:

- Fixes #1328 

