### PR TITLE
[Fix] Remove strictness in API trailing slashes, fixes #1635

### DIFF
--- a/flexget/api/app.py
+++ b/flexget/api/app.py
@@ -231,6 +231,7 @@ api_app = Flask(__name__, template_folder=os.path.join(__path__[0], 'templates')
 api_app.config['REMEMBER_COOKIE_NAME'] = 'flexget.token'
 api_app.config['DEBUG'] = True
 api_app.config['ERROR_404_HELP'] = False
+api_app.url_map.strict_slashes = False
 
 CORS(api_app)
 Compress(api_app)


### PR DESCRIPTION
### Motivation for changes:
Remove strict trailing slashes on API endpoints.
Fix for #1635

### Detailed changes:
- Change to Flask API app

### Addressed issues:

- Fixes #1635
