### PR TITLE
Fixed trakt images and translations

### DIFF
--- a/flexget/plugins/api/trakt_lookup.py
+++ b/flexget/plugins/api/trakt_lookup.py
@@ -6,7 +6,7 @@ from flask import jsonify
 from flask_restplus import inputs
 
 from flexget.api import api, APIResource
-from flexget.plugins.internal.api_trakt import ApiTrakt as at, list_actors, get_translations
+from flexget.plugins.internal.api_trakt import ApiTrakt as at, list_actors, get_translations_dict
 
 trakt_api = api.namespace('trakt', description='Trakt lookup endpoint')
 
@@ -161,7 +161,7 @@ class TraktSeriesSearchApi(APIResource):
         if include_actors:
             result['actors'] = list_actors(series.actors)
         if include_translations:
-            result['translations'] = get_translations(series.translate)
+            result['translations'] = get_translations_dict(series.translations, 'show')
         return jsonify(result)
 
 
@@ -187,5 +187,5 @@ class TraktMovieSearchApi(APIResource):
         if include_actors:
             result['actors'] = list_actors(movie.actors)
         if include_translations:
-            result['translations'] = get_translations(movie.translate)
+            result['translations'] = get_translations_dict(movie.translations, 'movie')
         return jsonify(result)

--- a/flexget/plugins/api/trakt_lookup.py
+++ b/flexget/plugins/api/trakt_lookup.py
@@ -18,7 +18,8 @@ class objects_container(object):
             "full": {"type": ["string", "null"]},
             "medium": {"type": ["string", "null"]},
             "thumb": {"type": ["string", "null"]}
-        }
+        },
+        'additionalProperties': False
     }
 
     images_object = {
@@ -28,8 +29,11 @@ class objects_container(object):
             "clearart": internal_image_object,
             "fanart": internal_image_object,
             "logo": internal_image_object,
-            "poster": internal_image_object
-        }}
+            "poster": internal_image_object,
+            "thumb": internal_image_object
+        },
+        'additionalProperties': False
+    }
 
     translation_object = {
         'type': 'object',
@@ -39,7 +43,8 @@ class objects_container(object):
                            "overview": {'type': 'string'},
                            "tagline": {'type': 'string'},
                            "title": {'type': 'string'},
-                       }}
+                       },
+                       'additionalProperties': False}
         }
     }
 
@@ -59,8 +64,10 @@ class objects_container(object):
                     "biography": {'type': ['string', 'null']},
                     "homepage": {'type': 'string'},
                     "death": {'type': ['string', 'null']}
-                }
-            }}}
+                },
+                'additionalProperties': False
+            }}
+    }
 
     base_return_object = {
         'type': 'object',
@@ -70,14 +77,23 @@ class objects_container(object):
             'cached_at': {'type': 'string', 'format': 'date-time'},
             'genres': {'type': 'array', 'items': {'type': 'string'}},
             'id': {'type': 'integer'},
-            "overview": {'type': ['string', 'null']},
-            "runtime": {'type': ['integer', 'null']},
-            "rating": {'type': ['number', 'null']},
-            "votes": {'type': ['integer', 'null']},
-            "language": {'type': ['string', 'null']},
-            "updated_at": {'type': 'string', 'format': 'date-time'},
-            "images": images_object
-        }
+            'overview': {'type': ['string', 'null']},
+            'runtime': {'type': ['integer', 'null']},
+            'rating': {'type': ['number', 'null']},
+            'votes': {'type': ['integer', 'null']},
+            'language': {'type': ['string', 'null']},
+            'updated_at': {'type': 'string', 'format': 'date-time'},
+            'images': images_object,
+            'main_image': {'type': ['string', 'null']},
+            'title': {'type': 'string'},
+            'year': {'type': ['integer', 'null']},
+            'homepage': {'type': ['string', 'null']},
+            'slug': {'type': ['string', 'null']},
+            'tmdb_id': {'type': ['integer', 'null']},
+            'imdb_id': {'type': ['string', 'null']}
+
+        },
+        'additionalProperties': False
     }
 
     series_return_object = copy.deepcopy(base_return_object)
