### PR TITLE
input plugin for kitsu.io

### DIFF
--- a/flexget/plugins/input/kitsu.py
+++ b/flexget/plugins/input/kitsu.py
@@ -42,9 +42,9 @@ class KitsuAnime(object):
         try:
             user_response = task.requests.get('https://kitsu.io/api/edge/users', params=user_payload)
         except RequestException as e:
-            status = getattr(getattr(e, 'response', None), 'status_code', None)
-            error_message = 'Error finding User url: {url} status: {status}'.format(
-                url=e.request.url, status=status)
+            error_message = 'Error finding User url: {url}'.format(url=e.request.url)
+            if hasattr(e, 'response'):
+                error_message += ' status: {status}'.format(status=e.response.status_code)
             log.debug(error_message, exc_info=True)
             raise plugin.PluginError(error_message)
         user = user_response.json()
@@ -56,9 +56,9 @@ class KitsuAnime(object):
         try:
             response = task.requests.get(next_url, params=payload)
         except RequestException as e:
-            status = getattr(getattr(e, 'response', None), 'status_code', None)
-            error_message = 'Error getting list from {url} status: {status}'.format(
-                url=e.request.url, status=status)
+            error_message = 'Error getting list from {url}'.format(url=e.request.url)
+            if hasattr(e, 'response'):
+                error_message += ' status: {status}'.format(status=e.response.status_code)
             log.debug(error_message, exc_info=True)
             log.info(error_message, exc_info=True)
             raise plugin.PluginError(error_message)
@@ -99,9 +99,9 @@ class KitsuAnime(object):
                 try:
                     response = task.requests.get(next_url)
                 except RequestException as e:
-                    status = getattr(getattr(e, 'response', None), 'status_code', None)
-                    error_message = 'Error getting list from next page url: {url} status: {status}'.format(
-                        url=e.request.url, status=status)
+                    error_message = 'Error getting list from next page url: {url}'.format(url=e.request.url)
+                    if hasattr(e, 'response'):
+                        error_message += ' status: {status}'.format(status=e.response.status_code)
                     log.debug(error_message, exc_info=True)
                     raise plugin.PluginError(error_message)
             else:

--- a/flexget/plugins/input/kitsu.py
+++ b/flexget/plugins/input/kitsu.py
@@ -1,0 +1,107 @@
+from __future__ import unicode_literals, division, absolute_import
+import logging
+
+from flexget import plugin
+from flexget.entry import Entry
+from flexget.event import event
+from flexget.utils.cached_input import cached
+from requests import RequestException
+
+log = logging.getLogger('kitsu')
+
+
+class KitsuAnime(object):
+    """Creates an entry for each item in your kitsu.io list.
+    Syntax:
+    kitsu:
+      username: <value>
+      lists:
+      	- <current|planned|completed|on_hold|dropped>
+      	- <current|planned|completed|on_hold|dropped>
+      latest: <yes|no>
+      finishedonly: <yes|no>
+      currentonly: <yes|no>
+    """
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'username': {'type': 'string'},
+            'lists': {'type': 'array',
+                      'items': {'type': 'string', 'enum': ['current', 'planned', 'completed', 'on_hold', 'dropped']}},
+            'latest': {'type': 'boolean', 'default': False},
+            'currentonly': {'type': 'boolean', 'default': False},
+            'finishedonly': {'type': 'boolean', 'default': False}
+        },
+        'required': ['username'],
+        'additionalProperties': False,
+    }
+
+    @cached('kitsu', persist='2 hours')
+    def on_task_input(self, task, config):
+        entries = []
+        try:
+            user_payload = {'filter[name]': config['username']}
+            user_response = task.requests.get('https://kitsu.io/api/edge/users', params=user_payload)
+            user_response.raise_for_status()
+            user = user_response.json()
+            if len(user['data']) < 1:
+                raise plugin.PluginError('no such username found on kitsu.io')
+            userId = user['data'][0]['id']
+        except RequestException:
+            raise plugin.PluginError('Error getting User ID from kitsu.io')
+
+        next_url = 'https://kitsu.io/api/edge/users/{userId}/library-entries'.format(**locals())
+        payload = {'filter[status]': ','.join(config['lists']), 'filter[media_type]': 'Anime', 'include': 'media',
+                   'page[limit]': 20}
+
+        try:
+            response = task.requests.get(next_url, params=payload)
+            response.raise_for_status()
+        except RequestException:
+            raise plugin.PluginError('Error getting list from kitsu.io')
+
+        while response:
+            json_data = response.json()
+
+            for item, anime in zip(json_data['data'], json_data['included']):
+                if item['relationships']['media']['data']['id'] != anime['id']:
+                    raise ValueError
+                if config.get('finishedonly') and anime['attributes']['endDate'] == None:
+                    continue
+                if config.get('currentonly') and anime['attributes']['endDate'] is not None:
+                    continue
+
+                entry = Entry()
+                entry['title'] = anime['attributes']['canonicalTitle']
+                if anime['attributes']['titles']['en']:
+                    entry['kitsu_title_en'] = anime['attributes']['titles']['en']
+                if anime['attributes']['titles']['en_jp']:
+                    entry['kitsu_title_en_jp'] = anime['attributes']['titles']['en_jp']
+                if anime['attributes']['titles']['ja_jp']:
+                    entry['kitsu_title_ja_jp'] = anime['attributes']['titles']['ja_jp']
+                entry['kitsu_url'] = anime['links']['self']
+                entry['url'] = ''
+                if entry.isvalid():
+                    if config.get('latest'):
+                        entry['series_episode'] = item['progress']
+                        entry['series_id_type'] = 'sequence'
+                        entry['title'] += ' ' + str(entry['progress'])
+                    entries.append(entry)
+
+            next_url = json_data['links'].get('next')
+            if next_url:
+                try:
+                    response = task.requests.get(next_url)
+                    response.raise_for_status()
+                except RequestException:
+                    raise plugin.PluginError('Error getting next url from kitsu.io')
+            else:
+                response = None
+
+        return entries
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(KitsuAnime, 'kitsu', api_ver=2)

--- a/flexget/plugins/input/kitsu.py
+++ b/flexget/plugins/input/kitsu.py
@@ -29,8 +29,7 @@ class KitsuAnime(object):
             'username': {'type': 'string'},
             'lists': one_or_more({'type': 'string', 'enum': ['current', 'planned', 'completed', 'on_hold', 'dropped']}),
             'latest': {'type': 'boolean', 'default': False},
-            'limit_to': {'type': 'string', 'enum': ['airing', 'finished']},
-            'finished_only': {'type': 'boolean', 'default': False}
+            'limit_to': {'type': 'string', 'enum': ['airing', 'finished']}
         },
         'required': ['username'],
         'additionalProperties': False,
@@ -76,7 +75,7 @@ class KitsuAnime(object):
                 if limit_to is not None:
                     if limit_to == 'airing' and anime['attributes']['endDate'] is not None:
                         continue
-                    if limit_to == 'finished' and anime['attributes']['endDate'] == None:
+                    if limit_to == 'finished' and anime['attributes']['endDate'] is None:
                         continue
 
                 entry = Entry()

--- a/flexget/plugins/input/kitsu.py
+++ b/flexget/plugins/input/kitsu.py
@@ -80,8 +80,7 @@ class KitsuAnime(object):
                     entry['kitsu_title_en_jp'] = anime['attributes']['titles']['en_jp']
                 if anime['attributes']['titles']['ja_jp']:
                     entry['kitsu_title_ja_jp'] = anime['attributes']['titles']['ja_jp']
-                entry['kitsu_url'] = anime['links']['self']
-                entry['url'] = ''
+                entry['url'] = anime['links']['self']
                 if entry.isvalid():
                     if config.get('latest'):
                         entry['series_episode'] = item['progress']

