### PR TITLE
Pending approval plugin

### DIFF
--- a/flexget/api/__init__.py
+++ b/flexget/api/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, division, absolute_import  # noqa
-  # noqa
+# noqa
 from .app import api_app, api, APIResource, APIClient  # noqa
 from .core import authentication, cached, database, plugins, server, tasks, user, format_checker  # noqa
 from .plugins import entry_list, failed, history, imdb_lookup, movie_list, rejected, schedule, secrets, seen  # noqa
-from .plugins import series, trakt_lookup, tvdb_lookup, tvmaze_lookup, tmdb_lookup, irc, status  # noqa
+from .plugins import series, trakt_lookup, tvdb_lookup, tvmaze_lookup, tmdb_lookup, irc, status, pending  # noqa

--- a/flexget/api/app.py
+++ b/flexget/api/app.py
@@ -22,7 +22,7 @@ from werkzeug.http import generate_etag
 
 from . import __path__
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 
 log = logging.getLogger('api')
 

--- a/flexget/api/plugins/pending.py
+++ b/flexget/api/plugins/pending.py
@@ -6,7 +6,6 @@ from math import ceil
 from flask import jsonify, request
 from flask_restplus import inputs
 from flexget.plugins.filter.pending_approval import list_pending_entries, PendingEntry, get_entry_by_id
-
 from flexget.api import api, APIResource
 from flexget.api.app import base_message_schema, success_response, NotFoundError, etag, pagination_headers, BadRequest
 from sqlalchemy.orm.exc import NoResultFound

--- a/flexget/api/plugins/pending.py
+++ b/flexget/api/plugins/pending.py
@@ -1,0 +1,108 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+from math import ceil
+
+from flask import jsonify, request
+from flask_restplus import inputs
+from flexget.plugins.filter.pending_approval import list_pending_entries, PendingEntry
+
+from flexget.api import api, APIResource
+from flexget.api.app import base_message_schema, success_response, NotFoundError, etag, pagination_headers
+
+pending_api = api.namespace('pending', description='View and manage pending entries')
+
+
+class ObjectsContainer(object):
+    pending_entry_object = {
+        'type': 'object',
+        'properties': {
+            'id': {'type': 'integer'},
+            'task_name': {'type': 'string'},
+            'title': {'type': 'string'},
+            'url': {'type': 'string'},
+            'approved': {'type': 'boolean'},
+            'added': {'type': 'string', 'format': 'date-time'}
+        }
+    }
+
+    pending_entry_list = {'type': 'array', 'items': pending_entry_object}
+
+
+pending_entry_schema = api.schema('pending.entry', ObjectsContainer.pending_entry_object)
+pending_entry_list_schema = api.schema('pending.entry_list', ObjectsContainer.pending_entry_list)
+
+sort_choices = ('added', 'task_name', 'title', 'url', 'approved')
+pending_parser = api.pagination_parser(sort_choices=sort_choices)
+pending_parser.add_argument('task_name', help='Filter by task name')
+pending_parser.add_argument('approved', type=inputs.boolean, help='Filter by approval status')
+
+
+@pending_api.route('/')
+@api.response(NotFoundError)
+@api.response(200, model=pending_entry_list_schema)
+@api.doc(parser=pending_parser)
+class PendingEntriesAPI(APIResource):
+    @etag
+    def get(self, session=None):
+        """List all pending entries"""
+        args = pending_parser.parse_args()
+
+        # Filter params
+        task_name = args.get('task_name')
+        approved = args.get('approved')
+
+        # Pagination and sorting params
+        page = args['page']
+        per_page = args['per_page']
+        sort_by = args['sort_by']
+        sort_order = args['order']
+
+        # Handle max size limit
+        if per_page > 100:
+            per_page = 100
+
+        descending = sort_order == 'desc'
+
+        # Handle max size limit
+        if per_page > 100:
+            per_page = 100
+
+        start = per_page * (page - 1)
+        stop = start + per_page
+
+        kwargs = {
+            'task_name': task_name,
+            'approved': approved,
+            'start': start,
+            'stop': stop,
+            'descending': descending,
+            'sort_by': sort_by,
+            'session': session
+        }
+
+        total_items = session.query(PendingEntry).count()
+
+        if not total_items:
+            return jsonify([])
+
+        pending_entries = [pending.to_dict() for pending in list_pending_entries(**kwargs)]
+
+        total_pages = int(ceil(total_items / float(per_page)))
+
+        if page > total_pages:
+            raise NotFoundError('page %s does not exist' % page)
+
+        # Actual results in page
+        actual_size = min(per_page, len(pending_entries))
+
+        # Get pagination headers
+        pagination = pagination_headers(total_pages, total_items, actual_size, request)
+
+        # Created response
+        rsp = jsonify(pending_entries)
+
+        # Add link header to response
+        rsp.headers.extend(pagination)
+
+        return rsp