@@ -86,15 +102,17 @@ class objects_container(object):
     series_return_object['properties']['first_aired'] = {'type': ['string', 'null'], 'format': 'date-time'}
     series_return_object['properties']['air_day'] = {'type': ['string', 'null']}
     series_return_object['properties']['air_time'] = {'type': ['string', 'null']}
-    series_return_object['properties']['certification'] = {'type': ['string', "null"]}
+    series_return_object['properties']['certification'] = {'type': ['string', 'null']}
     series_return_object['properties']['network'] = {'type': ['string', 'null']}
     series_return_object['properties']['country'] = {'type': ['string', 'null']}
     series_return_object['properties']['status'] = {'type': 'string'}
-    series_return_object['properties']['aired_episodes'] = {'type': 'integer'}
+    series_return_object['properties']['timezone'] = {'type': ['string', 'null']}
+    series_return_object['properties']['number_of_aired_episodes'] = {'type': ['integer', 'null']}
 
     movie_return_object = copy.deepcopy(base_return_object)
     movie_return_object['properties']['tagline'] = {'type': 'string'}
     movie_return_object['properties']['released'] = {'type': 'string'}
+    movie_return_object['properties']['trailer'] = {'type': 'string'}
 
     default_error_object = {
         'type': 'object',
@@ -141,9 +159,9 @@ class TraktSeriesSearchApi(APIResource):
                     }, 404
         result = series.to_dict()
         if include_actors:
-            result["actors"] = list_actors(series.actors)
+            result['actors'] = list_actors(series.actors)
         if include_translations:
-            result["translations"] = get_translations(series.translate)
+            result['translations'] = get_translations(series.translate)
         return jsonify(result)
 
 
@@ -167,7 +185,7 @@ class TraktMovieSearchApi(APIResource):
                     }, 404
         result = movie.to_dict()
         if include_actors:
-            result["actors"] = list_actors(movie.actors)
+            result['actors'] = list_actors(movie.actors)
         if include_translations:
-            result["translations"] = get_translations(movie.translate)
+            result['translations'] = get_translations(movie.translate)
         return jsonify(result)

--- a/flexget/plugins/internal/api_trakt.py
+++ b/flexget/plugins/internal/api_trakt.py
@@ -406,7 +406,18 @@ class TraktActor(Base):
             'trakt_id': self.id,
             'imdb_id': self.imdb,
             'tmdb_id': self.tmdb,
-            'images': list_images(self.images)
+            'images': {
+                'headshot': {
+                    'full': self.image_headshot_full,
+                    'medium': self.image_headshot_medium,
+                    'thumb': self.image_headshot_thumb
+                },
+                'fanart': {
+                    'full': self.image_fanart_full,
+                    'medium': self.image_fanart_medium,
+                    'thumb': self.image_fanart_thumb
+                }
+            }
         }
 
 
@@ -439,13 +450,6 @@ def get_db_actors(ident, style):
     except requests.RequestException as e:
         log.debug('Error searching for actors for trakt id %s', e)
         return
-
-
-def list_images(images):
-    res = {}
-    for image in images:
-        res.setdefault(image.ident, {})[image.style] = image.url
-    return res
 
 
 def get_translations(translate):
@@ -606,7 +610,16 @@ class TraktShow(Base):
             "genres": [g.name for g in self.genres],
             "updated_at": self.updated_at,
             "cached_at": self.cached_at,
-            "images": list_images(self.images)
+            "images": {
+                'poster': {
+                    'full': self.image_poster_full,
+                    'medium': self.image_poster_medium,
+                    'thumb': self.image_poster_thumb
+                },
+                'thumb': {
+                    'full': self.image_thumb_full
+                }
+            }
         }
 
     def __init__(self, trakt_show, session):
@@ -767,7 +780,30 @@ class TraktMovie(Base):
             "genres": [g.name for g in self.genres],
             "updated_at": self.updated_at,
             "cached_at": self.cached_at,
