### PR TITLE
Added for_undecided

### DIFF
--- a/flexget/plugins/output/exec.py
+++ b/flexget/plugins/output/exec.py
@@ -78,6 +78,7 @@ class PluginExec(object):
                     'for_entries': one_or_more({'type': 'string'}),
                     'for_accepted': one_or_more({'type': 'string'}),
                     'for_rejected': one_or_more({'type': 'string'}),
+                    'for_undecided': one_or_more({'type': 'string'}),
                     'for_failed': one_or_more({'type': 'string'})
                 },
                 'additionalProperties': False
@@ -120,7 +121,8 @@ class PluginExec(object):
             return
 
         name_map = {'for_entries': task.entries, 'for_accepted': task.accepted,
-                    'for_rejected': task.rejected, 'for_failed': task.failed}
+                    'for_rejected': task.rejected, 'for_undecided': task.undecided,
+                    'for_failed': task.failed}
 
         allow_background = config.get('allow_background')
         for operation, entries in name_map.iteritems():


### PR DESCRIPTION
### Motivation for changes:
Makes it possible to find duplicates much faster than with duplicates plugin (and without a bunch of workarounds to get it to work on shows), using the following config:
```
tasks:
  dups:
    assume_quality:
      h264: 480p
    seen: no
    configure_series:
      from:
        filesystem: /tv
    filesystem:
      path:
        - /tv
      recursive: yes
      retrieve: dirs
    if:
      - has_field('series_episode'):
          exec:
            on_output:
              for_undecided: echo {{series_name}} {{series_id}} {{quality}}  {{location}} >> `date +%y%m%d`.dups.out
```

### Detailed changes:
Added on_undecided in schema and in name_map. 
- 

### Addressed issues:

### Config usage if relevant (new plugin or updated schema):
```
    schema = {
        'oneOf': [
            one_or_more({'type': 'string'}),
            {
                'type': 'object',
                'properties': {
                    'on_start': {'$ref': '#/definitions/phaseSettings'},
                    'on_input': {'$ref': '#/definitions/phaseSettings'},
                    'on_filter': {'$ref': '#/definitions/phaseSettings'},
                    'on_output': {'$ref': '#/definitions/phaseSettings'},
                    'on_exit': {'$ref': '#/definitions/phaseSettings'},
                    'fail_entries': {'type': 'boolean'},
                    'auto_escape': {'type': 'boolean'},
                    'encoding': {'type': 'string'},
                    'allow_background': {'type': 'boolean'}
                },
                'additionalProperties': False
            }
        ],
        'definitions': {
            'phaseSettings': {
                'type': 'object',
                'properties': {
                    'phase': one_or_more({'type': 'string'}),
                    'for_entries': one_or_more({'type': 'string'}),
                    'for_accepted': one_or_more({'type': 'string'}),
                    'for_rejected': one_or_more({'type': 'string'}),
                    'for_undecided': one_or_more({'type': 'string'}),
                    'for_failed': one_or_more({'type': 'string'})
                },
                'additionalProperties': False
            }
        }
```
### Log and/or tests output (preferably both):
Quite self explanatory.