### PR TITLE
Fix wrong umask calculation in download test

### DIFF
--- a/flexget/tests/test_misc.py
+++ b/flexget/tests/test_misc.py
@@ -139,7 +139,7 @@ class TestDownload(object):
         testfile = task.entries[0]['location']
         assert os.path.exists(testfile), 'download file does not exists'
         testfile_stat = os.stat(testfile)
-        modes_equal = 0o666 - curr_umask == stat.S_IMODE(testfile_stat.st_mode)
+        modes_equal = 0o666 & ~curr_umask == stat.S_IMODE(testfile_stat.st_mode)
         assert modes_equal, 'download file mode not honoring umask'
 
 


### PR DESCRIPTION
Calculating the umask by subtraction only works by coincidence in some cases. The correct way is to use bitwise operations to unset any bits in the umask from the expected permissions. I found this since I run with `umask 077` and the test always failed on my system.