-            "images": list_images(self.images)
+            "images": {
+                'fanart': {
+                    'full': self.image_fanart_full,
+                    'medium': self.image_fanart_medium,
+                    'thumb': self.image_fanart_thumb
+                },
+                'poster': {
+                    'full': self.image_poster_full,
+                    'medium': self.image_poster_medium,
+                    'thumb': self.image_poster_thumb
+                },
+                'logo': {
+                    'full': self.image_logo_full
+                },
+                'clearart': {
+                    'full': self.image_clearart_full
+                },
+                'banner': {
+                    'full': self.image_banner_full
+                },
+                'thumb': {
+                    'full': self.image_thumb_full
+                }
+            }
         }
 
     def update(self, trakt_movie, session):

--- a/flexget/plugins/internal/api_trakt.py
+++ b/flexget/plugins/internal/api_trakt.py
@@ -582,6 +582,12 @@ class TraktShow(Base):
     updated_at = Column(DateTime)
     cached_at = Column(DateTime)
 
+    @property
+    def main_image(self):
+        for size in ['medium', 'full', 'thumb']:
+            if getattr(self, 'image_poster_%s' % size) is not None:
+                return getattr(self, 'image_poster_%s' % size)
+
     def to_dict(self):
         return {
             "id": self.id,
@@ -619,7 +625,8 @@ class TraktShow(Base):
                 'thumb': {
                     'full': self.image_thumb_full
                 }
-            }
+            },
+            "main_image": self.main_image
         }
 
     def __init__(self, trakt_show, session):
@@ -760,6 +767,13 @@ class TraktMovie(Base):
         super(TraktMovie, self).__init__()
         self.update(trakt_movie, session)
 
