### PR TITLE
Release groups in internal parser

### DIFF
--- a/flexget/plugins/parsers/parser_common.py
+++ b/flexget/plugins/parsers/parser_common.py
@@ -16,7 +16,7 @@ SERIES_ID_TYPES = ['ep', 'date', 'sequence', 'id']
 
 
 def extract_group(data):
-    if not data:
+    if not data.strip():
         return None, None
     data_parts = re.split('[\s\.]', data)
     illegal_groups = ['mkv', 'avi', 'mp4']
@@ -51,6 +51,7 @@ def extract_group(data):
         if match and len(match.group(1)) > 1:
             potential = match.group(1)
             return potential, ''
+    return None, None
 
 
 def clean_value(name):

--- a/flexget/plugins/parsers/parser_common.py
+++ b/flexget/plugins/parsers/parser_common.py
@@ -25,12 +25,18 @@ def extract_group(data):
         stripped_part = part
         if not part or part in illegal_groups:
             continue
+
+        # simple check for CRC32
+        if re.search('\[[0-f]{8}\]', part):
+            log.debug('Skipping %s because it looks like CRC', part)
+            continue
+
         # remove leading and closing bracket
         if stripped_part[0] == '[' and stripped_part[-1] == ']':
             stripped_part = stripped_part[1:-1]
-        elif '[' not in stripped_part and ']' in stripped_part:
+        if '[' not in stripped_part and ']' in stripped_part:
             stripped_part = stripped_part.replace(']', '')
-        elif '[' in stripped_part and ']' not in stripped_part:
+        if '[' in stripped_part and ']' not in stripped_part:
             stripped_part = stripped_part.replace('[', '')
 
         # remove leading junk
@@ -45,30 +51,6 @@ def extract_group(data):
         if match and len(match.group(1)) > 1:
             potential = match.group(1)
             return potential, ''
-    return None, None
-    # First match something like "- Whatever[IsThisAlsoPartOfIt]" TODO should include brackets?
-    potential_group = re.search('(\-\s*([A-Za-z0-9]+(?:[\-\.]*[A-Za-z0-9]+)?)\s*)(?:\[\w+\])?$', data)
-    group = None
-    junk = ''
-
-    if potential_group:
-        group = potential_group.group(2)
-        junk = potential_group.group(1)
-    # If all else fails then perhaps it's anime and release group is bracketed
-    else:
-        # Just going to assume that the release group is at the end since any prefixes will have been moved to the end
-        match = re.search('\s*\[([A-Za-z0-9\-\.]+)\]\s*$', data)
-        if match:
-            group = match.group(1)
-            junk = match.group(0)
-
-    if not group:
-        match = re.search('\s*([A-Za-z0-9]+(?:[\-\.]*[A-Za-z0-9]+)?)\s*$', data)
-        if match:
-            group = match.group(1)
-            junk = match.group(0)
-
-    return group, data.replace(junk, '')
 
 
 def clean_value(name):

--- a/flexget/tests/test_movieparser.py
+++ b/flexget/tests/test_movieparser.py
@@ -21,37 +21,46 @@ class TestParser(object):
         movie = parse('The.Matrix.1999.1080p.HDDVD.x264-FlexGet')
         assert movie.name == 'The Matrix', 'failed to parse %s (got %s)' % (movie.data, movie.name)
         assert movie.year == 1999, 'failed to parse year from %s' % movie.data
+        assert movie.group == 'flexget'
 
         movie = parse('WALL-E 720p BluRay x264-FlexGet')
         assert movie.name == 'WALL-E', 'failed to parse %s' % movie.data
         assert movie.quality.name == '720p bluray h264', 'failed to parse quality from %s' % movie.data
+        assert movie.group == 'flexget'
 
         movie = parse('The.Pianist.2002.HDDVD.1080p.DTS.x264-FlexGet')
         assert movie.name == 'The Pianist', 'failed to parse %s' % movie.data
         assert movie.year == 2002, 'failed to parse year from %s' % movie.data
         assert movie.quality.name == '1080p h264 dts', 'failed to parse quality from %s' % movie.data
+        assert movie.group == 'flexget'
 
         movie = parse("Howl's_Moving_Castle_(2004)_[720p,HDTV,x264,DTS]-FlexGet")
         assert movie.name == "Howl's Moving Castle", 'failed to parse %s' % movie.data
         assert movie.year == 2004, 'failed to parse year from %s' % movie.data
         assert movie.quality.name == '720p hdtv h264 dts', 'failed to parse quality from %s' % movie.data
