### PR TITLE
[fix] est_released_movies: Fixed crash with movie_year of None

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ node_modules/
 !raw_config.yml
 !variables.yml
 cached_resources/
+pyvenv.cfg

--- a/flexget/plugins/estimators/est_released_movies.py
+++ b/flexget/plugins/estimators/est_released_movies.py
@@ -17,12 +17,12 @@ class EstimatesReleasedMovies(object):
         if 'tmdb_released' in entry:
             log.verbose('Querying release estimation for %s' % entry['title'])
             return entry['tmdb_released']
-        elif 'movie_year' in entry:
+        elif 'movie_year' in entry and entry['movie_year'] is not None:
             try:
                 return datetime(year=entry['movie_year'], month=1, day=1)
             except ValueError:
                 pass
-        log.debug('Unable to check release for %s, tmdb_release field is not defined' % entry['title'])
+        log.debug('Unable to check release for %s, tmdb_release and movie_year fields are not defined' % entry['title'])
 
 
 @event('plugin.register')

--- a/flexget/plugins/estimators/est_released_movies.py
+++ b/flexget/plugins/estimators/est_released_movies.py
@@ -22,7 +22,7 @@ class EstimatesReleasedMovies(object):
                 return datetime(year=entry['movie_year'], month=1, day=1)
             except ValueError:
                 pass
-        log.debug('Unable to check release for %s, tmdb_release and movie_year fields are not defined' % entry['title'])
+        log.debug('Unable to check release for %s, tmdb_release and movie_year fields are not defined', entry['title'])
 
 
 @event('plugin.register')

--- a/flexget/plugins/list/trakt_list.py
+++ b/flexget/plugins/list/trakt_list.py
@@ -17,9 +17,26 @@ from flexget.utils.tools import split_title_year
 log = logging.getLogger('trakt_list')
 IMMUTABLE_LISTS = []
 
