### PR TITLE
[fix] divxatope to use new domain divxatope1

### DIFF
--- a/flexget/plugins/sites/divxatope.py
+++ b/flexget/plugins/sites/divxatope.py
@@ -31,14 +31,13 @@ class UrlRewriteDivxATope(object):
     # urlrewriter API
     def url_rewritable(self, task, entry):
         url = entry['url']
-        return (
-            url.startswith('http://www.divxatope.com/descargar') or url.startswith('http://divxatope.com/descargar')
-        )
+        rewritable_regex = '^http:\/\/(www.)?divxatope1?.com.*'
+        return re.match(rewritable_regex, url) and not url.endswith('.torrent')
 
     # urlrewriter API
     def url_rewrite(self, task, entry):
         # Rewrite divxatope.com/descargar/ to divxatope.com/descarga-torrent/
-        entry['url'] = re.sub('/descargar', '/descarga-torrent', entry['url'])
+        entry['url'] = re.sub("/descargar/", "/descarga-torrent/", entry['url'])
         entry['url'] = self.parse_download_page(entry['url'])
 
     @plugin.internet(log)
@@ -59,15 +58,18 @@ class UrlRewriteDivxATope(object):
             log.debug('Divxatope disabled')
             return set()
         log.debug('Search DivxATope')
-        url_search = 'http://www.divxatope.com/buscar/descargas/'
+        #url_search = 'http://www.divxatope.com/buscar/descargas/'
+        url_search = 'http://divxatope1.com/buscar/descargas'
         results = set()
         regex = re.compile("(.+) \(\d\d\d\d\)")
         for search_string in entry.get('search_strings', [entry['title']]):
             query = normalize_unicode(search_string)
-            query = regex.findall(query)[0]
+            if regex.findall(query):
+                query = regex.findall(query)[0]
             log.debug('Searching DivxATope %s' % query)
             query = query.encode('utf8', 'ignore')
-            data = {'search': query}
+            #data = {'search': query}
+            data = {'q': query}
             try:
                 response = task.requests.post(url_search, data=data)
             except requests.RequestException as e:
@@ -76,14 +78,27 @@ class UrlRewriteDivxATope(object):
             content = response.content
 
             soup = get_soup(content)
-            soup2 = soup.find('ul', attrs={'class': 'peliculas-box'})
+            if 'divxatope1.com' in url_search:
+                soup2 = soup.find('ul', attrs={'class': 'buscar-list'})
+            else:
+                soup2 = soup.find('ul', attrs={'class': 'peliculas-box'})
             children = soup2.findAll('a', href=True)
             for child in children:
                 entry = Entry()
                 entry['url'] = child['href']
-                entry_title = child.find('h2').contents[0]
-                quality_lan = child.find('strong').contents
-                log.debug(len(quality_lan))
+                entry_title = child.find('h2')
+                if entry_title is None:
+                    continue
+                entry_title = entry_title.contents
+                if not entry_title:
+                    continue
+                else:
+                    entry_title = entry_title[0]
+                quality_lan = child.find('strong')
+                if quality_lan is None:
+                    continue
+                quality_lan = quality_lan.contents
+                #log.debug(len(quality_lan))
                 if len(quality_lan) > 2:
                     if (isinstance(quality_lan[0], Tag)):
                         entry_quality_lan = quality_lan[1]

--- a/flexget/plugins/sites/divxatope.py
+++ b/flexget/plugins/sites/divxatope.py
@@ -61,7 +61,6 @@ class UrlRewriteDivxATope(object):
         #url_search = 'http://www.divxatope.com/buscar/descargas/'
         url_search = 'http://divxatope1.com/buscar/descargas'
         results = set()
-        regex = re.compile("(.+) \(\d\d\d\d\)")
         for search_string in entry.get('search_strings', [entry['title']]):
             query = normalize_unicode(search_string)
             query = re.sub(' \(\d\d\d\d\)$', '', query)

--- a/flexget/plugins/sites/divxatope.py
+++ b/flexget/plugins/sites/divxatope.py
@@ -31,7 +31,7 @@ class UrlRewriteDivxATope(object):
     # urlrewriter API
     def url_rewritable(self, task, entry):
         url = entry['url']
-        rewritable_regex = '^http:\/\/(www.)?divxatope1?.com.*'
+        rewritable_regex = '^https?:\/\/(www.)?divxatope1?.com.*'
         return re.match(rewritable_regex, url) and not url.endswith('.torrent')
 
     # urlrewriter API
@@ -64,11 +64,9 @@ class UrlRewriteDivxATope(object):
         regex = re.compile("(.+) \(\d\d\d\d\)")
         for search_string in entry.get('search_strings', [entry['title']]):
             query = normalize_unicode(search_string)
-            if regex.findall(query):
-                query = regex.findall(query)[0]
+            query = re.sub(' \(\d\d\d\d\)$', '', query)
             log.debug('Searching DivxATope %s' % query)
             query = query.encode('utf8', 'ignore')
-            #data = {'search': query}
             data = {'q': query}
             try:
                 response = task.requests.post(url_search, data=data)
@@ -98,7 +96,6 @@ class UrlRewriteDivxATope(object):
                 if quality_lan is None:
                     continue
                 quality_lan = quality_lan.contents
-                #log.debug(len(quality_lan))
                 if len(quality_lan) > 2:
                     if (isinstance(quality_lan[0], Tag)):
                         entry_quality_lan = quality_lan[1]

--- a/flexget/plugins/sites/divxatope.py
+++ b/flexget/plugins/sites/divxatope.py
@@ -37,7 +37,7 @@ class UrlRewriteDivxATope(object):
     # urlrewriter API
     def url_rewrite(self, task, entry):
         # Rewrite divxatope.com/descargar/ to divxatope.com/descarga-torrent/
-        entry['url'] = re.sub("/descargar/", "/descarga-torrent/", entry['url'])
+        entry['url'] = re.sub('/descargar/', '/descarga-torrent/', entry['url'])
         entry['url'] = self.parse_download_page(entry['url'])
 
     @plugin.internet(log)
@@ -58,7 +58,6 @@ class UrlRewriteDivxATope(object):
             log.debug('Divxatope disabled')
             return set()
         log.debug('Search DivxATope')
-        #url_search = 'http://www.divxatope.com/buscar/descargas/'
         url_search = 'http://divxatope1.com/buscar/descargas'
         results = set()
         for search_string in entry.get('search_strings', [entry['title']]):


### PR DESCRIPTION
New domain divxatope1 instead of divxatope. Updated urlrewrite and search.

### Motivation for changes:
divxatope redirected to divxatope1
### Detailed changes:

- Detect the new domain in function url_rewritable
- Updated search, use divxatope1

### Addressed issues:

### Config usage if relevant (new plugin or updated schema):

### Log and/or tests output (preferably both):
Search example
```
Entry 'El Hogar De Miss Peregrine Para Ni�os Peculiares  BluRayRip AC3 5.1                              ' URL rewritten to http://tumejorjuego.com/redirect/divxatope1.php?link=descargar-torrent/90323_el-hogar-de-miss-peregrine-para-nia-os-peculiares-bluray-rip-ac3-5-1-espaa-ol-castellano-2016/ (with divxatope)
```