--- a/flexget/plugins/cli/pending.py
+++ b/flexget/plugins/cli/pending.py
@@ -1,19 +1,32 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
+from argparse import ArgumentTypeError
+
 from flexget import options
 from flexget.event import event
 from flexget.manager import Session
-from flexget.plugins.filter.pending_approval import list_pending_entries
+from flexget.plugins.filter.pending_approval import list_pending_entries, get_entry_by_id
 from flexget.terminal import TerminalTable, TerminalTableError, table_parser, console, colorize
 from colorclass.toggles import disable_all_colors
+from sqlalchemy.orm.exc import NoResultFound
+
+
+def valid_entry(value):
+    try:
+        int(value)
+    except ValueError:
+        if value != 'all':
+            raise ArgumentTypeError('Must select \'all\' or valid entry ID')
+    return value
 
 
 def do_cli(manager, options):
     if hasattr(options, 'table_type') and options.table_type == 'porcelain':
         disable_all_colors()
     action_map = {
-        'list': list_entries
+        'list': list_entries,
+        'approve': approve_entries
     }
     action_map[options.action](options)
 
@@ -43,6 +56,29 @@ def list_entries(options):
             console('ERROR: %s' % str(e))
 
 
+def approve_entries(options):
+    """Approved pending entries"""
+    approve = options.approve
+    with Session() as session:
+        if approve == 'all':
+            entries = list_pending_entries(session=session, approved=False)
+        else:
+            try:
+                entry = get_entry_by_id(session, approve)
+                if entry.approved is True:
+                    console('ERROR: Entry with ID %s is already approved' % entry.id)
+                    sys.exit(1)
+            except NoResultFound:
+                console('Pending entry with ID %s does not exist' % approve)
+                sys.exit(1)
+            else:
+                entries = [entry]
+        for entry in entries:
+            if entry.approved is False:
+                console('Setting pending entry with ID %s status to approved' % entry.id)
+                entry.approved = True
+
+
 @event('options.register')
 def register_parser_arguments():
     parser = options.register_command('pending', do_cli, help='View and pending')
@@ -50,8 +86,11 @@ def register_parser_arguments():
 
     list_parser = subparsers.add_parser('list', help='Shows all existing pending entries', parents=[table_parser])
     list_parser.add_argument('--task-name', help='Filter by task name')
-    group = list_parser.add_mutually_exclusive_group()
-    group.add_argument('--pending', action='store_false', help='Show only pending entries', dest='approved',
-                       default=None)
-    group.add_argument('--approved', action='store_true', help='Show only approved entries', dest='approved',
-                       default=None)
+    list_group = list_parser.add_mutually_exclusive_group()
+    list_group.add_argument('--pending', action='store_false', help='Show only pending entries', dest='approved',
+                            default=None)
+    list_group.add_argument('--approved', action='store_true', help='Show only approved entries', dest='approved',
+                            default=None)
+
+    approve_parser = subparsers.add_parser('approve', help='Approved pending entries')
+    approve_parser.add_argument('approve', type=valid_entry, help='Entity ID or \'all\' to approve all pending entries')