+def generate_show_title(item):
+    show_info = item['show']
+    if show_info['year']:
+        return '%s (%s)' % (show_info['title'], show_info['year'])
+    else:
+        return show_info['title']
+
+def generate_episode_title(item):
+    show_info = item['show']
+    episode_info = item['episode']
+    if show_info['year']:
+        return ('%s (%s) S%02dE%02d %s' % (show_info['title'], show_info['year'], episode_info['season'],
+                                          episode_info['number'], episode_info['title'] or '')).strip()
+    else:
+        return ('%s S%02dE%02d %s' % (show_info['title'], episode_info['season'],
+                                          episode_info['number'], episode_info['title'] or '')).strip()
+
 field_maps = {
     'movie': {
-        'title': lambda i: '%s (%s)' % (i['movie']['title'], i['movie']['year']),
+        'title': lambda i: '%s (%s)' % (i['movie']['title'], i['movie']['year']) if i['movie']['year'] else '%s' % i['movie']['title'],
         'movie_name': 'movie.title',
         'movie_year': 'movie.year',
         'trakt_movie_name': 'movie.title',
@@ -30,8 +47,8 @@ field_maps = {
         'trakt_movie_slug': 'movie.ids.slug'
     },
     'show': {
-        'title': lambda i: '%s (%s)' % (i['show']['title'], i['show']['year']),
-        'series_name': lambda i: '%s (%s)' % (i['show']['title'], i['show']['year']),
+        'title': generate_show_title,
+        'series_name': generate_show_title,
         'trakt_series_name': 'show.title',
         'trakt_series_year': 'show.year',
         'imdb_id': 'show.ids.imdb',
@@ -42,9 +59,8 @@ field_maps = {
         'trakt_show_slug': 'show.ids.slug'
     },
     'episode': {
-        'title': lambda i: ('%s (%s) S%02dE%02d %s' % (i['show']['title'], i['show']['year'], i['episode']['season'],
-                                                       i['episode']['number'], i['episode']['title'] or '')).strip(),
-        'series_name': lambda i: '%s (%s)' % (i['show']['title'], i['show']['year']),
+        'title': generate_episode_title,
+        'series_name': generate_show_title,
         'trakt_series_name': 'show.title',
         'trakt_series_year': 'show.year',
         'series_season': 'episode.season',

--- a/flexget/plugins/list/trakt_list.py
+++ b/flexget/plugins/list/trakt_list.py
@@ -17,6 +17,7 @@ from flexget.utils.tools import split_title_year
 log = logging.getLogger('trakt_list')
 IMMUTABLE_LISTS = []
 
+
 def generate_show_title(item):
     show_info = item['show']
     if show_info['year']:
@@ -24,19 +25,22 @@ def generate_show_title(item):
     else:
         return show_info['title']
 
+
 def generate_episode_title(item):
     show_info = item['show']
     episode_info = item['episode']
     if show_info['year']:
         return ('%s (%s) S%02dE%02d %s' % (show_info['title'], show_info['year'], episode_info['season'],
-                                          episode_info['number'], episode_info['title'] or '')).strip()
+                                           episode_info['number'], episode_info['title'] or '')).strip()
     else:
         return ('%s S%02dE%02d %s' % (show_info['title'], episode_info['season'],
-                                          episode_info['number'], episode_info['title'] or '')).strip()
+                                      episode_info['number'], episode_info['title'] or '')).strip()
+
 
 field_maps = {
     'movie': {
-        'title': lambda i: '%s (%s)' % (i['movie']['title'], i['movie']['year']) if i['movie']['year'] else '%s' % i['movie']['title'],
+        'title': lambda i: '%s (%s)' % (i['movie']['title'], i['movie']['year'])
+        if i['movie']['year'] else '%s' % i['movie']['title'],
         'movie_name': 'movie.title',
         'movie_year': 'movie.year',
         'trakt_movie_name': 'movie.title',


### PR DESCRIPTION
### Motivation for changes:

Was seeing a crash when using a list containing a movie with no release date:

```
Traceback (most recent call last):
  File "/home/jacob/flexget/lib/python3.5/site-packages/flexget/task.py", line 477, in __run_plugin
    return method(*args, **kwargs)
  File "/home/jacob/flexget/lib/python3.5/site-packages/flexget/event.py", line 23, in __call__
    return self.func(*args, **kwargs)
  File "/home/jacob/flexget/lib/python3.5/site-packages/flexget/plugins/input/discover.py", line 289, in on_task_input
    entries = self.estimated(entries, estimation_mode)
  File "/home/jacob/flexget/lib/python3.5/site-packages/flexget/plugins/input/discover.py", line 201, in estimated
    est_date = estimator.estimate(entry)
  File "/home/jacob/flexget/lib/python3.5/site-packages/flexget/plugins/estimators/est_released.py", line 28, in estimate
    estimate = estimator(entry)
  File "/home/jacob/flexget/lib/python3.5/site-packages/flexget/plugins/estimators/est_released_movies.py", line 22, in estimate
    return datetime(year=entry['movie_year'], month=1, day=1)
TypeError: an integer is required (got type NoneType)
```

It looks like this plugin can't handle a movie_year of none, despite that being a valid value to be passed.
### Detailed changes:

- Simply have it check for none as well as existence of the value in the entry.
- I also noticed that the trakt_list plugin wasn't correctly generating the title in cases where the year was missing. I used the imdb_list as my guide for removing the (YEAR) at the end of the title if it doesn't exist.
- I didn't create a new test for this; I could add one but I was worried it would be brittle because things on trakt usually get dates added to them over time, and this would break the test. I ran into this issue personally with [this movie](https://trakt.tv/movies/fantastic-beasts-and-where-to-find-them-5)

### Addressed issues:

- No issue filed, I just made a PR for it, but I can make one if people want.

### Config usage if relevant (new plugin or updated schema):
```
N/A
```
### Log and/or tests output (preferably both):
```
============================= test session starts ==============================
platform linux -- Python 3.5.2, pytest-3.0.5, py-1.4.32, pluggy-0.4.0
rootdir: /home/jacob/Development/Flexget, inifile: setup.cfg
plugins: cov-2.2.1, xdist-1.15.0, capturelog-0.7
collected 1096 items

flexget/tests/test_abort.py .
flexget/tests/test_archives.py s...
flexget/tests/test_argparse.py ...
flexget/tests/test_assume_quality.py ....................
flexget/tests/test_backlog.py .
flexget/tests/test_cached_input.py ..
flexget/tests/test_condition.py ......
flexget/tests/test_config.py .
flexget/tests/test_config_schema.py ....................
flexget/tests/test_configure_series_betaseries_list.py ...
flexget/tests/test_content_filter.py ........
flexget/tests/test_content_size.py .......
flexget/tests/test_cookies.py .
flexget/tests/test_couchpotato_list.py ..
flexget/tests/test_crossmatch.py .
flexget/tests/test_decompress.py ss...
flexget/tests/test_delay.py .
flexget/tests/test_digest.py ......
flexget/tests/test_discover.py ......
flexget/tests/test_download.py ...sssss
flexget/tests/test_exec.py ..s
flexget/tests/test_exists_movie.py ..............ssssss
flexget/tests/test_exists_series.py ..................
flexget/tests/test_feed_control.py s..
flexget/tests/test_filesystem.py .............
flexget/tests/test_headers.py .
flexget/tests/test_html5lib.py .
flexget/tests/test_imdb.py ...........
flexget/tests/test_imdb_list_interface.py .
flexget/tests/test_imdb_parser.py ....
flexget/tests/test_input_sites.py ...
flexget/tests/test_inputs.py ..
flexget/tests/test_lazy_fields.py .
flexget/tests/test_limit_new.py .
flexget/tests/test_list_interface.py .............
flexget/tests/test_manipulate.py .....
flexget/tests/test_metainfo.py .........
flexget/tests/test_migrate.py .
flexget/tests/test_misc.py .........s.....
flexget/tests/test_movie_list.py ..............
flexget/tests/test_movieparser.py ..
flexget/tests/test_myepisodes.py s
flexget/tests/test_next_series_episodes.py ........................
flexget/tests/test_nfo_lookup.py .............
flexget/tests/test_npo_watchlist.py ..
flexget/tests/test_only_new.py .
flexget/tests/test_parsingapi.py ...
flexget/tests/test_path_by_space.py ......
flexget/tests/test_pathscrub.py ....
flexget/tests/test_pending_approval.py .
flexget/tests/test_pluginapi.py .....
flexget/tests/test_proper_movies.py ..
flexget/tests/test_qualities.py ........................................................................................................................
flexget/tests/test_regex_extract.py ....
flexget/tests/test_regexp.py .........
flexget/tests/test_regexp_list.py ..
flexget/tests/test_remember_rejected.py .
flexget/tests/test_reorder_quality.py ..
flexget/tests/test_rottentomatoes.py x
flexget/tests/test_rss.py .........
flexget/tests/test_rtorrent.py ...............
flexget/tests/test_secrets.py ..
flexget/tests/test_seen.py .......
flexget/tests/test_series.py ........................................................................................................................................................................
flexget/tests/test_series_premiere.py ................
flexget/tests/test_seriesparser.py .......s...................................................s............................................
flexget/tests/test_simple_persistence.py ..
flexget/tests/test_sort_by.py ....
flexget/tests/test_subtitle_list.py ...ssss.s.....
flexget/tests/test_t411.py ...........
flexget/tests/test_task.py .
flexget/tests/test_template.py ......
flexget/tests/test_thetvdb.py ..............
flexget/tests/test_thetvdb_list.py .
flexget/tests/test_tmdb.py .x
flexget/tests/test_torrent.py ...............
flexget/tests/test_trakt.py ....................x
flexget/tests/test_trakt_list_interface.py .......
flexget/tests/test_tvmaze.py ................X
flexget/tests/test_urlfix.py ..
flexget/tests/test_urlrewriting.py .....
flexget/tests/test_utils.py ...................
flexget/tests/test_validator.py ......
flexget/tests/api_tests/test_api_validator.py .
flexget/tests/api_tests/test_authentication_api.py .
flexget/tests/api_tests/test_cached_api.py .
flexget/tests/api_tests/test_database_api.py .
flexget/tests/api_tests/test_entry_list_api.py ......
flexget/tests/api_tests/test_etag.py .
flexget/tests/api_tests/test_execute_api.py ........
flexget/tests/api_tests/test_failed_api.py ....
flexget/tests/api_tests/test_format_checker_api.py ...........
flexget/tests/api_tests/test_history_api.py ...
flexget/tests/api_tests/test_imdb_lookup_api.py .
flexget/tests/api_tests/test_movie_list_api.py .........
flexget/tests/api_tests/test_pending_api.py ......
flexget/tests/api_tests/test_plugins_api.py .
flexget/tests/api_tests/test_rejected_api.py .......
flexget/tests/api_tests/test_schedule_api.py .................
flexget/tests/api_tests/test_secrets_api.py ..
flexget/tests/api_tests/test_seen_api.py ......
flexget/tests/api_tests/test_series_api.py ........................
flexget/tests/api_tests/test_server_api.py ......
flexget/tests/api_tests/test_status_api.py .......
flexget/tests/api_tests/test_tasks_api.py ........
flexget/tests/api_tests/test_tmdb_lookup.py ....
flexget/tests/api_tests/test_trakt_lookup_api.py .................
flexget/tests/api_tests/test_tvdb_lookup_api.py ...............
flexget/tests/api_tests/test_tvmaze_lookup_api.py .....
flexget/tests/api_tests/test_user_api.py ..
flexget/tests/notifiers/test_notify.py .
flexget/tests/notifiers/test_notify_abort.py ..
flexget/tests/notifiers/test_pushover.py .
flexget/tests/notifiers/test_sns_notifier.py ..

============================ pytest-warning summary ============================
WC1 None [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.
WI1 /home/jacob/Development/Flexget/lib/python3.5/site-packages/pytest_capturelog.py:171 'pytest_runtest_makereport' hook uses deprecated __multicall__ argument
WC1 None pytest_funcarg__cov: declaring fixtures using "pytest_funcarg__" prefix is deprecated and scheduled to be removed in pytest 4.0.  Please remove the prefix and use the @pytest.fixture decorator instead.
WC1 None pytest_funcarg__caplog: declaring fixtures using "pytest_funcarg__" prefix is deprecated and scheduled to be removed in pytest 4.0.  Please remove the prefix and use the @pytest.fixture decorator instead.
WC1 None pytest_funcarg__capturelog: declaring fixtures using "pytest_funcarg__" prefix is deprecated and scheduled to be removed in pytest 4.0.  Please remove the prefix and use the @pytest.fixture decorator instead.
 1067 passed, 25 skipped, 3 xfailed, 1 xpassed, 5 pytest-warnings in 245.16 seconds 
```

