### PR TITLE
Add extra fields in entries from HTML input to allow filtering later

### DIFF
--- a/flexget/plugins/input/html.py
+++ b/flexget/plugins/input/html.py
@@ -275,6 +275,25 @@ class InputHtml(object):
             entry['url'] = url
             entry['title'] = title
 
+            # If the element has no classes then None is returned
+            link_classes = link.get('class')
+            if link_classes:
+                entry['html_classes'] = link_classes
+
+            # Get the parent and grandparent HTML nodes of the link node. We
+            # will add extra fields to the entry with the tag and classes of
+            # these nodes to allow filtering the entry in subsequent phases.
+            html_parent = link.parent
+            entry['html_parent'] = html_parent.name
+            parent_classes = html_parent.get('class')
+            if parent_classes:
+                entry['html_parent_classes'] = parent_classes
+            html_grandparent = html_parent.parent
+            entry['html_grandparent'] = html_grandparent.name
+            grandparent_classes = html_grandparent.get('class')
+            if grandparent_classes:
+                entry['html_grandparent_classes'] = html_grandparent.get('class')
+
             if 'username' in config and 'password' in config:
                 entry['download_auth'] = (config['username'], config['password'])
 


### PR DESCRIPTION
### Motivation for changes:

Currently the entries returned by the HTML input plugin have basically the URL
field. Some more data could be useful to allow more flexible filtering in the
filter phase in flexget. I my particular case, I need to gather only links that
are in h2 headers, but at the filtering phase that information is lost. This
pull request adds the name of the parent and grandparent of the link, as well
as the list of classes for the link, the parent and the grandparent nodes.

With this, suppose the links you are interested in appear in `<h2>`
headers. You could then use the 'if' filter as

```
test-task:
  html: http://example.com
  if:
    - "html_parent == 'h2'": accept
  <some_output_plugin>
```
### Detailed changes:

Add the following fields to entries from the html input plugin:
- `html_classes`: Classes of the anchor tag containing the returned link
- `html_parent`: The element containing the anchor tag (a string)
- `html_parent_classes`: The classes of the parent (this is a list of strings)
- `html_grandparent`: The element containing the parent of the anchor tag (a string)
- `html_grandparent_classes`: The classes of the grandparent (this is a list of strings)

The fields with classes are only added if there is at least one class.
### Config usage if relevant (new plugin or updated schema):

There is no change in configuration. On the other hand, if adding these fields
is considered an overhead then an "add_extra_fields" option could be added to
html plugin config.