--- a/flexget/plugins/cli/pending.py
+++ b/flexget/plugins/cli/pending.py
@@ -1,0 +1,57 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+from flexget import options
+from flexget.event import event
+from flexget.manager import Session
+from flexget.plugins.filter.pending_approval import list_pending_entries
+from flexget.terminal import TerminalTable, TerminalTableError, table_parser, console, colorize
+from colorclass.toggles import disable_all_colors
+
+
+def do_cli(manager, options):
+    if hasattr(options, 'table_type') and options.table_type == 'porcelain':
+        disable_all_colors()
+    action_map = {
+        'list': list_entries
+    }
+    action_map[options.action](options)
+
+
+def list_entries(options):
+    """List pending entries"""
+    approved = options.approved
+    task_name = options.task_name
+
+    with Session() as session:
+        entries = list_pending_entries(session=session, task_name=task_name, approved=approved)
+        header = ['#', 'Task Name', 'Title', 'URL', 'Approved', 'Added']
+        table_data = [header]
+        for entry in entries:
+            table_data.append([
+                entry.id,
+                entry.task_name,
+                entry.title,
+                entry.url,
+                colorize('green', 'Yes') if entry.approved else 'No',
+                entry.added.strftime("%c"),
+            ])
+        table = TerminalTable(options.table_type, table_data, wrap_columns=[2, 1, 0], drop_columns=[4, 2])
+        try:
+            console(table.output)
+        except TerminalTableError as e:
+            console('ERROR: %s' % str(e))
+
+
+@event('options.register')
+def register_parser_arguments():
+    parser = options.register_command('pending', do_cli, help='View and pending')
+    subparsers = parser.add_subparsers(title='actions', metavar='<action>', dest='action')
+
+    list_parser = subparsers.add_parser('list', help='Shows all existing pending entries', parents=[table_parser])
+    list_parser.add_argument('--task-name', help='Filter by task name')
+    group = list_parser.add_mutually_exclusive_group()
+    group.add_argument('--pending', action='store_false', help='Show only pending entries', dest='approved',
+                       default=None)
+    group.add_argument('--approved', action='store_true', help='Show only approved entries', dest='approved',
+                       default=None)

--- a/flexget/plugins/filter/pending_approval.py
+++ b/flexget/plugins/filter/pending_approval.py
@@ -68,7 +68,9 @@ class PendingApproval(object):
             task.all_entries[:] = []
 
             # Pass all entries marked as approved
-            for approved_entry in session.query(PendingEntry).filter(PendingEntry.approved == True).all():
+            for approved_entry in session.query(PendingEntry)\
+                    .filter(PendingEntry.task_name == task.name)\
+                    .filter(PendingEntry.approved == True).all():
                 e = approved_entry.entry
                 e['approved'] = True
                 approved_entries.append(e)
@@ -80,7 +82,7 @@ class PendingApproval(object):
             return
         with Session() as session:
             # Delete all entries that have passed the pending phase
-            for entry in task.entries:
+            for entry in task.accepted:
                 if entry.get('approved', False) is True:
                     db_entry = self._item_query(entry, task, session)
                     if db_entry and db_entry.approved:

--- a/flexget/plugins/filter/pending_approval.py
+++ b/flexget/plugins/filter/pending_approval.py
@@ -1,0 +1,81 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+from hashlib import md5
+
+import logging
+
+from flexget.manager import Session
+from sqlalchemy import Column, String, Unicode, Boolean
+from flexget import db_schema, plugin
+from flexget.event import event
+
+log = logging.getLogger('pending_approval')
+Base = db_schema.versioned_base('pending_approval', 0)
+
+
+class PendingEntry(Base):
+    __tablename__ = 'pending_entries'
+
+    uid = Column(String, primary_key=True)
+    task_name = Column(Unicode)
+    title = Column(Unicode)
+    url = Column(String)
+    approved = Column(Boolean)
+
+    def __init__(self, task_name, title, url):
+        self.task_name = task_name
+        self.title = title
+        self.url = url
+        self.approved = False
+
+        uid = task_name.encode('utf-8') + title.encode('utf-8') + url.encode('utf-8')
+        self.uid = md5(uid).hexdigest()
+
+    def __repr__(self):
+        return '<PendingEntry(task_name={},title={},url={},approved={})>' \
+            .format(self.task_name, self.title, self.url, self.approved)
+
+
+class PendingApproval(object):
+    schema = {'type': 'boolean'}
+
+    @staticmethod
+    def _item_query(entry, task, session):
+        db_entry = session.query(PendingEntry) \
+            .filter(PendingEntry.task_name == task.name) \
+            .filter(PendingEntry.title == entry['title']) \
+            .filter(PendingEntry.url == entry['url']) \
+            .first()
+        return db_entry
+
+    @plugin.priority(0)
+    def on_task_filter(self, task, config):
+        if not config:
+            return
+
+        for entry in task.entries:
+            with Session() as session:
+                db_entry = self._item_query(entry, task, session)
+                if not db_entry:
+                    db_entry = PendingEntry(task_name=task.name, title=entry['title'], url=entry['url'])
+                    log.debug('creating new pending entry %s', db_entry)
+                session.merge(db_entry)
+
+                if db_entry.approved is True:
+                    entry.accept('approval was set to True')
+
+    def on_task_learn(self, task, config):
+        if not config:
+            return
+        for entry in task.accepted:
+            with Session() as session:
+                db_entry = self._item_query(entry, task, session)
+                if db_entry:
+                    log.debug('deleting approved entry %s', db_entry)
+                    session.delete(db_entry)
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(PendingApproval, 'pending_approval', api_ver=2)

