### PR TITLE
added extra recognized group format

### DIFF
--- a/flexget/tests/test_series.py
+++ b/flexget/tests/test_series.py
@@ -1451,6 +1451,8 @@ class TestFromGroup(object):
               - {title: 'Test.13.HDTV-Ignored'}
               - {title: 'Test.13.HDTV-FlexGet'}
               - {title: 'Test.14.HDTV-Name'}
+              - {title: 'Test :: h264 10-bit | Softsubs (FlexGet) | Episode 3'}
+              - {title: 'Test :: h264 10-bit | Softsubs (Ignore) | Episode 3'}
             series:
               - test: {from_group: [Name, FlexGet]}
     """
@@ -1461,6 +1463,7 @@ class TestFromGroup(object):
         assert task.find_entry('accepted', title='[FlexGet] Test 12')
         assert task.find_entry('accepted', title='Test.13.HDTV-FlexGet')
         assert task.find_entry('accepted', title='Test.14.HDTV-Name')
+        assert task.find_entry('accepted', title='Test :: h264 10-bit | Softsubs (FlexGet) | Episode 3')
 
 
 class TestBegin(object):

--- a/flexget/utils/titles/series.py
+++ b/flexget/utils/titles/series.py
@@ -250,7 +250,7 @@ class SeriesParser(TitleParser):
         if self.allow_groups:
             for group in self.allow_groups:
                 group = group.lower()
-                for fmt in ['[%s]', '-%s']:
+                for fmt in ['[%s]', '-%s', '(%s)']:
                     if fmt % group in data_stripped:
                         log.debug('%s is from group %s', self.data, group)
                         self.group = group


### PR DESCRIPTION
### Motivation for changes:
This change adds a new format to the from_group filter in the series plugin.
The existing formats do not cover AnimeBytes' torrent feeds.
### Detailed changes:
At the moment, upload-groups are only recognized in a '-Group' or '[Group]' format.
This PR adds recognition for the '(Group)' format.
In addition, I added unit test cases that check the recognition of this new format.