### PR TITLE
npo_watchlist: Rewrite, after big changes to npo.nl

### DIFF
--- a/flexget/plugins/input/npo_watchlist.py
+++ b/flexget/plugins/input/npo_watchlist.py
@@ -27,8 +27,9 @@ class NPOWatchlist(object):
         Entries can be downloaded using https://bitbucket.org/Carpetsmoker/download-npo
 
         If 'remove_accepted' is set to 'yes', the plugin will delete accepted entries from the watchlist after download
-        is complete.
-        If 'max_episode_age_days' is set (and not 0) 
+            is complete.
+        If 'max_episode_age_days' is set (and not 0), entries will only be generated for episodes broadcast in the last x days. 
+            This only applies to episodes related to series the user is following.
 
         For example:
             npo_watchlist:

--- a/flexget/plugins/input/npo_watchlist.py
+++ b/flexget/plugins/input/npo_watchlist.py
@@ -6,8 +6,8 @@ import logging
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.utils.soup import get_soup
 
-from bs4 import BeautifulSoup
 from datetime import date, timedelta
 
 import unicodedata
@@ -103,7 +103,7 @@ class NPOWatchlist(object):
         elif login_response.url != 'https://mijn.npo.nl/inloggen':
             raise plugin.PluginError('Unexpected login page: {}'.format(login_response.url))
 
-        login_page = BeautifulSoup(login_response.content, 'html5lib')
+        login_page = get_soup(login_response.content)
         token = login_page.find('input', attrs={'name': 'authenticity_token'})['value']
 
         email = config.get('email')
@@ -126,7 +126,7 @@ class NPOWatchlist(object):
         log.info('Retrieving npo.nl episode watchlist for %s', email)
 
         response = self._get_page(task, config, 'https://mijn.npo.nl/profiel/kijklijst')
-        page = BeautifulSoup(response.content, 'html5lib')
+        page = get_soup(response.content)
 
         self.csrf_token = page.find('meta', attrs={'name': 'csrf-token'})['content']
 
@@ -159,7 +159,7 @@ class NPOWatchlist(object):
     def _get_series_episodes(self, task, config, series_name, series_url):
         log.info('Retrieving new episodes for %s', series_name)
         response = task.requests.get(series_url + '/search?category=broadcasts')
-        page = BeautifulSoup(response.content, 'html5lib')
+        page = get_soup(response.content)
 
         if page.find('div', class_='npo3-show-items'):
             log.debug('Parsing as npo3')
@@ -244,7 +244,7 @@ class NPOWatchlist(object):
 
         log.info('Retrieving npo.nl favorite series for %s', email)
         response = self._get_page(task, config, 'https://mijn.npo.nl/profiel/favorieten')
-        page = BeautifulSoup(response.content, 'html5lib')
+        page = get_soup(response.content)
 
         entries = list()
         for listItem in page.findAll('div', class_='thumb-item'):

--- a/flexget/plugins/input/npo_watchlist.py
+++ b/flexget/plugins/input/npo_watchlist.py
@@ -8,13 +8,17 @@ from flexget.entry import Entry
 from flexget.event import event
 
 from bs4 import BeautifulSoup
+from datetime import date, timedelta
 
 import unicodedata
 import requests
 import re
 
 log = logging.getLogger('search_npo')
