### PR TITLE
Fix IPTorrents crashes

### DIFF
--- a/flexget/plugins/sites/iptorrents.py
+++ b/flexget/plugins/sites/iptorrents.py
@@ -137,7 +137,7 @@ class UrlRewriteIPTorrents(object):
             log.debug('searching with url: %s' % url)
             req = requests.get(url, cookies={'uid': str(config['uid']), 'pass': config['password']})
 
-            if '/u/' + str(config.get('uid')) not in req.content:
+            if '/u/' + str(config['uid']) not in req.text:
                 raise plugin.PluginError("Invalid cookies (user not logged in)...")
 
             soup = get_soup(req.content, parser="html.parser")
@@ -147,7 +147,7 @@ class UrlRewriteIPTorrents(object):
                 entry = Entry()
                 entry['url'] = "{base}{link}?torrent_pass={key}".format(
                     base=BASE_URL, link=torrent['href'], key=config.get('rss_key'))
-                entry['title'] = torrent.findPrevious("a", attrs={'class': 't_title'}).text
+                entry['title'] = torrent.findPrevious('a', attrs={'class': 'b'}).text
 
                 seeders = torrent.findNext('td', {'class': 'ac t_seeders'}).text
                 leechers = torrent.findNext('td', {'class': 'ac t_leechers'}).text


### PR DESCRIPTION
### Motivation for changes:
Fix both crash issues mentioned in #1643
### Detailed changes:

- Change login check to use req.text instead of req.content; this should fix Python 3 crashes
- Change parser to reflect changes to ITPtorrents page layout

### Addressed issues:

- Fixes #1643.
