### PR TITLE
relplace Safe by zxcvbn for password strength testing

### DIFF
--- a/flexget/webserver.py
+++ b/flexget/webserver.py
@@ -8,7 +8,7 @@ import socket
 import threading
 
 import cherrypy
-import safe
+import zxcvbn
 from flask import Flask, abort, redirect
 from flask_login import UserMixin
 from sqlalchemy import Column, Integer, Unicode
@@ -218,8 +218,8 @@ def get_user(username='flexget', session=None):
 
 @with_session
 def change_password(username='flexget', password='', session=None):
-    check = safe.check(password)
-    if check.strength not in ['medium', 'strong']:
+    check = zxcvbn.zxcvbn(password, user_inputs=[username])
+    if check['score'] < 3:
         raise WeakPassword('Password {0} is not strong enough'.format(password))
 
     user = get_user(username=username, session=session)

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,5 +29,5 @@ flask-compress>=1.2.1
 flask-login>=0.4.0
 flask-cors>=2.1.2
 pyparsing>=2.0.3
-Safe>=0.4
+zxcvbn-python
 future>=0.15.2


### PR DESCRIPTION
### Motivation for changes:
Currently in the webserver password strength is checked using the Python library [Safe](https://github.com/lepture/safe/). This library has not seen very much attention from its author in a while and it is quite simplistic in its approach.

Instead I propose to use the Python implementation of Dropbox's zxcvbn library [dwolfhub/zxcvbn-python](https://github.com/dwolfhub/zxcvbn-python). This is a more sophisticated password strength checker which is actively maintained. It is pure Python and does not introduce extra dependencies. Note that there are older forks of the code but this is the current officially endorsed one.

### Detailed changes:
Replace the dependency on Safe with one on zxcvbn-python.

It can provide a more detailed password analysis but at the most basic level it returns a score from the following list:

```
  0 # too guessable: risky password. (guesses < 10^3)
  1 # very guessable: protection from throttled online attacks. (guesses < 10^6)
  2 # somewhat guessable: protection from unthrottled online attacks. (guesses < 10^8)
  3 # safely unguessable: moderate protection from offline slow-hash scenario. (guesses < 10^10)
  4 # very unguessable: strong protection from offline slow-hash scenario. (guesses >= 10^10)
```

I require that the password have a score of at least 3 in order to be considered secure.