### PR TITLE
Disable warnings about disabling SSL verification.

### DIFF
--- a/flexget/plugins/operate/verify_ssl_certificates.py
+++ b/flexget/plugins/operate/verify_ssl_certificates.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # pylint: disable=unused-import, redefined-builtin
 
 import logging
-from  requests.packages import urllib3
+from requests.packages import urllib3
 
 from flexget import plugin
 from flexget.event import event

--- a/flexget/plugins/operate/verify_ssl_certificates.py
+++ b/flexget/plugins/operate/verify_ssl_certificates.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # pylint: disable=unused-import, redefined-builtin
 
 import logging
+from  requests.packages import urllib3
 
 from flexget import plugin
 from flexget.event import event
@@ -23,6 +24,16 @@ class VerifySSLCertificates(object):
     def on_task_start(self, task, config):
         if config is False:
             task.requests.verify = False
+            # Disabling verification results in a warning for every HTTPS
+            # request:
+            # "InsecureRequestWarning: Unverified HTTPS request is being made.
+            #  Adding certificate verification is strongly advised. See:
+            #  https://urllib3.readthedocs.io/en/latest/security.html"
+            # Disable those warnings because the user has explicitly disabled
+            # verification and the warning is not beneficial.
+            # This change is permanent rather than task scoped, but there won't
+            # be any warnings to disable when verification is enabled.
+            urllib3.disable_warnings()
 
 
 @event('plugin.register')

--- a/flexget/plugins/operate/verify_ssl_certificates.py
+++ b/flexget/plugins/operate/verify_ssl_certificates.py
@@ -33,7 +33,7 @@ class VerifySSLCertificates(object):
             # verification and the warning is not beneficial.
             # This change is permanent rather than task scoped, but there won't
             # be any warnings to disable when verification is enabled.
-            urllib3.disable_warnings()
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 @event('plugin.register')


### PR DESCRIPTION
### Motivation for changes:

Suppress expected warnings to avoid mails when run from cron.
### Detailed changes:
-     Disabling SSL certificate verification results in a warning for every
  HTTPS request:
  "InsecureRequestWarning: Unverified HTTPS request is being made.  Adding
   certificate verification is strongly advised. See:
   https://urllib3.readthedocs.io/en/latest/security.html"
  Disable those warnings because the user has explicitly disabled
  verification and so the warning is not beneficial.
### Addressed issues:
- Fixes # .
### Config usage if relevant (new plugin or updated schema):

```
paste_config_here
```
### Log and/or tests output (preferably both):

