### PR TITLE
[added] new search plugin for private tracker torrentday

### DIFF
--- a/flexget/plugins/sites/torrentday.py
+++ b/flexget/plugins/sites/torrentday.py
@@ -103,7 +103,7 @@ class UrlRewriteTorrentday(object):
         if 'url' not in entry:
             log.error("Didn't actually get a URL...")
         else:
-            log.debug("Got the URL: %s" % entry['url'])
+            log.debug("Got the URL: %s", entry['url'])
         if entry['url'].startswith('https://www.torrentday.com/browse'):
             # use search
             results = self.search(task, entry)
@@ -143,7 +143,11 @@ class UrlRewriteTorrentday(object):
             cookies["pass"] = config['passkey']
             cookies["__cfduid"] = config['cfduid']
 
-            page = requests.get(url, cookies=cookies).content
+            try:
+                page = requests.get(url, cookies=cookies).content
+            except RequestException as e:
+                raise PluginError('Could not connect to torrentday: %s', str(e))
+
             soup = get_soup(page)
 
             for tr in soup.find_all("tr", { "class": "browse" }):

--- a/flexget/plugins/sites/torrentday.py
+++ b/flexget/plugins/sites/torrentday.py
@@ -138,7 +138,7 @@ class UrlRewriteTorrentday(object):
             url = ('https://www.torrentday.com/browse.php?search=' +
                    quote(query.encode('utf-8')) + filter_url)
             log.debug('Using %s as torrentday search url' % url)
-	
+
             cookies = {}
             cookies["uid"] = config['uid']
             cookies["pass"] = config['passkey']
@@ -150,16 +150,16 @@ class UrlRewriteTorrentday(object):
             for tr in soup.find_all("tr", { "class": "browse" }):
                 entry = Entry()
                 # find the torrent names
-		title = tr.find("a", { "class": "torrentName" })
+                title = tr.find("a", { "class": "torrentName" })
                 entry['title'] = title.contents[0]
-		log.debug('title: %s' % title.contents[0])
+                log.debug('title: %s' % title.contents[0])
 
                 # find download link
                 torrent_url = tr.find("td", { "class": "dlLinksInfo" })
                 torrent_url = torrent_url.find("a").get('href')
 
-		# construct download URL
-		torrent_url = ( "https://www.torrentday.com/" + torrent_url + '?torrent_pass=' + config['rss_key'] )
+                # construct download URL
+                torrent_url = ( "https://www.torrentday.com/" + torrent_url + '?torrent_pass=' + config['rss_key'] )
                 log.debug('RSS-ified download link: %s' % torrent_url)
                 entry['url'] = torrent_url
 

--- a/flexget/plugins/sites/torrentday.py
+++ b/flexget/plugins/sites/torrentday.py
@@ -130,7 +130,6 @@ class UrlRewriteTorrentday(object):
         # If there are any text categories, turn them into their id number
         categories = [c if isinstance(c, int) else CATEGORIES[c] for c in categories]
         filter_url = '&cata=yes&c%s=1&clear-new=1' % ','.join(str(c) for c in categories)
-#        filter_url = '&cata=yes&c11=1&clear-new=1'
         entries = set()
         for search_string in entry.get('search_strings', [entry['title']]):
             query = normalize_unicode(search_string).replace(":", "")

--- a/flexget/plugins/sites/torrentday.py
+++ b/flexget/plugins/sites/torrentday.py
@@ -109,7 +109,6 @@ class UrlRewriteTorrentday(object):
             results = self.search(task, entry)
             if not results:
                 raise UrlRewritingError("No search results found")
-            # TODO: Search doesn't enforce close match to title, be more picky
             entry['url'] = results[0]['url']
 
     @plugin.internet(log)
@@ -120,9 +119,6 @@ class UrlRewriteTorrentday(object):
 
         if not isinstance(config, dict):
             config = {}
-            # sort = SORT.get(config.get('sort_by', 'seeds'))
-            # if config.get('sort_reverse'):
-            # sort += 1
         categories = config.get('category', 'all')
         # Make sure categories is a list
         if not isinstance(categories, list):
@@ -136,7 +132,7 @@ class UrlRewriteTorrentday(object):
             # urllib.quote will crash if the unicode string has non ascii characters, so encode in utf-8 beforehand
             url = ('https://www.torrentday.com/browse.php?search=' +
                    quote(query.encode('utf-8')) + filter_url)
