### PR TITLE
T411 url has changed (still one)

### DIFF
--- a/flexget/plugins/sites/torrent411.py
+++ b/flexget/plugins/sites/torrent411.py
@@ -398,7 +398,7 @@ class UrlRewriteTorrent411(object):
     #   urlrewriter API
     def url_rewritable(self, task, entry):
         url = entry['url']
-        if re.match(r'^(https?://)?(www\.)?t411\.ch/torrents/(?!download/)[-A-Za-z0-9+&@#/%|?=~_|!:,.;]+', url):
+        if re.match(r'^(https?://)?(www\.)?t411\.li/torrents/(?!download/)[-A-Za-z0-9+&@#/%|?=~_|!:,.;]+', url):
             return True
         return False
 


### PR DESCRIPTION
Hi, it stay one occurence of the old url in url-rewritter plugin torrent411: "plugins/sites/torrent411.py" line 401
Thanks