### PR TITLE
Daemon will now auto-reload config file if it changes

### DIFF
--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -245,6 +245,7 @@ class Manager(object):
         task_names = self.tasks
         # Only reload config if daemon
         if self.is_daemon and self.config_file_hash != self.hash_config():
+            log.info('Config change detected. Reloading.')
             self.load_config(output_to_console=False)
         # Handle --tasks
         if options.tasks:

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -12,6 +12,7 @@ import signal
 import sys
 import threading
 import traceback
+import hashlib
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 import io
@@ -115,6 +116,7 @@ class Manager(object):
             # Decode all arguments to unicode before parsing
             args = unicode_argv()[1:]
         self.args = args
+        self.config_file_hash = None
         self.config_base = None
         self.config_name = None
         self.config_path = None
@@ -241,6 +243,9 @@ class Manager(object):
             options_namespace.__dict__.update(options)
             options = options_namespace
         task_names = self.tasks
+        # Only reload config if daemon
+        if self.is_daemon and self.config_file_hash != self.hash_config():
+            self.load_config(output_to_console=False)
         # Handle --tasks
         if options.tasks:
             # Consider * the same as not specifying tasks at all (makes sure manual plugin still works)
@@ -519,6 +524,16 @@ class Manager(object):
         self.lockfile = os.path.join(self.config_base, '.%s-lock' % self.config_name)
         self.db_filename = os.path.join(self.config_base, 'db-%s.sqlite' % self.config_name)
 
+    def hash_config(self):
+        sha1_hash = hashlib.sha1()
+        with io.open(self.config_path, 'rb') as f:
+            while True:
+                data = f.read(65536)
+                if not data:
+                    break
+                sha1_hash.update(data)
+        return sha1_hash.hexdigest()
+
     def load_config(self, output_to_console=True):
         """
         Loads the config file from disk, validates and activates it.
@@ -533,6 +548,7 @@ class Manager(object):
                 log.critical('Config file must be UTF-8 encoded.')
                 raise ValueError('Config file is not UTF-8 encoded')
         try:
+            self.config_file_hash = self.hash_config()
             config = yaml.safe_load(raw_config) or {}
         except Exception as e:
             msg = str(e).replace('\n', ' ')


### PR DESCRIPTION
### Motivation for changes:
Why not
### Detailed changes:

- On initialization, a sha1 hash of the config file is saved in the manager.
- Before task execution the sha1 hash of the config file is compared to the cached one. Calls `load_config()` if they don't match and `self.is_daemon` is `True`. If new config is invalid, the hash is still saved so it doesn't try to reload it again, but the config changes will be rolled back to the last valid one (as has always been the case)

