### PR TITLE
archives plugin: treat IOErrors as “not a directory”

### DIFF
--- a/flexget/utils/archive.py
+++ b/flexget/utils/archive.py
@@ -209,6 +209,6 @@ def is_archive(path):
             archive.close()
             return True
     except (IOError, ArchiveError) as error:
-        log.debug('Failed to open file as archive: %s (%s)' % (path, error))
+        log.debug('Failed to open file as archive: %s (%s)', path, error)
 
     return False

--- a/flexget/utils/archive.py
+++ b/flexget/utils/archive.py
@@ -208,7 +208,7 @@ def is_archive(path):
         if archive:
             archive.close()
             return True
-    except ArchiveError as error:
+    except (IOError, ArchiveError) as error:
         error_message = 'Failed to open file as archive: %s (%s)' % (path, error)
         log.debug(error_message)
 

--- a/flexget/utils/archive.py
+++ b/flexget/utils/archive.py
@@ -209,7 +209,6 @@ def is_archive(path):
             archive.close()
             return True
     except (IOError, ArchiveError) as error:
-        error_message = 'Failed to open file as archive: %s (%s)' % (path, error)
-        log.debug(error_message)
+        log.debug('Failed to open file as archive: %s (%s)' % (path, error))
 
     return False


### PR DESCRIPTION
### Motivation for changes:
Prevent crashes when encountering directories

### Detailed changes:
- Add IOError as a handled exception in is_archive() function

### Addressed issues:

- Fixes #1525 .

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
```
paste output here
```


