### PR TITLE
Change config hash to use pprint

### DIFF
--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1638,10 +1638,9 @@ class SeriesDBManager(FilterSeriesBase):
 
     @plugin.priority(0)
     def on_task_start(self, task, config):
-        # TODO: broken currently, add new series to config and reload -> config is not changed?!
-        #if not task.config_modified:
-        #    log.trace('not task.config_modified, returning')
-        #    return
+        if not task.config_modified:
+            log.trace('not task.config_modified, returning')
+            return
 
         # Clear all series from this task
         with Session() as session:

--- a/flexget/plugins/operate/configure_series.py
+++ b/flexget/plugins/operate/configure_series.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # pylint: disable=unused-import, redefined-builtin
 
-import hashlib
 import logging
 
 from sqlalchemy import Column, Integer, Unicode
@@ -12,7 +11,7 @@ from flexget.event import event
 from flexget.manager import Session
 from flexget.plugin import PluginError
 from flexget.plugins.filter.series import FilterSeriesBase
-from flexget.utils.cached_input import get_config_hash
+from flexget.utils.tools import get_config_hash
 
 log = logging.getLogger('configure_series')
 Base = db_schema.versioned_base('import_series', 0)

--- a/flexget/plugins/operate/configure_series.py
+++ b/flexget/plugins/operate/configure_series.py
@@ -12,6 +12,7 @@ from flexget.event import event
 from flexget.manager import Session
 from flexget.plugin import PluginError
 from flexget.plugins.filter.series import FilterSeriesBase
+from flexget.utils.cached_input import get_config_hash
 
 log = logging.getLogger('configure_series')
 Base = db_schema.versioned_base('import_series', 0)
@@ -90,7 +91,7 @@ class ConfigureSeries(FilterSeriesBase):
                             s[key] = entry['configure_series_' + key]
 
         # Set the config_modified flag if the list of shows changed since last time
-        new_hash = str(hashlib.md5(str(sorted(series)).encode('utf-8')).hexdigest())
+        new_hash = get_config_hash(series)
         with Session() as session:
             last_hash = session.query(LastHash).filter(LastHash.task == task.name).first()
             if not last_hash:

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -21,10 +21,9 @@ from flexget.plugin import plugins as all_plugins
 from flexget.plugin import (
     DependencyError, get_plugins, phase_methods, plugin_schemas, PluginError, PluginWarning, task_phases)
 from flexget.utils import requests
-from flexget.utils.cached_input import get_config_hash
 from flexget.utils.database import with_session
 from flexget.utils.simple_persistence import SimpleTaskPersistence
-from flexget.utils.tools import merge_dict_from_to
+from flexget.utils.tools import merge_dict_from_to, get_config_hash
 
 log = logging.getLogger('task')
 Base = db_schema.versioned_base('feed', 0)

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -565,7 +565,8 @@ class Task(object):
             for template, value in self.manager.config.get('templates', {}).items():
                 if isinstance(templates, basestring) or isinstance(templates, list) and template in templates:
                     task_templates.update({template: value})
-            hashable_config = merge_dict_from_to(task_templates, copy.deepcopy(self.config))
+            hashable_config = copy.deepcopy(self.config)
+            merge_dict_from_to(task_templates, hashable_config)
             config_hash = get_config_hash(hashable_config)
             last_hash = session.query(TaskConfigHash).filter(TaskConfigHash.task == self.name).first()
             if self.is_rerun:

--- a/flexget/utils/cached_input.py
+++ b/flexget/utils/cached_input.py
@@ -1,24 +1,21 @@
 from __future__ import unicode_literals, division, absolute_import
-from builtins import *  # pylint: disable=unused-import, redefined-builtin
 
 import copy
 import logging
-import hashlib
 import pickle
 from datetime import datetime, timedelta
-from pprint import pformat
 
-from sqlalchemy.orm import relation
-from sqlalchemy import Column, Integer, String, DateTime, Unicode, select, ForeignKey
-
+from builtins import *  # pylint: disable=unused-import, redefined-builtin
 from flexget import db_schema
+from flexget.event import event
 from flexget.manager import Session
+from flexget.plugin import PluginError
 from flexget.utils import json
 from flexget.utils.database import entry_synonym
-from flexget.utils.tools import parse_timedelta, TimedDict
-from flexget.event import event
-from flexget.plugin import PluginError
 from flexget.utils.sqlalchemy_utils import table_schema, table_add_column