-            log.debug('Using %s as torrentday search url' % url)
+            log.debug('Using %s as torrentday search url', url)
 
             cookies = {}
             cookies["uid"] = config['uid']
@@ -146,7 +142,7 @@ class UrlRewriteTorrentday(object):
             try:
                 page = requests.get(url, cookies=cookies).content
             except RequestException as e:
-                raise PluginError('Could not connect to torrentday: %s', str(e))
+                raise PluginError('Could not connect to torrentday')
 
             soup = get_soup(page)
 
@@ -155,7 +151,7 @@ class UrlRewriteTorrentday(object):
                 # find the torrent names
                 title = tr.find("a", { "class": "torrentName" })
                 entry['title'] = title.contents[0]
-                log.debug('title: %s' % title.contents[0])
+                log.debug('title: %s', title.contents[0])
 
                 # find download link
                 torrent_url = tr.find("td", { "class": "dlLinksInfo" })
@@ -163,7 +159,7 @@ class UrlRewriteTorrentday(object):
 
                 # construct download URL
                 torrent_url = ( "https://www.torrentday.com/" + torrent_url + '?torrent_pass=' + config['rss_key'] )
-                log.debug('RSS-ified download link: %s' % torrent_url)
+                log.debug('RSS-ified download link: %s', torrent_url)
                 entry['url'] = torrent_url
 
                 # us tr object for seeders/leechers

--- a/flexget/plugins/sites/torrentday.py
+++ b/flexget/plugins/sites/torrentday.py
@@ -142,7 +142,7 @@ class UrlRewriteTorrentday(object):
             try:
                 page = requests.get(url, cookies=cookies).content
             except RequestException as e:
-                raise PluginError('Could not connect to torrentday')
+                raise PluginError('Could not connect to torrentday: %s' % e)
 
             soup = get_soup(page)
 

--- a/flexget/plugins/sites/torrentday.py
+++ b/flexget/plugins/sites/torrentday.py
@@ -101,14 +101,14 @@ class UrlRewriteTorrentday(object):
     # urlrewriter API
     def url_rewrite(self, task, entry):
         if 'url' not in entry:
-            log.error("Didn't actually get a URL...")
+            log.error('Didn\'t actually get a URL...')
         else:
-            log.debug("Got the URL: %s", entry['url'])
+            log.debug('Got the URL: %s', entry['url'])
         if entry['url'].startswith('https://www.torrentday.com/browse'):
             # use search
             results = self.search(task, entry)
             if not results:
-                raise UrlRewritingError("No search results found")
+                raise UrlRewritingError('No search results found')
             entry['url'] = results[0]['url']
 
     @plugin.internet(log)
@@ -128,7 +128,7 @@ class UrlRewriteTorrentday(object):
         for search_string in entry.get('search_strings', [entry['title']]):
 
             url = 'https://www.torrentday.com/browse.php'
-            params["search"] = normalize_unicode(search_string).replace(":", "")
+            params['search'] = normalize_unicode(search_string).replace(':', '')
             cookies = { 'uid': config['uid'], 'pass': config['passkey'], '__cfduid': config['cfduid'] }
 
             try:
@@ -138,30 +138,30 @@ class UrlRewriteTorrentday(object):
 
             soup = get_soup(page)
 
-            for tr in soup.find_all("tr", { "class": "browse" }):
+            for tr in soup.find_all('tr', { 'class': 'browse' }):
                 entry = Entry()
                 # find the torrent names
-                title = tr.find("a", { "class": "torrentName" })
+                title = tr.find('a', { 'class': 'torrentName' })
                 entry['title'] = title.contents[0]
                 log.debug('title: %s', title.contents[0])
 
                 # find download link
-                torrent_url = tr.find("td", { "class": "dlLinksInfo" })
-                torrent_url = torrent_url.find("a").get('href')
+                torrent_url = tr.find('td', { 'class': 'dlLinksInfo' })
+                torrent_url = torrent_url.find('a').get('href')
 
                 # construct download URL
-                torrent_url = ( "https://www.torrentday.com/" + torrent_url + '?torrent_pass=' + config['rss_key'] )
+                torrent_url = ( 'https://www.torrentday.com/' + torrent_url + '?torrent_pass=' + config['rss_key'] )
                 log.debug('RSS-ified download link: %s', torrent_url)
                 entry['url'] = torrent_url
 
                 # us tr object for seeders/leechers
