### PR TITLE
Improve internal series parser performance?

### DIFF
--- a/flexget/plugins/parsers/parser_internal.py
+++ b/flexget/plugins/parsers/parser_internal.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # pylint: disable=unused-import, redefined-builtin
 
+import functools
 import logging
 import time
 
@@ -12,6 +13,20 @@ from flexget.utils.titles.series import SeriesParser
 from .parser_common import ParseWarning
 
 log = logging.getLogger('parser_internal')
+
+series_parser_cache = functools.lru_cache()(SeriesParser)
+
+
+def series_parser_factory(**kwargs):
+    """Returns a series parser from the cache, or creates one."""
+    if not kwargs.get('name'):
+        # Don't cache parsing calls that aren't for a specific series (e.g. from metainfo_series or series_premiere)
+        return SeriesParser(**kwargs)
+    # Turn our list arguments to tuples so that they are hashable by lru_cache
+    for key, val in kwargs.items():
+        if isinstance(val, list):
+            kwargs[key] = tuple(val)
+    return series_parser_cache(**kwargs)
 
 
 class ParserInternal(object):
@@ -35,7 +50,7 @@ class ParserInternal(object):
     def parse_series(self, data, **kwargs):
         log.debug('Parsing series: `%s` kwargs: %s', data, kwargs)
         start = time.clock()
-        parser = SeriesParser(**kwargs)
+        parser = series_parser_factory(**kwargs)
         try:
             parser.parse(data)
         except ParseWarning as pw:

--- a/flexget/plugins/parsers/parser_internal.py
+++ b/flexget/plugins/parsers/parser_internal.py
@@ -1,9 +1,13 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # pylint: disable=unused-import, redefined-builtin
 
-import functools
 import logging
 import time
+
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
 
 from flexget import plugin
 from flexget.event import event
@@ -14,7 +18,7 @@ from .parser_common import ParseWarning
 
 log = logging.getLogger('parser_internal')
 
-series_parser_cache = functools.lru_cache()(SeriesParser)
+series_parser_cache = lru_cache()(SeriesParser)
 
 
 def series_parser_factory(**kwargs):

--- a/flexget/utils/titles/series.py
+++ b/flexget/utils/titles/series.py
@@ -103,7 +103,7 @@ class SeriesParser(TitleParser):
         """
 
         self.name = name
-        self.alternate_names = alternate_names or []
+        self.alternate_names = list(alternate_names or ())
         self.data = ''
         self.identified_by = identified_by
         # Stores the type of identifier found, 'ep', 'date', 'sequence' or 'special'
@@ -114,7 +114,9 @@ class SeriesParser(TitleParser):
         for mode in ID_TYPES:
             listname = mode + '_regexps'
             if locals()[listname]:
-                setattr(self, listname, ReList(locals()[listname] + getattr(SeriesParser, listname)))
+                newrelist = ReList(locals()[listname])
+                newrelist.extend(getattr(SeriesParser, listname))
+                setattr(self, listname, newrelist)
         self.specials = self.specials + [i.lower() for i in (special_ids or [])]
         self.prefer_specials = prefer_specials
         self.assume_special = assume_special

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ flask-cors>=2.1.2
 pyparsing>=2.0.3
 Safe>=0.4
 future>=0.15.2
+backports.functools_lru_cache; python_version <= '2.7'


### PR DESCRIPTION
### Motivation for changes:

Currently, calls to the series parser from series plugin end up instantiating one parser per series per entry. Instantiating a new parser involves compiling regexes for that series again, which may be slow.
### Detailed changes:

Add an lru cache where internal parser keeps instantiated parsers for configured series. This means the parsers should be instantiated once per series in your config, rather than once per series per entry.
### Caveats and a Request

I haven't done any performance testing, this was just a gut reaction. If anyone would like to do some scientific performance testing, or just test this branch out with your (series heavy) config and post results it would be appreciated.
