### PR TITLE
rutracker_auth plugin fix

### DIFF
--- a/flexget/_version.py
+++ b/flexget/_version.py
@@ -7,4 +7,4 @@ The version should always be set to the <next release version>.dev
 The jenkins release job will automatically strip the .dev for release,
 and update the version again for continued development.
 """
-__version__ = '2.9.10'
+__version__ = '2.9.11.dev'

--- a/flexget/plugins/services/kodi_library.py
+++ b/flexget/plugins/services/kodi_library.py
@@ -20,7 +20,7 @@ class KodiLibrary(object):
             'action': {'type': 'string', 'enum': ['clean', 'scan']},
             'category': {'type': 'string', 'enum': ['audio', 'video']},
             'url': {'type': 'string', 'format': 'url'},
-            'port': {'type': 'integer'},
+            'port': {'type': 'integer', 'default': 8080},
             'username': {'type': 'string'},
             'password': {'type': 'string'},
             'only_on_accepted': {'type': 'boolean', 'default': True}
@@ -34,8 +34,7 @@ class KodiLibrary(object):
         if task.accepted or not config['only_on_accepted']:
             # make the url without trailing slash
             base_url = config['url'][:-1] if config['url'].endswith('/') else config['url']
-            if config.get('port'):
-                base_url += ':{0}'.format(config['port'])
+            base_url += ':{0}'.format(config['port'])
 
             url = base_url + JSON_URI
             # create the params


### PR DESCRIPTION
### Motivation for changes:
would like to fix broken rutracker_auth plugin

### Detailed changes:
Edit /usr/local/lib/python2.7/dist-packages/flexget/plugins/sites/rutracker.py
change login URL in this line:
```
s.post("http://login.rutracker.org/forum/login.php", data=payload)
```
to
```
s.post("http://rutracker.org/forum/login.php", data=payload)
```
and URL in this line
```
r.prepare_url(url='http://dl.rutracker.org/forum/dl.php?t=' + id, params=None)
```
to this
```
r.prepare_url(url='http://rutracker.org/forum/dl.php?t=' + id, params=None)
```

### Addressed issues:
- Fixes #1656

### Config usage
[rutracker.zip](https://github.com/Flexget/Flexget/files/735415/rutracker.zip)
:
```
...
rutracker_task
  accept_all: yes
  rutracker_auth:
    username: '{? rutracker.username ?}'
    password: '{? rutracker.password ?}'

  inputs:
    - rss: http://feed.rutracker.org/atom/f/313.atom

  deluge: yes
```
### Log and/or tests output (preferably both):
Missed log with exception since I fixed it already

