### PR TITLE
Leading zeros on both hours and mins of "Timeframe waiting"

### DIFF
--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1600,7 +1600,7 @@ class FilterSeries(FilterSeriesBase):
             hours += diff.days * 24
             minutes, _ = divmod(remainder, 60)
 
-            log.info('Timeframe waiting %s for %sh:%smin, currently best is %s' %
+            log.info('Timeframe waiting %s for %02dh:%02dmin, currently best is %s' %
                      (episode.series.name, hours, minutes, best['title']))
 
             # add best entry to backlog (backlog is able to handle duplicate adds)

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1600,8 +1600,8 @@ class FilterSeries(FilterSeriesBase):
             hours += diff.days * 24
             minutes, _ = divmod(remainder, 60)
 
-            log.info('Timeframe waiting %s for %02dh:%02dmin, currently best is %s' %
-                     (episode.series.name, hours, minutes, best['title']))
+            log.info('Timeframe waiting %s for %02dh:%02dmin, currently best is %s',
+                     episode.series.name, hours, minutes, best['title'])
 
             # add best entry to backlog (backlog is able to handle duplicate adds)
             if self.backlog:


### PR DESCRIPTION
### Motivation for changes:
This is purly cosmetic and has no functional value other than to aid in the reading of logs.

### Detailed changes:
This very minor change will prepend a leading zero to single digit hours or minutes of timeframe waiting messages.
- 

### Addressed issues:

- Fixes # .
none
### Config usage if relevant (new plugin or updated schema):
```
N/A
```
### Log and/or tests output (preferably both):
```
2016-11-07 10:23 INFO     series        tv_task   Timeframe waiting w***w***d for 41h:07min, currently best is W***w***d S01E06 PROPER HDTV x264-KILLERS
```


When scanning the logs, many timeframe waiting messages in a row apear "broken up" when one of them has a single digit recorded against the hour or minute value of the entry. This very minor change will prepend a leading zero to single digit hours or minutes of timeframe waiting messages.
This is purly cosmetic and has no functional value other than to aid in the reading of logs.
cheers
mh