### PR TITLE
Update Crossmatch with Exact (yes/no) search option

### DIFF
--- a/flexget/plugins/filter/crossmatch.py
+++ b/flexget/plugins/filter/crossmatch.py
@@ -69,7 +69,7 @@ class CrossMatch(object):
         for entry in task.entries:
             for generated_entry in match_entries:
                 log.trace('checking if %s matches %s' % (entry['title'], generated_entry['title']))
-                common = self.entry_intersects(entry, generated_entry, fields, config.get('exact', 1))
+                common = self.entry_intersects(entry, generated_entry, fields, config.get('exact', True))
                 if common:
                     msg = 'intersects with %s on field(s) %s' % \
                           (generated_entry['title'], ', '.join(common))

--- a/flexget/plugins/filter/crossmatch.py
+++ b/flexget/plugins/filter/crossmatch.py
@@ -30,7 +30,7 @@ class CrossMatch(object):
             'fields': {'type': 'array', 'items': {'type': 'string'}},
             'action': {'enum': ['accept', 'reject']},
             'from': {'type': 'array', 'items': {'$ref': '/schema/plugins?phase=input'}},
-            'exact': {'type': 'boolean'}
+            'exact': {'type': 'boolean', 'default': True}
 
         },
         'required': ['fields', 'action', 'from'],
@@ -69,7 +69,7 @@ class CrossMatch(object):
         for entry in task.entries:
             for generated_entry in match_entries:
                 log.trace('checking if %s matches %s' % (entry['title'], generated_entry['title']))
-                common = self.entry_intersects(entry, generated_entry, fields, config.get('exact', True))
+                common = self.entry_intersects(entry, generated_entry, fields, config.get('exact'))
                 if common:
                     msg = 'intersects with %s on field(s) %s' % \
                           (generated_entry['title'], ', '.join(common))

--- a/flexget/plugins/filter/crossmatch.py
+++ b/flexget/plugins/filter/crossmatch.py
@@ -21,6 +21,7 @@ class CrossMatch(object):
         fields:
           - title
         action: reject
+        fuzzy: no
     """
 
     schema = {
@@ -28,7 +29,9 @@ class CrossMatch(object):
         'properties': {
             'fields': {'type': 'array', 'items': {'type': 'string'}},
             'action': {'enum': ['accept', 'reject']},
-            'from': {'type': 'array', 'items': {'$ref': '/schema/plugins?phase=input'}}
+            'from': {'type': 'array', 'items': {'$ref': '/schema/plugins?phase=input'}},
+            'fuzzy': {'type': 'boolean'}
+
         },
         'required': ['fields', 'action', 'from'],
         'additionalProperties': False
@@ -66,7 +69,7 @@ class CrossMatch(object):
         for entry in task.entries:
             for generated_entry in match_entries:
                 log.trace('checking if %s matches %s' % (entry['title'], generated_entry['title']))
-                common = self.entry_intersects(entry, generated_entry, fields)
+                common = self.entry_intersects(entry, generated_entry, fields, config)
                 if common:
                     msg = 'intersects with %s on field(s) %s' % \
                           (generated_entry['title'], ', '.join(common))
@@ -78,7 +81,7 @@ class CrossMatch(object):
                     if action == 'accept':
                         entry.accept(msg)
 
-    def entry_intersects(self, e1, e2, fields=None):
+    def entry_intersects(self, e1, e2, fields=None, config=None):
         """
         :param e1: First :class:`flexget.entry.Entry`
         :param e2: Second :class:`flexget.entry.Entry`
@@ -99,10 +102,17 @@ class CrossMatch(object):
             log.trace('v1: %r' % v1)
             log.trace('v2: %r' % v2)
 
-            if v1 == v2:
-                common_fields.append(field)
+            if config.get('fuzzy', {}):
+                if v2 in v1:
+                    common_fields.append(field)
+                else:
+                    log.trace('not matching')
             else:
-                log.trace('not matching')
+                if v1 == v2:
+                    common_fields.append(field)
+                else:
+                    log.trace('not matching')
+
         return common_fields
 
 

--- a/flexget/plugins/filter/crossmatch.py
+++ b/flexget/plugins/filter/crossmatch.py
@@ -21,7 +21,7 @@ class CrossMatch(object):
         fields:
           - title
         action: reject
