### PR TITLE
Limetorrents Search Plugin

### DIFF
--- a/flexget/plugins/sites/limetorrents.py
+++ b/flexget/plugins/sites/limetorrents.py
@@ -1,0 +1,113 @@
+from __future__ import unicode_literals, division, absolute_import
+from future.moves.urllib.parse import quote
+from builtins import *  # pylint: disable=unused-import, redefined-builtin
+
+import logging
+
+from flexget import plugin
+from flexget.entry import Entry
+from flexget.event import event
+from flexget.utils.requests import RequestException
+from flexget.utils.soup import get_soup
+from flexget.utils.search import torrent_availability
+from flexget.plugins.plugin_urlrewriting import UrlRewritingError
+
+log = logging.getLogger('limetorrents')
+
+class limetorrents(object):
+    """
+        limetorrents search plugin.
+    """
+
+    schema = {
+        'oneOf': [
+            {'type': 'boolean'},
+            {
+                'type': 'object',
+                'properties': {
+                    'category': {'type': 'string', 'enum': ['all', 'anime', 'applications', 'games', 'movies', 'music', 'tv', 'other'], 'default': 'all'},
+                    'order_by': {'type': 'string', 'enum': ['date', 'seeds'], 'default': 'date'}
+                },
+                'additionalProperties': False
+            }
+        ]
+    }
+
+    base_url = 'https://www.limetorrents.cc/'
+    errors = False
+
+
+    @plugin.internet(log)
+    def search(self, task, entry, config):
+        """
+            Search for entries on limetorents
+        """
+
+        if not isinstance(config, dict):
+            config = {'category': config}
+
+        order_by = ''
+        if isinstance(config.get('order_by'), str):
+            if config['order_by'] != 'date':
+                order_by = '{0}/1'.format(config['order_by'])
+
+        category = 'all'
+        if isinstance(config.get('category'), str):
+            category = '{0}'.format(config['category'])
+
+        entries = set()
+
+        for search_string in entry.get('search_strings', [entry['title']]):
+
+            query = 'search/{0}/{1}/{2}'.format(category,quote(search_string.encode('utf8')),order_by)
+            log.debug('Using search params: %s; category: %s; ordering by: %s',search_string, category, order_by or 'default')
+            try:
+                page = task.requests.get(self.base_url + query)
+                log.debug('requesting: %s', page.url)
+            except RequestException as e:
+                log.error('limetorrents request failed: %s', e)
+                continue
+
+            soup = get_soup(page.content)
+            if soup.find('a', attrs={'class':'csprite_dl14'}) is not None:
+                for link in soup.findAll('a', attrs={'class': 'csprite_dl14'}):
+
+                    row = link.find_parent('tr')
+                    info_url = str(link.get('href'))
+
+                    # Get the title from the URL as it's complete versus the actual Title text which gets cut off
+                    title = str(link.next_sibling.get('href'))
+                    title = title[:title.rfind('-torrent')].replace('-', ' ')
+                    title = title[1:]
+
+                    data = row.findAll('td', attrs={'class': 'tdnormal'})
+                    size = str(data[1].text).replace(',','')
+
+                    seeds = int(row.find('td', attrs={'class': 'tdseed'}).text.replace(',',''))
+                    leeches = int(row.find('td', attrs={'class': 'tdleech'}).text.replace(',',''))
+
+                    if size.split()[1] == 'GB':
+                        size = int(float(size.split()[0].replace(',', '')) * 1000 ** 3 / 1024 ** 2)
+                    elif size.split()[1] == 'MB':
+                        size = int(float(size.split()[0].replace(',', '')) * 1000 ** 2 / 1024 ** 2)
+                    elif size.split()[1] == 'KB':
+                        size = int(float(size.split()[0].replace(',', '')) * 1000 / 1024 ** 2)
+                    else:
+                        size = int(float(size.split()[0].replace(',', '')) / 1024 ** 2)
+
+                    e = Entry()
+
+                    e['url'] = info_url
+                    e['title'] = title
+                    e['torrent_seeds'] = seeds
+                    e['torrent_leeches'] = leeches
+                    e['search_sort'] = torrent_availability(e['torrent_seeds'], e['torrent_leeches'])
+                    e['content_size'] = size
+
+                    entries.add(e)
+
+        return entries
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(limetorrents, 'limetorrents', groups=['search'], api_ver=2)

--- a/flexget/plugins/sites/limetorrents.py
+++ b/flexget/plugins/sites/limetorrents.py
@@ -11,7 +11,7 @@ from flexget.utils.requests import RequestException
 from flexget.utils.soup import get_soup
 from flexget.utils.search import torrent_availability
 
-log = logging.getLogger('Limetorrents')
+log = logging.getLogger('limetorrents')
 
 
 class Limetorrents(object):