+    @property
+    def main_image(self):
+        for size in ['medium', 'full', 'thumb']:
+            for type in ['poster', 'fanart']:
+                if getattr(self, 'image_%s_%s' % (type, size)) is not None:
+                    return getattr(self, 'image_%s_%s' % (type, size))
+
     def to_dict(self):
         return {
             "id": self.id,
@@ -780,6 +794,7 @@ class TraktMovie(Base):
             "genres": [g.name for g in self.genres],
             "updated_at": self.updated_at,
             "cached_at": self.cached_at,
+            "main_image": self.main_image,
             "images": {
                 'fanart': {
                     'full': self.image_fanart_full,

--- a/flexget/plugins/internal/api_trakt.py
+++ b/flexget/plugins/internal/api_trakt.py
@@ -1156,7 +1156,7 @@ class ApiTrakt(object):
                 log.debug('Error refreshing movie data from trakt, using cached. %s', e)
                 return movie
             raise
-        movie = session.query(TraktMovie).filter(TraktMovie.id == trakt_movie['ids']['trakt']).first()
+        movie = TraktMovie(trakt_movie, session)
         session.merge(movie)
         if movie and title.lower() == movie.title.lower():
             return movie

--- a/flexget/plugins/internal/api_trakt.py
+++ b/flexget/plugins/internal/api_trakt.py
@@ -174,6 +174,12 @@ def get_access_token(account, token=None, refresh=False, re_auth=False, called_f
                 raise plugin.PluginError('Token exchange with trakt failed: {0}'.format(e))
 
 
+def set_image_attributes(obj, data):
+    for image, images in data['images'].items():
+        for size, url in images.items():
+            setattr(obj, 'image_%s_%s' % (image, size), url)
+
+
 def make_list_slug(name):
     """Return the slug for use in url for given list name."""
     slug = name.lower()
@@ -403,9 +409,7 @@ class TraktActor(Base):
             self.death = dateutil_parse(actor.get('death'))
         self.homepage = actor.get('homepage')
         if actor.get('images'):
-            for image, images in actor['images'].items():
-                for size, url in images.items():
-                    setattr(self, 'image_%s_%s' % (image, size), url)
+            set_image_attributes(self, actor)
 
     def to_dict(self):
         return {
@@ -532,9 +536,7 @@ class TraktEpisode(Base):
         self.tmdb_id = trakt_episode['ids']['tmdb']
         self.tvrage_id = trakt_episode['ids']['tvrage']
         if trakt_episode.get('images'):
-            for image, images in trakt_episode['images'].items():
-                for size, url in images.items():
-                    setattr(self, 'image_%s_%s' % (image, size), url)
+            set_image_attributes(self, trakt_episode)
         self.tvdb_id = trakt_episode['ids']['tvdb']
         self.first_aired = None
         if trakt_episode.get('first_aired'):
@@ -653,9 +655,7 @@ class TraktShow(Base):
         self.tvrage_id = trakt_show['ids']['tvrage']
         self.tvdb_id = trakt_show['ids']['tvdb']
         if trakt_show.get('images'):
-            for image, images in trakt_show['images'].items():
-                for size, url in images.items():
-                    setattr(self, 'image_%s_%s' % (image, size), url)
+            set_image_attributes(self, trakt_show)
         if trakt_show.get('airs'):
             airs = trakt_show.get('airs')
             self.air_day = airs.get('day')
@@ -848,9 +848,7 @@ class TraktMovie(Base):
         self.translations[:] = get_db_trans(trakt_movie.get('available_translations', []), session)
         self.cached_at = datetime.now()
         if trakt_movie.get('images'):
-            for image, images in trakt_movie['images'].items():
-                for size, url in images.items():
-                    setattr(self, 'image_%s_%s' % (image, size), url)
+            set_image_attributes(self, trakt_movie)
 
     @property
     def expired(self):

--- a/flexget/plugins/internal/api_trakt.py
+++ b/flexget/plugins/internal/api_trakt.py
@@ -379,6 +379,13 @@ class TraktActor(Base):
         super(TraktActor, self).__init__()
         self.update(actor, session)
 
+    @property
+    def main_image(self):
+        for size in ['medium', 'full', 'thumb']:
+            for image_type in ['headshot', 'fanart']:
+                if getattr(self, 'image_%s_%s' % (image_type, size)) is not None:
+                    return getattr(self, 'image_%s_%s' % (image_type, size))
+
     def update(self, actor, session):
         if self.id and self.id != actor.get('ids').get('trakt'):
             raise Exception('Tried to update db actors with different actor data')
@@ -417,7 +424,8 @@ class TraktActor(Base):
                     'medium': self.image_fanart_medium,
                     'thumb': self.image_fanart_thumb
                 }
-            }
+            },
+            "main_image": self.main_image
         }
 
 
@@ -770,9 +778,9 @@ class TraktMovie(Base):
     @property
     def main_image(self):
         for size in ['medium', 'full', 'thumb']:
-            for type in ['poster', 'fanart']:
-                if getattr(self, 'image_%s_%s' % (type, size)) is not None:
-                    return getattr(self, 'image_%s_%s' % (type, size))
+            for image_type in ['poster', 'fanart']:
+                if getattr(self, 'image_%s_%s' % (image_type, size)) is not None:
+                    return getattr(self, 'image_%s_%s' % (image_type, size))
 
     def to_dict(self):
         return {

--- a/flexget/plugins/internal/api_trakt.py
+++ b/flexget/plugins/internal/api_trakt.py
@@ -350,7 +350,7 @@ movie_genres_table = Table('trakt_movie_genres', Base.metadata,
 Base.register_table(movie_genres_table)
 
 
-def get_db_genres(genres, session):
+def get_db_genres(genres):
     """Takes a list of genres as strings, returns the database instances for them."""
     db_genres = []
     for genre in genres:
@@ -673,7 +673,7 @@ class TraktShow(Base):
                     'trailer', 'homepage']:
             setattr(self, col, trakt_show.get(col))
 
-        self.genres[:] = get_db_genres(trakt_show.get('genres') or [], session)
+        self.genres[:] = get_db_genres(trakt_show.get('genres') or [])
         self.translations[:] = get_db_trans(trakt_show.get('available_translations') or [], session)
         self.cached_at = datetime.now()
 
@@ -842,7 +842,7 @@ class TraktMovie(Base):
         if trakt_movie.get('released'):
             self.released = dateutil_parse(trakt_movie.get('released'), ignoretz=True)
         self.updated_at = dateutil_parse(trakt_movie.get('updated_at'), ignoretz=True)
-        self.genres[:] = get_db_genres(trakt_movie.get('genres', []), session)
+        self.genres[:] = get_db_genres(trakt_movie.get('genres', []))
         self.translations[:] = get_db_trans(trakt_movie.get('available_translations', []), session)
         self.cached_at = datetime.now()
         if trakt_movie.get('images'):

--- a/flexget/plugins/internal/api_trakt.py
+++ b/flexget/plugins/internal/api_trakt.py
@@ -350,16 +350,6 @@ movie_genres_table = Table('trakt_movie_genres', Base.metadata,
 Base.register_table(movie_genres_table)
 
 
-def get_db_genres(genres):
-    """Takes a list of genres as strings, returns the database instances for them."""
-    db_genres = []
-    for genre in genres:
-        genre = genre.replace('-', ' ')
-        db_genre = TraktGenre(name=genre)
-        db_genres.append(db_genre)
-    return db_genres
-
-
 class TraktActor(Base):
     __tablename__ = 'trakt_actors'
 
@@ -673,7 +663,7 @@ class TraktShow(Base):
                     'trailer', 'homepage']:
             setattr(self, col, trakt_show.get(col))
 
-        self.genres[:] = get_db_genres(trakt_show.get('genres') or [])
+        self.genres = [TraktGenre(name=g.replace(' ', '-')) for g in trakt_show.get('genres', [])]
         self.translations[:] = get_db_trans(trakt_show.get('available_translations') or [], session)
         self.cached_at = datetime.now()
 
@@ -842,7 +832,7 @@ class TraktMovie(Base):
         if trakt_movie.get('released'):
             self.released = dateutil_parse(trakt_movie.get('released'), ignoretz=True)
         self.updated_at = dateutil_parse(trakt_movie.get('updated_at'), ignoretz=True)
-        self.genres[:] = get_db_genres(trakt_movie.get('genres', []))
+        self.genres = [TraktGenre(name=g.replace(' ', '-')) for g in trakt_movie.get('genres', [])]
         self.translations[:] = get_db_trans(trakt_movie.get('available_translations', []), session)
         self.cached_at = datetime.now()
         if trakt_movie.get('images'):

--- a/flexget/plugins/internal/api_trakt.py
+++ b/flexget/plugins/internal/api_trakt.py
@@ -1119,8 +1119,7 @@ class ApiTrakt(object):
                 log.debug('Error refreshing show data from trakt, using cached. %s', e)
                 return series
             raise
-        series = TraktShow(trakt_show, session)
-        session.merge(series)
+        series = session.merge(TraktShow(trakt_show, session))
         if series and title.lower() == series.title.lower():
             return series
         elif series and title and not found:
@@ -1156,8 +1155,7 @@ class ApiTrakt(object):
                 log.debug('Error refreshing movie data from trakt, using cached. %s', e)
                 return movie
             raise
-        movie = TraktMovie(trakt_movie, session)
-        session.merge(movie)
+        movie = session.merge(TraktMovie(trakt_movie, session))
         if movie and title.lower() == movie.title.lower():
             return movie
         if movie and title and not found:

--- a/flexget/plugins/internal/api_trakt.py
+++ b/flexget/plugins/internal/api_trakt.py
@@ -358,6 +358,7 @@ def get_db_genres(genres, session):
         genre = genre.replace('-', ' ')
         db_genre = TraktGenre(name=genre)
         session.merge(db_genre)
+        session.commit()
         db_genres.append(db_genre)
     return db_genres
 

--- a/flexget/plugins/internal/api_trakt.py
+++ b/flexget/plugins/internal/api_trakt.py
@@ -1126,7 +1126,7 @@ class ApiTrakt(object):
         elif series and title and not found:
             if not session.query(TraktShowSearchResult).filter(TraktShowSearchResult.search == title.lower()).first():
                 log.debug('Adding search result to db')
-                session.add(TraktShowSearchResult(search=title, series=series))
+                session.merge(TraktShowSearchResult(search=title, series=series))
         elif series and found:
             log.debug('Updating search result in db')
             found.series = series
@@ -1163,7 +1163,7 @@ class ApiTrakt(object):
         if movie and title and not found:
             if not session.query(TraktMovieSearchResult).filter(TraktMovieSearchResult.search == title.lower()).first():
                 log.debug('Adding search result to db')
-                session.add(TraktMovieSearchResult(search=title, movie=movie))
+                session.merge(TraktMovieSearchResult(search=title, movie=movie))
         elif movie and found:
             log.debug('Updating search result in db')
             found.movie = movie

--- a/flexget/plugins/metainfo/trakt_lookup.py
+++ b/flexget/plugins/metainfo/trakt_lookup.py
@@ -109,7 +109,7 @@ class PluginTraktLookup(object):
         'trakt_actors': lambda show: list_actors(show.actors),
     }
     show_translate_map = {
-        'trakt_translations': lambda show: get_translations(show.translate),
+        'trakt_translations': lambda show: get_translations(show.id, 'show'),
     }
 
     # Episode info
@@ -165,7 +165,7 @@ class PluginTraktLookup(object):
     }
 
     movie_translate_map = {
-        'trakt_translations': lambda movie: get_translations(movie.translate),
+        'trakt_translations': lambda movie: get_translations(movie.id, 'movie'),
     }
 
     movie_actor_map = {

--- a/flexget/plugins/metainfo/trakt_lookup.py
+++ b/flexget/plugins/metainfo/trakt_lookup.py
@@ -10,7 +10,7 @@ from flexget.event import event
 from flexget.manager import Session
 
 try:
-    from flexget.plugins.internal.api_trakt import ApiTrakt, list_actors, list_images, get_translations
+    from flexget.plugins.internal.api_trakt import ApiTrakt, list_actors, get_translations
 
     lookup_series = ApiTrakt.lookup_series
     lookup_movie = ApiTrakt.lookup_movie

--- a/flexget/plugins/metainfo/trakt_lookup.py
+++ b/flexget/plugins/metainfo/trakt_lookup.py
@@ -10,7 +10,7 @@ from flexget.event import event
 from flexget.manager import Session
 
 try:
-    from flexget.plugins.internal.api_trakt import ApiTrakt, list_actors, get_translations
+    from flexget.plugins.internal.api_trakt import ApiTrakt, list_actors, get_translations_dict
 
     lookup_series = ApiTrakt.lookup_series
     lookup_movie = ApiTrakt.lookup_movie
@@ -109,7 +109,7 @@ class PluginTraktLookup(object):
         'trakt_actors': lambda show: list_actors(show.actors),
     }
     show_translate_map = {
-        'trakt_translations': lambda show: get_translations(show.id, 'show'),
+        'trakt_translations': lambda show: get_translations_dict(show.translations, 'show'),
     }
 
     # Episode info
