### PR TITLE
notify_abort

### DIFF
--- a/flexget/_version.py
+++ b/flexget/_version.py
@@ -7,4 +7,4 @@ The version should always be set to the <next release version>.dev
 The jenkins release job will automatically strip the .dev for release,
 and update the version again for continued development.
 """
-__version__ = '2.8.5'
+__version__ = '2.8.6.dev'


### PR DESCRIPTION
### Motivation for changes:
notify templates harmonization -> no file_template used for notify_abort
instead of : "Task get_xxxxxx has aborted!" subject

### Detailed changes:

- notify_abort: 
          title:"[FlexGet] {{ task.name }}: Aborted"
          to: 
            - email: ...............

### Addressed issues:

- Fixes # .

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
```
paste output here
```

