### PR TITLE
Remove notify phase

### DIFF
--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -156,7 +156,6 @@ DEFAULT_PRIORITY = 128
 # task phases, in order of their execution; note that this can be extended by
 # registering new phases at runtime
 task_phases = ['start', 'input', 'metainfo', 'filter', 'download', 'modify', 'output', 'learn', 'exit']
-suppress_abort_phases = set()
 
 # map phase names to method names
 phase_methods = {
@@ -176,7 +175,7 @@ _plugin_options = []
 _new_phase_queue = {}
 
 
-def register_task_phase(name, before=None, after=None, suppress_abort=False):
+def register_task_phase(name, before=None, after=None):
     """
     Adds a new task phase to the available phases.
 
@@ -188,8 +187,6 @@ def register_task_phase(name, before=None, after=None, suppress_abort=False):
         raise RegisterException('You must specify either a before or after phase.')
     if name in task_phases or name in _new_phase_queue:
         raise RegisterException('Phase %s already exists.' % name)
-    if suppress_abort:
-        suppress_abort_phases.add(name)
 
     def add_phase(phase_name, before, after):
         if before is not None and before not in task_phases:

--- a/flexget/plugins/notifiers/notification_framework.py
+++ b/flexget/plugins/notifiers/notification_framework.py
@@ -12,9 +12,6 @@ A plugin who wishes to send messages using this notification framework should im
     send_notification = plugin.get_plugin_by_name('notification_framework').instance.send_notification
     send_notification('the title', 'the message', the_notifiers)
 
-This plugin also adds the 'notify' task phase. If a plugin using the framework runs on the notify phase,
-(`on_task_notify`,) errors from the notification will not otherwise affect the task.
-
 Delivering Messages
 -------------------
 To implement a plugin that can deliver messages, it should implement a `notify` method, which takes
@@ -127,4 +124,3 @@ class NotificationFramework(object):
 @event('plugin.register')
 def register_plugin():
     plugin.register(NotificationFramework, 'notification_framework', api_ver=2, interfaces=[])
-    plugin.register_task_phase('notify', before='exit', suppress_abort=True)

--- a/flexget/plugins/output/sns.py
+++ b/flexget/plugins/output/sns.py
@@ -62,7 +62,10 @@ class SNSNotification(object):
             log.debug("Error importing boto3: %s", e)
             raise plugin.DependencyError("sns", "boto3", "Boto3 module required. ImportError: %s" % e)
 
-    def on_task_notify(self, task, config):
+    # this has to run near the end of the plugin chain, because we
+    # should notify after all other outputs.
+    @plugin.priority(0)
+    def on_task_output(self, task, config):
         sender = SNSNotificationEmitter(config)
         sender.send_notifications(task)
 


### PR DESCRIPTION
### Motivation for changes:
Notify phase was added to enable plugins that don't end up propagating errors to task. We since combined all notify plugins into one master 'notify' plugin, which means there is already a common place to catch the errors without a special phase.

### Detailed changes:
- Remove notify phase. 'notify' plugin runs on output phase and catches child plugin errors itself

### Addressed issues:

- Fixes #1634 