--- a/flexget/plugins/filter/pending_approval.py
+++ b/flexget/plugins/filter/pending_approval.py
@@ -4,6 +4,7 @@ from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 import logging
 
 from flexget.manager import Session
+from flexget.utils.database import entry_synonym
 from sqlalchemy import Column, String, Unicode, Boolean, Integer
 from flexget import db_schema, plugin
 from flexget.event import event
@@ -20,12 +21,15 @@ class PendingEntry(Base):
     title = Column(Unicode)
     url = Column(String)
     approved = Column(Boolean)
+    _json = Column('json', Unicode)
+    entry = entry_synonym('_json')
 
-    def __init__(self, task_name, title, url):
+    def __init__(self, task_name, entry):
         self.task_name = task_name
-        self.title = title
-        self.url = url
+        self.title = entry['title']
+        self.url = entry['url']
         self.approved = False
+        self.entry = entry
 
     def __repr__(self):
         return '<PendingEntry(task_name={},title={},url={},approved={})>' \
@@ -44,31 +48,44 @@ class PendingApproval(object):
             .first()
         return db_entry
 
-    @plugin.priority(0)
-    def on_task_filter(self, task, config):
+    @plugin.priority(-1)
+    def on_task_input(self, task, config):
         if not config:
             return
 
-        for entry in task.entries:
-            with Session() as session:
-                db_entry = self._item_query(entry, task, session)
-                if not db_entry:
-                    db_entry = PendingEntry(task_name=task.name, title=entry['title'], url=entry['url'])
-                    log.debug('creating new pending entry %s', db_entry)
-                session.merge(db_entry)
+        approved_entries = []
+        with Session() as session:
+            # Let details plugin know that it is ok if this task doesn't produce any entries
+            task.no_entries_ok = True
 
-                if db_entry.approved is True:
-                    entry.accept('approval was set to True')
+            for entry in task.entries:
+                # Cache all new task entries
+                if not self._item_query(entry, task, session):
+                    log.verbose('creating new pending entry %s', entry)
+                    session.add(PendingEntry(task_name=task.name, entry=entry))
+
+            # Clear the current entries from the task now that they are stored
+            task.all_entries[:] = []
+
+            # Pass all entries marked as approved
+            for approved_entry in session.query(PendingEntry).filter(PendingEntry.approved == True).all():
+                e = approved_entry.entry
+                e['approved'] = True
+                approved_entries.append(e)
+
+        return approved_entries
 
     def on_task_learn(self, task, config):
         if not config:
             return
-        for entry in task.accepted:
-            with Session() as session:
-                db_entry = self._item_query(entry, task, session)
-                if db_entry:
-                    log.debug('deleting approved entry %s', db_entry)
-                    session.delete(db_entry)
+        with Session() as session:
+            # Delete all entries that have passed the pending phase
+            for entry in task.entries:
+                if entry.get('approved', False) is True:
+                    db_entry = self._item_query(entry, task, session)
+                    if db_entry and db_entry.approved:
+                        log.debug('deleting approved entry %s', db_entry)
+                        session.delete(db_entry)
 
 
 @event('plugin.register')

