### PR TITLE
added filename->out option for aria2

### DIFF
--- a/flexget/plugins/clients/aria2.py
+++ b/flexget/plugins/clients/aria2.py
@@ -33,6 +33,7 @@ class OutputAria2(object):
             'username': {'type': 'string', 'default': ''}, # NOTE: To be deprecated by aria2
             'password': {'type': 'string', 'default': ''},
             'path': {'type': 'string'},
+            'filename': {'type': 'string'},
             'options': {
                 'type': 'object',
                 'additionalProperties': {'oneOf': [{'type': 'string'}, {'type': 'integer'}]}
@@ -105,6 +106,11 @@ class OutputAria2(object):
             options['dir'] = os.path.expanduser(entry.render(config['path']).rstrip('/'))
         except RenderError as e:
             entry.fail('failed to render \'path\': %s' % e)
+            return
+        try:
+            options['out'] = os.path.expanduser(entry.render(config['filename']))
+        except RenderError as e:
+            entry.fail('failed to render \'filename\': %s' % e)
             return
         secret = None
         if config['secret']:

--- a/flexget/plugins/clients/aria2.py
+++ b/flexget/plugins/clients/aria2.py
@@ -107,11 +107,12 @@ class OutputAria2(object):
         except RenderError as e:
             entry.fail('failed to render \'path\': %s' % e)
             return
-        try:
-            options['out'] = os.path.expanduser(entry.render(config['filename']))
-        except RenderError as e:
-            entry.fail('failed to render \'filename\': %s' % e)
-            return
+	if 'filename' in config:
+             try:
+                 options['out'] = os.path.expanduser(entry.render(config['filename']))
+             except RenderError as e:
+                 entry.fail('failed to render \'filename\': %s' % e)
+                 return
         secret = None
         if config['secret']:
             secret = 'token:%s' % config['secret']

--- a/flexget/plugins/clients/aria2.py
+++ b/flexget/plugins/clients/aria2.py
@@ -107,7 +107,7 @@ class OutputAria2(object):
         except RenderError as e:
             entry.fail('failed to render \'path\': %s' % e)
             return
-	if 'filename' in config:
+        if 'filename' in config:
              try:
                  options['out'] = os.path.expanduser(entry.render(config['filename']))
              except RenderError as e:


### PR DESCRIPTION
### Motivation for changes:

I am pulling down a podcast feed which uses random strings for filenames, but there was no way to pass in the "--out" parameter to aria to make it rename the file

### Detailed changes:

Used the same logic that was there for path for filename 

### Example config:
```
tasks:
  podcast-1:
    rss:
      url: https://podcast.feed/rss.xml
    regexp:
      accept:
        - .*
    aria2:
      path: '/downloads'
      filename: '{{title|pathscrub}}.mp4'
```