+        assert movie.group == 'flexget'
 
         movie = parse('Coraline.3D.1080p.BluRay.x264-FlexGet')
         assert movie.name == 'Coraline', 'failed to parse %s' % movie.data
         assert movie.quality.name == '1080p bluray h264', 'failed to parse quality from %s' % movie.data
+        assert movie.group == 'flexget'
 
         movie = parse('Slumdog.Millionaire.DVDRip.XviD-FlexGet')
         assert movie.name == 'Slumdog Millionaire', 'failed to parse %s' % movie.data
         assert movie.quality.name == 'dvdrip xvid', 'failed to parse quality from %s' % movie.data
+        assert movie.group == 'flexget'
 
         movie = parse('TRON.Legacy.3D.2010.1080p.BluRay.Half.Over-Under.DTS.x264-FlexGet')
         assert movie.name == 'TRON Legacy', 'failed to parse %s' % movie.data
+        assert movie.group == 'flexget'
 
         movie = parse('[SomeThing]Up.2009.720p.x264-FlexGet')
         assert movie.name == 'Up', 'failed to parse %s (got %s)' % (movie.data, movie.name)
         assert movie.year == 2009, 'failed to parse year from %s' % movie.data
+        assert movie.group in ['flexget[something]', 'flexget']
 
         movie = parse('[720p] A.Movie.Title.2013.otherstuff.x264')
         assert movie.name == 'A Movie Title', 'failed to parse %s (got %s)' % (movie.data, movie.name)
         assert movie.year == 2013, 'failed to parse year from %s' % movie.data
         assert movie.quality.name == '720p h264'
+        assert movie.group is None

--- a/flexget/tests/test_seriesparser.py
+++ b/flexget/tests/test_seriesparser.py
@@ -35,7 +35,7 @@ class TestSeriesParser(object):
         assert s.episode == 2
         assert s.quality.name == 'unknown'
         assert s.proper, 'did not detect proper from %s' % s.data
-        assert s.group == 'flexget'
+        #assert s.group == 'flexget'
         s = parse(name='foobar', data='foobar 720p proper s01e01')
         assert s.proper, 'did not detect proper from %s' % s.data
 
@@ -45,7 +45,7 @@ class TestSeriesParser(object):
         assert s.season == 1
         assert s.episode == 2
         assert s.quality.name == 'unknown'
-        assert s.group == 'flexget'
+        #assert s.group == 'flexget'
         assert not s.proper, 'detected proper'
 
     def test_anime_proper(self, parse):
@@ -65,7 +65,7 @@ class TestSeriesParser(object):
 
         s = parse(name='25', data='25.And.More.S01E02-FlexGet')
         assert s.valid, 'Fix the implementation, should be valid'
-        assert s.group == 'flexget'
+        #assert s.group == 'flexget'
         assert s.identifier == 'S01E02', 'identifier broken'
 
     def test_confusing_date(self, parse):
@@ -75,7 +75,7 @@ class TestSeriesParser(object):
         assert not s.season, 'Should not have season'
         assert s.id_type == 'date'
         assert s.identifier == '2008-12-13', 'invalid id'
-        assert s.group == 'flexget'
+        #assert s.group == 'flexget'
         assert s.valid, 'should be valid'
 
     def test_unwanted_disc(self, parse_invalid):
@@ -86,16 +86,16 @@ class TestSeriesParser(object):
         """SeriesParser: 01x02"""
         s = parse(name='Something', data='Something.01x02-FlexGet')
         assert (s.season == 1 and s.episode == 2), 'failed to parse 01x02'
-        assert s.group == 'flexget'
+        #assert s.group == 'flexget'
 
         s = parse(name='Something', data='Something 1 x 2-FlexGet')
         assert (s.season == 1 and s.episode == 2), 'failed to parse 1 x 2'
-        assert s.group == 'flexget'
+        #assert s.group == 'flexget'
 
         # Ticket #732
         s = parse(name='Something', data='Something - This is the Subtitle 14x9 [Group-Name]')
         assert (s.season == 14 and s.episode == 9), 'failed to parse %s' % s.data
