### PR TITLE
Prevent unicode encoding errors while logging

### DIFF
--- a/flexget/logger.py
+++ b/flexget/logger.py
@@ -1,9 +1,9 @@
 from __future__ import unicode_literals, division, absolute_import, print_function
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
+import codecs
 import collections
 import contextlib
-import io
 import logging
 import logging.handlers
 import sys
@@ -12,6 +12,7 @@ import uuid
 import warnings
 
 from flexget import __version__
+from flexget.utils.tools import io_encoding
 
 # A level more detailed than DEBUG
 TRACE = 5
@@ -205,7 +206,11 @@ def start(filename=None, level=logging.INFO, to_console=True, to_file=True):
     # without --cron we log to console
     if to_console:
         # Make sure we don't send any characters that the current terminal doesn't support printing
-        safe_stdout = io.TextIOWrapper(sys.stdout.buffer, encoding=sys.stdout.encoding, errors='replace')
+        stdout = sys.stdout
+        if hasattr(stdout, 'buffer'):
+            # On python 3, we need to get the buffer directly to support writing bytes
+            stdout = stdout.buffer
+        safe_stdout = codecs.getwriter(io_encoding)(stdout, 'replace')
         console_handler = logging.StreamHandler(safe_stdout)
         console_handler.setFormatter(formatter)
         console_handler.setLevel(level)

--- a/flexget/logger.py
+++ b/flexget/logger.py
@@ -1,4 +1,6 @@
 from __future__ import unicode_literals, division, absolute_import, print_function
+
+import io
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 import collections
@@ -203,7 +205,8 @@ def start(filename=None, level=logging.INFO, to_console=True, to_file=True):
 
     # without --cron we log to console
     if to_console:
-        console_handler = logging.StreamHandler(sys.stdout)
+        safe_stdout = io.TextIOWrapper(sys.stdout.buffer, encoding=sys.stdout.encoding, errors='backslashreplace')
+        console_handler = logging.StreamHandler(safe_stdout)
         console_handler.setFormatter(formatter)
         console_handler.setLevel(level)
         logger.addHandler(console_handler)

--- a/flexget/logger.py
+++ b/flexget/logger.py
@@ -1,10 +1,9 @@
 from __future__ import unicode_literals, division, absolute_import, print_function
-
-import io
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 import collections
 import contextlib
+import io
 import logging
 import logging.handlers
 import sys

--- a/flexget/logger.py
+++ b/flexget/logger.py
@@ -204,7 +204,8 @@ def start(filename=None, level=logging.INFO, to_console=True, to_file=True):
 
     # without --cron we log to console
     if to_console:
-        safe_stdout = io.TextIOWrapper(sys.stdout.buffer, encoding=sys.stdout.encoding, errors='backslashreplace')
+        # Make sure we don't send any characters that the current terminal doesn't support printing
+        safe_stdout = io.TextIOWrapper(sys.stdout.buffer, encoding=sys.stdout.encoding, errors='replace')
         console_handler = logging.StreamHandler(safe_stdout)
         console_handler.setFormatter(formatter)
         console_handler.setLevel(level)

--- a/flexget/terminal.py
+++ b/flexget/terminal.py
@@ -263,6 +263,6 @@ def console(text, *args, **kwargs):
     try:
         print(text, *args, **kwargs)
     except UnicodeEncodeError:
-        text = text.encode(io_encoding, 'backslashreplace').decode(io_encoding)
+        text = text.encode(io_encoding, 'replace').decode(io_encoding)
         print(text, *args, **kwargs)
     kwargs['file'].flush()  # flush to make sure the output is printed right away

--- a/flexget/terminal.py
+++ b/flexget/terminal.py
@@ -263,6 +263,6 @@ def console(text, *args, **kwargs):
     try:
         print(text, *args, **kwargs)
     except UnicodeEncodeError:
-        text = text.encode(io_encoding, 'replace').decode(io_encoding)
+        text = text.encode(io_encoding, 'backslashreplace').decode(io_encoding)
         print(text, *args, **kwargs)
     kwargs['file'].flush()  # flush to make sure the output is printed right away


### PR DESCRIPTION
### Motivation for changes:
As seen in #1558, if we try to log a character that the user's terminal doesn't support, it causes a crash.

### Detailed changes:
Our console logging handler now makes sure to replace any characters the terminal is unable to display with a `?`.

### Addressed issues:

- Fixes #1558
