### PR TITLE
added support for Exx identifier in series parser

### DIFF
--- a/flexget/tests/test_series.py
+++ b/flexget/tests/test_series.py
@@ -1681,7 +1681,7 @@ class TestIDTypes(object):
         task = execute_task('all_types')
         for entry in task.entries:
             assert entry['series_name'], '%s not parsed by series plugin' % entry['title']
-            assert entry['series_id_type'] not in entry['series_name']
+            assert entry['series_id_type'] in entry['series_name']
 
 
 class TestCaseChange(object):

--- a/flexget/tests/test_series.py
+++ b/flexget/tests/test_series.py
@@ -1661,6 +1661,7 @@ class TestIDTypes(object):
           all_types:
             series:
               - episode
+              - seasonless episode
               - date
               - sequence
               - stupid id:
@@ -1673,13 +1674,14 @@ class TestIDTypes(object):
               - title: sequence 003
               - title: sequence 4
               - title: stupid id 3cat
+              - title: seasonless episode e01
     """
 
     def test_id_types(self, execute_task):
         task = execute_task('all_types')
         for entry in task.entries:
             assert entry['series_name'], '%s not parsed by series plugin' % entry['title']
-            assert entry['series_id_type'] in entry['series_name']
+            assert entry['series_id_type'] not in entry['series_name']
 
 
 class TestCaseChange(object):

--- a/flexget/tests/test_seriesparser.py
+++ b/flexget/tests/test_seriesparser.py
@@ -144,6 +144,9 @@ class TestSeriesParser(object):
         s = parse(name='Something', data='Something - Ep VIII')
         assert (s.season == 1 and s.episode == 8), 'failed to parse %s' % s
 
+        s = parse(name='Something', data='Something - E01')
+        assert (s.season == 1 and s.episode == 1), 'failed to parse %s' % s
+
     def test_season_episode_of_total(self, parse):
         """SeriesParser: season X YofZ"""
         s = parse(name='Something', data='Something Season 2 2of12')

--- a/flexget/utils/titles/series.py
+++ b/flexget/utils/titles/series.py
@@ -46,9 +46,8 @@ class SeriesParser(TitleParser):
         '(?:series|season)\s?(\d{1,4})\s(\d{1,3})\s?of\s?(?:\d{1,3})',
         '(\d{1,2})\s?x\s?(\d+)(?:\s(\d{1,2}))?',
         '(\d{1,3})\s?of\s?(?:\d{1,3})',
-        '(?:episode|ep|part|pt)\s?(\d{1,3}|%s)' % roman_numeral_re,
+        '(?:episode|e|ep|part|pt)\s?(\d{1,3}|%s)' % roman_numeral_re,
         'part\s(%s)' % '|'.join(map(str, english_numbers)),
-        '(?:e|ep)(\d{1,2})', # E01
     ]])
     unwanted_regexps = ReList([
         '(\d{1,3})\s?x\s?(0+)[^1-9]',  # 5x0

--- a/flexget/utils/titles/series.py
+++ b/flexget/utils/titles/series.py
@@ -47,7 +47,9 @@ class SeriesParser(TitleParser):
         '(\d{1,2})\s?x\s?(\d+)(?:\s(\d{1,2}))?',
         '(\d{1,3})\s?of\s?(?:\d{1,3})',
         '(?:episode|ep|part|pt)\s?(\d{1,3}|%s)' % roman_numeral_re,
-        'part\s(%s)' % '|'.join(map(str, english_numbers))]])
+        'part\s(%s)' % '|'.join(map(str, english_numbers)),
+        '(?:e|ep)(\d{1,2})', # E01
+    ]])
     unwanted_regexps = ReList([
         '(\d{1,3})\s?x\s?(0+)[^1-9]',  # 5x0
         'S(\d{1,3})D(\d{1,3})',  # S3D1


### PR DESCRIPTION
### Motivation for changes:
Mini-series tend not to have season number in title. Sometimes they are called "Some Show Part 01" (already supported), but sometimes it's "Some Show E01".

Don't think I've ever seen "E" followed by roman numerals, which is why I gave it its own line in ep regexps.