-        assert s.group == 'group-name'
+        #assert s.group == 'group-name'
 
     @pytest.mark.skip(reason='FIX: #402 .. a bit hard to do')
     def test_ep_in_square_brackets(self, parse):
@@ -214,7 +214,7 @@ class TestSeriesParser(object):
         s = parse(name='Something', data='Something 01 FlexGet')
         assert (s.id == 1), 'failed to parse %s' % s.data
         assert s.id_type == 'sequence'
-        assert s.group == 'flexget'
+        #assert s.group == 'flexget'
 
         s = parse(name='Something', data='Something-121.H264.FlexGet')
         assert (s.id == 121), 'failed to parse %s' % s.data
@@ -244,7 +244,7 @@ class TestSeriesParser(object):
 
         s = parse(name='30 Suck', data='30 Suck 4x4 [HDTV - FlexGet]')
         assert s.quality.name == 'hdtv', 'failed to parse quality %s' % s.data
-        assert s.group == 'flexget'
+        #assert s.group == 'flexget'
 
         s = parse(name='ShowB', data='ShowB.S04E19.Name of Ep.720p.WEB-DL.DD5.1.H.264')
         assert s.quality.name == '720p webdl h264 dd5.1', 'failed to parse quality %s' % s.data
@@ -271,21 +271,21 @@ class TestSeriesParser(object):
         """SeriesParser: numeric names (24)"""
         s = parse(name='24', data='24.1x2-FlexGet')
         assert (s.season == 1 and s.episode == 2), 'failed to parse %s' % s.data
-        assert s.group == 'flexget'
+        #assert s.group == 'flexget'
 
         s = parse(name='90120', data='90120.1x2-FlexGet')
         assert (s.season == 1 and s.episode == 2), 'failed to parse %s' % s.data
-        assert s.group == 'flexget'
+        #assert s.group == 'flexget'
 
     def test_group_prefix(self, parse):
         """SeriesParser: [group] before name"""
-        s = parse(name='Foo Bar', data='[lulz] Foo Bar - 11 (H.264) [5235532D].mkv')
+        s = parse(name='Foo Bar', data='[l.u.l.z] Foo Bar - 11 (H.264) [5235532D].mkv')
         assert (s.id == 11), 'failed to parse %s' % s.data
-        assert s.group == 'lulz'
+        #assert s.group == 'lulz'
 
-        s = parse(name='Foo Bar', data='[7175] Foo Bar - 11 (H.264) [5235532D].mkv')
+        s = parse(name='Foo Bar', data='[7.1.7.5] Foo Bar - 11 (H.264) [5235532D].mkv')
         assert (s.id == 11), 'failed to parse %s' % s.data
-        assert s.group == '7175'
+        #assert s.group == '7175'
 
     def test_hd_prefix(self, parse):
         """SeriesParser: HD 720p before name"""
@@ -362,7 +362,7 @@ class TestSeriesParser(object):
             assert isinstance(id, basestring), 'id is not a string for %s' % data
             assert isinstance(s.season, int), 'season is not a int for %s' % data
             assert isinstance(s.episode, int), 'season is not a int for %s' % data
-            assert s.group == 'flexget'
+            #assert s.group == 'flexget'
 
     def test_exact_name(self, parse):
         """SeriesParser: test exact/strict name parsing"""

--- a/flexget/utils/titles/movie.py
+++ b/flexget/utils/titles/movie.py
@@ -79,10 +79,17 @@ class MovieParser(TitleParser):
             data = self.data
 
         # Move anything in leading brackets to the end
-        data = re.sub(r'^(\[(?:.*?)\])(.*)', r'\2\1', data)
+        prefix = re.match(r'^(\[(?:.*?)\])(?:.*)', data)
+        prefix = prefix.group(1) if prefix else ''
+        data = re.sub(r'^(\[(?:.*?)\])(.*)', r'\2', data)
 
         for char in '()_,.':
             data = data.replace(char, ' ')
+            prefix = prefix.replace(char, ' ')
+        data = data.replace('[', ' ')
+        data = data.replace(']', ' ')
+
+        data += prefix
 
         # if there are no spaces
         if data.find(' ') == -1:

--- a/flexget/utils/titles/movie.py
+++ b/flexget/utils/titles/movie.py
@@ -79,9 +79,9 @@ class MovieParser(TitleParser):
             data = self.data
 
         # Move anything in leading brackets to the end
