### PR TITLE
Add url rewrite support for bt.hliang.com

### DIFF
--- a/flexget/plugins/sites/hliang.py
+++ b/flexget/plugins/sites/hliang.py
@@ -33,7 +33,7 @@ class UrlRewriteHliang(object):
             soup = get_soup(page.text)
         except Exception as e:
             raise UrlRewritingError(e)
-        down_link = soup.find('a', attrs={'href': re.compile("down.php?.*")})
+        down_link = soup.find('a', attrs={'href': re.compile("down\.php\?.*")})
         if not down_link:
             raise UrlRewritingError('Unable to locate download link from url "%s"' % url)
         return 'http://bt.hliang.com/' + down_link.get('href')

--- a/flexget/plugins/sites/hliang.py
+++ b/flexget/plugins/sites/hliang.py
@@ -30,7 +30,7 @@ class UrlRewriteHliang(object):
         try:
             page = requests.get(url, headers=txheaders)
         except requests.exceptions.RequestException as e:
-            log.exception('Cannot open "%s"' % url, e)
+            log.error('Cannot open "%s" : %s', url, e)
             raise UrlRewritingError(e)
 
         try:

--- a/flexget/plugins/sites/hliang.py
+++ b/flexget/plugins/sites/hliang.py
@@ -30,13 +30,14 @@ class UrlRewriteHliang(object):
         try:
             page = requests.get(url, headers=txheaders)
         except requests.exceptions.RequestException as e:
-            log.error('Cannot open "%s" : %s', url, e)
-            raise UrlRewritingError(e)
+            msg = 'Cannot open "%s" : %s'% (url, e.message)
+            log.error(msg)
+            raise UrlRewritingError(msg)
 
         try:
             soup = get_soup(page.text)
         except Exception as e:
-            raise UrlRewritingError(e)
+            raise UrlRewritingError(e.message)
         
         down_link = soup.find('a', attrs={'href': re.compile("down\.php\?.*")})
         if not down_link:

--- a/flexget/plugins/sites/hliang.py
+++ b/flexget/plugins/sites/hliang.py
@@ -30,14 +30,14 @@ class UrlRewriteHliang(object):
         try:
             page = requests.get(url, headers=txheaders)
         except requests.exceptions.RequestException as e:
-            msg = 'Cannot open "%s" : %s'% (url, e.message)
+            msg = 'Cannot open "%s" : %s'% (url, str(e))
             log.error(msg)
             raise UrlRewritingError(msg)
 
         try:
             soup = get_soup(page.text)
         except Exception as e:
-            raise UrlRewritingError(e.message)
+            raise UrlRewritingError(str(e))
         
         down_link = soup.find('a', attrs={'href': re.compile("down\.php\?.*")})
         if not down_link:

--- a/flexget/plugins/sites/hliang.py
+++ b/flexget/plugins/sites/hliang.py
@@ -29,9 +29,15 @@ class UrlRewriteHliang(object):
         txheaders = {'User-agent': 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT)'}
         try:
             page = requests.get(url, headers=txheaders)
+        except requests.exceptions.RequestException as e:
+            log.exception('Cannot open "%s"' % url, e)
+            raise UrlRewritingError(e)
+
+        try:
             soup = get_soup(page.text)
         except Exception as e:
             raise UrlRewritingError(e)
+        
         down_link = soup.find('a', attrs={'href': re.compile("down\.php\?.*")})
         if not down_link:
             raise UrlRewritingError('Unable to locate download link from url "%s"' % url)

--- a/flexget/plugins/sites/hliang.py
+++ b/flexget/plugins/sites/hliang.py
@@ -1,0 +1,44 @@
+from __future__ import unicode_literals, division, absolute_import
+import urllib2
+import logging
+from flexget import plugin
+from flexget.event import event
+from flexget.plugins.internal.urlrewriting import UrlRewritingError
+from flexget.utils.soup import get_soup
+
+import re
+
+log = logging.getLogger('hliang')
+
+
+class UrlRewriteHliang(object):
+    """Hliang urlrewriter."""
+
+    # urlrewriter API
+    def url_rewritable(self, task, entry):
+        url = entry['url']
+        if url.startswith('http://bt.hliang.com/show.php'):
+            return True
+        return False
+
+    # urlrewriter API
+    def url_rewrite(self, task, entry):
+        entry['url'] = self.parse_download_page(entry['url'], task.requests)
+
+    @plugin.internet(log)
+    def parse_download_page(self, url, requests):
+        txheaders = {'User-agent': 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT)'}
+        page = requests.get(url, headers=txheaders)
+        try:
+            soup = get_soup(page.text)
+        except Exception as e:
+            raise UrlRewritingError(e)
+        down_link = soup.find('a', attrs={'href': re.compile("down.php?.*")})
+        if not down_link:
+            raise UrlRewritingError('Unable to locate download link from url "%s"' % url)
+        return 'http://bt.hliang.com/' + down_link.get('href')
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(UrlRewriteHliang, 'hliang', groups=['urlrewriter'], api_ver=2)
+

--- a/flexget/plugins/sites/hliang.py
+++ b/flexget/plugins/sites/hliang.py
@@ -1,15 +1,14 @@
 from __future__ import unicode_literals, division, absolute_import
-import urllib2
+
 import logging
+import re
+
 from flexget import plugin
 from flexget.event import event
 from flexget.plugins.internal.urlrewriting import UrlRewritingError
 from flexget.utils.soup import get_soup
 
-import re
-
 log = logging.getLogger('hliang')
-
 
 class UrlRewriteHliang(object):
     """Hliang urlrewriter."""
@@ -28,8 +27,8 @@ class UrlRewriteHliang(object):
     @plugin.internet(log)
     def parse_download_page(self, url, requests):
         txheaders = {'User-agent': 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT)'}
-        page = requests.get(url, headers=txheaders)
         try:
+            page = requests.get(url, headers=txheaders)
             soup = get_soup(page.text)
         except Exception as e:
             raise UrlRewritingError(e)
@@ -40,5 +39,5 @@ class UrlRewriteHliang(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(UrlRewriteHliang, 'hliang', groups=['urlrewriter'], api_ver=2)
+    plugin.register(UrlRewriteHliang, 'hliang', interfaces=['urlrewriter'], api_ver=2)
 


### PR DESCRIPTION
bt.hliang.com provides asian tv show torrents.  However, it does not support rss feeds.  To auto download shows, use http plugin to download the homepage of bt.hliang.com, and this url rewrite plugin will do the following:

1.  Go through each entry url and follow the link to open the details page.
2.  In the details page, search for the actual torrent download url (any link that contains "down.php?[unique id]"
3. Return the url if found, or raise UrlRewriteError.