@@ -165,7 +165,7 @@ class PluginTraktLookup(object):
     }
 
     movie_translate_map = {
-        'trakt_translations': lambda movie: get_translations(movie.id, 'movie'),
+        'trakt_translations': lambda movie: get_translations_dict(movie.translations, 'movie'),
     }
 
     movie_actor_map = {

--- a/flexget/plugins/metainfo/trakt_lookup.py
+++ b/flexget/plugins/metainfo/trakt_lookup.py
@@ -155,7 +155,7 @@ class PluginTraktLookup(object):
         'trakt_fanart_full': 'image_fanart_full',
         'trakt_fanart_medium': 'image_fanart_medium',
         'trakt_fanart_thumb': 'image_fanart_thumb',
-        'trakt_poster_full': 'image__poster_full',
+        'trakt_poster_full': 'image_poster_full',
         'trakt_poster_medium': 'image_poster_medium',
         'trakt_poster_thumb': 'image_poster_thumb',
         'trakt_logo': 'image_logo_full',

--- a/flexget/plugins/metainfo/trakt_lookup.py
+++ b/flexget/plugins/metainfo/trakt_lookup.py
@@ -98,7 +98,10 @@ class PluginTraktLookup(object):
         'trakt_series_language': 'language',
         'trakt_series_aired_episodes': 'aired_episodes',
         'trakt_series_episodes': lambda show: [episodes.title for episodes in show.episodes],
-        'trakt_series_images': lambda im: list_images(im.images),
+        'trakt_series_poster_full': 'image_poster_full',
+        'trakt_series_poster_medium': 'image_poster_medium',
+        'trakt_series_poster_thumb': 'image_poster_thumb',
+        'trakt_series_thumb': 'image_thumb_full',
         'trakt_languages': lambda i: [t.name for t in i.translations],
     }
 
