### PR TITLE
Convert if plugin to use jinja expressions instead of python eval.

### DIFF
--- a/flexget/plugins/filter/if_condition.py
+++ b/flexget/plugins/filter/if_condition.py
@@ -1,29 +1,20 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 from future.moves import builtins
-from past.builtins import basestring
 
 import logging
-import re
 import datetime
 from copy import copy
+
+from jinja2 import UndefinedError
 
 from flexget import plugin
 from flexget.event import event
 from flexget.task import Task
 from flexget.entry import Entry
+from flexget.utils.template import evaluate_expression
 
 log = logging.getLogger('if')
-
-
-def safer_eval(statement, locals):
-    """A safer eval function. Does not allow __ or try statements, only includes certain 'safe' builtins."""
-    allowed_builtins = ['True', 'False', 'str', 'bytes', 'int', 'float', 'len', 'any', 'all', 'sorted']
-    for name in allowed_builtins:
-        locals[name] = getattr(builtins, name)
-    if re.search(r'__|try\s*:|lambda', statement):
-        raise ValueError('`__`, lambda or try blocks not allowed in if statements.')
-    return eval(statement, {'__builtins__': None}, locals)
 
 
 class FilterIf(object):
@@ -54,16 +45,16 @@ class FilterIf(object):
                             'now': datetime.datetime.now()})
         try:
             # Restrict eval namespace to have no globals and locals only from eval_locals
-            passed = safer_eval(condition, eval_locals)
+            passed = evaluate_expression(condition, eval_locals)
             if passed:
                 log.debug('%s matched requirement %s' % (entry['title'], condition))
             return passed
-        except NameError as e:
+        except UndefinedError as e:
             # Extract the name that did not exist
             missing_field = e.args[0].split('\'')[1]
             log.debug('%s does not contain the field %s' % (entry['title'], missing_field))
         except Exception as e:
-            log.error('Error occured while evaluating statement `%s`. (%s)' % (condition, e))
+            log.error('Error occurred while evaluating statement `%s`. (%s)' % (condition, e))
 
     def __getattr__(self, item):
         """Provides handlers for all phases."""
@@ -81,7 +72,7 @@ class FilterIf(object):
             for item in config:
                 requirement, action = list(item.items())[0]
                 passed_entries = [e for e in task.entries if self.check_condition(requirement, e)]
-                if isinstance(action, basestring):
+                if isinstance(action, str):
                     if not phase == 'filter':
                         continue
                     # Simple entry action (accept, reject or fail) was specified as a string

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -232,3 +232,17 @@ def render_from_task(template, task):
     """
     variables = {'task': task, 'now': datetime.now(), 'task_name': task.name}
     return render(template, variables)
+
+
+def evaluate_expression(expression, context):
+    """
+    Evaluate a jinja `expression` using a given `context` with support for `LazyDict`s (`Entry`s.)
+
+    :param str expression:  A jinja expression to evaluate
+    :param context: dictlike, supporting LazyDicts
+    """
+    compiled_expr = environment.compile_expression(expression)
+    # If we have a LazyDict, grab the underlying store. Our environment supports LazyFields directly
+    if isinstance(context, LazyDict):
+        context = context.store
+    return compiled_expr(**context)


### PR DESCRIPTION
### Motivation for changes:
Python eval is not safe for user input. Jinja expressions are much more appropriate.

### Detailed changes:
- `if` plugin statements are now evaluated as jinja [expressions](http://jinja.pocoo.org/docs/dev/templates/#expressions)
- As jinja expressions have mostly the same syntax as the limited form of python we intended with the if plugin, most current configs should still work.
- We can now also use jinja [filters](http://jinja.pocoo.org/docs/dev/templates/#filters) and [tests](http://jinja.pocoo.org/docs/dev/templates/#tests) in if statements.
- implemented the expression evaluation via `flexget.utils.evaluate_expression` which allows for lazy fields to stay lazy for evaluation. (which the fully default jinja method wouldn't do by itself)

Our tests seem to just pass, not sure if there are cases where config changes could be needed.