### PR TITLE
updates trakt.tv API URL

### DIFF
--- a/flexget/plugins/internal/api_trakt.py
+++ b/flexget/plugins/internal/api_trakt.py
@@ -30,7 +30,7 @@ log = logging.getLogger('api_trakt')
 # Production Site
 CLIENT_ID = '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af'
 CLIENT_SECRET = 'db4af7531e8df678b134dbc22445a2c04ebdbdd7213be7f5b6d17dfdfabfcdc2'
-API_URL = 'https://api-v2launch.trakt.tv/'
+API_URL = 'https://api.trakt.tv/'
 PIN_URL = 'http://trakt.tv/pin/346'
 # Stores the last time we checked for updates for shows/movies
 updated = SimplePersistence('api_trakt')


### PR DESCRIPTION
### Motivation for changes:

Trakt.tv internal plugin is broken because of an outdated API URL

### Detailed changes:

- updates the value of constant API_URL to the correct URL http://docs.trakt.apiary.io/#introduction/api-url

### Addressed issues:

- Fixes # .

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
```
paste output here
```


The URL for the API can be found here http://docs.trakt.apiary.io/#introduction/api-url