--- a/flexget/plugins/filter/pending_approval.py
+++ b/flexget/plugins/filter/pending_approval.py
@@ -1,12 +1,10 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
-from hashlib import md5
-
 import logging
 
 from flexget.manager import Session
-from sqlalchemy import Column, String, Unicode, Boolean
+from sqlalchemy import Column, String, Unicode, Boolean, Integer
 from flexget import db_schema, plugin
 from flexget.event import event
 
@@ -17,7 +15,7 @@ Base = db_schema.versioned_base('pending_approval', 0)
 class PendingEntry(Base):
     __tablename__ = 'pending_entries'
 
-    uid = Column(String, primary_key=True)
+    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
     task_name = Column(Unicode)
     title = Column(Unicode)
     url = Column(String)
@@ -28,9 +26,6 @@ class PendingEntry(Base):
         self.title = title
         self.url = url
         self.approved = False
-
-        uid = task_name.encode('utf-8') + title.encode('utf-8') + url.encode('utf-8')
-        self.uid = md5(uid).hexdigest()
 
     def __repr__(self):
         return '<PendingEntry(task_name={},title={},url={},approved={})>' \

--- a/flexget/plugins/filter/pending_approval.py
+++ b/flexget/plugins/filter/pending_approval.py
@@ -41,12 +41,11 @@ class PendingApproval(object):
 
     @staticmethod
     def _item_query(entry, task, session):
-        db_entry = session.query(PendingEntry) \
+        return session.query(PendingEntry) \
             .filter(PendingEntry.task_name == task.name) \
             .filter(PendingEntry.title == entry['title']) \
             .filter(PendingEntry.url == entry['url']) \
             .first()
-        return db_entry
 
     @plugin.priority(-1)
     def on_task_input(self, task, config):
@@ -68,9 +67,10 @@ class PendingApproval(object):
             task.all_entries[:] = []
 
             # Pass all entries marked as approved
-            for approved_entry in session.query(PendingEntry)\
-                    .filter(PendingEntry.task_name == task.name)\
-                    .filter(PendingEntry.approved == True).all():
+            for approved_entry in session.query(PendingEntry) \
+                    .filter(PendingEntry.task_name == task.name) \
+                    .filter(PendingEntry.approved == True) \
+                    .all():
                 e = approved_entry.entry
                 e['approved'] = True
                 approved_entries.append(e)

--- a/flexget/plugins/filter/pending_approval.py
+++ b/flexget/plugins/filter/pending_approval.py
@@ -105,3 +105,7 @@ def list_pending_entries(session, task_name=None, approved=None, start=None, sto
     else:
         query = query.order_by(getattr(PendingEntry, order_by))
     return query.slice(start, stop).all()
+
+
+def get_entry_by_id(session, entry_id):
+    return session.query(PendingEntry).filter(PendingEntry.id == entry_id).one()

--- a/flexget/plugins/filter/pending_approval.py
+++ b/flexget/plugins/filter/pending_approval.py
@@ -88,6 +88,8 @@ class PendingApproval(object):
 
     @plugin.priority(-1)
     def on_task_filter(self, task, config):
+        if not config:
+            return
         for entry in task.entries:
             if entry.get('approved'):
                 entry.accept('entry is marked as approved')

--- a/flexget/plugins/filter/pending_approval.py
+++ b/flexget/plugins/filter/pending_approval.py
@@ -37,6 +37,16 @@ class PendingEntry(Base):
         return '<PendingEntry(task_name={},title={},url={},approved={})>' \
             .format(self.task_name, self.title, self.url, self.approved)
 
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'task_name': self.task_name,
+            'title': self.title,
+            'url': self.url,
+            'approved': self.approved,
+            'added': self.added
+        }
+
 
 class PendingApproval(object):
     schema = {'type': 'boolean'}
@@ -100,7 +110,7 @@ def register_plugin():
     plugin.register(PendingApproval, 'pending_approval', api_ver=2)
 
 