@@ -123,7 +126,9 @@ class PluginTraktLookup(object):
         'trakt_season': 'season',
         'trakt_episode': 'number',
         'trakt_ep_id': lambda ep: 'S%02dE%02d' % (ep.season, ep.number),
-        'trakt_ep_images': lambda im: list_images(im.images),
+        'trakt_ep_screenshot_full': 'image_screenshot_full',
+        'trakt_ep_screenshot_medium': 'image_screenshot_medium',
+        'trakt_ep_screenshot_thumb': 'image_screenshot_thumb',
     }
 
     # Movie info
@@ -146,8 +151,17 @@ class PluginTraktLookup(object):
         'trakt_trailer': 'trailer',
         'trakt_language': 'language',
         'trakt_genres': lambda i: [db_genre.name for db_genre in i.genres],
-        'trakt_images': lambda im: list_images(im.images),
-        'trakt_languages': lambda i: [t.name for t in i.translations]
+        'trakt_languages': lambda i: [t.name for t in i.translations],
+        'trakt_fanart_full': 'image_fanart_full',
+        'trakt_fanart_medium': 'image_fanart_medium',
+        'trakt_fanart_thumb': 'image_fanart_thumb',
+        'trakt_poster_full': 'image__poster_full',
+        'trakt_poster_medium': 'image_poster_medium',
+        'trakt_poster_thumb': 'image_poster_thumb',
+        'trakt_logo': 'image_logo_full',
+        'trakt_clearart': 'image_clearart_full',
+        'trakt_banner': 'image_banner_full',
+        'trakt_thumb': 'image_thumb_full'
     }
 
     movie_translate_map = {

--- a/flexget/plugins/metainfo/trakt_lookup.py
+++ b/flexget/plugins/metainfo/trakt_lookup.py
@@ -102,7 +102,7 @@ class PluginTraktLookup(object):
         'trakt_series_poster_medium': 'image_poster_medium',
         'trakt_series_poster_thumb': 'image_poster_thumb',
         'trakt_series_thumb': 'image_thumb_full',
-        'trakt_languages': lambda i: [t.name for t in i.translations],
+        'trakt_languages': 'translation_languages',
     }
 
     series_actor_map = {
@@ -151,7 +151,7 @@ class PluginTraktLookup(object):
         'trakt_trailer': 'trailer',
         'trakt_language': 'language',
         'trakt_genres': lambda i: [db_genre.name for db_genre in i.genres],
-        'trakt_languages': lambda i: [t.name for t in i.translations],
+        'trakt_languages': 'translation_languages',
         'trakt_fanart_full': 'image_fanart_full',
         'trakt_fanart_medium': 'image_fanart_medium',
         'trakt_fanart_thumb': 'image_fanart_thumb',

--- a/flexget/ui/src/plugins/movies/components/movie-entry/movie-entry.tmpl.html
+++ b/flexget/ui/src/plugins/movies/components/movie-entry/movie-entry.tmpl.html
@@ -1,6 +1,6 @@
 <md-card class="movie-entry">
   <div class="movie-poster">
-    <img ng-src="/api/cached/?url={{ ::vm.metadata.images.poster.medium }}"/>
+    <img ng-src="/api/cached/?url={{ ::vm.metadata.main_image }}"/>
   </div>
   <div class="movie-info">
     <h3>{{ ::vm.movie.title }} ({{ ::vm.movie.year }})


### PR DESCRIPTION
### Motivation for changes:
Crash logs are not fun
### Detailed changes:

- Removed image tables and hardcoded images as columns. Gonna suck if they change the format.
- Changed translations to many-to-one instead of m2m. Much saner.

### Addressed issues:

- Fixes #1191.
