### PR TITLE
Digest auth in rtorrent

### DIFF
--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -18,7 +18,6 @@ from flexget.entry import Entry
 from flexget.config_schema import one_or_more
 from flexget.utils.bittorrent import Torrent, is_torrent_file
 
-import requests
 from requests.auth import HTTPDigestAuth, HTTPBasicAuth
 
 log = logging.getLogger('rtorrent')

--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -273,10 +273,7 @@ class RTorrent(object):
 
         # Use a special transport if http(s)
         if parsed_uri.scheme in ['http', 'https']:
-            try:
-                self._server = sp(self.uri, transport=HTTPDigestTransport(parsed_uri.scheme, session))
-            except requests.HTTPError as e:
-                log.error(dir(e))
+            self._server = sp(self.uri, transport=HTTPDigestTransport(parsed_uri.scheme, session))
         else:
             self._server = sp(self.uri)
 


### PR DESCRIPTION
### Motivation for changes:
We seem to be moving in a direction where Digest authentication will replace Basic HTTP authentication for common seedbox setups. This change uses requests to handle the auth when uri is http(s).
