### PR TITLE
Getting CSV input on PY3 to work

### DIFF
--- a/flexget/plugins/input/input_csv.py
+++ b/flexget/plugins/input/input_csv.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # pylint: disable=unused-import, redefined-builtin
+from future.utils import PY3
 
 import logging
 import csv
@@ -61,7 +62,10 @@ class InputCSV(object):
         except RequestException as e:
             raise plugin.PluginError('Error fetching `%s`: %s' % (config['url'], e))
         # CSV module needs byte strings, we'll convert back to unicode later
-        page = r.text.encode('utf-8').splitlines()
+        if PY3:
+            page = r.text.splitlines()
+        else:
+            page = r.text.encode('utf-8').splitlines()
         for row in csv.reader(page):
             if not row:
                 continue
@@ -69,7 +73,10 @@ class InputCSV(object):
             for name, index in list(config.get('values', {}).items()):
                 try:
                     # Convert the value back to unicode
-                    entry[name] = row[index - 1].decode('utf-8').strip()
+                    if PY3:
+                        entry[name] = row[index - 1].strip()
+                    else:
+                        entry[name] = row[index - 1].decode('utf-8').strip()
                 except IndexError:
                     raise plugin.PluginError('Field `%s` index is out of range' % name)
 


### PR DESCRIPTION
### Motivation for changes:
csv input was not working on PY3

### Detailed changes:
CSV reader in Python 2 is broken and does not support unicode strings. It therefore needs byte strings, but Python 3 needs unicode strings.

csv plugin has been changed to transform the string to the proper format based on Python version.

### Addressed issues:

http://discuss.flexget.com/t/input-csv-py-not-working-on-python3/2797