### PR TITLE
support size unit of "B". if sizes doesn't match log and ignore.

### DIFF
--- a/flexget/plugins/sites/piratebay.py
+++ b/flexget/plugins/sites/piratebay.py
@@ -151,7 +151,7 @@ class UrlRewritePirateBay(object):
                     if size:
                         entry['content_size'] = parse_filesize(size.group(1))
                     else:
-                        log.error('Malformed search result? Title: "%s", No size? %s' % (entry['title'], sizeText))
+                        log.error('Malformed search result? Title: "%s", No size? %s', (entry['title'], sizeText))
 
                 entries.add(entry)
 

--- a/flexget/plugins/sites/piratebay.py
+++ b/flexget/plugins/sites/piratebay.py
@@ -145,10 +145,13 @@ class UrlRewritePirateBay(object):
                 entry['torrent_leeches'] = int(tds[-1].contents[0])
                 entry['search_sort'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
                 # Parse content_size
-                size = link.find_next(attrs={'class': 'detDesc'}).get_text()
-                size = re.search('Size (\d+(\.\d+)?\xa0(?:[PTGMK])iB)', size)
-
-                entry['content_size'] = parse_filesize(size.group(1))
+                sizeText = link.find_next(attrs={'class': 'detDesc'}).get_text()
+                if sizeText:
+                    size = re.search('Size (\d+(\.\d+)?\xa0(?:[PTGMK])?i?B)', sizeText)
+                    if size:
+                        entry['content_size'] = parse_filesize(size.group(1))
+                    else:
+                        log.error('Malformed search result? Title: "%s", No size? %s' % (entry['title'], sizeText))
 
                 entries.add(entry)
 

--- a/flexget/plugins/sites/piratebay.py
+++ b/flexget/plugins/sites/piratebay.py
@@ -151,7 +151,7 @@ class UrlRewritePirateBay(object):
                     if size:
                         entry['content_size'] = parse_filesize(size.group(1))
                     else:
-                        log.error('Malformed search result? Title: "%s", No size? %s', (entry['title'], sizeText))
+                        log.error('Malformed search result? Title: "%s", No size? %s', entry['title'], sizeText)
 
                 entries.add(entry)
 


### PR DESCRIPTION
some results were so small they reported bytes and the regex didn't match. (resulting in an exception being thrown) This makes missed parses of size not trigger an exception, as well as supporting Bytes.