-def list_pending_entries(session, task_name=None, approved=None, start=None, stop=None, order_by='added',
+def list_pending_entries(session, task_name=None, approved=None, start=None, stop=None, sort_by='added',
                          descending=True):
     log.debug('querying pending entries')
     query = session.query(PendingEntry)
@@ -109,9 +119,9 @@ def list_pending_entries(session, task_name=None, approved=None, start=None, sto
     if approved is not None:
         query = query.filter(PendingEntry.approved == approved)
     if descending:
-        query = query.order_by(getattr(PendingEntry, order_by).desc())
+        query = query.order_by(getattr(PendingEntry, sort_by).desc())
     else:
-        query = query.order_by(getattr(PendingEntry, order_by))
+        query = query.order_by(getattr(PendingEntry, sort_by))
     return query.slice(start, stop).all()
 
 

--- a/flexget/tests/api_tests/test_pending_api.py
+++ b/flexget/tests/api_tests/test_pending_api.py
@@ -1,0 +1,191 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+from flexget.api.app import base_message
+from flexget.entry import Entry
+
+from flexget.utils import json
+from flexget.plugins.filter.pending_approval import PendingEntry
+from flexget.api.plugins.pending import ObjectsContainer as OC
+from flexget.manager import Session
+
+
+class TestPendingAPI(object):
+    config = "{'tasks': {}}"
+
+    def test_pending_api_get_all(self, api_client, schema_match):
+        rsp = api_client.get('/pending/')
+        assert rsp.status_code == 200
+
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(OC.pending_entry_list, data)
+        assert not errors
+
+        e1 = Entry(title='test.title1', url='http://bla.com')
+        e2 = Entry(title='test.title1', url='http://bla.com')
+
+        with Session() as session:
+            pe1 = PendingEntry('test_task', e1)
+            pe2 = PendingEntry('test_task', e2)
+            session.bulk_save_objects([pe1, pe2])
+
+        rsp = api_client.get('/pending/')
+        assert rsp.status_code == 200
+
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(OC.pending_entry_list, data)
+        assert not errors
+        assert len(data) == 2
+        assert all(e['approved'] is False for e in data)
+
+    def test_pending_api_put_all(self, api_client, schema_match):
+        e1 = Entry(title='test.title1', url='http://bla.com')
+        e2 = Entry(title='test.title1', url='http://bla.com')
+
+        with Session() as session:
+            pe1 = PendingEntry('test_task', e1)
+            pe2 = PendingEntry('test_task', e2)
+            session.bulk_save_objects([pe1, pe2])
+
+        payload = {'operation': 'approve'}
+
+        rsp = api_client.json_put('/pending/', data=json.dumps(payload))
+        assert rsp.status_code == 201
+
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(OC.pending_entry_list, data)
+        assert not errors
+
+        assert len(data) == 2
+        assert all(e['approved'] is True for e in data)
+
+        rsp = api_client.json_put('/pending/', data=json.dumps(payload))
+        assert rsp.status_code == 204
+
+        payload = {'operation': 'reject'}
+
+        rsp = api_client.json_put('/pending/', data=json.dumps(payload))
+        assert rsp.status_code == 201
+
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(OC.pending_entry_list, data)
+        assert not errors
+
+        assert len(data) == 2
+        assert all(e['approved'] is False for e in data)
+
+        rsp = api_client.json_put('/pending/', data=json.dumps(payload))
+        assert rsp.status_code == 204
+
+    def test_pending_api_delete_all(self, api_client, schema_match):
+        e1 = Entry(title='test.title1', url='http://bla.com')
+        e2 = Entry(title='test.title1', url='http://bla.com')
+
+        with Session() as session:
+            pe1 = PendingEntry('test_task', e1)
+            pe2 = PendingEntry('test_task', e2)
+            session.bulk_save_objects([pe1, pe2])
+
+        rsp = api_client.delete('/pending/')
+        assert rsp.status_code == 200
+
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(base_message, data)
+        assert not errors
+
+    def test_pending_api_get_entry(self, api_client, schema_match):
+        e1 = Entry(title='test.title1', url='http://bla.com')
+        e2 = Entry(title='test.title1', url='http://bla.com')
+
+        with Session() as session:
+            pe1 = PendingEntry('test_task', e1)
+            pe2 = PendingEntry('test_task', e2)
+            session.bulk_save_objects([pe1, pe2])
+
+        rsp = api_client.get('/pending/1/')
+        assert rsp.status_code == 200
+
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(OC.pending_entry_object, data)
+        assert not errors
+
+        assert data['approved'] is False
+
+    def test_pending_api_put_entry(self, api_client, schema_match):
+        e1 = Entry(title='test.title1', url='http://bla.com')
+        e2 = Entry(title='test.title1', url='http://bla.com')
+
+        with Session() as session:
+            pe1 = PendingEntry('test_task', e1)
+            pe2 = PendingEntry('test_task', e2)
+            session.bulk_save_objects([pe1, pe2])
+
+        payload = {'operation': 'approve'}
+
+        rsp = api_client.json_put('/pending/1/', data=json.dumps(payload))
+        assert rsp.status_code == 201
+
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(OC.pending_entry_object, data)
+        assert not errors
+
+        assert data['approved'] is True
+
+        rsp = api_client.json_put('/pending/1/', data=json.dumps(payload))
+        assert rsp.status_code == 400
+
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(base_message, data)
+        assert not errors
+
+        payload = {'operation': 'reject'}
+
+        rsp = api_client.json_put('/pending/1/', data=json.dumps(payload))
+        assert rsp.status_code == 201
+
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(OC.pending_entry_object, data)
+        assert not errors
+
+        assert data['approved'] is False
+
+        rsp = api_client.json_put('/pending/1/', data=json.dumps(payload))
+        assert rsp.status_code == 400
+
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(base_message, data)
+        assert not errors
+
+    def test_pending_api_delete_entry(self, api_client, schema_match):
+        e1 = Entry(title='test.title1', url='http://bla.com')
+        e2 = Entry(title='test.title1', url='http://bla.com')
+
+        with Session() as session:
+            pe1 = PendingEntry('test_task', e1)
+            pe2 = PendingEntry('test_task', e2)
+            session.bulk_save_objects([pe1, pe2])
+
+        rsp = api_client.delete('/pending/1/')
+        assert rsp.status_code == 200
+
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(base_message, data)
+        assert not errors
+
+        rsp = api_client.delete('/pending/1/')
+        assert rsp.status_code == 404
+
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(base_message, data)
+        assert not errors

--- a/flexget/tests/test_pending_approval.py
+++ b/flexget/tests/test_pending_approval.py
@@ -1,0 +1,36 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+from flexget.manager import Session
+from flexget.plugins.filter.pending_approval import PendingEntry
+
+
+class TestPendingApproval(object):
+    config = """
+        tasks:
+          test:
+            mock:
+              - {title: 'title 1', url: 'http://localhost/title1', other_attribute: 'bla'}
+            pending_approval: yes
+            accept_all: yes
+    """
+
+    def test_pending_approval(self, execute_task, manager):
+        task = execute_task('test')
+        assert len(task.entries) == 0
+        assert len(task.accepted) == 0
+
+        # Mark entry as approved, this will be done by CLI/API
+        with Session() as session:
+            pnd_entry = session.query(PendingEntry).first()
+            pnd_entry.approved = True
+
+        task = execute_task('test')
+        assert len(task.entries) == 1
+        assert len(task.accepted) == 1
+
+        assert task.find_entry(other_attribute='bla')
+
+        task = execute_task('test')
+        assert len(task.entries) == 0
+        assert len(task.accepted) == 0

--- a/flexget/tests/test_pending_approval.py
+++ b/flexget/tests/test_pending_approval.py
@@ -12,7 +12,6 @@ class TestPendingApproval(object):
             mock:
               - {title: 'title 1', url: 'http://localhost/title1', other_attribute: 'bla'}
             pending_approval: yes
-            accept_all: yes
     """
 
     def test_pending_approval(self, execute_task, manager):


### PR DESCRIPTION
### Motivation for changes:
A more generic approach to the `pending` idea, this will work with a single task, not list dependent.

### Detailed changes:

- Each entry in `task.entries` will be cached.
- If `db_entry.approved` is True entry will be accepted

Currently this operates inside a single task, but schema can take task name and try to inject it into any other task if needed. Not sure if that's useful or not, it's @gazpachoking idea ;-)

#### To Do:
- [x] CLI
- [x] API
- [x] Tests
- [x] DB Cleanup


