### PR TITLE
FIX Unicode-objects must be encoded before hashing

### DIFF
--- a/flexget/plugins/input/betaseries_list.py
+++ b/flexget/plugins/input/betaseries_list.py
@@ -114,7 +114,7 @@ def create_token(api_key, login, password):
     """
     r = requests.post(API_URL_PREFIX + 'members/auth', params={
         'login': login,
-        'password': md5(password).hexdigest()
+        'password': md5(password.encode('utf-8')).hexdigest()
     }, headers={
         'Accept': 'application/json',
         'X-BetaSeries-Version': '2.1',


### PR DESCRIPTION
### Motivation for changes:
plugin betaseries_list has a bug when using python 3 (BUG: Unhandled error in plugin configure_series: Unicode-objects must be encoded before hashing)

### Detailed changes:

- encode the password in utf-8 to avoid crash

### Addressed issues:

- Fixes # .

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
```
paste output here
```
Tested on a local installation