--- a/flexget/plugins/input/kitsu.py
+++ b/flexget/plugins/input/kitsu.py
@@ -41,10 +41,10 @@ class KitsuAnime(object):
         user_payload = {'filter[name]': config['username']}
         try:
             user_response = task.requests.get('https://kitsu.io/api/edge/users', params=user_payload)
-            user_response.raise_for_status()
         except RequestException as e:
+            status = getattr(getattr(e, 'response', None), 'status_code', None)
             error_message = 'Error finding User url: {url} status: {status}'.format(
-                url=e.request.url, status=e.response.status_code)
+                url=e.request.url, status=status)
             log.debug(error_message, exc_info=True)
             raise plugin.PluginError(error_message)
         user = user_response.json()
@@ -55,10 +55,10 @@ class KitsuAnime(object):
                    'page[limit]': 20}
         try:
             response = task.requests.get(next_url, params=payload)
-            response.raise_for_status()
         except RequestException as e:
+            status = getattr(getattr(e, 'response', None), 'status_code', None)
             error_message = 'Error getting list from {url} status: {status}'.format(
-                url=e.request.url, status=e.response.status_code)
+                url=e.request.url, status=status)
             log.debug(error_message, exc_info=True)
             log.info(error_message, exc_info=True)
             raise plugin.PluginError(error_message)
@@ -98,10 +98,10 @@ class KitsuAnime(object):
             if next_url:
                 try:
                     response = task.requests.get(next_url)
-                    response.raise_for_status()
                 except RequestException as e:
+                    status = getattr(getattr(e, 'response', None), 'status_code', None)
                     error_message = 'Error getting list from next page url: {url} status: {status}'.format(
-                        url=e.request.url, status=e.response.status_code)
+                        url=e.request.url, status=status)
                     log.debug(error_message, exc_info=True)
                     raise plugin.PluginError(error_message)
             else:

--- a/flexget/plugins/input/kitsu.py
+++ b/flexget/plugins/input/kitsu.py
@@ -60,7 +60,6 @@ class KitsuAnime(object):
             if hasattr(e, 'response'):
                 error_message += ' status: {status}'.format(status=e.response.status_code)
             log.debug(error_message, exc_info=True)
-            log.info(error_message, exc_info=True)
             raise plugin.PluginError(error_message)
 
         while response:

--- a/flexget/plugins/input/kitsu.py
+++ b/flexget/plugins/input/kitsu.py
@@ -1,12 +1,14 @@
 from __future__ import unicode_literals, division, absolute_import
+
 import logging
+
 
 from flexget import plugin
 from flexget.config_schema import one_or_more
 from flexget.entry import Entry
 from flexget.event import event
 from flexget.utils.cached_input import cached
-from requests import RequestException
+from flexget.utils.requests import RequestException
 
 log = logging.getLogger('kitsu')
 
@@ -19,7 +21,7 @@ class KitsuAnime(object):
       lists:
       	- <current|planned|completed|on_hold|dropped>
       	- <current|planned|completed|on_hold|dropped>
