### PR TITLE
Support for 2160p

### DIFF
--- a/flexget/plugins/parsers/parser_common.py
+++ b/flexget/plugins/parsers/parser_common.py
@@ -69,7 +69,9 @@ def old_assume_quality(guessed_quality, assumed_quality):
 default_ignore_prefixes = [
     '(?:\[[^\[\]]*\])',  # ignores group names before the name, eg [foobar] name
     '(?:HD.720p?:)',
-    '(?:HD.1080p?:)']
+    '(?:HD.1080p?:)',
+    '(?:HD.2160p?:)'
+]
 
 
 def name_to_re(name, ignore_prefixes=None, parser=None):

--- a/flexget/tests/test_qualities.py
+++ b/flexget/tests/test_qualities.py
@@ -30,6 +30,7 @@ class TestQualityParser(object):
 
     @pytest.mark.parametrize("test_quality", [
         ('Test.File 1080p.web', '1080p webdl'),
+        ('Test.File.2160p.web', '2160p webdl'),
         ('Test.File.1080.web-random', '1080p webdl'),
         ('Test.File.1080.webrandom', '1080p'),
         ('Test.File 1080p.web-dl', '1080p webdl'),
@@ -38,6 +39,7 @@ class TestQualityParser(object):
         ('Test.File.720p.bluray', '720p bluray'),
         ('Test.File.720hd.bluray', '720p bluray'),
         ('Test.File.1080p.bluray', '1080p bluray'),
+        ('Test.File.2160p.bluray', '2160p bluray'),
         ('Test.File.1080p.cam', '1080p cam'),
         ('A Movie 2011 TS 576P XviD-DTRG', '576p ts xvid'),
 
@@ -61,6 +63,7 @@ class TestQualityParser(object):
         ('Test.File.web-dl', 'webdl'),
         ('Test.File.720P', '720p'),
         ('Test.File.1920x1080', '1080p'),
+        ('Test.File.3840x2160', '2160p'),
         ('Test.File.1080i', '1080i'),
         ('Test File blurayrip', 'bluray'),
         ('Test.File.br-rip', 'bluray'),

--- a/flexget/tests/test_seriesparser.py
+++ b/flexget/tests/test_seriesparser.py
@@ -376,7 +376,7 @@ class TestSeriesParser(object):
                 # There's nothing that can be done with those failing cases with the
                 # current
                 # "grab leftmost occurrence of highest quality-like thing" algorithm.
-                if int(mock_ep1) >= int(mock_ep2):
+                if int(mock_ep1) >= int(mock_ep2) or int(mock_ep2) > 999:
                     continue
 
                 s = parse('FooBar - %s %s-FlexGet' % (mock_ep1, quality2.name), name='FooBar')

--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -126,7 +126,8 @@ _resolutions = [
     QualityComponent('resolution', 50, '720i'),
     QualityComponent('resolution', 60, '720p', '(1280x)?720(p|hd)?x?(50)?'),
     QualityComponent('resolution', 70, '1080i'),
-    QualityComponent('resolution', 80, '1080p', '(1920x)?1080p?x?(50)?')
+    QualityComponent('resolution', 80, '1080p', '(1920x)?1080p?x?(50)?'),
+    QualityComponent('resolution', 90, '2160p', '((3840x)?2160p?x?(50)?)|4k')
 ]
 _sources = [
     QualityComponent('source', 10, 'workprint', modifier=-8),


### PR DESCRIPTION
### Motivation for changes:
Bored

### Related
 - #748

### Detailed changes:

- Added 2160p support. 3840x2160 or 2160p or 4K are all valid. KNOWN LIMITATION: guessit cannot parse 'Some title 4K' as 2160p, but there's no reason the internal parser shouldn't be allowed to (I think).