--- a/flexget/plugins/sites/limetorrents.py
+++ b/flexget/plugins/sites/limetorrents.py
@@ -10,13 +10,13 @@ from flexget.event import event
 from flexget.utils.requests import RequestException
 from flexget.utils.soup import get_soup
 from flexget.utils.search import torrent_availability
-from flexget.plugins.plugin_urlrewriting import UrlRewritingError
 
-log = logging.getLogger('limetorrents')
+log = logging.getLogger('Limetorrents')
 
-class limetorrents(object):
+
+class Limetorrents(object):
     """
-        limetorrents search plugin.
+        Limetorrents search plugin.
     """
 
     schema = {
@@ -40,7 +40,7 @@ class limetorrents(object):
     @plugin.internet(log)
     def search(self, task, entry, config):
         """
-            Search for entries on limetorents
+            Search for entries on Limetorrents
         """
 
         if not isinstance(config, dict):
@@ -110,4 +110,4 @@ class limetorrents(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(limetorrents, 'limetorrents', groups=['search'], api_ver=2)
+    plugin.register(Limetorrents, 'limetorrents', groups=['search'], api_ver=2)

--- a/flexget/plugins/sites/limetorrents.py
+++ b/flexget/plugins/sites/limetorrents.py
@@ -25,7 +25,8 @@ class Limetorrents(object):
             {
                 'type': 'object',
                 'properties': {
-                    'category': {'type': 'string', 'enum': ['all', 'anime', 'applications', 'games', 'movies', 'music', 'tv', 'other'], 'default': 'all'},
+                    'category': {'type': 'string', 'enum': ['all', 'anime', 'applications', 'games', 'movies', 'music',
+                                                            'tv', 'other'], 'default': 'all'},
                     'order_by': {'type': 'string', 'enum': ['date', 'seeds'], 'default': 'date'}
                 },
                 'additionalProperties': False
@@ -58,17 +59,17 @@ class Limetorrents(object):
 
         for search_string in entry.get('search_strings', [entry['title']]):
 
-            query = 'search/{0}/{1}/{2}'.format(category,quote(search_string.encode('utf8')),order_by)
-            log.debug('Using search params: %s; category: %s; ordering by: %s',search_string, category, order_by or 'default')
+            query = 'search/{0}/{1}/{2}'.format(category, quote(search_string.encode('utf8')), order_by)
+            log.debug('Using search: %s; category: %s; ordering: %s', search_string, category, order_by or 'default')
             try:
                 page = task.requests.get(self.base_url + query)
                 log.debug('requesting: %s', page.url)
             except RequestException as e:
-                log.error('limetorrents request failed: %s', e)
+                log.error('Limetorrents request failed: %s', e)
                 continue
 
             soup = get_soup(page.content)
-            if soup.find('a', attrs={'class':'csprite_dl14'}) is not None:
+            if soup.find('a', attrs={'class': 'csprite_dl14'}) is not None:
                 for link in soup.findAll('a', attrs={'class': 'csprite_dl14'}):
 
                     row = link.find_parent('tr')
@@ -80,10 +81,10 @@ class Limetorrents(object):
                     title = title[1:]
 
                     data = row.findAll('td', attrs={'class': 'tdnormal'})
-                    size = str(data[1].text).replace(',','')
+                    size = str(data[1].text).replace(',', '')
 
-                    seeds = int(row.find('td', attrs={'class': 'tdseed'}).text.replace(',',''))
-                    leeches = int(row.find('td', attrs={'class': 'tdleech'}).text.replace(',',''))
+                    seeds = int(row.find('td', attrs={'class': 'tdseed'}).text.replace(',', ''))
+                    leeches = int(row.find('td', attrs={'class': 'tdleech'}).text.replace(',', ''))
 
                     if size.split()[1] == 'GB':
                         size = int(float(size.split()[0].replace(',', '')) * 1000 ** 3 / 1024 ** 2)
@@ -106,6 +107,7 @@ class Limetorrents(object):
                     entries.add(e)
 
         return entries
+
 
 @event('plugin.register')
 def register_plugin():

--- a/flexget/plugins/sites/limetorrents.py
+++ b/flexget/plugins/sites/limetorrents.py
@@ -36,7 +36,6 @@ class Limetorrents(object):
     base_url = 'https://www.limetorrents.cc/'
     errors = False
 
-
     @plugin.internet(log)
     def search(self, task, entry, config):
         """


### PR DESCRIPTION
### Motivation for changes:
Create a way to search limetorrents

### Config usage if relevant (new plugin or updated schema):
```
Either
- limetorrents: yes
or
- limetorrents:
      order_by: (date|seeds)
      category: (all|anime|applications|games|movies|tv|other)

category defaults to all if not specified.  You may specify order_by and not category or vice versa.  You may only select one category.
```




