### PR TITLE
[fix] Possible crashes on generating random URLs on Python3

### DIFF
--- a/flexget/options.py
+++ b/flexget/options.py
@@ -115,7 +115,7 @@ class InjectAction(Action):
         if values:
             kwargs['url'] = values.pop(0)
         else:
-            kwargs['url'] = 'http://localhost/inject/%s' % ''.join(random.sample(string.letters + string.digits, 30))
+            kwargs['url'] = 'http://localhost/inject/%s' % ''.join(random.sample(string.ascii_letters + string.digits, 30))
         if 'force' in [v.lower() for v in values]:
             kwargs['immortal'] = True
         entry = Entry(**kwargs)

--- a/flexget/plugins/cli/inject.py
+++ b/flexget/plugins/cli/inject.py
@@ -35,7 +35,7 @@ def do_cli(manager, options):
     if options.url:
         entry['url'] = options.url
     else:
-        entry['url'] = 'http://localhost/inject/%s' % ''.join(random.sample(string.letters + string.digits, 30))
+        entry['url'] = 'http://localhost/inject/%s' % ''.join(random.sample(string.ascii_letters + string.digits, 30))
     if options.force:
         entry['immortal'] = True
     if options.accept:

--- a/flexget/plugins/input/gen_series.py
+++ b/flexget/plugins/input/gen_series.py
@@ -49,7 +49,7 @@ class GenSeries(object):
                         entry['title'] = 'series %d name - S%02dE%02d - %s' % \
                                          (num, season + 1, episode + 1, quality)
                         entry['url'] = 'http://localhost/mock/%s' % \
-                                       ''.join([random.choice(string.letters + string.digits) for x in range(1, 30)])
+                                       ''.join([random.choice(string.ascii_letters + string.digits) for x in range(1, 30)])
                         self.entries.append(entry)
         log.info('Generated %d entries' % len(self.entries))
 

--- a/flexget/plugins/input/generate.py
+++ b/flexget/plugins/input/generate.py
@@ -24,9 +24,9 @@ class Generate(object):
             import random
             entry['url'] = 'http://localhost/generate/%s/%s' % (
                 i,
-                ''.join([random.choice(string.letters + string.digits) for x in range(1, 30)]))
-            entry['title'] = ''.join([random.choice(string.letters + string.digits) for x in range(1, 30)])
-            entry['description'] = ''.join([random.choice(string.letters + string.digits) for x in range(1, 1000)])
+                ''.join([random.choice(string.ascii_letters + string.digits) for x in range(1, 30)]))
+            entry['title'] = ''.join([random.choice(string.ascii_letters + string.digits) for x in range(1, 30)])
+            entry['description'] = ''.join([random.choice(string.ascii_letters + string.digits) for x in range(1, 1000)])
             entries.append(entry)
         return entries
 


### PR DESCRIPTION
### Motivation for changes:

Flexget crashes on generating random URLs, for example on injecting an entry, using Python3:
```
[/opt/local/flexget-test] # flexget inject FooBar --learn
Traceback (most recent call last):
  File "/opt/bin/flexget", line 11, in <module>
    sys.exit(main())
  File "/opt/lib/python3.5/site-packages/flexget/__init__.py", line 42, in main
    manager.start()
  File "/opt/lib/python3.5/site-packages/flexget/manager.py", line 326, in start
    self.handle_cli()
  File "/opt/lib/python3.5/site-packages/flexget/manager.py", line 353, in handle_cli
    options.cli_command_callback(self, command_options)
  File "/opt/lib/python3.5/site-packages/flexget/plugins/cli/inject.py", line 38, in do_cli
    entry['url'] = 'http://localhost/inject/%s' % ''.join(random.sample(string.letters + string.digits, 30))
AttributeError: module 'string' has no attribute 'letters'
```

### Detailed changes:

Python3 standard library module `string` doesn't have attribute `letters`, `ascii_letters` is used instead.