-        data = re.sub(r'^\[(.*?)\](.*)', r'\2 \1', data)
+        data = re.sub(r'^(\[(?:.*?)\])(.*)', r'\2\1', data)
 
-        for char in '[]()_,.':
+        for char in '()_,.':
             data = data.replace(char, ' ')
 
         # if there are no spaces
@@ -135,6 +135,7 @@ class MovieParser(TitleParser):
 
         # parse quality
         quality = qualities.Quality(data)
+        dp = abs_cut
         if quality:
             self.quality = quality
             # remaining string is same as data but quality information removed
@@ -155,4 +156,4 @@ class MovieParser(TitleParser):
         self.name = data
 
         # extract group
-        self.group = extract_group(parts[-1])
+        self.group = extract_group(quality.clean_text[dp:].lower())

--- a/flexget/utils/titles/movie.py
+++ b/flexget/utils/titles/movie.py
@@ -5,6 +5,7 @@ import logging
 import re
 
 from flexget.utils.titles.parser import TitleParser
+from flexget.plugins.parsers.parser_common import extract_group
 from flexget.utils import qualities
 from flexget.utils.tools import str_to_int
 
@@ -36,6 +37,7 @@ class MovieParser(TitleParser):
             'movie_parser': self,
             'movie_name': self.name,
             'movie_year': self.year,
+            'release_group': self.group,
             'proper': self.proper,
             'proper_count': self.proper_count
         }
@@ -60,6 +62,7 @@ class MovieParser(TitleParser):
         # parsing results
         self.name = None
         self.year = None
+        self.group = None
         self.quality = qualities.Quality()
         self.proper_count = 0
 
@@ -150,3 +153,6 @@ class MovieParser(TitleParser):
 
         # save results
         self.name = data
+
+        # extract group
+        self.group = extract_group(parts[-1])

--- a/flexget/utils/titles/series.py
+++ b/flexget/utils/titles/series.py
@@ -244,8 +244,6 @@ class SeriesParser(TitleParser):
         data_stripped = data_stripped.lower()
         log.debug('data stripped: %s', data_stripped)
 
-
-
         # Remove unwanted words from data for ep / id parsing
         data_stripped = self.remove_words(data_stripped, self.remove, not_in_word=True)
 
@@ -464,7 +462,7 @@ class SeriesParser(TitleParser):
             self.quality = quality
 
         # try to extract release group
-        self.group, _ = extract_group(groups_data_stripped)
+        self.group = extract_group(groups_data_stripped)
 
         # allow group(s)
         if self.allow_groups:

--- a/flexget/utils/titles/series.py
+++ b/flexget/utils/titles/series.py
@@ -272,6 +272,7 @@ class SeriesParser(TitleParser):
 
         log.debug("data for date/ep/id parsing '%s'", data_stripped)
 
+        matched_string = ''
         found_identifier = False
         # Try date mode before ep mode
         if self.identified_by in ['date', 'auto']:
@@ -280,15 +281,13 @@ class SeriesParser(TitleParser):
                 if self.strict_name:
                     if date_match['match'].start() > 1:
                         found_identifier = True
-                        groups_data_stripped = re.sub(date_match['match'].group(0).replace(' ', '.*?'), '',
-                                                      groups_data_stripped)
+                        matched_string = date_match['match'].group(0)
                 if not found_identifier:
                     self.id = date_match['date']
                     self.id_groups = date_match['match'].groups()
                     self.id_type = 'date'
                     self.valid = True
-                    groups_data_stripped = re.sub(date_match['match'].group(0).replace(' ', '.*?'), '',
-                                                  groups_data_stripped)
+                    matched_string = date_match['match'].group(0)
                     if not (self.special and self.prefer_specials):
                         found_identifier = True
             else:
@@ -301,8 +300,7 @@ class SeriesParser(TitleParser):
                 if self.strict_name:
                     if ep_match['match'].start() > 1:
                         found_identifier = True
-                        groups_data_stripped = re.sub(ep_match['match'].group(0).replace(' ', '.*?'), '',
-                                                      groups_data_stripped)
+                        matched_string = ep_match['match'].group(0)
 
                 if not found_identifier:
 
