### PR TITLE
Added ability to always send task scoped 

### DIFF
--- a/flexget/plugins/notifiers/notify.py
+++ b/flexget/plugins/notifiers/notify.py
@@ -64,6 +64,7 @@ class Notify(object):
                                    '{%if task.failed %} {{task.failed|length}} failed entries.{% endif %}'
                                    '{% if task.accepted %} {{task.accepted|length}} new entries downloaded.{% endif %}'},
                     'template': {'type': 'string', 'default': 'default.template'},
+                    'always_send': {'type': 'boolean', 'default': False},
                     'via': VIA_SCHEMA
                 },
                 'required': ['via'],
@@ -122,7 +123,7 @@ class Notify(object):
                 self.send_notification(config['entries']['title'], message, config['entries']['via'],
                                        template_renderer=entry.render)
         if 'task' in config:
-            if not (task.accepted or task.failed):
+            if not (task.accepted or task.failed) and not config['always_send']:
                 log.verbose('No accepted or failed entries, not sending a notification.')
                 return
             try:

--- a/flexget/plugins/notifiers/notify.py
+++ b/flexget/plugins/notifiers/notify.py
@@ -60,9 +60,13 @@ class Notify(object):
                 'properties': {
                     'title': {
                         'type': 'string',
-                        'default': '[FlexGet] {{task.name}}:'
-                                   '{%if task.failed %} {{task.failed|length}} failed entries.{% endif %}'
-                                   '{% if task.accepted %} {{task.accepted|length}} new entries downloaded.{% endif %}'},
+                        'default': '{% if not task.failed or not task.accepted %} Task {{task.name}} did not'
+                                   ' produce any entries.'
+                                   '{% else %} [FlexGet] {{task.name}}:'
+                                   '{% if task.failed %} {{task.failed|length}} failed entries.{% endif %}'
+                                   '{% if task.accepted %} {{task.accepted|length}} new entries downloaded.{% endif %}'
+                                   '{% endif %}'
+                    },
                     'template': {'type': 'string', 'default': 'default.template'},
                     'always_send': {'type': 'boolean', 'default': False},
                     'via': VIA_SCHEMA

--- a/flexget/plugins/notifiers/notify.py
+++ b/flexget/plugins/notifiers/notify.py
@@ -123,7 +123,7 @@ class Notify(object):
                 self.send_notification(config['entries']['title'], message, config['entries']['via'],
                                        template_renderer=entry.render)
         if 'task' in config:
-            if not (task.accepted or task.failed) and not config['always_send']:
+            if not (task.accepted or task.failed) and not config['task']['always_send']:
                 log.verbose('No accepted or failed entries, not sending a notification.')
                 return
             try:

--- a/flexget/templates/task/default.template
+++ b/flexget/templates/task/default.template
@@ -13,4 +13,5 @@ The following entries have failed for task {{group.grouper}}:
 - {{entry.title}} ({{entry.url}}) Reason: {{entry.reason|d('unknown')}}
   {% endfor %}
 {% endfor %}
+{% else %} Task did not produce any entries.
 {% endif %}

--- a/flexget/templates/task/html.template
+++ b/flexget/templates/task/html.template
@@ -349,4 +349,5 @@ div.clear {
 
     </body>
 </html>
+{% else %} Task did not produce any entries
 {% endif %}


### PR DESCRIPTION
### Motivation for changes:
Someone wanted this.
### Detailed changes:

- Added `always_send` option to `task` 

### Addressed issues:

- Fixes #1657 

### Config usage if relevant (new plugin or updated schema):
```yaml
tasks:
  not_test:
    mock:
      - {title: 'bla'}
    disable: seen
    notify:
      task:
        always_send: yes
        via:
          - toast: yes
```