-        fuzzy: no
+        exact: yes
     """
 
     schema = {
@@ -30,7 +30,7 @@ class CrossMatch(object):
             'fields': {'type': 'array', 'items': {'type': 'string'}},
             'action': {'enum': ['accept', 'reject']},
             'from': {'type': 'array', 'items': {'$ref': '/schema/plugins?phase=input'}},
-            'fuzzy': {'type': 'boolean'}
+            'exact': {'type': 'boolean'}
 
         },
         'required': ['fields', 'action', 'from'],
@@ -69,7 +69,7 @@ class CrossMatch(object):
         for entry in task.entries:
             for generated_entry in match_entries:
                 log.trace('checking if %s matches %s' % (entry['title'], generated_entry['title']))
-                common = self.entry_intersects(entry, generated_entry, fields, config)
+                common = self.entry_intersects(entry, generated_entry, fields, config.get('exact', 1))
                 if common:
                     msg = 'intersects with %s on field(s) %s' % \
                           (generated_entry['title'], ', '.join(common))
@@ -81,7 +81,7 @@ class CrossMatch(object):
                     if action == 'accept':
                         entry.accept(msg)
 
-    def entry_intersects(self, e1, e2, fields=None, config=None):
+    def entry_intersects(self, e1, e2, fields=None, exact=None):
         """
         :param e1: First :class:`flexget.entry.Entry`
         :param e2: Second :class:`flexget.entry.Entry`
@@ -102,7 +102,7 @@ class CrossMatch(object):
             log.trace('v1: %r' % v1)
             log.trace('v2: %r' % v2)
 
-            if config.get('fuzzy', {}):
+            if not exact:
                 if v2 in v1:
                     common_fields.append(field)
                 else:

--- a/flexget/plugins/filter/crossmatch.py
+++ b/flexget/plugins/filter/crossmatch.py
@@ -81,7 +81,7 @@ class CrossMatch(object):
                     if action == 'accept':
                         entry.accept(msg)
 
-    def entry_intersects(self, e1, e2, fields=None, exact=None):
+    def entry_intersects(self, e1, e2, fields=None, exact=True):
         """
         :param e1: First :class:`flexget.entry.Entry`
         :param e2: Second :class:`flexget.entry.Entry`


### PR DESCRIPTION
### Motivation for changes:
 - Add functionality for non-Exact searching to crossmatch plugin instead of only exact matches

### Detailed changes:

- if Exact: no is specified in config then "if v2 in v1:" will be used for matching instead
- if Exact: yes is specified or is not in config then the default matching is used "if v1 == v2:"

### Addressed issues:

- Fixes # .  (N/A)

### Config usage if relevant (new plugin or updated schema):
  ---  Test / Example config  ---  
```
tasks:
  hasitleaked:
    make_html:
      file: ~/thefile.html
    crossmatch:
      from:
        - csv:
            url: file:///home/flexget/ss.csv
            values:
              title: 1
              url: 2
      fields:
        - title
      action: accept
      exact: no
    rss:
      url: http://hasitleaked.com/leakedfeed/


```
### Log and/or tests output (preferably both):
```
  ---  Exact not specified in config  ---  
2016-09-28 15:08 VERBOSE  manager                       Creating new database /home/flexget/db-config.sqlite - DO NOT INTERUPT ...
2016-09-28 15:09 VERBOSE  details       hasitleaked     Produced 20 entries.
2016-09-28 15:09 VERBOSE  details       hasitleaked     Summary - Accepted: 0 (Rejected: 0 Undecided: 20 Failed: 0)
2016-09-28 15:09 VERBOSE  make_html     hasitleaked     Writing output html to /home/flexget/thefile.html
  ---  "Exact: yes" specified in config  ---  
2016-09-28 15:09 VERBOSE  task_queue                    There are 1 tasks to execute. Shutdown will commence when they have completed.
2016-09-28 15:09 VERBOSE  details       hasitleaked     Produced 20 entries.
2016-09-28 15:09 VERBOSE  details       hasitleaked     Summary - Accepted: 0 (Rejected: 0 Undecided: 20 Failed: 0)
2016-09-28 15:09 VERBOSE  make_html     hasitleaked     Writing output html to /home/flexget/thefile.html
  ---  "Exact: no" specified in config  ---  
2016-09-28 15:09 VERBOSE  task_queue                    There are 1 tasks to execute. Shutdown will commence when they have completed.
2016-09-28 15:09 VERBOSE  details       hasitleaked     Produced 20 entries.
2016-09-28 15:09 VERBOSE  task          hasitleaked     ACCEPTED: `Loscil : Monument Builders` by crossmatch plugin because intersects with Monument on field(s) title
2016-09-28 15:09 VERBOSE  details       hasitleaked     Summary - Accepted: 1 (Rejected: 0 Undecided: 19 Failed: 0)
2016-09-28 15:09 VERBOSE  make_html     hasitleaked     Writing output html to /home/flexget/thefile.html

```