```
Test output:
1 failed, 1041 passed, 26 skipped, 2 xfailed, 2 xpassed, 5 pytest-warnings in 396.33 seconds

Failed test seems unrelated:
______________________________________________________________________________________ TestFilesystem.test_non_ascii ______________________________________________________________________________[104/472]

self = <flexget.tests.test_filesystem.TestFilesystem object at 0x115c58c50>, execute_task = <function execute at 0x115a46938>

    def test_non_ascii(self, execute_task):
        task_name = 'non_ascii'
        should_exist = ['\u0161 dir', '\u0152 file.txt']
        task = execute_task(task_name)

>       self.assert_check(task, task_name, 'positive', should_exist)

test_filesystem.py:210:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <flexget.tests.test_filesystem.TestFilesystem object at 0x115c58c50>, task = <flexget.task.Task object at 0x115acb510>, task_name = 'non_ascii', test_type = 'positive'
filenames = ['š dir', 'Œ file.txt']

    def assert_check(self, task, task_name, test_type, filenames):
        for file in filenames:
            file = Path(file)
            if test_type == 'positive':
                assertion_error = 'Failed %s %s test, did not find %s' % (test_type, task_name, file)
>               assert task.find_entry(title=file.namebase), assertion_error
E               AssertionError: Failed positive non_ascii test, did not find š dir
E               assert None
E                +  where None = <bound method Task.find_entry of <flexget.task.Task object at 0x115acb510>>(title=Path(u'\u0161 dir'))
E                +    where <bound method Task.find_entry of <flexget.task.Task object at 0x115acb510>> = <flexget.task.Task object at 0x115acb510>.find_entry
E                +    and   Path(u'\u0161 dir') = Path(u'\u0161 dir').namebase

test_filesystem.py:91: AssertionError
----------------------------------------------------------------------------------------------- Captured log -----------------------------------------------------------------------------------------------
manager.py                 115 INFO     last manager was not torn down correctly
manager.py                 172 DEBUG    sys.defaultencoding: ascii
manager.py                 173 DEBUG    sys.getfilesystemencoding: utf-8
manager.py                 174 DEBUG    os.path.supports_unicode_filenames: True
conftest.py                309 DEBUG    database_uri: sqlite:///:memory:
plugin.py                  383 DEBUG    Trying to load plugins from: [u'/Users/johntobin/src/plugins', '/Users/johntobin/src/upstream-flexget/flexget/plugins']
plugin.py                  404 DEBUG    (u'Plugin `%s` requires `%s` to load.', u'memusage', u'ext lib `guppy`')
plugin.py                  468 DEBUG    Plugins took 0.07 seconds to load. 264 plugins in registry.
manager.py                 713 DEBUG    Connecting to: sqlite:///:memory:
db_schema.py                92 DEBUG    Initializing plugin feed schema version to 0
db_schema.py                92 DEBUG    Initializing plugin api_trakt schema version to 6
db_schema.py                92 DEBUG    Initializing plugin trakt_auth schema version to 0
db_schema.py                92 DEBUG    Initializing plugin make_rss schema version to 0
db_schema.py                92 DEBUG    Initializing plugin series schema version to 13
db_schema.py                92 DEBUG    Initializing plugin discover schema version to 0
db_schema.py                92 DEBUG    Initializing plugin alpharatio schema version to 0
db_schema.py                92 DEBUG    Initializing plugin seen schema version to 4
db_schema.py                92 DEBUG    Initializing plugin pogcal_acquired schema version to 0
db_schema.py                92 DEBUG    Initializing plugin archive schema version to 0
db_schema.py                92 DEBUG    Initializing plugin digest schema version to 1
db_schema.py                92 DEBUG    Initializing plugin remember_rejected schema version to 3
db_schema.py                92 DEBUG    Initializing plugin telegram_chat_ids schema version to 0
db_schema.py                92 DEBUG    Initializing plugin simple_persistence schema version to 4
db_schema.py                92 DEBUG    Initializing plugin telegram_chat_ids schema version to 0                                                                                                   [52/472]
db_schema.py                92 DEBUG    Initializing plugin simple_persistence schema version to 4
db_schema.py                92 DEBUG    Initializing plugin myepisodes schema version to 0
db_schema.py                92 DEBUG    Initializing plugin delay schema version to 2
db_schema.py                92 DEBUG    Initializing plugin failed schema version to 3
db_schema.py                92 DEBUG    Initializing plugin tail schema version to 0
db_schema.py                92 DEBUG    Initializing plugin api_tvdb schema version to 7
db_schema.py                92 DEBUG    Initializing plugin imdb_lookup schema version to 8
db_schema.py                92 DEBUG    Initializing plugin template_hash schema version to 0
db_schema.py                92 DEBUG    Initializing plugin status schema version to 1
db_schema.py                92 DEBUG    Initializing plugin movie_list schema version to 0
db_schema.py                92 DEBUG    Initializing plugin torrent411 schema version to 0
db_schema.py                92 DEBUG    Initializing plugin api_tmdb schema version to 4
db_schema.py                92 DEBUG    Initializing plugin log_once schema version to 0
db_schema.py                92 DEBUG    Initializing plugin entry_list schema version to 1
db_schema.py                92 DEBUG    Initializing plugin regexp_list schema version to 1
db_schema.py                92 DEBUG    Initializing plugin api_bluray schema version to 0
db_schema.py                92 DEBUG    Initializing plugin subtitle_list schema version to 1
db_schema.py                92 DEBUG    Initializing plugin api_rottentomatoes schema version to 2
db_schema.py                92 DEBUG    Initializing plugin version_checker schema version to 0
db_schema.py                92 DEBUG    Initializing plugin secrets schema version to 0
db_schema.py                92 DEBUG    Initializing plugin morethantv schema version to 0
db_schema.py                92 DEBUG    Initializing plugin t411 schema version to 0
db_schema.py                92 DEBUG    Initializing plugin input_cache schema version to 1
db_schema.py                92 DEBUG    Initializing plugin import_series schema version to 0
db_schema.py                92 DEBUG    Initializing plugin tvmaze schema version to 6
db_schema.py                92 DEBUG    Initializing plugin imdb_list schema version to 0
db_schema.py                92 DEBUG    Initializing plugin rutracker_auth schema version to 0
db_schema.py                92 DEBUG    Initializing plugin backlog schema version to 2
manager.py                 639 DEBUG    New config data loaded.
db_schema.py                39 DEBUG    entering flexget version 2.5.6.dev to db
plugin_parsing.py           32 DEBUG    setting default movie parser to internal. (options: {u'internal': <flexget.plugins.parsers.parser_internal.ParserInternal object at 0x11393f990>, u'guessit': <flexg
et.plugins.parsers.parser_guessit.ParserGuessit object at 0x112cca650>})
plugin_parsing.py           32 DEBUG    setting default series parser to internal. (options: {u'internal': <flexget.plugins.parsers.parser_internal.ParserInternal object at 0x11393f990>, u'guessit': <flex
get.plugins.parsers.parser_guessit.ParserGuessit object at 0x112cca650>})
conftest.py                 89 INFO     ********** Running task: non_ascii **********
task.py                    570 DEBUG    executing non_ascii
status.py                   66 DEBUG    Adding new task non_ascii
logger.py                  127 VERBOSE  Starting to scan folders.
logger.py                  127 VERBOSE  Scanning folder filesystem_test_dir//Test3. Recursion is set to True.
filesystem.py              165 DEBUG    Scanning filesystem_test_dir//Test3
filesystem.py              170 DEBUG    Checking if filesystem_test_dir//Test3/š dir qualifies to be added as an entry.
filesystem.py              170 DEBUG    Checking if filesystem_test_dir//Test3/š dir/Œ file.txt qualifies to be added as an entry.
backlog.py                 182 DEBUG    0 entries purged from backlog
logger.py                  127 VERBOSE  Produced 2 entries.
urlrewriting.py             30 DEBUG    Checking 0 entries
logger.py                  127 VERBOSE  Summary - Accepted: 0 (Rejected: 0 Undecided: 2 Failed: 0)
simple_persistence.py      150 DEBUG    Flushing simple persistence for task non_ascii to db.
```