+from flexget.utils.tools import parse_timedelta, TimedDict, get_config_hash
+from sqlalchemy import Column, Integer, String, DateTime, Unicode, select, ForeignKey
+from sqlalchemy.orm import relation
 
 log = logging.getLogger('input_cache')
 Base = db_schema.versioned_base('input_cache', 1)
@@ -69,18 +66,6 @@ def db_cleanup(manager, session):
     result = session.query(InputCache).filter(InputCache.added < datetime.now() - timedelta(days=7)).delete()
     if result:
         log.verbose('Removed %s old input caches.' % result)
-
-
-def get_config_hash(config):
-    """
-    :param dict config: Configuration
-    :return: MD5 hash for *config*
-    """
-    if isinstance(config, dict) or isinstance(config, list):
-        # this does in fact support nested dicts, they're sorted too!
-        return hashlib.md5(pformat(config).encode('utf-8')).hexdigest()
-    else:
-        return hashlib.md5(str(config).encode('utf-8')).hexdigest()
 
 
 class cached(object):

--- a/flexget/utils/cached_input.py
+++ b/flexget/utils/cached_input.py
@@ -6,6 +6,7 @@ import logging
 import hashlib
 import pickle
 from datetime import datetime, timedelta
+from pprint import pformat
 
 from sqlalchemy.orm import relation
 from sqlalchemy import Column, Integer, String, DateTime, Unicode, select, ForeignKey
@@ -70,14 +71,14 @@ def db_cleanup(manager, session):
         log.verbose('Removed %s old input caches.' % result)
 
 
-def config_hash(config):
+def get_config_hash(config):
     """
     :param dict config: Configuration
     :return: MD5 hash for *config*
     """
-    if isinstance(config, dict):
+    if isinstance(config, dict) or isinstance(config, list):
         # this does in fact support nested dicts, they're sorted too!
-        return hashlib.md5(str(sorted(config.items())).encode('utf-8')).hexdigest()
+        return hashlib.md5(pformat(config).encode('utf-8')).hexdigest()
     else:
         return hashlib.md5(str(config).encode('utf-8')).hexdigest()
 
@@ -118,9 +119,9 @@ class cached(object):
                 # get name for a cache from tasks configuration
                 if self.name not in task.config:
                     raise Exception('@cache config name %s is not configured in task %s' % (self.name, task.name))
-                hash = config_hash(task.config[self.name])
+                hash = get_config_hash(task.config[self.name])
             else:
-                hash = config_hash(args[2])
+                hash = get_config_hash(args[2])
 
             log.trace('self.name: %s' % self.name)
             log.trace('hash: %s' % hash)

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -1,5 +1,8 @@
 """Contains miscellaneous helpers"""
 from __future__ import unicode_literals, division, absolute_import
+
+from pprint import pformat
+
 from builtins import *  # pylint: disable=unused-import, redefined-builtin
 from future.moves.urllib import request
 from future.utils import PY2
@@ -525,3 +528,15 @@ def trim_dir(directory):
     file_name = os.path.join(directory, files[0])
     log.debug('removing least accessed file: %s', file_name)
     os.remove(file_name)
+
+
+def get_config_hash(config):
+    """
+    :param dict config: Configuration
+    :return: MD5 hash for *config*
+    """
+    if isinstance(config, dict) or isinstance(config, list):
+        # this does in fact support nested dicts, they're sorted too!
+        return hashlib.md5(pformat(config).encode('utf-8')).hexdigest()
+    else:
+        return hashlib.md5(str(config).encode('utf-8')).hexdigest()

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -1,8 +1,5 @@
 """Contains miscellaneous helpers"""
 from __future__ import unicode_literals, division, absolute_import
-
-from pprint import pformat
-
 from builtins import *  # pylint: disable=unused-import, redefined-builtin
 from future.moves.urllib import request
 from future.utils import PY2
@@ -21,6 +18,7 @@ import sys
 import io
 from collections import MutableMapping
 from datetime import timedelta, datetime
+from pprint import pformat
 
 import flexget
 import queue


### PR DESCRIPTION
### Motivation for changes:
Current method for hashing the config falls apart when the config is nested dicts.
### Detailed changes:

- Changed it to use pprint.pformat

### Related issues

- Fixes #1406

