### PR TITLE
npo_watchlist: Date parsing fix + allow use with thetvdb_lookup

### DIFF
--- a/flexget/plugins/input/npo_watchlist.py
+++ b/flexget/plugins/input/npo_watchlist.py
@@ -152,6 +152,7 @@ class NPOWatchlist(object):
             e['series_name'] = series_name
             e['series_name_plain'] = self._strip_accents(series_name)
             e['series_date'] = entry_date
+            e['series_id_type'] = 'date'
             e['description'] = listItem.find('p').text
             e['remove_url'] = self._prefix_url('https://mijn.npo.nl', remove_url)
 
@@ -202,6 +203,7 @@ class NPOWatchlist(object):
             e['series_name'] = series_name
             e['series_name_plain'] = self._strip_accents(series_name)
             e['series_date'] = entry_date
+            e['series_id_type'] = 'date'
             e['description'] = listItem.find('p').text
 
             entries.append(e)
@@ -238,6 +240,7 @@ class NPOWatchlist(object):
             e['series_name'] = series_name
             e['series_name_plain'] = self._strip_accents(series_name)
             e['series_date'] = entry_date
+            e['series_id_type'] = 'date'
             e['description'] = listItem.find('p').text
 
             entries.append(e)

--- a/flexget/plugins/input/npo_watchlist.py
+++ b/flexget/plugins/input/npo_watchlist.py
@@ -16,7 +16,7 @@ import re
 
 log = logging.getLogger('search_npo')
 fragment_regex = re.compile('[A-Z][^/]+/')
-date_regex = re.compile('([1-3]?[0-9]) ([a-z]{3}) ([0-9]{4})')
+date_regex = re.compile('([1-3]?[0-9]) ([a-z]{3})(?: ([0-9]{4})|\W)')
 days_ago_regex = re.compile('([0-9]+) dagen geleden')
 months = ['jan', 'feb', 'mrt', 'apr', 'mei', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec']
 
@@ -78,7 +78,13 @@ class NPOWatchlist(object):
         if date_match:
             day = int(date_match.group(1))
             month = months.index(date_match.group(2))+1
-            year = int(date_match.group(3))
+            
+            year = date_match.group(3)
+            if year is None:
+                year = date.today().year
+            else:
+                year = int(year)
+            
             return date(year, month, day)
         elif days_ago_match:
             days_ago = int(days_ago_match.group(1))


### PR DESCRIPTION
### Motivation for changes:

@mfonville reported that npo_watchlist episode entries cannot be looked up using thetvdb_lookup. 

### Detailed changes:

- Adding series_id_type=date to each entry, to allow episode details to be looked up using thetvdb_lookup (using broadcast date)
- Extended date parsing, to accept dates without a year specified (defaulting to current year)

### Config usage if relevant (new plugin or updated schema):
```
            npo_watchlist:
              email: aaaa@bbb.nl
              password: xxx
              remove_accepted: yes
              max_episode_age_days: 7
            thetvdb_lookup: yes
            ...
```