-      list_only: <airing|finished>
+      status: <airing|finished>
       latest: <yes|no>
     """
 
@@ -29,7 +31,7 @@ class KitsuAnime(object):
             'username': {'type': 'string'},
             'lists': one_or_more({'type': 'string', 'enum': ['current', 'planned', 'completed', 'on_hold', 'dropped']}),
             'latest': {'type': 'boolean', 'default': False},
-            'limit_to': {'type': 'string', 'enum': ['airing', 'finished']}
+            'status': {'type': 'string', 'enum': ['airing', 'finished']}
         },
         'required': ['username'],
         'additionalProperties': False,
@@ -48,7 +50,7 @@ class KitsuAnime(object):
             log.debug(error_message, exc_info=True)
             raise plugin.PluginError(error_message)
         user = user_response.json()
-        if len(user['data']) < 1:
+        if not len(user['data']):
             raise plugin.PluginError('no such username found "{name}"'.format(name=config['username']))
         next_url = 'https://kitsu.io/api/edge/users/{id}/library-entries'.format(id=user['data'][0]['id'])
         payload = {'filter[status]': ','.join(config['lists']), 'filter[media_type]': 'Anime', 'include': 'media',
@@ -62,29 +64,33 @@ class KitsuAnime(object):
             log.debug(error_message, exc_info=True)
             raise plugin.PluginError(error_message)
 
-        while response:
-            json_data = response.json()
+        json_data = response.json()
+
+        while json_data:
 
             for item, anime in zip(json_data['data'], json_data['included']):
                 if item['relationships']['media']['data']['id'] != anime['id']:
                     raise ValueError(
                         'Anime IDs {id1} and {id2} do not match'.format(
                             id1=item['relationships']['media']['data']['id'], id2=anime['id']))
-                limit_to = config.get('limit_to')
-                if limit_to is not None:
-                    if limit_to == 'airing' and anime['attributes']['endDate'] is not None:
+                status = config.get('status')
+                if status is not None:
+                    if status == 'airing' and anime['attributes']['endDate'] is not None:
                         continue
-                    if limit_to == 'finished' and anime['attributes']['endDate'] is None:
+                    if status == 'finished' and anime['attributes']['endDate'] is None:
                         continue
 
                 entry = Entry()
                 entry['title'] = anime['attributes']['canonicalTitle']
-                if anime['attributes']['titles']['en']:
-                    entry['kitsu_title_en'] = anime['attributes']['titles']['en']
-                if anime['attributes']['titles']['en_jp']:
-                    entry['kitsu_title_en_jp'] = anime['attributes']['titles']['en_jp']
-                if anime['attributes']['titles']['ja_jp']:
-                    entry['kitsu_title_ja_jp'] = anime['attributes']['titles']['ja_jp']
+                titles_en = anime['attributes']['titles'].get('en')
+                if titles_en:
+                    entry['kitsu_title_en'] = titles_en
+                titles_en_jp = anime['attributes']['titles'].get('en_jp')
+                if titles_en_jp:
+                    entry['kitsu_title_en_jp'] = titles_en_jp
+                titles_ja_jp = anime['attributes']['titles'].get('ja_jp')
+                if titles_ja_jp:
+                    entry['kitsu_title_ja_jp'] = titles_ja_jp
                 entry['url'] = anime['links']['self']
                 if entry.isvalid():
                     if config.get('latest'):
@@ -103,8 +109,9 @@ class KitsuAnime(object):
                         error_message += ' status: {status}'.format(status=e.response.status_code)
                     log.debug(error_message, exc_info=True)
                     raise plugin.PluginError(error_message)
+                json_data = response.json()
             else:
-                response = None
+                break
 
         return entries
 


### PR DESCRIPTION
### Motivation for changes:

making Flexget able to accept anime series based on their status in the kitsu.io library (former hummingbird.me)

### Detailed changes:

- updatted the old hummingbiird plugins [here](https://github.com/matthewdias/hummingbird_list) to the new api
- Entry fields
  - always:
    - title
    - url `= ''`
  - when available:
    - kitsu_title_en
    - kitsu_title_en_jp
    - kitsu_title_ja_jp
  - if `latest` is set:
    - series_episode
    - series_id_type `= 'sequential'`

### Config usage if relevant (new plugin or updated schema):
```yaml
Syntax:
    kitsu:
      username: <value>
      lists:
        - <current|planned|completed|on_hold|dropped>
        - <current|planned|completed|on_hold|dropped>
      latest: <yes|no>
      limit_to: <airing|finished>

Example:
    configure_series:
      settings:
        identified_by: sequence
      from:
        kitsu:
          username: NikkyAi
          lists:
            - current
            - planned
          limit_to: airing
          latest: no
```

### possible additional features
- authetication (oath)
  - shows series marked as private
  - allows to update the series progress
- kitsu.io drama (but atm it seems like the drama category is a placeholder)
- kitsu.io manga (would people use flexget for that?)