### PR TITLE
Update Crossmatch to Merge with Clobbering

### DIFF
--- a/flexget/plugins/filter/crossmatch.py
+++ b/flexget/plugins/filter/crossmatch.py
@@ -70,7 +70,9 @@ class CrossMatch(object):
                 if common:
                     msg = 'intersects with %s on field(s) %s' % \
                           (generated_entry['title'], ', '.join(common))
-                    entry.update(generated_entry)
+                    for key in generated_entry:
+                        if key not in entry:
+                            entry[key] = generated_entry[key]
                     if action == 'reject':
                         entry.reject(msg)
                     if action == 'accept':


### PR DESCRIPTION
Code change to prevent existing fields from being overwritten by Crossmatch during entry merge

### Motivation for changes:
Previous [change](https://github.com/Flexget/Flexget/commit/f461f428f0c0ff468ba0ae63c849227c8cf76a10) to add merge functionality to cross match causes existing fields from the input to be overwritten by fields in the crossmatch input.  If the input for crossmatch supplies the field 'URL' the "Real URL" is overwritten and the download fails 

### Detailed changes:

- Removed entry.update statement
- Added for loop with conditional to merge entry only if the field is not present in the existing entry
