### PR TITLE
Formalize declaring a plugin's implemented interfaces

### DIFF
--- a/docs/develop/list_interface.rst
+++ b/docs/develop/list_interface.rst
@@ -199,15 +199,7 @@ After creating the base class, the plugin class itself need to be created.
 
     @event('plugin.register')
     def register_plugin():
-        plugin.register(EntryList, 'entry_list', api_ver=2, groups=['list'])
+        plugin.register(EntryList, 'entry_list', api_ver=2, interfaces=['list', 'task'])
 
-Note the ``get_list(config)`` method which is mandatory, and the ``on_task_input`` method which enable to use the plugin
-as an input plugin.
-
-Also note to register the plugin under the ``list`` group.
-
-
-
-
-
-
+All list plugins must declare the `list` interface, and implement the ``get_list(config)`` method. Declaring the `task`
+interface and the ``on_task_input`` method will allow the plugin to be used as an input plugin.

--- a/flexget/api/core/plugins.py
+++ b/flexget/api/core/plugins.py
@@ -61,7 +61,6 @@ def plugin_to_dict(plugin):
         'api_ver': plugin.api_ver,
         'builtin': plugin.builtin,
         'category': plugin.category,
-        'contexts': plugin.contexts,
         'debug': plugin.debug,
         'groups': plugin.groups,
         'phase_handlers': [dict(phase=handler, priority=event.priority) for handler, event in

--- a/flexget/api/core/plugins.py
+++ b/flexget/api/core/plugins.py
@@ -51,7 +51,7 @@ plugin_parser.add_argument('include_schema', type=inputs.boolean, default=False,
 
 plugins_parser = api.pagination_parser(plugin_parser)
 
-plugins_parser.add_argument('group', case_sensitive=False, help='Show plugins belonging to this group')
+plugins_parser.add_argument('interface', case_sensitive=False, help='Show plugins which implement this interface')
 plugins_parser.add_argument('phase', case_sensitive=False, help='Show plugins that act on this phase')
 
 
@@ -62,7 +62,7 @@ def plugin_to_dict(plugin):
         'builtin': plugin.builtin,
         'category': plugin.category,
         'debug': plugin.debug,
-        'groups': plugin.groups,
+        'interfaces': plugin.interfaces,
         'phase_handlers': [dict(phase=handler, priority=event.priority) for handler, event in
                            plugin.phase_handlers.items()]
     }
@@ -92,7 +92,7 @@ class PluginsAPI(APIResource):
 
         plugin_list = []
         try:
-            for plugin in get_plugins(phase=args['phase'], group=args['group']):
+            for plugin in get_plugins(phase=args['phase'], interface=args['interface']):
                 p = plugin_to_dict(plugin)
                 if args['include_schema']:
                     p['schema'] = plugin.schema

--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -216,7 +216,8 @@ class PluginInfo(dict):
     # Counts duplicate registrations
     dupe_counter = 0
 
-    def __init__(self, plugin_class, name=None, interfaces=None, builtin=False, debug=False, api_ver=1, category=None):
+    def __init__(self, plugin_class, name=None, interfaces=None, builtin=False, debug=False, api_ver=1, category=None,
+                 groups=None):
         """
         Register a plugin.
 
@@ -228,9 +229,14 @@ class PluginInfo(dict):
         :param int api_ver: Signature of callback hooks (1=task; 2=task,config).
         :param string category: The type of plugin. Can be one of the task phases.
             Defaults to the package name containing the plugin.
+        :param groups: DEPRECATED
         """
         dict.__init__(self)
 
+        if groups is not None:
+            warnings.warn('The `group` argument for plugin registration is deprecated. `interfaces` should be used '
+                          'instead. Plugin %s' % name, DeprecationWarning, stacklevel=2)
+            interfaces = ['task'] + groups
         if interfaces is None:
             interfaces = ['task']
         if name is None:

--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -233,12 +233,12 @@ class PluginInfo(dict):
         """
         dict.__init__(self)
 
-        if groups is not None:
-            warnings.warn('The `group` argument for plugin registration is deprecated. `interfaces` should be used '
-                          'instead. Plugin %s' % name, DeprecationWarning, stacklevel=2)
-            interfaces = ['task'] + groups
         if interfaces is None:
             interfaces = ['task']
+        if groups is not None:
+            warnings.warn('The `groups` argument for plugin registration is deprecated. `interfaces` should be used '
+                          'instead. Plugin %s' % name, DeprecationWarning, stacklevel=2)
+            interfaces.extend(groups)
         if name is None:
             # Convention is to take camel-case class name and rewrite it to an underscore form,
             # e.g. 'PluginName' to 'plugin_name'

--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -216,13 +216,13 @@ class PluginInfo(dict):
     # Counts duplicate registrations
     dupe_counter = 0
 
-    def __init__(self, plugin_class, name=None, groups=None, builtin=False, debug=False, api_ver=1, category=None):
+    def __init__(self, plugin_class, name=None, interfaces=None, builtin=False, debug=False, api_ver=1, category=None):
         """
         Register a plugin.
 
         :param plugin_class: The plugin factory.
         :param string name: Name of the plugin (if not given, default to factory class name in underscore form).
-        :param list groups: Groups this plugin belongs to.
+        :param list interfaces: Interfaces this plugin implements.
         :param bool builtin: Auto-activated?
         :param bool debug: True if plugin is for debugging purposes.
         :param int api_ver: Signature of callback hooks (1=task; 2=task,config).
@@ -231,8 +231,8 @@ class PluginInfo(dict):
         """
         dict.__init__(self)
 
-        if groups is None:
-            groups = ['task']
+        if interfaces is None:
+            interfaces = ['task']
         if name is None:
             # Convention is to take camel-case class name and rewrite it to an underscore form,
             # e.g. 'PluginName' to 'plugin_name'
@@ -248,7 +248,7 @@ class PluginInfo(dict):
         # Set basic info attributes
         self.api_ver = api_ver
         self.name = name
-        self.groups = groups
+        self.interfaces = interfaces
         self.builtin = builtin
         self.debug = debug
         self.category = category
@@ -459,12 +459,12 @@ def load_plugins(extra_dirs=None):
     log.debug('Plugins took %.2f seconds to load. %s plugins in registry.', took, len(plugins.keys()))
 
 
-def get_plugins(phase=None, group=None, category=None, name=None, min_api=None):
+def get_plugins(phase=None, interface=None, category=None, name=None, min_api=None):
     """
     Query other plugins characteristics.
 
     :param string phase: Require phase
-    :param string group: Plugin must belong to this group.
+    :param string interface: Plugin must implement this interface.
     :param string category: Type of plugin, phase names.
     :param string name: Name of the plugin.
     :param int min_api: Minimum api version.
@@ -477,7 +477,7 @@ def get_plugins(phase=None, group=None, category=None, name=None, min_api=None):
             raise ValueError('Unknown phase %s' % phase)
         if phase and phase not in plugin.phase_handlers:
             return False
-        if group and group not in plugin.groups:
+        if interface and interface not in plugin.interfaces:
             return False
         if category and not category == plugin.category:
             return False

--- a/flexget/plugins/cli/plugins.py
+++ b/flexget/plugins/cli/plugins.py
@@ -17,7 +17,7 @@ def plugins_summary(manager, options):
         disable_all_colors()
     header = ['Keyword', 'Phases', 'Flags']
     table_data = [header]
-    for plugin in sorted(get_plugins(phase=options.phase, group=options.group)):
+    for plugin in sorted(get_plugins(phase=options.phase, interface=options.interface)):
         if options.builtins and not plugin.builtin:
             continue
         flags = []

--- a/flexget/plugins/cli/try_regexp.py
+++ b/flexget/plugins/cli/try_regexp.py
@@ -66,6 +66,8 @@ class PluginTryRegexp(object):
 
 @event('plugin.register')
 def register_plugin():
+    # This plugin runs on task phases, but should not be allowed in the config, so we do not declare the 'task'
+    # interface. This may break if we start checking for the task interface for more than just config schemas.
     plugin.register(PluginTryRegexp, '--try-regexp', builtin=True, interfaces=[], api_ver=2)
 
 

--- a/flexget/plugins/cli/try_regexp.py
+++ b/flexget/plugins/cli/try_regexp.py
@@ -66,7 +66,7 @@ class PluginTryRegexp(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginTryRegexp, '--try-regexp', builtin=True, api_ver=2)
+    plugin.register(PluginTryRegexp, '--try-regexp', builtin=True, groups=[], api_ver=2)
 
 
 @event('options.register')

--- a/flexget/plugins/cli/try_regexp.py
+++ b/flexget/plugins/cli/try_regexp.py
@@ -66,7 +66,7 @@ class PluginTryRegexp(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginTryRegexp, '--try-regexp', builtin=True, groups=[], api_ver=2)
+    plugin.register(PluginTryRegexp, '--try-regexp', builtin=True, interfaces=[], api_ver=2)
 
 
 @event('options.register')

--- a/flexget/plugins/estimators/est_release_series_internal_db.py
+++ b/flexget/plugins/estimators/est_release_series_internal_db.py
@@ -59,4 +59,4 @@ class EstimatesSeriesInternal(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(EstimatesSeriesInternal, 'est_series_internal', groups=['estimate_release'], api_ver=2)
+    plugin.register(EstimatesSeriesInternal, 'est_series_internal', interfaces=['estimate_release'], api_ver=2)

--- a/flexget/plugins/estimators/est_release_series_tvmaze.py
+++ b/flexget/plugins/estimators/est_release_series_tvmaze.py
@@ -62,4 +62,4 @@ class EstimatesSeriesTVMaze(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(EstimatesSeriesTVMaze, 'est_series_tvmaze', groups=['estimate_release'], api_ver=2)
+    plugin.register(EstimatesSeriesTVMaze, 'est_series_tvmaze', interfaces=['estimate_release'], api_ver=2)

--- a/flexget/plugins/estimators/est_released.py
+++ b/flexget/plugins/estimators/est_released.py
@@ -21,7 +21,7 @@ class EstimateRelease(object):
         """
 
         log.debug(entry['title'])
-        estimators = [e.instance.estimate for e in plugin.get_plugins(group='estimate_release')]
+        estimators = [e.instance.estimate for e in plugin.get_plugins(interface='estimate_release')]
         for estimator in sorted(
                 estimators, key=lambda e: getattr(e, 'priority', plugin.DEFAULT_PRIORITY), reverse=True
         ):

--- a/flexget/plugins/estimators/est_released_movies.py
+++ b/flexget/plugins/estimators/est_released_movies.py
@@ -27,4 +27,4 @@ class EstimatesReleasedMovies(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(EstimatesReleasedMovies, 'est_released_movies', groups=['estimate_release'], api_ver=2)
+    plugin.register(EstimatesReleasedMovies, 'est_released_movies', interfaces=['estimate_release'], api_ver=2)

--- a/flexget/plugins/estimators/est_released_movies_bluray.py
+++ b/flexget/plugins/estimators/est_released_movies_bluray.py
@@ -45,4 +45,4 @@ class EstimatesMoviesBluray(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(EstimatesMoviesBluray, 'est_movies_bluray', groups=['estimate_release'], api_ver=2)
+    plugin.register(EstimatesMoviesBluray, 'est_movies_bluray', interfaces=['estimate_release'], api_ver=2)

--- a/flexget/plugins/filter/exists_movie.py
+++ b/flexget/plugins/filter/exists_movie.py
@@ -194,4 +194,4 @@ class FilterExistsMovie(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(FilterExistsMovie, 'exists_movie', groups=['task'], api_ver=2)
+    plugin.register(FilterExistsMovie, 'exists_movie', interfaces=['task'], api_ver=2)

--- a/flexget/plugins/filter/exists_movie.py
+++ b/flexget/plugins/filter/exists_movie.py
@@ -194,4 +194,4 @@ class FilterExistsMovie(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(FilterExistsMovie, 'exists_movie', groups=['exists'], api_ver=2)
+    plugin.register(FilterExistsMovie, 'exists_movie', groups=['task'], api_ver=2)

--- a/flexget/plugins/filter/exists_series.py
+++ b/flexget/plugins/filter/exists_series.py
@@ -123,4 +123,4 @@ class FilterExistsSeries(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(FilterExistsSeries, 'exists_series', groups=['exists'], api_ver=2)
+    plugin.register(FilterExistsSeries, 'exists_series', groups=['task'], api_ver=2)

--- a/flexget/plugins/filter/exists_series.py
+++ b/flexget/plugins/filter/exists_series.py
@@ -123,4 +123,4 @@ class FilterExistsSeries(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(FilterExistsSeries, 'exists_series', groups=['task'], api_ver=2)
+    plugin.register(FilterExistsSeries, 'exists_series', interfaces=['task'], api_ver=2)

--- a/flexget/plugins/filter/list_match.py
+++ b/flexget/plugins/filter/list_match.py
@@ -16,7 +16,7 @@ class ListMatch(object):
         'properties': {
             'from': {'type': 'array', 'items':
                 {'allOf': [
-                    {'$ref': '/schema/plugins?group=list'},
+                    {'$ref': '/schema/plugins?interface=list'},
                     {'maxProperties': 1,
                      'error_maxProperties': 'Plugin options within list_match plugin must be indented '
                                             '2 more spaces than the first letter of the plugin name.',

--- a/flexget/plugins/generic/archive.py
+++ b/flexget/plugins/generic/archive.py
@@ -292,4 +292,4 @@ def search(session, text, tags=None, sources=None, desc=False):
 @event('plugin.register')
 def register_plugin():
     plugin.register(Archive, 'archive', api_ver=2)
-    plugin.register(UrlrewriteArchive, 'flexget_archive', groups=['search'], api_ver=2)
+    plugin.register(UrlrewriteArchive, 'flexget_archive', interfaces=['search'], api_ver=2)

--- a/flexget/plugins/input/anidb_list.py
+++ b/flexget/plugins/input/anidb_list.py
@@ -94,4 +94,4 @@ class AnidbList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(AnidbList, 'anidb_list', api_ver=2, groups=['task', 'list'])
+    plugin.register(AnidbList, 'anidb_list', api_ver=2, interfaces=['task', 'list'])

--- a/flexget/plugins/input/anidb_list.py
+++ b/flexget/plugins/input/anidb_list.py
@@ -94,4 +94,4 @@ class AnidbList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(AnidbList, 'anidb_list', api_ver=2, groups=['list'])
+    plugin.register(AnidbList, 'anidb_list', api_ver=2, groups=['task', 'list'])

--- a/flexget/plugins/input/betaseries_list.py
+++ b/flexget/plugins/input/betaseries_list.py
@@ -197,4 +197,4 @@ def query_series(api_key, user_token, member_name=None):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(BetaSeriesList, 'betaseries_list', api_ver=2, groups=['list'])
+    plugin.register(BetaSeriesList, 'betaseries_list', api_ver=2, groups=['task', 'list'])

--- a/flexget/plugins/input/betaseries_list.py
+++ b/flexget/plugins/input/betaseries_list.py
@@ -197,4 +197,4 @@ def query_series(api_key, user_token, member_name=None):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(BetaSeriesList, 'betaseries_list', api_ver=2, groups=['task', 'list'])
+    plugin.register(BetaSeriesList, 'betaseries_list', api_ver=2, interfaces=['task', 'list'])

--- a/flexget/plugins/input/discover.py
+++ b/flexget/plugins/input/discover.py
@@ -68,7 +68,7 @@ class Discover(object):
                 'allOf': [{'$ref': '/schema/plugins?phase=input'}, {'maxProperties': 1, 'minProperties': 1}]
             }},
             'from': {'type': 'array', 'items': {
-                'allOf': [{'$ref': '/schema/plugins?group=search'}, {'maxProperties': 1, 'minProperties': 1}]
+                'allOf': [{'$ref': '/schema/plugins?interface=search'}, {'maxProperties': 1, 'minProperties': 1}]
             }},
             'interval': {'type': 'string', 'format': 'interval', 'default': '5 hours'},
             'release_estimations': {

--- a/flexget/plugins/input/myepisodes_list.py
+++ b/flexget/plugins/input/myepisodes_list.py
@@ -101,4 +101,4 @@ class MyEpisodesList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(MyEpisodesList, 'myepisodes_list', api_ver=2, groups=['task', 'list'])
+    plugin.register(MyEpisodesList, 'myepisodes_list', api_ver=2, interfaces=['task', 'list'])

--- a/flexget/plugins/input/myepisodes_list.py
+++ b/flexget/plugins/input/myepisodes_list.py
@@ -101,4 +101,4 @@ class MyEpisodesList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(MyEpisodesList, 'myepisodes_list', api_ver=2, groups=['list'])
+    plugin.register(MyEpisodesList, 'myepisodes_list', api_ver=2, groups=['task', 'list'])

--- a/flexget/plugins/input/npo_watchlist.py
+++ b/flexget/plugins/input/npo_watchlist.py
@@ -347,4 +347,4 @@ class NPOWatchlist(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(NPOWatchlist, 'npo_watchlist', api_ver=2, groups=['list'])
+    plugin.register(NPOWatchlist, 'npo_watchlist', api_ver=2, groups=['task', 'list'])

--- a/flexget/plugins/input/npo_watchlist.py
+++ b/flexget/plugins/input/npo_watchlist.py
@@ -347,4 +347,4 @@ class NPOWatchlist(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(NPOWatchlist, 'npo_watchlist', api_ver=2, groups=['task', 'list'])
+    plugin.register(NPOWatchlist, 'npo_watchlist', api_ver=2, interfaces=['task', 'list'])

--- a/flexget/plugins/input/rottentomatoes_list.py
+++ b/flexget/plugins/input/rottentomatoes_list.py
@@ -78,4 +78,4 @@ class RottenTomatoesList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(RottenTomatoesList, 'rottentomatoes_list', api_ver=2, groups=['list'])
+    plugin.register(RottenTomatoesList, 'rottentomatoes_list', api_ver=2, groups=['task', 'list'])

--- a/flexget/plugins/input/rottentomatoes_list.py
+++ b/flexget/plugins/input/rottentomatoes_list.py
@@ -78,4 +78,4 @@ class RottenTomatoesList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(RottenTomatoesList, 'rottentomatoes_list', api_ver=2, groups=['task', 'list'])
+    plugin.register(RottenTomatoesList, 'rottentomatoes_list', api_ver=2, interfaces=['task', 'list'])

--- a/flexget/plugins/internal/urlrewriting.py
+++ b/flexget/plugins/internal/urlrewriting.py
@@ -39,7 +39,7 @@ class PluginUrlRewriting(object):
     # API method
     def url_rewritable(self, task, entry):
         """Return True if entry is urlrewritable by registered rewriter."""
-        for urlrewriter in plugin.get_plugins(group='urlrewriter'):
+        for urlrewriter in plugin.get_plugins(interface='urlrewriter'):
             if urlrewriter.name in self.disabled_rewriters:
                 log.trace('Skipping rewriter %s since it\'s disabled' % urlrewriter.name)
                 continue
@@ -58,7 +58,7 @@ class PluginUrlRewriting(object):
             if tries > 20:
                 raise UrlRewritingError('URL rewriting was left in infinite loop while rewriting url for %s, '
                                         'some rewriter is returning always True' % entry)
-            for urlrewriter in plugin.get_plugins(group='urlrewriter'):
+            for urlrewriter in plugin.get_plugins(interface='urlrewriter'):
                 name = urlrewriter.name
                 if name in self.disabled_rewriters:
                     log.trace('Skipping rewriter %s since it\'s disabled' % name)

--- a/flexget/plugins/list/couchpotato_list.py
+++ b/flexget/plugins/list/couchpotato_list.py
@@ -248,4 +248,4 @@ class CouchPotatoList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(CouchPotatoList, 'couchpotato_list', api_ver=2, groups=['task', 'list'])
+    plugin.register(CouchPotatoList, 'couchpotato_list', api_ver=2, interfaces=['task', 'list'])

--- a/flexget/plugins/list/couchpotato_list.py
+++ b/flexget/plugins/list/couchpotato_list.py
@@ -248,4 +248,4 @@ class CouchPotatoList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(CouchPotatoList, 'couchpotato_list', api_ver=2, groups=['list'])
+    plugin.register(CouchPotatoList, 'couchpotato_list', api_ver=2, groups=['task', 'list'])

--- a/flexget/plugins/list/entry_list.py
+++ b/flexget/plugins/list/entry_list.py
@@ -189,7 +189,7 @@ class EntryList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(EntryList, 'entry_list', api_ver=2, groups=['list'])
+    plugin.register(EntryList, 'entry_list', api_ver=2, groups=['task', 'list'])
 
 
 @with_session

--- a/flexget/plugins/list/entry_list.py
+++ b/flexget/plugins/list/entry_list.py
@@ -189,7 +189,7 @@ class EntryList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(EntryList, 'entry_list', api_ver=2, groups=['task', 'list'])
+    plugin.register(EntryList, 'entry_list', api_ver=2, interfaces=['task', 'list'])
 
 
 @with_session

--- a/flexget/plugins/list/imdb_list.py
+++ b/flexget/plugins/list/imdb_list.py
@@ -353,4 +353,4 @@ class ImdbList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(ImdbList, 'imdb_list', api_ver=2, groups=['list'])
+    plugin.register(ImdbList, 'imdb_list', api_ver=2, groups=['task', 'list'])

--- a/flexget/plugins/list/imdb_list.py
+++ b/flexget/plugins/list/imdb_list.py
@@ -353,4 +353,4 @@ class ImdbList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(ImdbList, 'imdb_list', api_ver=2, groups=['task', 'list'])
+    plugin.register(ImdbList, 'imdb_list', api_ver=2, interfaces=['task', 'list'])

--- a/flexget/plugins/list/movie_list.py
+++ b/flexget/plugins/list/movie_list.py
@@ -253,7 +253,7 @@ class PluginMovieList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginMovieList, 'movie_list', api_ver=2, groups=['task', 'list'])
+    plugin.register(PluginMovieList, 'movie_list', api_ver=2, interfaces=['task', 'list'])
 
 
 @with_session

--- a/flexget/plugins/list/movie_list.py
+++ b/flexget/plugins/list/movie_list.py
@@ -253,7 +253,7 @@ class PluginMovieList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginMovieList, 'movie_list', api_ver=2, groups=['list'])
+    plugin.register(PluginMovieList, 'movie_list', api_ver=2, groups=['task', 'list'])
 
 
 @with_session

--- a/flexget/plugins/list/movie_list.py
+++ b/flexget/plugins/list/movie_list.py
@@ -31,7 +31,7 @@ class MovieListBase(object):
     @property
     def supported_ids(self):
         # Return a list of supported series identifier as registered via their plugins
-        return [p.instance.movie_identifier for p in plugin.get_plugins(group='movie_metainfo')]
+        return [p.instance.movie_identifier for p in plugin.get_plugins(interface='movie_metainfo')]
 
 
 class MovieListList(Base):

--- a/flexget/plugins/list/regexp_list.py
+++ b/flexget/plugins/list/regexp_list.py
@@ -233,4 +233,4 @@ def add_to_list_by_name(list_name, regexp, session=None):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginRegexpList, 'regexp_list', api_ver=2, groups=['task', 'list'])
+    plugin.register(PluginRegexpList, 'regexp_list', api_ver=2, interfaces=['task', 'list'])

--- a/flexget/plugins/list/regexp_list.py
+++ b/flexget/plugins/list/regexp_list.py
@@ -233,4 +233,4 @@ def add_to_list_by_name(list_name, regexp, session=None):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginRegexpList, 'regexp_list', api_ver=2, groups=['list'])
+    plugin.register(PluginRegexpList, 'regexp_list', api_ver=2, groups=['task', 'list'])

--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -278,4 +278,4 @@ class SonarrList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(SonarrList, 'sonarr_list', api_ver=2, groups=['list'])
+    plugin.register(SonarrList, 'sonarr_list', api_ver=2, groups=['task', 'list'])

--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -278,4 +278,4 @@ class SonarrList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(SonarrList, 'sonarr_list', api_ver=2, groups=['task', 'list'])
+    plugin.register(SonarrList, 'sonarr_list', api_ver=2, interfaces=['task', 'list'])

--- a/flexget/plugins/list/subtitle_list.py
+++ b/flexget/plugins/list/subtitle_list.py
@@ -320,4 +320,4 @@ class PluginSubtitleList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginSubtitleList, 'subtitle_list', api_ver=2, groups=['list'])
+    plugin.register(PluginSubtitleList, 'subtitle_list', api_ver=2, groups=['task', 'list'])

--- a/flexget/plugins/list/subtitle_list.py
+++ b/flexget/plugins/list/subtitle_list.py
@@ -320,4 +320,4 @@ class PluginSubtitleList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginSubtitleList, 'subtitle_list', api_ver=2, groups=['task', 'list'])
+    plugin.register(PluginSubtitleList, 'subtitle_list', api_ver=2, interfaces=['task', 'list'])

--- a/flexget/plugins/list/thetvdb_list.py
+++ b/flexget/plugins/list/thetvdb_list.py
@@ -130,4 +130,4 @@ class TheTVDBList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(TheTVDBList, 'thetvdb_list', api_ver=2, groups=['task', 'list'])
+    plugin.register(TheTVDBList, 'thetvdb_list', api_ver=2, interfaces=['task', 'list'])

--- a/flexget/plugins/list/thetvdb_list.py
+++ b/flexget/plugins/list/thetvdb_list.py
@@ -130,4 +130,4 @@ class TheTVDBList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(TheTVDBList, 'thetvdb_list', api_ver=2, groups=['list'])
+    plugin.register(TheTVDBList, 'thetvdb_list', api_ver=2, groups=['task', 'list'])

--- a/flexget/plugins/list/trakt_list.py
+++ b/flexget/plugins/list/trakt_list.py
@@ -327,4 +327,4 @@ class TraktList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(TraktList, 'trakt_list', api_ver=2, groups=['task', 'list'])
+    plugin.register(TraktList, 'trakt_list', api_ver=2, interfaces=['task', 'list'])

--- a/flexget/plugins/list/trakt_list.py
+++ b/flexget/plugins/list/trakt_list.py
@@ -327,4 +327,4 @@ class TraktList(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(TraktList, 'trakt_list', api_ver=2, groups=['list'])
+    plugin.register(TraktList, 'trakt_list', api_ver=2, groups=['task', 'list'])

--- a/flexget/plugins/metainfo/bluray_lookup.py
+++ b/flexget/plugins/metainfo/bluray_lookup.py
@@ -77,4 +77,4 @@ class PluginBlurayLookup(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginBlurayLookup, 'bluray_lookup', api_ver=2, groups=['movie_metainfo'])
+    plugin.register(PluginBlurayLookup, 'bluray_lookup', api_ver=2, groups=['task', 'movie_metainfo'])

--- a/flexget/plugins/metainfo/bluray_lookup.py
+++ b/flexget/plugins/metainfo/bluray_lookup.py
@@ -77,4 +77,4 @@ class PluginBlurayLookup(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginBlurayLookup, 'bluray_lookup', api_ver=2, groups=['task', 'movie_metainfo'])
+    plugin.register(PluginBlurayLookup, 'bluray_lookup', api_ver=2, interfaces=['task', 'movie_metainfo'])

--- a/flexget/plugins/metainfo/imdb_lookup.py
+++ b/flexget/plugins/metainfo/imdb_lookup.py
@@ -470,4 +470,4 @@ class ImdbLookup(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(ImdbLookup, 'imdb_lookup', api_ver=2, groups=['task', 'movie_metainfo'])
+    plugin.register(ImdbLookup, 'imdb_lookup', api_ver=2, interfaces=['task', 'movie_metainfo'])

--- a/flexget/plugins/metainfo/imdb_lookup.py
+++ b/flexget/plugins/metainfo/imdb_lookup.py
@@ -470,4 +470,4 @@ class ImdbLookup(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(ImdbLookup, 'imdb_lookup', api_ver=2, groups=['movie_metainfo'])
+    plugin.register(ImdbLookup, 'imdb_lookup', api_ver=2, groups=['task', 'movie_metainfo'])

--- a/flexget/plugins/metainfo/tmdb_lookup.py
+++ b/flexget/plugins/metainfo/tmdb_lookup.py
@@ -89,4 +89,4 @@ class PluginTmdbLookup(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginTmdbLookup, 'tmdb_lookup', api_ver=2, groups=['movie_metainfo'])
+    plugin.register(PluginTmdbLookup, 'tmdb_lookup', api_ver=2, groups=['task', 'movie_metainfo'])

--- a/flexget/plugins/metainfo/tmdb_lookup.py
+++ b/flexget/plugins/metainfo/tmdb_lookup.py
@@ -89,4 +89,4 @@ class PluginTmdbLookup(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginTmdbLookup, 'tmdb_lookup', api_ver=2, groups=['task', 'movie_metainfo'])
+    plugin.register(PluginTmdbLookup, 'tmdb_lookup', api_ver=2, interfaces=['task', 'movie_metainfo'])

--- a/flexget/plugins/metainfo/trakt_lookup.py
+++ b/flexget/plugins/metainfo/trakt_lookup.py
@@ -431,4 +431,4 @@ class PluginTraktLookup(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginTraktLookup, 'trakt_lookup', api_ver=3, interfaces=['task', 'series_metainfo', 'movie_metainfo'])
+    plugin.register(PluginTraktLookup, 'trakt_lookup', api_ver=2, interfaces=['task', 'series_metainfo', 'movie_metainfo'])

--- a/flexget/plugins/metainfo/trakt_lookup.py
+++ b/flexget/plugins/metainfo/trakt_lookup.py
@@ -431,4 +431,4 @@ class PluginTraktLookup(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginTraktLookup, 'trakt_lookup', api_ver=3, groups=['task', 'series_metainfo', 'movie_metainfo'])
+    plugin.register(PluginTraktLookup, 'trakt_lookup', api_ver=3, interfaces=['task', 'series_metainfo', 'movie_metainfo'])

--- a/flexget/plugins/metainfo/trakt_lookup.py
+++ b/flexget/plugins/metainfo/trakt_lookup.py
@@ -431,4 +431,4 @@ class PluginTraktLookup(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginTraktLookup, 'trakt_lookup', api_ver=3, groups=['series_metainfo', 'movie_metainfo'])
+    plugin.register(PluginTraktLookup, 'trakt_lookup', api_ver=3, groups=['task', 'series_metainfo', 'movie_metainfo'])

--- a/flexget/plugins/metainfo/tvmaze_lookup.py
+++ b/flexget/plugins/metainfo/tvmaze_lookup.py
@@ -171,4 +171,4 @@ class PluginTVMazeLookup(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginTVMazeLookup, 'tvmaze_lookup', api_ver=3)
+    plugin.register(PluginTVMazeLookup, 'tvmaze_lookup', api_ver=2)

--- a/flexget/plugins/modify/list_clear.py
+++ b/flexget/plugins/modify/list_clear.py
@@ -16,7 +16,7 @@ class ListClear(object):
         'properties': {
             'what': {'type': 'array', 'items':
                 {'allOf': [
-                    {'$ref': '/schema/plugins?group=list'},
+                    {'$ref': '/schema/plugins?interface=list'},
                     {'maxProperties': 1,
                      'error_maxProperties': 'Plugin options within list_clear plugin must be indented '
                                             '2 more spaces than the first letter of the plugin name.',

--- a/flexget/plugins/modify/torrent_scrub.py
+++ b/flexget/plugins/modify/torrent_scrub.py
@@ -105,4 +105,4 @@ class TorrentScrub(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(TorrentScrub, groups=["torrent"], api_ver=2)
+    plugin.register(TorrentScrub, groups=['task', 'torrent'], api_ver=2)

--- a/flexget/plugins/modify/torrent_scrub.py
+++ b/flexget/plugins/modify/torrent_scrub.py
@@ -105,4 +105,4 @@ class TorrentScrub(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(TorrentScrub, groups=['task', 'torrent'], api_ver=2)
+    plugin.register(TorrentScrub, interfaces=['task', 'torrent'], api_ver=2)

--- a/flexget/plugins/modify/urlrewrite_search.py
+++ b/flexget/plugins/modify/urlrewrite_search.py
@@ -31,7 +31,7 @@ class PluginSearch(object):
         'type': 'array',
         'items': {
             'allOf': [
-                {'$ref': '/schema/plugins?group=search'},
+                {'$ref': '/schema/plugins?interface=search'},
                 {'maxProperties': 1, 'minProperties': 1}
             ]
         }
@@ -45,7 +45,7 @@ class PluginSearch(object):
             return
 
         plugins = {}
-        for p in plugin.get_plugins(group='search'):
+        for p in plugin.get_plugins(interface='search'):
             plugins[p.name] = p.instance
 
         # search accepted

--- a/flexget/plugins/notifiers/email.py
+++ b/flexget/plugins/notifiers/email.py
@@ -169,4 +169,4 @@ class EmailNotifier(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(EmailNotifier, __name__, api_ver=2, groups=['notifiers'])
+    plugin.register(EmailNotifier, __name__, api_ver=2, interfaces=['notifiers'])

--- a/flexget/plugins/notifiers/join.py
+++ b/flexget/plugins/notifiers/join.py
@@ -115,4 +115,4 @@ class JoinNotifier(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(JoinNotifier, __name__, api_ver=2, groups=['notifiers'])
+    plugin.register(JoinNotifier, __name__, api_ver=2, interfaces=['notifiers'])

--- a/flexget/plugins/notifiers/notify.py
+++ b/flexget/plugins/notifiers/notify.py
@@ -44,7 +44,7 @@ class NotifyBase(object):
             'to': {
                 'type': 'array', 'items':
                     {'allOf': [
-                        {'$ref': '/schema/plugins?group=notifiers'},
+                        {'$ref': '/schema/plugins?interface=notifiers'},
                         {'maxProperties': 1,
                          'error_maxProperties': 'Plugin options indented 2 more spaces than the first letter of the'
                                                 ' plugin name.',

--- a/flexget/plugins/notifiers/notify_osd.py
+++ b/flexget/plugins/notifiers/notify_osd.py
@@ -60,4 +60,4 @@ class OutputNotifyOsd(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(OutputNotifyOsd, __name__, api_ver=2, groups=['notifiers'])
+    plugin.register(OutputNotifyOsd, __name__, api_ver=2, interfaces=['notifiers'])

--- a/flexget/plugins/notifiers/notifymyandroid.py
+++ b/flexget/plugins/notifiers/notifymyandroid.py
@@ -102,4 +102,4 @@ class NotifyMyAndroidNotifier(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(NotifyMyAndroidNotifier, __name__, api_ver=2, groups=['notifiers'])
+    plugin.register(NotifyMyAndroidNotifier, __name__, api_ver=2, interfaces=['notifiers'])

--- a/flexget/plugins/notifiers/prowl.py
+++ b/flexget/plugins/notifiers/prowl.py
@@ -96,4 +96,4 @@ class ProwlNotifier(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(ProwlNotifier, __name__, api_ver=2, groups=['notifiers'])
+    plugin.register(ProwlNotifier, __name__, api_ver=2, interfaces=['notifiers'])

--- a/flexget/plugins/notifiers/pushalot.py
+++ b/flexget/plugins/notifiers/pushalot.py
@@ -97,4 +97,4 @@ class PushalotNotifier(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PushalotNotifier, __name__, api_ver=2, groups=['notifiers'])
+    plugin.register(PushalotNotifier, __name__, api_ver=2, interfaces=['notifiers'])

--- a/flexget/plugins/notifiers/pushbullet.py
+++ b/flexget/plugins/notifiers/pushbullet.py
@@ -146,4 +146,4 @@ class PushbulletNotifier(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PushbulletNotifier, __name__, api_ver=2, groups=['notifiers'])
+    plugin.register(PushbulletNotifier, __name__, api_ver=2, interfaces=['notifiers'])

--- a/flexget/plugins/notifiers/pushover.py
+++ b/flexget/plugins/notifiers/pushover.py
@@ -143,4 +143,4 @@ class PushoverNotifier(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PushoverNotifier, __name__, api_ver=2, groups=['notifiers'])
+    plugin.register(PushoverNotifier, __name__, api_ver=2, interfaces=['notifiers'])

--- a/flexget/plugins/notifiers/rapidpush.py
+++ b/flexget/plugins/notifiers/rapidpush.py
@@ -100,4 +100,4 @@ class RapidpushNotifier(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(RapidpushNotifier, __name__, api_ver=2, groups=['notifiers'])
+    plugin.register(RapidpushNotifier, __name__, api_ver=2, interfaces=['notifiers'])

--- a/flexget/plugins/notifiers/slack.py
+++ b/flexget/plugins/notifiers/slack.py
@@ -74,4 +74,4 @@ class SlackNotifier(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(SlackNotifier, __name__, api_ver=2, groups=['notifiers'])
+    plugin.register(SlackNotifier, __name__, api_ver=2, interfaces=['notifiers'])

--- a/flexget/plugins/notifiers/sms_ru.py
+++ b/flexget/plugins/notifiers/sms_ru.py
@@ -89,4 +89,4 @@ class SMSRuNotifier(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(SMSRuNotifier, __name__, api_ver=2, groups=['notifiers'])
+    plugin.register(SMSRuNotifier, __name__, api_ver=2, interfaces=['notifiers'])

--- a/flexget/plugins/notifiers/sns.py
+++ b/flexget/plugins/notifiers/sns.py
@@ -111,4 +111,4 @@ class SNSNotifier(object):
 
 @event('plugin.register')
 def register_sns_plugin():
-    plugin.register(SNSNotifier, __name__, api_ver=2, groups=['notifiers'])
+    plugin.register(SNSNotifier, __name__, api_ver=2, interfaces=['notifiers'])

--- a/flexget/plugins/notifiers/telegram.py
+++ b/flexget/plugins/notifiers/telegram.py
@@ -458,4 +458,4 @@ class TelegramNotifier(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(TelegramNotifier, _PLUGIN_NAME, api_ver=2, groups=['notifiers'])
+    plugin.register(TelegramNotifier, _PLUGIN_NAME, api_ver=2, interfaces=['notifiers'])

--- a/flexget/plugins/notifiers/xmpp.py
+++ b/flexget/plugins/notifiers/xmpp.py
@@ -84,4 +84,4 @@ class XMPPNotifier(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(XMPPNotifier, __name__, api_ver=2, groups=['notifiers'])
+    plugin.register(XMPPNotifier, __name__, api_ver=2, interfaces=['notifiers'])

--- a/flexget/plugins/operate/include.py
+++ b/flexget/plugins/operate/include.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
-from past.builtins import basestring
 
 import io
 import logging
@@ -34,7 +33,7 @@ class PluginInclude(object):
             return
 
         files = config
-        if isinstance(config, basestring):
+        if isinstance(config, str):
             files = [config]
 
         for name in files:
@@ -42,7 +41,7 @@ class PluginInclude(object):
             if not os.path.isabs(name):
                 name = os.path.join(task.manager.config_base, name)
             include = yaml.load(io.open(name, encoding='utf-8'))
-            errors = process_config(include, plugin.plugin_schemas(context='task'))
+            errors = process_config(include, plugin.plugin_schemas(interface='task'))
             if errors:
                 log.error('Included file %s has invalid config:' % name)
                 for error in errors:

--- a/flexget/plugins/operate/template.py
+++ b/flexget/plugins/operate/template.py
@@ -149,7 +149,7 @@ def register_plugin():
 def register_config():
     root_config_schema = {
         'type': 'object',
-        'additionalProperties': plugin.plugin_schemas(context='task')
+        'additionalProperties': plugin.plugin_schemas(group='task')
     }
     register_config_key('templates', root_config_schema)
 

--- a/flexget/plugins/operate/template.py
+++ b/flexget/plugins/operate/template.py
@@ -149,7 +149,7 @@ def register_plugin():
 def register_config():
     root_config_schema = {
         'type': 'object',
-        'additionalProperties': plugin.plugin_schemas(group='task')
+        'additionalProperties': plugin.plugin_schemas(interface='task')
     }
     register_config_key('templates', root_config_schema)
 

--- a/flexget/plugins/output/list_add.py
+++ b/flexget/plugins/output/list_add.py
@@ -15,7 +15,7 @@ class ListAdd(object):
         'type': 'array',
         'items': {
             'allOf': [
-                {'$ref': '/schema/plugins?group=list'},
+                {'$ref': '/schema/plugins?interface=list'},
                 {
                     'maxProperties': 1,
                     'error_maxProperties': 'Plugin options within list_add plugin must be indented 2 more spaces than '

--- a/flexget/plugins/output/list_remove.py
+++ b/flexget/plugins/output/list_remove.py
@@ -15,7 +15,7 @@ class ListRemove(object):
         'type': 'array',
         'items': {
             'allOf': [
-                {'$ref': '/schema/plugins?group=list'},
+                {'$ref': '/schema/plugins?interface=list'},
                 {
                     'maxProperties': 1,
                     'error_maxProperties': 'Plugin options within list_remove plugin must be indented 2 more spaces '

--- a/flexget/plugins/parsers/parser_guessit.py
+++ b/flexget/plugins/parsers/parser_guessit.py
@@ -363,4 +363,4 @@ class ParserGuessit(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(ParserGuessit, 'parser_guessit', groups=['movie_parser', 'series_parser'], api_ver=2)
+    plugin.register(ParserGuessit, 'parser_guessit', interfaces=['movie_parser', 'series_parser'], api_ver=2)

--- a/flexget/plugins/parsers/parser_internal.py
+++ b/flexget/plugins/parsers/parser_internal.py
@@ -47,4 +47,4 @@ class ParserInternal(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(ParserInternal, 'parser_internal', groups=['movie_parser', 'series_parser'], api_ver=2)
+    plugin.register(ParserInternal, 'parser_internal', interfaces=['movie_parser', 'series_parser'], api_ver=2)

--- a/flexget/plugins/parsers/plugin_parsing.py
+++ b/flexget/plugins/parsers/plugin_parsing.py
@@ -22,7 +22,7 @@ def init_parsers(manager):
     """Prepare our list of parsing plugins and default parsers."""
     for parser_type in PARSER_TYPES:
         parsers[parser_type] = {}
-        for p in plugin.get_plugins(group=parser_type + '_parser'):
+        for p in plugin.get_plugins(interface=parser_type + '_parser'):
             parsers[parser_type][p.name.replace('parser_', '')] = p.instance
         # Select default parsers based on priority
         func_name = 'parse_' + parser_type
@@ -40,7 +40,7 @@ class PluginParsing(object):
         # Create a schema allowing only our registered parsers to be used under the key of each parser type
         properties = {}
         for parser_type in PARSER_TYPES:
-            parser_names = [p.name.replace('parser_', '') for p in plugin.get_plugins(group=parser_type + '_parser')]
+            parser_names = [p.name.replace('parser_', '') for p in plugin.get_plugins(interface=parser_type + '_parser')]
             properties[parser_type] = {'type': 'string', 'enum': parser_names}
         s = {
             'type': 'object',

--- a/flexget/plugins/sites/alpharatio.py
+++ b/flexget/plugins/sites/alpharatio.py
@@ -219,4 +219,4 @@ class SearchAlphaRatio(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(SearchAlphaRatio, 'alpharatio', groups=['search'], api_ver=2)
+    plugin.register(SearchAlphaRatio, 'alpharatio', interfaces=['search'], api_ver=2)

--- a/flexget/plugins/sites/animeindex.py
+++ b/flexget/plugins/sites/animeindex.py
@@ -27,4 +27,4 @@ class UrlRewriteAnimeIndex(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteAnimeIndex, 'animeindex', groups=['urlrewriter'], api_ver=2)
+    plugin.register(UrlRewriteAnimeIndex, 'animeindex', interfaces=['urlrewriter'], api_ver=2)

--- a/flexget/plugins/sites/anirena.py
+++ b/flexget/plugins/sites/anirena.py
@@ -21,4 +21,4 @@ class UrlRewriteAniRena(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteAniRena, 'anirena', groups=['urlrewriter'], api_ver=2)
+    plugin.register(UrlRewriteAniRena, 'anirena', interfaces=['urlrewriter'], api_ver=2)

--- a/flexget/plugins/sites/archetorrent.py
+++ b/flexget/plugins/sites/archetorrent.py
@@ -30,4 +30,4 @@ class UrlRewriteArchetorrent(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteArchetorrent, 'archetorrent', groups=['urlrewriter'], api_ver=2)
+    plugin.register(UrlRewriteArchetorrent, 'archetorrent', interfaces=['urlrewriter'], api_ver=2)

--- a/flexget/plugins/sites/bakabt.py
+++ b/flexget/plugins/sites/bakabt.py
@@ -44,4 +44,4 @@ class UrlRewriteBakaBT(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteBakaBT, 'bakabt', groups=['urlrewriter'], api_ver=2)
+    plugin.register(UrlRewriteBakaBT, 'bakabt', interfaces=['urlrewriter'], api_ver=2)

--- a/flexget/plugins/sites/btn.py
+++ b/flexget/plugins/sites/btn.py
@@ -88,4 +88,4 @@ class SearchBTN(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(SearchBTN, 'btn', groups=['search'], api_ver=2)
+    plugin.register(SearchBTN, 'btn', interfaces=['search'], api_ver=2)

--- a/flexget/plugins/sites/cinemageddon.py
+++ b/flexget/plugins/sites/cinemageddon.py
@@ -23,4 +23,4 @@ class UrlRewriteCinemageddon(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteCinemageddon, 'cinemageddon', groups=['urlrewriter'], api_ver=2)
+    plugin.register(UrlRewriteCinemageddon, 'cinemageddon', interfaces=['urlrewriter'], api_ver=2)

--- a/flexget/plugins/sites/cpasbien.py
+++ b/flexget/plugins/sites/cpasbien.py
@@ -131,4 +131,4 @@ class SearchCPASBIEN(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(SearchCPASBIEN, 'cpasbien', groups=['search'], api_ver=2)
+    plugin.register(SearchCPASBIEN, 'cpasbien', interfaces=['search'], api_ver=2)

--- a/flexget/plugins/sites/deadfrog.py
+++ b/flexget/plugins/sites/deadfrog.py
@@ -44,4 +44,4 @@ class UrlRewriteDeadFrog(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteDeadFrog, 'deadfrog', groups=['urlrewriter'], api_ver=2)
+    plugin.register(UrlRewriteDeadFrog, 'deadfrog', interfaces=['urlrewriter'], api_ver=2)

--- a/flexget/plugins/sites/divxatope.py
+++ b/flexget/plugins/sites/divxatope.py
@@ -99,9 +99,4 @@ class UrlRewriteDivxATope(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(
-        UrlRewriteDivxATope,
-        'divxatope',
-        groups=['urlrewriter', 'search'],
-        api_ver=2
-    )
+    plugin.register(UrlRewriteDivxATope, 'divxatope', interfaces=['urlrewriter', 'search'], api_ver=2)

--- a/flexget/plugins/sites/extratorrent.py
+++ b/flexget/plugins/sites/extratorrent.py
@@ -104,4 +104,4 @@ class UrlRewriteExtraTorrent(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteExtraTorrent, 'extratorrent', groups=['urlrewriter', 'search'], api_ver=2)
+    plugin.register(UrlRewriteExtraTorrent, 'extratorrent', interfaces=['urlrewriter', 'search'], api_ver=2)

--- a/flexget/plugins/sites/eztv.py
+++ b/flexget/plugins/sites/eztv.py
@@ -60,4 +60,4 @@ class UrlRewriteEztv(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteEztv, 'eztv', groups=['urlrewriter'], api_ver=2)
+    plugin.register(UrlRewriteEztv, 'eztv', interfaces=['urlrewriter'], api_ver=2)

--- a/flexget/plugins/sites/frenchtorrentdb.py
+++ b/flexget/plugins/sites/frenchtorrentdb.py
@@ -54,4 +54,4 @@ class UrlRewriteFTDB(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteFTDB, 'frenchtorrentdb', groups=['urlrewriter'], api_ver=2)
+    plugin.register(UrlRewriteFTDB, 'frenchtorrentdb', interfaces=['urlrewriter'], api_ver=2)

--- a/flexget/plugins/sites/fuzer.py
+++ b/flexget/plugins/sites/fuzer.py
@@ -176,4 +176,4 @@ class UrlRewriteFuzer(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteFuzer, 'fuzer', groups=['search'], api_ver=2)
+    plugin.register(UrlRewriteFuzer, 'fuzer', interfaces=['search'], api_ver=2)

--- a/flexget/plugins/sites/google_cse.py
+++ b/flexget/plugins/sites/google_cse.py
@@ -93,5 +93,5 @@ class UrlRewriteGoogle(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteGoogleCse, 'google_cse', groups=['urlrewriter'], api_ver=2)
-    plugin.register(UrlRewriteGoogle, 'google', groups=['urlrewriter'], api_ver=2)
+    plugin.register(UrlRewriteGoogleCse, 'google_cse', interfaces=['urlrewriter'], api_ver=2)
+    plugin.register(UrlRewriteGoogle, 'google', interfaces=['urlrewriter'], api_ver=2)

--- a/flexget/plugins/sites/horriblesubs.py
+++ b/flexget/plugins/sites/horriblesubs.py
@@ -69,4 +69,4 @@ class HorribleSubs(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(HorribleSubs, 'horriblesubs', groups=['task', 'search'], api_ver=2)
+    plugin.register(HorribleSubs, 'horriblesubs', interfaces=['task', 'search'], api_ver=2)

--- a/flexget/plugins/sites/horriblesubs.py
+++ b/flexget/plugins/sites/horriblesubs.py
@@ -69,4 +69,4 @@ class HorribleSubs(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(HorribleSubs, 'horriblesubs', groups=['search'], api_ver=2)
+    plugin.register(HorribleSubs, 'horriblesubs', groups=['task', 'search'], api_ver=2)

--- a/flexget/plugins/sites/iptorrents.py
+++ b/flexget/plugins/sites/iptorrents.py
@@ -168,4 +168,4 @@ class UrlRewriteIPTorrents(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteIPTorrents, 'iptorrents', groups=['urlrewriter', 'search'], api_ver=2)
+    plugin.register(UrlRewriteIPTorrents, 'iptorrents', interfaces=['urlrewriter', 'search'], api_ver=2)

--- a/flexget/plugins/sites/koreus.py
+++ b/flexget/plugins/sites/koreus.py
@@ -42,4 +42,4 @@ class UrlRewriteKoreus(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteKoreus, 'koreus', groups=['urlrewriter'], api_ver=2)
+    plugin.register(UrlRewriteKoreus, 'koreus', interfaces=['urlrewriter'], api_ver=2)

--- a/flexget/plugins/sites/limetorrents.py
+++ b/flexget/plugins/sites/limetorrents.py
@@ -105,4 +105,4 @@ class Limetorrents(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(Limetorrents, 'limetorrents', groups=['search'], api_ver=2)
+    plugin.register(Limetorrents, 'limetorrents', interfaces=['search'], api_ver=2)

--- a/flexget/plugins/sites/morethantv.py
+++ b/flexget/plugins/sites/morethantv.py
@@ -256,4 +256,4 @@ class SearchMoreThanTV(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(SearchMoreThanTV, 'morethantv', groups=['search'], api_ver=2)
+    plugin.register(SearchMoreThanTV, 'morethantv', interfaces=['search'], api_ver=2)

--- a/flexget/plugins/sites/newpct.py
+++ b/flexget/plugins/sites/newpct.py
@@ -67,4 +67,4 @@ class UrlRewriteNewPCT(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteNewPCT, 'newpct', groups=['urlrewriter'], api_ver=2)
+    plugin.register(UrlRewriteNewPCT, 'newpct', interfaces=['urlrewriter'], api_ver=2)

--- a/flexget/plugins/sites/newtorrents.py
+++ b/flexget/plugins/sites/newtorrents.py
@@ -127,4 +127,4 @@ class NewTorrents(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(NewTorrents, 'newtorrents', groups=['urlrewriter', 'search'], api_ver=2)
+    plugin.register(NewTorrents, 'newtorrents', interfaces=['urlrewriter', 'search'], api_ver=2)

--- a/flexget/plugins/sites/newznab.py
+++ b/flexget/plugins/sites/newznab.py
@@ -124,4 +124,4 @@ class Newznab(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(Newznab, 'newznab', api_ver=2, groups=['search'])
+    plugin.register(Newznab, 'newznab', api_ver=2, interfaces=['search'])

--- a/flexget/plugins/sites/nnmclub.py
+++ b/flexget/plugins/sites/nnmclub.py
@@ -38,4 +38,4 @@ class UrlRewriteNnmClub(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteNnmClub, 'nnm-club', groups=['urlrewriter'], api_ver=2)
+    plugin.register(UrlRewriteNnmClub, 'nnm-club', interfaces=['urlrewriter'], api_ver=2)

--- a/flexget/plugins/sites/nyaa.py
+++ b/flexget/plugins/sites/nyaa.py
@@ -87,4 +87,4 @@ class UrlRewriteNyaa(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteNyaa, 'nyaa', groups=['search', 'urlrewriter'], api_ver=2)
+    plugin.register(UrlRewriteNyaa, 'nyaa', interfaces=['search', 'urlrewriter'], api_ver=2)

--- a/flexget/plugins/sites/piratebay.py
+++ b/flexget/plugins/sites/piratebay.py
@@ -168,4 +168,4 @@ class UrlRewritePirateBay(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewritePirateBay, 'piratebay', groups=['urlrewriter', 'search'], api_ver=2)
+    plugin.register(UrlRewritePirateBay, 'piratebay', interfaces=['urlrewriter', 'search'], api_ver=2)

--- a/flexget/plugins/sites/ptn.py
+++ b/flexget/plugins/sites/ptn.py
@@ -143,4 +143,4 @@ class SearchPTN(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(SearchPTN, 'ptn', groups=['search'], api_ver=2)
+    plugin.register(SearchPTN, 'ptn', interfaces=['search'], api_ver=2)

--- a/flexget/plugins/sites/rarbg.py
+++ b/flexget/plugins/sites/rarbg.py
@@ -182,4 +182,4 @@ class SearchRarBG(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(SearchRarBG, 'rarbg', groups=['search'], api_ver=2)
+    plugin.register(SearchRarBG, 'rarbg', interfaces=['search'], api_ver=2)

--- a/flexget/plugins/sites/rss.py
+++ b/flexget/plugins/sites/rss.py
@@ -45,4 +45,4 @@ class SearchRSS(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(SearchRSS, 'search_rss', groups=['search'], api_ver=2)
+    plugin.register(SearchRSS, 'search_rss', interfaces=['search'], api_ver=2)

--- a/flexget/plugins/sites/sceneaccess.py
+++ b/flexget/plugins/sites/sceneaccess.py
@@ -291,4 +291,4 @@ class SceneAccessSearch(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(SceneAccessSearch, 'sceneaccess', groups=['search'], api_ver=2)
+    plugin.register(SceneAccessSearch, 'sceneaccess', interfaces=['search'], api_ver=2)

--- a/flexget/plugins/sites/serienjunkies.py
+++ b/flexget/plugins/sites/serienjunkies.py
@@ -191,4 +191,4 @@ class UrlRewriteSerienjunkies(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteSerienjunkies, 'serienjunkies', groups=['urlrewriter'], api_ver=2)
+    plugin.register(UrlRewriteSerienjunkies, 'serienjunkies', interfaces=['urlrewriter'], api_ver=2)

--- a/flexget/plugins/sites/shortened.py
+++ b/flexget/plugins/sites/shortened.py
@@ -23,4 +23,4 @@ class UrlRewriteShortened(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteShortened, 'shortened', groups=['urlrewriter'], api_ver=2)
+    plugin.register(UrlRewriteShortened, 'shortened', interfaces=['urlrewriter'], api_ver=2)

--- a/flexget/plugins/sites/site_1337x.py
+++ b/flexget/plugins/sites/site_1337x.py
@@ -132,4 +132,4 @@ class Site1337x(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(Site1337x, '1337x', groups=['urlrewriter', 'search'], api_ver=2)
+    plugin.register(Site1337x, '1337x', interfaces=['urlrewriter', 'search'], api_ver=2)

--- a/flexget/plugins/sites/t411.py
+++ b/flexget/plugins/sites/t411.py
@@ -154,5 +154,5 @@ class T411LookupPlugin(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(T411InputPlugin, 't411', groups=['search', 'input'], api_ver=2)
+    plugin.register(T411InputPlugin, 't411', groups=['task', 'search'], api_ver=2)
     plugin.register(T411LookupPlugin, 't411_lookup', api_ver=2)

--- a/flexget/plugins/sites/t411.py
+++ b/flexget/plugins/sites/t411.py
@@ -154,5 +154,5 @@ class T411LookupPlugin(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(T411InputPlugin, 't411', groups=['task', 'search'], api_ver=2)
+    plugin.register(T411InputPlugin, 't411', interfaces=['task', 'search'], api_ver=2)
     plugin.register(T411LookupPlugin, 't411_lookup', api_ver=2)

--- a/flexget/plugins/sites/torrent411.py
+++ b/flexget/plugins/sites/torrent411.py
@@ -515,7 +515,4 @@ class UrlRewriteTorrent411(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteTorrent411, 'torrent411',
-                    groups=['urlrewriter', 'search'],
-                    api_ver=2
-                    )
+    plugin.register(UrlRewriteTorrent411, 'torrent411', interfaces=['urlrewriter', 'search'], api_ver=2)

--- a/flexget/plugins/sites/torrentleech.py
+++ b/flexget/plugins/sites/torrentleech.py
@@ -171,4 +171,4 @@ class UrlRewriteTorrentleech(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteTorrentleech, 'torrentleech', groups=['urlrewriter', 'search'], api_ver=2)
+    plugin.register(UrlRewriteTorrentleech, 'torrentleech', interfaces=['urlrewriter', 'search'], api_ver=2)

--- a/flexget/plugins/sites/torrentshack.py
+++ b/flexget/plugins/sites/torrentshack.py
@@ -186,4 +186,4 @@ class TorrentShackSearch(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(TorrentShackSearch, 'torrentshack', groups=['search'], api_ver=2)
+    plugin.register(TorrentShackSearch, 'torrentshack', interfaces=['search'], api_ver=2)

--- a/flexget/plugins/sites/urlrewrite.py
+++ b/flexget/plugins/sites/urlrewrite.py
@@ -74,4 +74,4 @@ class UrlRewrite(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewrite, 'urlrewrite', groups=['task', 'urlrewriter'], api_ver=2)
+    plugin.register(UrlRewrite, 'urlrewrite', interfaces=['task', 'urlrewriter'], api_ver=2)

--- a/flexget/plugins/sites/urlrewrite.py
+++ b/flexget/plugins/sites/urlrewrite.py
@@ -74,4 +74,4 @@ class UrlRewrite(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewrite, 'urlrewrite', groups=['urlrewriter'], api_ver=2)
+    plugin.register(UrlRewrite, 'urlrewrite', groups=['task', 'urlrewriter'], api_ver=2)

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -662,7 +662,7 @@ class Task(object):
 
     @staticmethod
     def validate_config(config):
-        schema = plugin_schemas(context='task')
+        schema = plugin_schemas(interface='task')
         # Don't validate commented out plugins
         schema['patternProperties'] = {'^_': {}}
         return config_schema.process_config(config, schema)
@@ -698,7 +698,7 @@ class Task(object):
 def register_config_key():
     task_config_schema = {
         'type': 'object',
-        'additionalProperties': plugin_schemas(group='task')
+        'additionalProperties': plugin_schemas(interface='task')
     }
 
     config_schema.register_config_key('tasks', task_config_schema, required=True)

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -698,7 +698,7 @@ class Task(object):
 def register_config_key():
     task_config_schema = {
         'type': 'object',
-        'additionalProperties': plugin_schemas(context='task')
+        'additionalProperties': plugin_schemas(group='task')
     }
 
     config_schema.register_config_key('tasks', task_config_schema, required=True)

--- a/flexget/tests/api_tests/test_plugins_api.py
+++ b/flexget/tests/api_tests/test_plugins_api.py
@@ -24,14 +24,14 @@ class TestPluginsAPI(object):
         errors = schema_match(OC.plugin_list_reply, data)
         assert not errors
 
-        rsp = api_client.get('/plugins/?group=search')
+        rsp = api_client.get('/plugins/?interface=search')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
         data = json.loads(rsp.get_data(as_text=True))
 
         errors = schema_match(OC.plugin_list_reply, data)
         assert not errors
 
-        rsp = api_client.get('/plugins/?group=fgfg')
+        rsp = api_client.get('/plugins/?interface=fgfg')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
         data = json.loads(rsp.get_data(as_text=True))
 

--- a/flexget/tests/test_discover.py
+++ b/flexget/tests/test_discover.py
@@ -25,7 +25,7 @@ class SearchPlugin(object):
         return [Entry(entry)]
 
 
-plugin.register(SearchPlugin, 'test_search', groups=['search'], api_ver=2)
+plugin.register(SearchPlugin, 'test_search', interfaces=['search'], api_ver=2)
 
 
 class EstRelease(object):
@@ -35,7 +35,7 @@ class EstRelease(object):
         return entry.get('est_release')
 
 
-plugin.register(EstRelease, 'test_release', groups=['estimate_release'], api_ver=2)
+plugin.register(EstRelease, 'test_release', interfaces=['estimate_release'], api_ver=2)
 
 
 class TestDiscover(object):

--- a/flexget/tests/test_parsingapi.py
+++ b/flexget/tests/test_parsingapi.py
@@ -14,7 +14,7 @@ class TestParsingAPI(object):
 
     def test_parsing_plugins_have_parse_methods(self):
         for parser_type in plugin_parsing.PARSER_TYPES:
-            for plugin in get_plugins(group='%s_parser' % parser_type):
+            for plugin in get_plugins(interface='%s_parser' % parser_type):
                 assert hasattr(plugin.instance, 'parse_%s' % parser_type), \
                     '{type} parsing plugin {name} has no parse_{type} method'.format(type=parser_type, name=plugin.name)
 


### PR DESCRIPTION
### Motivation for changes:
As we get more types of plugins, there were cases where plugins designed for use outside of a normal task scope would still be allowed in the config at task level.

### Detailed changes:
There was an old plugin attribute 'context' which was meant to solve this problem. Plugins were never updated to use this properly, and we've since settled on using the 'group' attribute to define other plugin contexts. This PR removes the 'context' attribute, renames the former 'groups' attribute to 'interfaces', and adds a new interface, 'task'. Plugins which should be allowed into the config at the task level should declare themselves to implement this interface and define a 'schema' attribute with a json schema to validate their config. In order to avoid changing every plugin, if a plugin registers without the interfaces attribute, it is assumed to implement the 'task', (and only the 'task',) interface.

### Config usage if relevant (new plugin or updated schema):
This shouldn't make any config changes needed, except for users who had errors in the config due to plugins being configured in the wrong spots, which previously were unreported and ignored.
