### PR TITLE
imdb_watchlist: added support for choosing types

### DIFF
--- a/flexget/plugins/input/imdb_watchlist.py
+++ b/flexget/plugins/input/imdb_watchlist.py
@@ -5,15 +5,31 @@ import logging
 from requests.exceptions import HTTPError
 
 from flexget import plugin
+from flexget.config_schema import one_or_more
 from flexget.event import event
 from flexget.utils.imdb import extract_id
 from flexget.utils.cached_input import cached
 from flexget.entry import Entry
 from flexget.utils.soup import get_soup
+
+
 log = logging.getLogger('imdb_watchlist')
 USER_ID_RE = r'^ur\d{7,8}$'
 CUSTOM_LIST_RE = r'^ls\d{7,10}$'
 USER_LISTS = ['watchlist', 'ratings', 'checkins']
+TITLE_TYPE_MAP = {
+    'Feature': 'movies',
+    'Short Film': 'short films',
+    'Documentary': 'documentary',
+    'Video Game': 'games',
+    'Mini-Series': 'mini series',
+    'TV Series': 'shows',
+    'TV Episode': 'episodes',
+    'TV Movie': 'tv movies',
+    'TV Special': 'tv specials',
+    'Video': 'videos',
+    'all': 'all'
+}
 
 
 class ImdbWatchlist(object):
@@ -37,7 +53,9 @@ class ImdbWatchlist(object):
             },
             'force_language':
                 {'type': 'string',
-                 'default': 'en-us'}
+                 'default': 'en-us'},
+            'type': one_or_more({'type': 'string', 'enum': list(TITLE_TYPE_MAP.values()), 'default': 'all'},
+                                unique_items=True)
         },
         'additionalProperties': False,
         'required': ['list'],
@@ -50,6 +68,9 @@ class ImdbWatchlist(object):
 
     @cached('imdb_watchlist', persist='2 hours')
     def on_task_input(self, task, config):
+        if not isinstance(config['type'], list):
+            config['type'] = [config['type']]
+
         # Create movie entries by parsing imdb list page(s) html using beautifulsoup
         log.verbose('Retrieving imdb list: %s', config['list'])
 
@@ -72,23 +93,25 @@ class ImdbWatchlist(object):
         soup = get_soup(page.text)
 
         try:
-            total_movie_count = int(soup.find('div', class_='desc').get('data-size'))
+            total_item_count = int(soup.find('div', class_='desc').get('data-size'))
+            log.verbose('imdb list contains %s items', total_item_count)
         except AttributeError:
-            total_movie_count = 0
+            total_item_count = 0
         except ValueError as e:
             # TODO Something is wrong if we get a ValueError, I think
             raise plugin.PluginError('Received invalid movie count: %s - %s' %
                                      (soup.find('div', class_='desc').get('data-size'), e))
 
-        if total_movie_count == 0:
+        if total_item_count == 0:
             log.verbose('No movies were found in imdb list: %s', config['list'])
             return
 
         entries = []
-        while len(entries) < total_movie_count:
+        items_processed = 0
+        while items_processed < total_item_count:
             # Fetch the next page unless we've just begun
-            if len(entries) != 0:
-                params['start'] = len(entries) + 1
+            if items_processed:
+                params['start'] = items_processed + 1
                 page = task.requests.get(url, params=params)
                 if page.status_code != 200:
                     raise plugin.PluginError('Unable to get imdb list.')
@@ -97,13 +120,20 @@ class ImdbWatchlist(object):
             items = soup.find_all(attrs={'data-item-id': True, 'class': 'list_item'})
 
             for item in items:
+                items_processed += 1
                 a = item.find('td', class_='title').find('a')
                 if not a:
                     log.debug('no title link found for row, skipping')
                     continue
+
+                title_type = item.find('td', class_='title_type').text.strip()
+                if 'all' not in config['type'] and TITLE_TYPE_MAP.get(title_type) not in config['type']:
+                    log.verbose('Skipping title %s since it is a %s', a.text, TITLE_TYPE_MAP.get(title_type))
+                    continue
                 link = ('http://www.imdb.com' + a.get('href')).rstrip('/')
                 entry = Entry()
                 entry['title'] = a.text
+                entry['imdb_type'] = title_type
                 try:
                     year = int(item.find('td', class_='year').text)
                     entry['title'] += ' (%s)' % year

--- a/flexget/plugins/input/imdb_watchlist.py
+++ b/flexget/plugins/input/imdb_watchlist.py
@@ -128,7 +128,8 @@ class ImdbWatchlist(object):
 
                 title_type = item.find('td', class_='title_type').text.strip()
                 if 'all' not in config['type'] and TITLE_TYPE_MAP.get(title_type) not in config['type']:
-                    log.verbose('Skipping title %s since it is a %s', a.text, TITLE_TYPE_MAP.get(title_type))
+                    log.verbose('Skipping title %s since it is a %s', a.text,
+                                TITLE_TYPE_MAP.get(title_type).rstrip('s'))
                     continue
                 link = ('http://www.imdb.com' + a.get('href')).rstrip('/')
                 entry = Entry()


### PR DESCRIPTION
### Motivation for changes:
#1639
### Detailed changes:

- Added support for types and added it as an entry field as well

### Addressed issues:

- Closes #1639

### Config usage if relevant (new plugin or updated schema):
```
    imdb_watchlist:
      user_id: ur11111111
      list: watchlist
      type:
        - mini series
        - episodes
```
### Log and/or tests output (preferably both):
```
2017-01-18 15:52 VERBOSE  imdb_watchlist test_imdbwatchlist Skipping title Andaz Apna Apna since it is a movie
2017-01-18 15:52 VERBOSE  imdb_watchlist test_imdbwatchlist Skipping title L. A. Confidential since it is a movie
2017-01-18 15:52 VERBOSE  imdb_watchlist test_imdbwatchlist Skipping title Taboo since it is a show
```

