### PR TITLE
Added 'optimistic' config option to release_estimations in discover.

### DIFF
--- a/flexget/plugins/input/discover.py
+++ b/flexget/plugins/input/discover.py
@@ -274,6 +274,7 @@ class Discover(object):
             config['release_estimations'] = {'mode': config['release_estimations']}
 
         config['release_estimations'].setdefault('mode', 'strict')
+        config['release_estimations'].setdefault('optimistic', '0 days')
 
         task.no_entries_ok = True
         entries = self.execute_inputs(config, task)

--- a/flexget/plugins/input/discover.py
+++ b/flexget/plugins/input/discover.py
@@ -284,7 +284,7 @@ class Discover(object):
         # TODO: the entries that are estimated should be given priority over expiration
         entries = self.interval_expired(config, task, entries)
         estimation_mode = config['release_estimations']
-        if estimation_mode != 'ignore':
+        if estimation_mode['mode'] != 'ignore':
             entries = self.estimated(entries, estimation_mode)
         return self.execute_searches(config, entries, task)
 


### PR DESCRIPTION
### Motivation for changes:
Blurays are always leaked before official release, so if you want a movie ASAP you have to start searching a bit before official release date.
### Detailed changes:

- Added dict option to `release_estimations`. No config upgrade required.

### Config usage if relevant (new plugin or updated schema):
```
discover:
  optimistic: 7 days
```
### Log and/or tests output (preferably both):
```
2016-08-15 08:48 DEBUG    discover      test_est        Suits S06E07 will be released at 2016-08-24 00:00:00. Ignoring release estimation because estimated release date is in less than 10 days
```