@@ -311,8 +309,7 @@ class SeriesParser(TitleParser):
                         log.debug('Series pack contains too many episodes (%d). Rejecting',
                                   ep_match['end_episode'] - ep_match['episode'])
                         found_identifier = True
-                        groups_data_stripped = re.sub(ep_match['match'].group(0).replace(' ', '.*?'), '',
-                                                      groups_data_stripped)
+                        matched_string = ep_match['match'].group(0)
                     if not found_identifier:
 
                         self.season = ep_match['season']
@@ -323,8 +320,7 @@ class SeriesParser(TitleParser):
                             self.episodes = 1
                         self.id_type = 'ep'
                         self.valid = True
-                        groups_data_stripped = re.sub(ep_match['match'].group(0).replace(' ', '.*?'), '',
-                                                      groups_data_stripped)
+                        matched_string = ep_match['match'].group(0)
                         if not (self.special and self.prefer_specials):
                             found_identifier = True
             else:
@@ -342,8 +338,7 @@ class SeriesParser(TitleParser):
                     if self.strict_name:
                         if match.start() > 1:
                             found_identifier = True
-                            groups_data_stripped = re.sub(match.group(0).replace(' ', '.*?'), '',
-                                                          groups_data_stripped)
+                            matched_string = match.group(0)
 
                     if not found_identifier:
 
@@ -352,9 +347,7 @@ class SeriesParser(TitleParser):
                         log.debug(self)
                         self.id_type = 'ep'
                         self.valid = True
-                        found_identifier = True
-                        groups_data_stripped = re.sub(match.group(0).replace(' ', '.*?'), '',
-                                                      groups_data_stripped)
+                        matched_string = match.group(0)
                 else:
                     log.debug('-> no luck with the expect_ep')
 
@@ -367,8 +360,7 @@ class SeriesParser(TitleParser):
                     if self.strict_name:
                         if match.start() > 1:
                             found_identifier = True
-                            groups_data_stripped = re.sub(match.group(0).replace(' ', '.*?'), '',
-                                                          groups_data_stripped)
+                            matched_string = match.group(0)
                             break
                     found_id = '-'.join(g for g in match.groups() if g)
                     if not found_id:
@@ -377,8 +369,7 @@ class SeriesParser(TitleParser):
                     self.id = found_id
                     self.id_type = 'id'
                     self.valid = True
-                    groups_data_stripped = re.sub(match.group(0).replace(' ', '.*?'), '',
-                                                  groups_data_stripped)
+                    matched_string = match.group(0)
                     log.debug('found id \'%s\' with regexp \'%s\'', self.id, id_re.pattern)
                     if not (self.special and self.prefer_specials):
                         found_identifier = True
@@ -401,8 +392,7 @@ class SeriesParser(TitleParser):
                     if self.strict_name:
                         if match.start() > 1:
                             found_identifier = True
-                            groups_data_stripped = re.sub(match.group(0).replace(' ', '.*?'), '',
-                                                          groups_data_stripped)
+                            matched_string = match.group(0)
                             break
                     # First matching group is the sequence number
                     try:
@@ -417,8 +407,7 @@ class SeriesParser(TitleParser):
                             self.proper_count = int(match.group('version')) - 1
                     self.id_type = 'sequence'
                     self.valid = True
-                    groups_data_stripped = re.sub(match.group(0).replace(' ', '.*?'), '',
-                                                  groups_data_stripped)
+                    matched_string = match.group(0)
                     log.debug('found id \'%s\' with regexp \'%s\'', self.id, sequence_re.pattern)
                     if not (self.special and self.prefer_specials):
                         found_identifier = True
@@ -446,6 +435,10 @@ class SeriesParser(TitleParser):
             else:
                 msg += 'a(n) `%s` style identifier.' % self.identified_by
             raise ParseWarning(self, msg)
+
+        # Remove episode id
+        if found_identifier and matched_string:
+            groups_data_stripped = re.sub(matched_string.replace(' ', '.*?'), '', groups_data_stripped)
 
         # Find quality and clean from data
         log.debug('parsing quality ->')


### PR DESCRIPTION
### Motivation for changes:

Nice information to have.
### Detailed changes:

This is pretty much just a PoC. Some of the code is weird, some of it should be changed etc.
- Changed the series parser to work more like the movie parser in that it cuts the parsed bits. This means we'll end up with a string that contains the release group and very little else.
