### PR TITLE
Preserve torrents based on presence of trackers

### DIFF
--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -685,7 +685,7 @@ class PluginTransmissionClean(TransmissionBase):
                                 is_minratio_reached or
                                 (is_torrent_seed_only and is_torrent_idlelimit_since_added_reached) or
                                 (not is_torrent_seed_only and is_torrent_idlelimit_since_finished_reached))
-                    and is_directories_matching (not is_preserve_tracker_matching and is_tracker_matching)):
+                    and is_directories_matching and (not is_preserve_tracker_matching and is_tracker_matching)):
                 if task.options.test:
                     log.info('Would remove finished torrent `%s` from transmission', torrent.name)
                     continue


### PR DESCRIPTION
### Motivation for changes:

Forum discussion about skipping cleanup for certain torrents based on the presence of a tracker in the torrent's tracker list

### Detailed changes:
Creation of a new config setting "preserve_tracker" and adding corresponding logic

### Addressed issues:

None

### Config usage if relevant (new plugin or updated schema):
clean_transmission:
  host: localhost
  port: 9091
  username: myusername
  password: mypassword
  tracker: nyaa|animebytes
  preserve_tracker: alpharatio|what

