### PR TITLE
add missing movie_metainfo, series_metainfo property's

### DIFF
--- a/flexget/plugins/metainfo/rottentomatoes_lookup.py
+++ b/flexget/plugins/metainfo/rottentomatoes_lookup.py
@@ -116,7 +116,12 @@ class PluginRottenTomatoesLookup(object):
         for entry in task.entries:
             entry.register_lazy_func(self.lazy_loader, self.field_map)
 
+    @property
+    def movie_identifier(self):
+        """Returns the plugin main identifier type"""
+        return 'rt_id'
+
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginRottenTomatoesLookup, 'rottentomatoes_lookup', api_ver=2)
+    plugin.register(PluginRottenTomatoesLookup, 'rottentomatoes_lookup', api_ver=2, groups=['movie_metainfo'])

--- a/flexget/plugins/metainfo/thetvdb_lookup.py
+++ b/flexget/plugins/metainfo/thetvdb_lookup.py
@@ -184,7 +184,12 @@ class PluginThetvdbLookup(object):
                     lazy_episode_lookup = partial(self.lazy_episode_lookup, language=language)
                     entry.register_lazy_func(lazy_episode_lookup, self.episode_map)
 
+    @property
+    def series_identifier(self):
+        """Returns the plugin main identifier type"""
+        return 'tvdb_id'
+
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginThetvdbLookup, 'thetvdb_lookup', api_ver=2)
+    plugin.register(PluginThetvdbLookup, 'thetvdb_lookup', api_ver=2, groups=['series_metainfo'])

--- a/flexget/plugins/metainfo/tvmaze_lookup.py
+++ b/flexget/plugins/metainfo/tvmaze_lookup.py
@@ -168,7 +168,12 @@ class PluginTVMazeLookup(object):
                 if ('series_season' in entry and 'series_episode' in entry) or ('series_date' in entry):
                     entry.register_lazy_func(self.lazy_episode_lookup, self.episode_map)
 
+    @property
+    def series_identifier(self):
+        """Returns the plugin main identifier type"""
+        return 'tvmaze_id'
+
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginTVMazeLookup, 'tvmaze_lookup', api_ver=3)
+    plugin.register(PluginTVMazeLookup, 'tvmaze_lookup', api_ver=3, groups=['series_metainfo'])


### PR DESCRIPTION
### Motivation for changes:
Some plugins did not support the movie_metainfo, series_metainfo group tag/property.

### Detailed changes:
added movie_metainfo to rottentomatoes_lookup
added series_metainfo to thetvdb_lookup, tvmaze_lookup