-                seeders, leechers = tr.find_all('td', { "class": ["seedersInfo", "leechersInfo"]})
-                entry['torrent_seeds'] = int(seeders.contents[0].replace(",", ""))
-                entry['torrent_leeches'] = int(leechers.contents[0].replace(",", ""))
+                seeders, leechers = tr.find_all('td', { 'class': ['seedersInfo', 'leechersInfo']})
+                entry['torrent_seeds'] = int(seeders.contents[0].replace(',', ''))
+                entry['torrent_leeches'] = int(leechers.contents[0].replace(',', ''))
                 entry['search_sort'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
 
                 # use tr object for size
-                size = tr.find("td", text=re.compile('([\.\d]+) ([TGMKk]?)B')).contents[0]
+                size = tr.find('td', text=re.compile('([\.\d]+) ([TGMKk]?)B')).contents[0]
                 size = re.search('([\.\d]+) ([TGMKk]?)B', str(size))
 
                 entry['content_size'] = parse_filesize(size.group(0))

--- a/flexget/plugins/sites/torrentday.py
+++ b/flexget/plugins/sites/torrentday.py
@@ -1,0 +1,185 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+from future.moves.urllib.parse import quote
+
+import re
+import logging
+
+from requests.exceptions import RequestException
+
+from flexget import plugin
+from flexget.config_schema import one_or_more
+from flexget.entry import Entry
+from flexget.event import event
+from flexget.plugin import PluginError
+from flexget.plugins.internal.urlrewriting import UrlRewritingError
+from flexget.utils import requests
+from flexget.utils.soup import get_soup
+from flexget.utils.search import torrent_availability, normalize_unicode
+from flexget.utils.tools import parse_filesize
+
+log = logging.getLogger('torrentday')
+
+CATEGORIES = {
+    'all': 0,
+    # Movies
+    'mov480p': 25,
+    'movHD': 11,
+    'movBD': 5,
+    'movDVD': 3,
+    'movMP4': 21,
+    'movNonEnglish': 22,
+    'movPACKS': 13,
+    'movSDx264': 44,
+    'movX265': 48,
+    'movXVID': 1,
+
+    # TV
+    'tv480p': 24,
+    'tvBRD': 32,
+    'tvDVD': 31,
+    'tvDVDrip': 33,
+    'tvMOBILE': 46,
+    'tvPACKS': 14,
+    'tvSDx264': 26,
+    'tvHDx264': 7,
+    'tvX265': 34,
+    'tvXVID': 2
+}
+
+
+class UrlRewriteTorrentday(object):
+    """
+        Torrentday urlrewriter and search plugin.
+
+        torrentday:
+          uid: xxxxxxxxxxxxx  (required)    NOT YOUR LOGIN. find this in your browser's cookies
+          passkey: xxxxxxxxx  (required)    NOT YOUR PASSWORD. see previous
+          cfduid: xxxxxxxxxx  (required)    AGAIN IN THE COOKIES
+          rss_key: xxxxxxxxx  (required)    get this from your profile page
+          category: xxxxxxxx
+
+          Category can be one of 
+            ID from browsing site OR 'name'
+            movies:
+              mov480p, movHD, movBD, movDVD,
+              movMP4, movNonEnglish, movPACKS,
+              movSDx264, movX265, movXVID
+            tv:
+              tv480p, tvBRD, tvDVD, tvDVDrip,
+              tvMOBILE, tvPACKS, tvSDx264, 
+              tvHDx264, tvX265, tvXVID
+    """
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'rss_key': {'type': 'string'},
+            'uid': {'type': 'string'},
+            'passkey': {'type': 'string'},
+            'cfduid': {'type': 'string'},
+            'category': {
+                'oneOf': [
+                    {'type': 'integer'},
+                    {'type': 'string', 'enum': list(CATEGORIES)},
+                ]
+            },
+        },
+        'required': ['rss_key', 'uid', 'passkey', 'cfduid'],
+        'additionalProperties': False
+    }
+
+    # urlrewriter API
+    def url_rewritable(self, task, entry):
+        url = entry['url']
+        if url.find('.torrent'):
+            return False
+        if url.startswith('https://www.torrentday.com'):
+            return True
+        return False
+
+    # urlrewriter API
+    def url_rewrite(self, task, entry):
+        if 'url' not in entry:
+            log.error("Didn't actually get a URL...")
+        else:
+            log.debug("Got the URL: %s" % entry['url'])
+        if entry['url'].startswith('https://www.torrentday.com/browse'):
+            # use search
+            results = self.search(task, entry)
+            if not results:
+                raise UrlRewritingError("No search results found")
+            # TODO: Search doesn't enforce close match to title, be more picky
+            entry['url'] = results[0]['url']
+
+    @plugin.internet(log)
+    def search(self, task, entry, config=None):
+        """
+        Search for name from torrentday.
+        """
+
+        if not isinstance(config, dict):
+            config = {}
+            # sort = SORT.get(config.get('sort_by', 'seeds'))
+            # if config.get('sort_reverse'):
+            # sort += 1
+        categories = config.get('category', 'all')
+        # Make sure categories is a list
+        if not isinstance(categories, list):
+            categories = [categories]
+        # If there are any text categories, turn them into their id number
+        categories = [c if isinstance(c, int) else CATEGORIES[c] for c in categories]
+        filter_url = '&cata=yes&c%s=1&clear-new=1' % ','.join(str(c) for c in categories)
+#        filter_url = '&cata=yes&c11=1&clear-new=1'
+        entries = set()
+        for search_string in entry.get('search_strings', [entry['title']]):
+            query = normalize_unicode(search_string).replace(":", "")
+            # urllib.quote will crash if the unicode string has non ascii characters, so encode in utf-8 beforehand
+            url = ('https://www.torrentday.com/browse.php?search=' +
+                   quote(query.encode('utf-8')) + filter_url)
+            log.debug('Using %s as torrentday search url' % url)
+	
+            cookies = {}
+            cookies["uid"] = config['uid']
+            cookies["pass"] = config['passkey']
+            cookies["__cfduid"] = config['cfduid']
+
+            page = requests.get(url, cookies=cookies).content
+            soup = get_soup(page)
+
+            for tr in soup.find_all("tr", { "class": "browse" }):
+                entry = Entry()
+                # find the torrent names
+		title = tr.find("a", { "class": "torrentName" })
+                entry['title'] = title.contents[0]
+		log.debug('title: %s' % title.contents[0])
+
+                # find download link
+                torrent_url = tr.find("td", { "class": "dlLinksInfo" })
+                torrent_url = torrent_url.find("a").get('href')
+
+		# construct download URL
+		torrent_url = ( "https://www.torrentday.com/" + torrent_url + '?torrent_pass=' + config['rss_key'] )
+                log.debug('RSS-ified download link: %s' % torrent_url)
+                entry['url'] = torrent_url
+
+                # us tr object for seeders/leechers
+                seeders, leechers = tr.find_all('td', { "class": ["seedersInfo", "leechersInfo"]})
+                entry['torrent_seeds'] = int(seeders.contents[0])
+                entry['torrent_leeches'] = int(leechers.contents[0])
+                entry['search_sort'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
+
+                # use tr object for size
+                size = tr.find("td", text=re.compile('([\.\d]+) ([TGMKk]?)B')).contents[0]
+                size = re.search('([\.\d]+) ([TGMKk]?)B', str(size))
+
+                entry['content_size'] = parse_filesize(size.group(0))
+
+                entries.add(entry)
+
+        return sorted(entries, reverse=True, key=lambda x: x.get('search_sort'))
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(UrlRewriteTorrentday, 'torrentday', groups=['urlrewriter', 'search'], api_ver=2)


### PR DESCRIPTION
i used torrentleech as a starting point. The main difference being that TL uses uname/pass to login, generate the cookies & access the search pages. TD's login page has captcha, so instead i put the 3 cookies it needs as required keys. this should be fine, because in my browser they all have expiry date of 2038. Beyond that, the 2 sites have a slightly different CSS so i'm look for some different classes and divs (this is my first PR ever, so plz be gentle)

### Motivation for changes:
TD is my primary private tracker and TL secondary 
i'd like to discover stuff. maybe others will too

### Detailed changes:

- new private tracker search plugin

### Config usage if relevant (new plugin or updated schema):
```
    discover:
      from:
        - torrentday:
           uid: xxxxxxxxxxxxx  (required)  NOT YOUR LOGIN. find this in your browser's cookies
           passkey: xxxxxxxxx  (required)  NOT YOUR PASSWORD. see previous
           cfduid: xxxxxxxxxx  (required)  AGAIN IN THE COOKIES
           rss_key: xxxxxxxxx  (required)  get this from your profile page
           category: xxxxxxxx
```
### Log and/or tests output (preferably both):
https://dl.dropboxusercontent.com/u/28529352/flexget-torrentday-test.log
