### PR TITLE
Convert string-like values to plain strings in Entry

### DIFF
--- a/flexget/entry.py
+++ b/flexget/entry.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # pylint: disable=unused-import, redefined-builtin
-from future.utils import PY2, native_str
+from future.utils import PY2, native_str, text_type
 
 import copy
 import functools
@@ -195,6 +195,10 @@ class Entry(LazyDict):
                 raise EntryUnicodeError(key, value)
         elif isinstance(value, bytes):
             raise EntryUnicodeError(key, value)
+        # Coerce any enriched strings (such as those returned by BeautifulSoup) to plain strings to avoid serialization
+        # troubles.
+        elif isinstance(value, text_type) and type(value) != text_type:
+            value = text_type(value)
 
         # url and original_url handling
         if key == 'url':

--- a/flexget/entry.py
+++ b/flexget/entry.py
@@ -197,7 +197,7 @@ class Entry(LazyDict):
             raise EntryUnicodeError(key, value)
         # Coerce any enriched strings (such as those returned by BeautifulSoup) to plain strings to avoid serialization
         # troubles.
-        elif isinstance(value, text_type) and type(value) != text_type:
+        elif isinstance(value, text_type) and type(value) != text_type:  # pylint: disable=unidiomatic-typecheck
             value = text_type(value)
 
         # url and original_url handling

--- a/flexget/tests/test_misc.py
+++ b/flexget/tests/test_misc.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # pylint: disable=unused-import, redefined-builtin
+from future.utils import text_type
 
 import os
 import stat
@@ -148,6 +149,15 @@ class TestEntryUnicodeError(object):
         e = Entry('title', 'url')
         with pytest.raises(EntryUnicodeError):
             e['invalid'] = b'\x8e'
+
+class TestEntryStringCoercion(object):
+    def test_coercion(self):
+        class EnrichedString(text_type):
+            pass
+
+        e = Entry('title', 'url')
+        e['test'] = EnrichedString("test")
+        assert type(e['test']) == text_type
 
 
 class TestFilterRequireField(object):

--- a/flexget/tests/test_misc.py
+++ b/flexget/tests/test_misc.py
@@ -1,3 +1,5 @@
+# pylint: disable=no-self-use
+
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # pylint: disable=unused-import, redefined-builtin
 from future.utils import text_type
@@ -150,6 +152,7 @@ class TestEntryUnicodeError(object):
         with pytest.raises(EntryUnicodeError):
             e['invalid'] = b'\x8e'
 
+
 class TestEntryStringCoercion(object):
     def test_coercion(self):
         class EnrichedString(text_type):
@@ -157,7 +160,7 @@ class TestEntryStringCoercion(object):
 
         e = Entry('title', 'url')
         e['test'] = EnrichedString("test")
-        assert type(e['test']) == text_type
+        assert type(e['test']) == text_type  # pylint: disable=unidiomatic-typecheck
 
 
 class TestFilterRequireField(object):


### PR DESCRIPTION
### Motivation for changes:

BeautifulSoup, as used in some search plugins, returns strings from HTML
document structures in "enriched" form - instances of unicode/str mixed
in with another class. Those strings carry references to the whole
document tree, which can cause issues when attempting to serialize entry
values for saving to the database.

### Detailed changes:

To avoid that, coerce any values whose type is a subtype of text_type,
but not *exactly* text_type, to text_type, with text_type being unicode
in Py2 and str in Py3. That should ensure we throw away any extra
baggage that might be attached but keep the exact same content.

Supersedes #1302 and fixes #1301.