### PR TITLE
Make sure series_name_plain is really plain

### DIFF
--- a/flexget/plugins/input/npo_watchlist.py
+++ b/flexget/plugins/input/npo_watchlist.py
@@ -61,9 +61,9 @@ class NPOWatchlist(object):
 
     csrf_token = None
 
-    def _strip_accents(self, s):
+    def _convert_plain(self, s):
         return ''.join(c for c in unicodedata.normalize('NFD', s)
-                       if unicodedata.category(c) != 'Mn')
+                       if not re.match('Mn|P[^cd]', unicodedata.category(c)))
 
     def _prefix_url(self, prefix, url):
         if ':' not in url:
@@ -152,7 +152,7 @@ class NPOWatchlist(object):
             e['url'] = self._prefix_url('https://mijn.npo.nl', url)
             e['title'] = title
             e['series_name'] = series_name
-            e['series_name_plain'] = self._strip_accents(series_name)
+            e['series_name_plain'] = self._convert_plain(series_name)
             e['series_date'] = entry_date
             e['series_id_type'] = 'date'
             e['description'] = listItem.find('p').text
@@ -217,7 +217,7 @@ class NPOWatchlist(object):
             e['url'] = self._prefix_url('http://www.npo.nl', url)
             e['title'] = title
             e['series_name'] = series_name
-            e['series_name_plain'] = self._strip_accents(series_name)
+            e['series_name_plain'] = self._convert_plain(series_name)
             e['series_date'] = entry_date
             e['series_id_type'] = 'date'
             e['description'] = listItem.find('p').text
@@ -259,7 +259,7 @@ class NPOWatchlist(object):
             e['url'] = self._prefix_url('http://www.npo.nl', url)
             e['title'] = title
             e['series_name'] = series_name
-            e['series_name_plain'] = self._strip_accents(series_name)
+            e['series_name_plain'] = self._convert_plain(series_name)
             e['series_date'] = entry_date
             e['series_id_type'] = 'date'
             e['description'] = listItem.find('p').text


### PR DESCRIPTION
Needs to remove also some special character processing to produce filesystem-safe strings

### Motivation for changes:
Current series_name_plain produced outputs that are unprocessable on e.g. Windows filesystems or Samba shares; for passing a better value to `download-npo` a further processed plain string is more practical

### Detailed changes:

- Rewrote the `_strip_accents` function into a `_convert_plain` function