-search_results_regex = re.compile('<a href="([^"]+)" data-scorecard="{&quot;name&quot;:&quot;zoeken')
+fragment_regex = re.compile('[A-Z][^/]+/')
+date_regex = re.compile('([1-3]?[0-9]) ([a-z]{3}) ([0-9]{4})')
+days_ago_regex = re.compile('([0-9]+) dagen geleden')
+months = ['jan', 'feb', 'mrt', 'apr', 'mei', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec']
 
 
 class NPOWatchlist(object):
@@ -24,12 +28,14 @@ class NPOWatchlist(object):
 
         If 'remove_accepted' is set to 'yes', the plugin will delete accepted entries from the watchlist after download
         is complete.
+        If 'max_episode_age_days' is set (and not 0) 
 
         For example:
             npo_watchlist:
               email: aaaa@bbb.nl
               password: xxx
               remove_accepted: yes
+              max_episode_age_days: 7
             accept_all: yes
             exec:
               fail_entries: yes
@@ -44,7 +50,8 @@ class NPOWatchlist(object):
         'properties': {
             'email': {'type': 'string'},
             'password': {'type': 'string'},
-            'remove_accepted': {'type': 'boolean', 'default': False}
+            'remove_accepted': {'type': 'boolean', 'default': False},
+            'max_episode_age_days': {'type': 'integer', 'default': -1},
         },
         'required': ['email', 'password'],
         'additionalProperties': False
@@ -55,10 +62,41 @@ class NPOWatchlist(object):
     def _strip_accents(self, s):
         return ''.join(c for c in unicodedata.normalize('NFD', s)
                        if unicodedata.category(c) != 'Mn')
-
-    def _get_profile(self, task, config):
-        login_response = task.requests.get('https://mijn.npo.nl/inloggen')
-        if login_response.url == 'http://www.npo.nl/profiel':
+                       
+    def _prefix_url(self, prefix, url):
+        if ':' not in url:
+            url = prefix + url
+        
+        return url
+        
+    def _parse_date(self, date_text):
+        date_match = date_regex.search(date_text)
+        days_ago_match = days_ago_regex.search(date_text)
+        first_word = date_text.split(' ')[0].lower().strip()
+        
+        if date_match:
+            day = int(date_match.group(1))
+            month = months.index(date_match.group(2))+1
+            year = int(date_match.group(3))
+            return date(year, month, day)
+        elif days_ago_match:
+            days_ago = int(days_ago_match.group(1))
+            return date.today() - timedelta(days=days_ago)
+        elif first_word in ['vandaag', 'vanochtend', 'vanmiddag', 'vanavond']:
+            return date.today()
+        elif first_word == 'gisteren':
+            return date.today() - timedelta(days=1)
+        elif first_word == 'eergisteren':
+            return date.today() - timedelta(days=2)
+        elif first_word == 'kijk':
+            return None
+        else:
+            log.error("Cannot understand date '%s'", date_text)
+            return date.today()
+        
+    def _get_page(self, task, config, url):
+        login_response = task.requests.get(url)
+        if login_response.url == url:
             log.debug('Already logged in')
             return login_response
         elif login_response.url != 'https://mijn.npo.nl/inloggen':
@@ -77,39 +115,38 @@ class NPOWatchlist(object):
 
         if profile_response.url == 'https://mijn.npo.nl/sessions':
             raise plugin.PluginError('Failed to login. Check username and password.')
-        elif profile_response.url != 'https://mijn.npo.nl/profiel':
-            raise plugin.PluginError('Unexpected profile page: {}'.format(profile_response.url))
+        elif profile_response.url != url:
+            raise plugin.PluginError('Unexpected page: {} (expected {})'.format(profile_response.url, url))
 
         return profile_response
 
-    def on_task_input(self, task, config):
+    def _get_watchlist_entries(self, task, config):
         email = config.get('email')
-        log.info('Retrieving npo.nl watchlist for %s', email)
+        log.info('Retrieving npo.nl episode watchlist for %s', email)
 
-        profile_response = self._get_profile(task, config)
-        profile_page = BeautifulSoup(profile_response.content, 'html5lib')
+        response = self._get_page(task, config, 'https://mijn.npo.nl/profiel/kijklijst')
+        page = BeautifulSoup(response.content, 'html5lib')
 
-        self.csrf_token = profile_page.find('meta', attrs={'name': 'csrf-token'})['content']
+        self.csrf_token = page.find('meta', attrs={'name': 'csrf-token'})['content']
 
         entries = list()
-        for listItem in profile_page.findAll('div', class_='list-item'):
-            title = next(listItem.find('h4').stripped_strings)
-            subtitle = listItem.find('h5').text
+        for listItem in page.findAll('div', class_='watch-list-item'):
             url = listItem.find('a')['href']
-            remove_url = listItem.find('a', class_='remove-button')['href']
-
-            if subtitle == 'Serie':
-                log.debug('Skipping series entry for %s', title)
-                continue
+            series_name = next(listItem.find('h3').stripped_strings)
+            remove_url = listItem.find('a', class_='unwatch-confirm')['href']
+            entry_date = self._parse_date(listItem.find('span', class_='global__content-info').text)
+            
+            episode_id = url.split('/')[-1]
+            title = '{} ({})'.format(series_name, episode_id)
 
             e = Entry()
-            e['title'] = '{} ({})'.format(title, subtitle)
-            e['url'] = url
-
-            e['series_name'] = title
-            e['series_name_plain'] = self._strip_accents(title)
+            e['url'] = self._prefix_url('https://mijn.npo.nl', url)
+            e['title'] = title
+            e['series_name'] = series_name
+            e['series_name_plain'] = self._strip_accents(series_name)
+            e['series_date'] = entry_date
             e['description'] = listItem.find('p').text
-            e['remove_url'] = remove_url
+            e['remove_url'] = self._prefix_url('https://mijn.npo.nl', remove_url)
 
             if config.get('remove_accepted'):
                 e.on_complete(self.entry_complete, task=task)
@@ -117,7 +154,131 @@ class NPOWatchlist(object):
             entries.append(e)
 
         return entries
+        
+    def _get_series_episodes(self, task, config, series_name, series_url):
+        log.info('Retrieving new episodes for %s', series_name)
+        response = task.requests.get(series_url + '/search?category=broadcasts')
+        page = BeautifulSoup(response.content, 'html5lib')
 
+        if page.find('div', class_='npo3-show-items'):
+            log.debug('Parsing as npo3')
+            entries = self._parse_episodes_npo3(task, config, series_name, page)
+        else:
+            log.debug('Parsing as std')
+            entries = self._parse_episodes_std(task, config, series_name, page)
+            
+        if not entries:
+            log.warning('No episodes found for %s', series_name)
+
+        return entries
+
+    def _parse_episodes_npo3(self, task, config, series_name, page):
+        max_age = config.get('max_episode_age_days')
+        
+        entries = list()
+        for listItem in page.findAll('div', class_='item'):
+            url = listItem.find('a')['href']
+            title = listItem.find('h3').text
+            
+            episode_id = url.split('/')[-1]
+            title = '{} ({})'.format(title, episode_id)
+            
+            entry_date = list(listItem.find('h4').stripped_strings)[1]
+            entry_date = self._parse_date(entry_date)
+            if max_age >= 0 and (date.today() - entry_date) > timedelta(days=max_age):
+                log.debug('Skipping %s, aired on %s', title, entry_date)
+                continue
+                
+            e = Entry()
+            e['url'] = self._prefix_url('http://www.npo.nl', url)
+            e['title'] = title
+            e['series_name'] = series_name
+            e['series_name_plain'] = self._strip_accents(series_name)
+            e['series_date'] = entry_date
+            e['description'] = listItem.find('p').text
+
+            entries.append(e)
+        
+        return entries
+        
+    def _parse_episodes_std(self, task, config, series_name, page):
+        max_age = config.get('max_episode_age_days')
+
+        entries = list()
+        for listItem in page.findAll('div', class_='list-item'):
+            url = listItem.find('a')['href']
+            title = next(listItem.find('h4').stripped_strings)
+            subtitle = listItem.find('h5').text
+            
+            episode_id = url.split('/')[-1]
+            title = '{} ({})'.format(title, episode_id)
+            
+            if listItem.find('div', class_='program-not-available'):
+                log.debug('Skipping %s, no longer available', title)
+                continue
+            elif fragment_regex.search(url):
+                log.debug('Skipping fragment: %s', title)
+                continue
+            
+            entry_date = self._parse_date(subtitle)
+            if max_age >= 0 and (date.today() - entry_date) > timedelta(days=max_age):
+                log.debug('Skipping %s, aired on %s', title, entry_date)
+                continue
+                
+            e = Entry()
+            e['url'] = self._prefix_url('http://www.npo.nl', url)
+            e['title'] = title
+            e['series_name'] = series_name
+            e['series_name_plain'] = self._strip_accents(series_name)
+            e['series_date'] = entry_date
+            e['description'] = listItem.find('p').text
+
+            entries.append(e)
+        
+        return entries
+            
+    def _get_favorites_entries(self, task, config):
+        email = config.get('email')
+        max_age = config.get('max_episode_age_days')
+
+        log.info('Retrieving npo.nl favorite series for %s', email)
+        response = self._get_page(task, config, 'https://mijn.npo.nl/profiel/favorieten')
+        page = BeautifulSoup(response.content, 'html5lib')
+
+        entries = list()
+        for listItem in page.findAll('div', class_='thumb-item'):
+            url = listItem.find('a')['href']
+            
+            if url == '/profiel/favorieten/favorieten-toevoegen':
+                log.debug("Skipping 'add favorite' button")
+                continue
+
+            url = self._prefix_url('https://mijn.npo.nl', url)
+            series_name = next(listItem.find('div', class_='thumb-item__title').stripped_strings)
+            
+            last_aired_text = listItem.find('div', class_='thumb-item__subtitle').text
+            last_aired_text = last_aired_text.rsplit('Laatste aflevering ')[-1]
+            last_aired = self._parse_date(last_aired_text)
+            
+            if last_aired is None:
+                log.info('Series %s did not yet start', series_name)
+                continue
+            elif max_age >= 0 and (date.today() - last_aired) > timedelta(days=max_age):
+                log.debug('Skipping %s, last aired on %s', series_name, last_aired)
+                continue
+            elif (date.today() - last_aired) > timedelta(days=365*2):
+                log.info('Series %s last aired on %s', series_name, last_aired)
+            
+            entries += self._get_series_episodes(task, config, series_name, url)
+
+        return entries
+        
+    def on_task_input(self, task, config):
+        entries = self._get_watchlist_entries(task, config)
+        entries += self._get_favorites_entries(task, config)
+        
+        return entries
+    
     def entry_complete(self, e, task=None):
         if not e.accepted:
             log.warning('Not removing %s entry %s', e.state, e['title'])
@@ -130,7 +291,7 @@ class NPOWatchlist(object):
 
             headers = {
                 'Origin': 'https://mijn.npo.nl/',
-                'Referer': 'https://mijn.npo.nl/profiel',
+                'Referer': 'https://mijn.npo.nl/profiel/kijklijst',
                 'X-CSRF-Token': self.csrf_token,
                 'X-Requested-With': 'XMLHttpRequest'
             }

--- a/flexget/plugins/input/npo_watchlist.py
+++ b/flexget/plugins/input/npo_watchlist.py
@@ -28,7 +28,7 @@ class NPOWatchlist(object):
 
         If 'remove_accepted' is set to 'yes', the plugin will delete accepted entries from the watchlist after download
             is complete.
-        If 'max_episode_age_days' is set (and not 0), entries will only be generated for episodes broadcast in the last x days. 
+        If 'max_episode_age_days' is set (and not 0), entries will only be generated for episodes broadcast in the last x days.
             This only applies to episodes related to series the user is following.
 
         For example:
@@ -63,7 +63,7 @@ class NPOWatchlist(object):
     def _strip_accents(self, s):
         return ''.join(c for c in unicodedata.normalize('NFD', s)
                        if unicodedata.category(c) != 'Mn')
-                       
+
     def _prefix_url(self, prefix, url):
         if ':' not in url:
             url = prefix + url


### PR DESCRIPTION
### Motivation for changes:

npo.nl completely changed the set-up of its watchlist, requiring a rewrite of the plug-in.

### Detailed changes:

Now creates entries for:
- individual episodes put on watchlist
- all episodes for series on watchlist (since max_episode_age_days)

### Config usage if relevant (new plugin or updated schema):
```
            npo_watchlist:
              email: aaaa@bbb.nl
              password: xxx
              remove_accepted: yes
              max_episode_age_days: 7
            accept_all: yes
            exec:
              fail_entries: yes
              auto_escape: yes
              on_output:
                for_accepted:
                  - download-npo -o "path/to/directory/{{series_name_plain}}" -f "{serie_titel} - {datum} {aflevering_titel} ({episode_id})" -t {{url}}

