### PR TITLE
[WIP] Never crash when writing to stdout.

### DIFF
--- a/flexget/logger.py
+++ b/flexget/logger.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals, division, absolute_import, print_function
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
-import codecs
 import collections
 import contextlib
 import logging
@@ -12,7 +11,6 @@ import uuid
 import warnings
 
 from flexget import __version__
-from flexget.utils.tools import io_encoding
 
 # A level more detailed than DEBUG
 TRACE = 5
@@ -205,13 +203,7 @@ def start(filename=None, level=logging.INFO, to_console=True, to_file=True):
 
     # without --cron we log to console
     if to_console:
-        # Make sure we don't send any characters that the current terminal doesn't support printing
-        stdout = sys.stdout
-        if hasattr(stdout, 'buffer'):
-            # On python 3, we need to get the buffer directly to support writing bytes
-            stdout = stdout.buffer
-        safe_stdout = codecs.getwriter(io_encoding)(stdout, 'replace')
-        console_handler = logging.StreamHandler(safe_stdout)
+        console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setFormatter(formatter)
         console_handler.setLevel(level)
         logger.addHandler(console_handler)

--- a/flexget/terminal.py
+++ b/flexget/terminal.py
@@ -7,7 +7,6 @@ from textwrap import wrap
 from colorclass import Windows, Color
 from flexget.logger import local_context
 from flexget.options import ArgumentParser
-from flexget.utils.tools import io_encoding
 from terminaltables import AsciiTable, SingleTable, DoubleTable, GithubFlavoredMarkdownTable, PorcelainTable
 from terminaltables.terminal_io import terminal_size
 
@@ -262,10 +261,7 @@ def console(text, *args, **kwargs):
 
     Accepts arguments like the `print` function does.
     """
+
     kwargs['file'] = getattr(local_context, 'output', sys.stdout)
-    try:
-        print(text, *args, **kwargs)
-    except UnicodeEncodeError:
-        text = text.encode(io_encoding, 'replace').decode(io_encoding)
-        print(text, *args, **kwargs)
+    print(text, *args, **kwargs)
     kwargs['file'].flush()  # flush to make sure the output is printed right away

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -5,6 +5,7 @@ from future.moves.urllib import request
 from future.utils import PY2
 from past.builtins import basestring
 
+import codecs
 import logging
 import ast
 import copy
@@ -237,6 +238,16 @@ else:
         io_encoding = 'utf8'
     elif io_encoding in ['us-ascii', '646', 'ansi_x3.4-1968']:
         io_encoding = 'ascii'
+
+
+# Writing text that cannot be encoded to the stdout encoding can cause a crash.
+# Using safe_stdout instead will cause the characters to be replaced with `?` rather than crash.
+# TODO: This should not be a magic side effect of importing this module. Move it somewhere better before merging.
+if hasattr(sys.stdout, 'buffer'):
+    # On python 3, we need to get the buffer directly to support writing bytes
+    sys.stdout = codecs.getwriter(io_encoding)(sys.stdout.buffer, 'replace')
+else:
+    sys.stdout = codecs.getwriter(io_encoding)(sys.stdout, 'replace')
 
 
 def parse_timedelta(value):


### PR DESCRIPTION
### Motivation for changes:
#1508

### Detailed changes:
- Replaces sys.stdout with a stream that does replaces unprintable text with `?` rather than crashing.
I would like to just create our own stream that our loggers and console function use rather than replacing sys.stdout, but the colorclass wrapper of sys.stdout made that a bit more complicated.

### TODO
- [ ] Right now sys.stdout gets replaced when importing utils.tools, which is silly. Put it in a function and call it somewhere during init.
- [x] Someone confirm it actually fixes #1508
- [ ] Use our own stream in loggers and `console` function rather than replace sys.stdout? Requires figuring out how to wrap it properly for colorclass colors on Windows. (i.e. Emulate `Windows.enable` on our custom stream.)