### PR TITLE
Seen `learn` event

### DIFF
--- a/flexget/plugins/filter/pending_approval.py
+++ b/flexget/plugins/filter/pending_approval.py
@@ -90,7 +90,7 @@ class PendingApproval(object):
                 elif not self._item_query(entry, task, session):
                     log.verbose('creating new pending entry %s', entry)
                     session.add(PendingEntry(task_name=task.name, entry=entry))
-                    entry.reject('new unapproved entry, caching and waiting for approval')
+                    entry.reject('entry is unapproved, caching and waiting for approval')
                     fire_event('learn', task, entry, reason='pending entry already added', local=True)
 
     def on_task_learn(self, task, config):

--- a/flexget/plugins/filter/pending_approval.py
+++ b/flexget/plugins/filter/pending_approval.py
@@ -91,7 +91,7 @@ class PendingApproval(object):
                     log.verbose('creating new pending entry %s', entry)
                     session.add(PendingEntry(task_name=task.name, entry=entry))
                     entry.reject('entry is unapproved, caching and waiting for approval')
-                    fire_event('learn', task, entry, reason='pending entry already added', local=True)
+                    fire_event('learn', task, entry, reason='pending entry already added')
 
     def on_task_learn(self, task, config):
         if not config:

--- a/flexget/plugins/filter/pending_approval.py
+++ b/flexget/plugins/filter/pending_approval.py
@@ -5,7 +5,7 @@ import logging
 from datetime import datetime, timedelta
 
 from flexget import db_schema, plugin
-from flexget.event import event
+from flexget.event import event, fire_event
 from flexget.manager import Session
 from flexget.utils.database import entry_synonym
 from sqlalchemy import Column, String, Unicode, Boolean, Integer, DateTime
@@ -91,6 +91,7 @@ class PendingApproval(object):
                     log.verbose('creating new pending entry %s', entry)
                     session.add(PendingEntry(task_name=task.name, entry=entry))
                     entry.reject('new unapproved entry, caching and waiting for approval')
+                    fire_event('learn', task, entry, reason='pending entry already added', local=True)
 
     def on_task_learn(self, task, config):
         if not config:

--- a/flexget/plugins/filter/seen.py
+++ b/flexget/plugins/filter/seen.py
@@ -155,18 +155,18 @@ def forget(value):
         log.debug('forget called with %s', value)
         count = 0
         field_count = 0
-        for se in session.query(SeenEntry).filter(or_(SeenEntry.title == value, SeenEntry.task == value)).all():
-            field_count += len(se.fields)
+        for seen_entry in session.query(SeenEntry).filter(or_(SeenEntry.title == value, SeenEntry.task == value)).all():
+            field_count += len(seen_entry.fields)
             count += 1
-            log.debug('forgetting %s', se)
-            session.delete(se)
+            log.debug('forgetting %s', seen_entry)
+            session.delete(seen_entry)
 
-        for sf in session.query(SeenField).filter(SeenField.value == value).all():
-            se = session.query(SeenEntry).filter(SeenEntry.id == sf.seen_entry_id).first()
-            field_count += len(se.fields)
+        for seen_field in session.query(SeenField).filter(SeenField.value == value).all():
+            seen_entry = session.query(SeenEntry).filter(SeenEntry.id == seen_field.seen_entry_id).first()
+            field_count += len(seen_entry.fields)
             count += 1
-            log.debug('forgetting %s', se)
-            session.delete(se)
+            log.debug('forgetting %s', seen_entry)
+            session.delete(seen_entry)
     return count, field_count
 
 
@@ -176,7 +176,7 @@ def learn(task, entry, fields=None, reason=None, local=False):
     # no explicit fields given, use default
     if not fields:
         fields = ['title', 'url', 'original_url']
-    se = SeenEntry(entry['title'], str(task.name), reason, local)
+    seen_entry = SeenEntry(entry['title'], str(task.name), reason, local)
     remembered = []
     for field in fields:
         if field not in entry:
@@ -185,12 +185,12 @@ def learn(task, entry, fields=None, reason=None, local=False):
         if entry[field] in remembered:
             continue
         remembered.append(entry[field])
-        sf = SeenField(str(field), str(entry[field]))
-        se.fields.append(sf)
+        seen_field = SeenField(str(field), str(entry[field]))
+        seen_entry.fields.append(seen_field)
         log.debug("Learned '%s' (field: %s, local: %d)", entry[field], field, local)
     # Only add the entry to the session if it has one of the required fields
-    if se.fields:
-        task.session.add(se)
+    if seen_entry.fields:
+        task.session.add(seen_entry)
 
 
 @with_session

--- a/flexget/tests/test_pending_approval.py
+++ b/flexget/tests/test_pending_approval.py
@@ -36,3 +36,8 @@ class TestPendingApproval(object):
         assert len(task.all_entries) == 1
         assert len(task.rejected) == 1
         assert len(task.accepted) == 0
+
+        # Verify that pending entry is not re-added on another execution
+        with Session() as session:
+            pnd_entry = session.query(PendingEntry).first()
+            assert pnd_entry is None

--- a/flexget/tests/test_pending_approval.py
+++ b/flexget/tests/test_pending_approval.py
@@ -14,7 +14,7 @@ class TestPendingApproval(object):
             pending_approval: yes
     """
 
-    def test_pending_approval(self, execute_task, manager):
+    def test_pending_approval(self, execute_task):
         task = execute_task('test')
         assert len(task.all_entries) == 1
         assert len(task.rejected) == 1
@@ -31,6 +31,26 @@ class TestPendingApproval(object):
         assert len(task.accepted) == 1
 
         assert task.find_entry(other_attribute='bla')
+
+        task = execute_task('test')
+        assert len(task.all_entries) == 1
+        assert len(task.rejected) == 1
+        assert len(task.accepted) == 0
+
+        # Verify that pending entry is not re-added on another execution
+        with Session() as session:
+            pnd_entry = session.query(PendingEntry).first()
+            assert pnd_entry is None
+
+    def test_delete_without_approving(self, execute_task):
+        task = execute_task('test')
+        assert len(task.all_entries) == 1
+        assert len(task.rejected) == 1
+        assert len(task.accepted) == 0
+
+        with Session() as session:
+            pnd_entry = session.query(PendingEntry).first()
+            session.delete(pnd_entry)
 
         task = execute_task('test')
         assert len(task.all_entries) == 1


### PR DESCRIPTION
## Motivation for changes:
Pending plugin works is a unique way, and it needs to be able to reject entries that weren't accepted in the past. This is achieved by calling `seen` plugin using the new `learn` event

### Detailed changes:

- Created the `learn` event
- Minor change to `seen` plugin to use the same code path
- Firing event via `pending_approval` on `PendingEntry` creation in DB

### Problem: 
When the `learn` event is called, the `local` var is set to `None` by default. But if the user uses `seen: local` in his task, then the seen entry won't match and it'll get re-created on new execution. Need to figure out a way to couple `local` seen value to `learn` event call...




