### PR TITLE
add ssl support to webserver

### DIFF
--- a/flexget/webserver.py
+++ b/flexget/webserver.py
@@ -235,11 +235,11 @@ class WebServer(threading.Thread):
             host = '127.0.0.1'
 
         if self.ssl_certificate and self.ssl_private_key:
-            proto = 'https'
+            protocol = 'https'
         else:
-            proto = 'http'
+            protocol = 'http'
 
-        log.info('Web interface available at %s://%s:%s' % (proto, host, self.port))
+        log.info('Web interface available at %s://%s:%s' % (protocol, host, self.port))
 
         # Start the CherryPy WSGI web server
         cherrypy.engine.start()

--- a/flexget/webserver.py
+++ b/flexget/webserver.py
@@ -39,7 +39,11 @@ web_config_schema = {
                 'ssl_certificate': {'type': 'string', 'format': 'string', 'default': ''},
                 'ssl_private_key': {'type': 'string', 'format': 'string', 'default': ''},
             },
-            'additionalProperties': False
+            'additionalProperties': False,
+            'dependencies': {
+                'ssl_certificate': ['ssl_private_key'],
+                'ssl_private_key': ['ssl_certificate'],
+            }
         }
     ]
 }
@@ -75,7 +79,6 @@ def get_secret(session=None):
 
 
 class WeakPassword(Exception):
-
     def __init__(self, value, logger=log, **kwargs):
         super(WeakPassword, self).__init__()
         # Value is expected to be a string
@@ -232,9 +235,11 @@ class WebServer(threading.Thread):
             host = '127.0.0.1'
 
         if self.ssl_certificate and self.ssl_private_key:
-            log.info('Web interface available at https://%s:%s' % (host, self.port))
+            proto = 'https'
         else:
-            log.info('Web interface available at http://%s:%s' % (host, self.port))
+            proto = 'http'
+
+        log.info('Web interface available at %s://%s:%s' % (proto, host, self.port))
 
         # Start the CherryPy WSGI web server
         cherrypy.engine.start()

--- a/flexget/webserver.py
+++ b/flexget/webserver.py
@@ -239,7 +239,7 @@ class WebServer(threading.Thread):
         else:
             protocol = 'http'
 
-        log.info('Web interface available at %s://%s:%s' % (protocol, host, self.port))
+            log.info('Web interface available at %s://%s:%s', protocol, host, self.port)
 
         # Start the CherryPy WSGI web server
         cherrypy.engine.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,4 +31,4 @@ flask-cors>=2.1.2
 pyparsing>=2.0.3
 Safe>=0.4
 future>=0.15.2
-
+pyopenssl>=16.1.0


### PR DESCRIPTION
### Motivation for changes:

- remote access to flexget

### Detailed changes:

- add ssl support to webserver.py (cherrypy)

### Config usage if relevant (new plugin or updated schema):
```
web_server:
  bind: 0.0.0.0
  port: 3539
  ssl_certificate: '/etc/ssl/private/myCert.pem'
  ssl_private_key: '/etc/ssl/private/myKey.key'
api: yes
webui: yes
```

