### PR TITLE
Restart task queue if it has crashed (daemon only)

### DIFF
--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -370,7 +370,7 @@ class Manager(object):
         if self.task_queue.is_alive() or self.is_daemon:
             if not self.task_queue.is_alive():
                 log.error('Task queue has died unexpectedly. Restarting it. Please open an issue on Github and include'
-                          'any previous error logs.')
+                          ' any previous error logs.')
                 self.task_queue = TaskQueue()
                 self.task_queue.start()
             if len(self.task_queue):

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -367,7 +367,10 @@ class Manager(object):
         :param options: argparse options
         """
         fire_event('manager.execute.started', self, options)
-        if self.task_queue.is_alive():
+        if self.task_queue.is_alive() or self.is_daemon:
+            if not self.task_queue.is_alive():
+                self.task_queue = TaskQueue()
+                self.task_queue.start()
             if len(self.task_queue):
                 log.verbose('There is a task already running, execution queued.')
             finished_events = self.execute(options, output=logger.get_capture_stream(),

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -369,6 +369,8 @@ class Manager(object):
         fire_event('manager.execute.started', self, options)
         if self.task_queue.is_alive() or self.is_daemon:
             if not self.task_queue.is_alive():
+                log.error('Task queue has died unexpectedly. Restarting it. Please open an issue on Github and include'
+                          'any previous error logs.')
                 self.task_queue = TaskQueue()
                 self.task_queue.start()
             if len(self.task_queue):


### PR DESCRIPTION
### Motivation for changes:

Fix stuff
### Detailed changes:
- Restart task queue if is_alive() returns False when executing a task in daemon
### Addressed issues:
- Fixes #1254
