### PR TITLE
Fix #1588 in npo_watchlist

### DIFF
--- a/flexget/plugins/input/npo_watchlist.py
+++ b/flexget/plugins/input/npo_watchlist.py
@@ -76,21 +76,7 @@ class NPOWatchlist(object):
         days_ago_match = days_ago_regex.search(date_text)
         first_word = date_text.split(' ')[0].lower().strip()
 
-        if date_match:
-            day = int(date_match.group(1))
-            month = months.index(date_match.group(2)) + 1
-
-            year = date_match.group(3)
-            if year is None:
-                year = date.today().year
-            else:
-                year = int(year)
-
-            return date(year, month, day)
-        elif days_ago_match:
-            days_ago = int(days_ago_match.group(1))
-            return date.today() - timedelta(days=days_ago)
-        elif first_word in ['vandaag', 'vanochtend', 'vanmiddag', 'vanavond']:
+        if first_word in ['vandaag', 'vanochtend', 'vanmiddag', 'vanavond']:
             return date.today()
         elif first_word == 'gisteren':
             return date.today() - timedelta(days=1)
@@ -98,6 +84,18 @@ class NPOWatchlist(object):
             return date.today() - timedelta(days=2)
         elif first_word == 'kijk':
             return None
+        elif date_match:
+            day = int(date_match.group(1))
+            month = months.index(date_match.group(2)) + 1
+            year = date_match.group(3)
+            if year is None:
+                year = date.today().year
+            else:
+                year = int(year)
+            return date(year, month, day)
+        elif days_ago_match:
+            days_ago = int(days_ago_match.group(1))
+            return date.today() - timedelta(days=days_ago)
         else:
             log.error("Cannot understand date '%s'", date_text)
             return date.today()


### PR DESCRIPTION
### Motivation for changes:
Prefer word-matching first; if there is more info in the date like runtime, it can confuse the date-number matching regex.

### Detailed changes:

- Switched the order, by first checking for the word, this should make the system more robust.

### Addressed issues:

- Fixes #1588 


