### PR TITLE
Upgrade guessit to 2.1.0 (dependency constraint removed)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,12 +11,11 @@ rpyc
 jinja2
 # There is a bug in requests 2.4.0 where it leaks urllib3 exceptions
 requests>=2.8.0, <3.0
-#Guessit requires python-dateutil<=2.5.2
 python-dateutil>=2.5.2
 jsonschema>=2.0
 path.py>=8.1.1
 pathlib>=1.0
-guessit<=2.0.4
+guessit>=2.1.0
 apscheduler>=3.2.0
 terminaltables>=3.0.0
 colorclass>=2.2.0


### PR DESCRIPTION
### Motivation for changes:

Use guessit 2.1.0 as it contains many fixes since 2.0.4.
### Detailed changes:

guessit 2.1.0 removes the version constraint on python-dateutils module while keeping the previous behavior for date guessing. That's the reason guessit was locked to an older version. see https://github.com/guessit-io/guessit/issues/329 and https://github.com/guessit-io/guessit/issues/291
### Addressed issues:
- Fixes #1072 . (and maybe others)
