### PR TITLE
[wip] centralized list interface framework

### DIFF
--- a/flexget/api/__init__.py
+++ b/flexget/api/__init__.py
@@ -3,4 +3,4 @@ from __future__ import unicode_literals, division, absolute_import  # noqa
 from .app import api_app, api, APIResource, APIClient  # noqa
 from .core import authentication, cached, database, plugins, server, tasks, user, format_checker  # noqa
 from .plugins import entry_list, failed, history, imdb_lookup, movie_list, rejected, schedule, variables, seen  # noqa
-from .plugins import series, trakt_lookup, tvdb_lookup, tvmaze_lookup, tmdb_lookup, irc, status, pending  # noqa
+from .plugins import series, trakt_lookup, tvdb_lookup, tvmaze_lookup, tmdb_lookup, irc, status, pending, lists  # noqa

--- a/flexget/api/plugins/lists.py
+++ b/flexget/api/plugins/lists.py
@@ -1,0 +1,126 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+import copy
+
+from flask import request
+
+from flexget import plugin
+from flexget.api import api, APIResource
+from flexget.api.app import BadRequest, success_response, base_message_schema
+from flexget.entry import Entry
+from flexget.plugin import PluginError
+
+lists_api = api.namespace('lists', description='Manage list interface plugins')
+
+
+class ObjectsContainer(object):
+    base_entry_object = {
+        'type': 'object',
+        'properties': {
+            'title': {'type': 'string'},
+            'url': {'type': 'string'}
+        },
+        'required': ['title', 'url'],
+        'additionalProperties': {'type': 'object'}
+    }
+
+    list_of_entries = {
+        'type': 'array',
+        'items': base_entry_object
+    }
+
+    single_list = {
+        'allOf': [
+            {'$ref': '/schema/plugins?interface=list'},
+            {'maxProperties': 1,
+             'minProperties': 1
+             }
+        ]}
+
+    list_of_lists = {
+        'type': 'array',
+        'items': single_list,
+        'minProperties': 1
+    }
+
+    action_payload = {
+        'type': 'object',
+        'properties': {
+            'lists': list_of_lists,
+            'entries': list_of_entries
+        },
+        'required': ['lists', 'entries'],
+        'additionalProperties': False
+    }
+
+    clear_payload = copy.deepcopy(action_payload)
+    clear_payload['required'] = ['lists']
+    del clear_payload['properties']['entries']
+
+
+action_schema = api.schema('lists.action_payload', ObjectsContainer.action_payload)
+clear_schema = api.schema('lists.clear_payload', ObjectsContainer.clear_payload)
+
+
+@lists_api.route('/add/')
+class ListsAPI(APIResource):
+    @api.validate(action_schema)
+    @api.response(200, 'successfully added entries to list', model=base_message_schema)
+    @api.response(BadRequest)
+    def post(self, session):
+        """Add entries to a list"""
+        data = request.json
+        lists = data['lists']
+        entries = [Entry(entry) for entry in data['entries']]
+        for item in lists:
+            for plugin_name, plugin_config in item.items():
+                try:
+                    framework = plugin.get_plugin_by_name('list_framework').instance
+                    list_manager = framework.ListManager(plugin_name, plugin_config)
+                except PluginError as e:
+                    raise BadRequest(e.value)
+                list_manager.add(entries)
+                return success_response('successfully added entries to list {} - {}'.format(plugin_name, plugin_config))
+
+
+@lists_api.route('/remove/')
+class ListsAPI(APIResource):
+    @api.validate(action_schema)
+    @api.response(200, 'successfully removed entries from list', model=base_message_schema)
+    @api.response(BadRequest)
+    def post(self, session):
+        """Removed entries from a list"""
+        data = request.json
+        lists = data['lists']
+        entries = [Entry(entry) for entry in data['entries']]
+        for item in lists:
+            for plugin_name, plugin_config in item.items():
+                try:
+                    framework = plugin.get_plugin_by_name('list_framework').instance
+                    list_manager = framework.ListManager(plugin_name, plugin_config)
+                except PluginError as e:
+                    raise BadRequest(e.value)
+                list_manager.remove(entries)
+                return success_response(
+                    'successfully removed entries from list {} - {}'.format(plugin_name, plugin_config))
+
+
+@lists_api.route('/clear/')
+class ListsAPI(APIResource):
+    @api.validate(clear_schema)
+    @api.response(200, 'successfully cleared entries from a list', model=base_message_schema)
+    @api.response(BadRequest)
+    def post(self, session):
+        """Clear an entire list"""
+        data = request.json
+        lists = data['lists']
+        for item in lists:
+            for plugin_name, plugin_config in item.items():
+                try:
+                    framework = plugin.get_plugin_by_name('list_framework').instance
+                    list_manager = framework.ListManager(plugin_name, plugin_config)
+                except PluginError as e:
+                    raise BadRequest(e.value)
+                list_manager.clear()
+                return success_response('successfully cleared list {} - {}'.format(plugin_name, plugin_config))

--- a/flexget/plugins/list/list_framework.py
+++ b/flexget/plugins/list/list_framework.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 
 class ListFramework(object):
-    def __init__(self, plugin_name, plugin_config):
+    def initialize(self, plugin_name, plugin_config):
         try:
             self.plugin_name = plugin_name
             self.plugin_config = plugin_config

--- a/flexget/plugins/list/list_framework.py
+++ b/flexget/plugins/list/list_framework.py
@@ -24,7 +24,7 @@ class ListFramework(object):
                 raise PluginError(self.list.immutable)
 
         def add(self, entries):
-            log.verbose('adding entries from %s - %s', self.plugin_name, self.plugin_config)
+            log.verbose('adding entries to %s - %s', self.plugin_name, self.plugin_config)
             self.list |= entries
 
         def remove(self, entries):

--- a/flexget/plugins/list/list_framework.py
+++ b/flexget/plugins/list/list_framework.py
@@ -12,27 +12,28 @@ log = logging.getLogger(__name__)
 
 
 class ListFramework(object):
-    def initialize(self, plugin_name, plugin_config):
-        try:
-            self.plugin_name = plugin_name
-            self.plugin_config = plugin_config
-            self.list = plugin.get_plugin_by_name(plugin_name).instance.get_list(plugin_config)
-        except AttributeError:
-            raise PluginError('Plugin %s does not support list interface' % plugin_name)
-        if self.list.immutable:
-            raise PluginError(self.list.immutable)
+    class ListManager(object):
+        def __init__(self, plugin_name, plugin_config):
+            try:
+                self.plugin_name = plugin_name
+                self.plugin_config = plugin_config
+                self.list = plugin.get_plugin_by_name(plugin_name).instance.get_list(plugin_config)
+            except AttributeError:
+                raise PluginError('Plugin %s does not support list interface' % plugin_name)
+            if self.list.immutable:
+                raise PluginError(self.list.immutable)
 
-    def add(self, entries):
-        log.verbose('adding entries from %s - %s', self.plugin_name, self.plugin_config)
-        self.list |= entries
+        def add(self, entries):
+            log.verbose('adding entries from %s - %s', self.plugin_name, self.plugin_config)
+            self.list |= entries
 
-    def remove(self, entries):
-        log.verbose('removing entries from %s - %s', self.plugin_name, self.plugin_config)
-        self.list -= entries
+        def remove(self, entries):
+            log.verbose('removing entries from %s - %s', self.plugin_name, self.plugin_config)
+            self.list -= entries
 
-    def clear(self):
-        log.verbose('clearing all items from %s - %s', self.plugin_name, self.plugin_config)
-        self.list.clear()
+        def clear(self):
+            log.verbose('clearing all items from %s - %s', self.plugin_name, self.plugin_config)
+            self.list.clear()
 
 
 @event('plugin.register')

--- a/flexget/plugins/list/list_framework.py
+++ b/flexget/plugins/list/list_framework.py
@@ -1,0 +1,40 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+import logging
+
+from flexget import plugin
+from flexget.event import event
+from flexget.plugin import PluginError
+
+__name__ = 'list_framework'
+log = logging.getLogger(__name__)
+
+
+class ListFramework(object):
+    def __init__(self, plugin_name, plugin_config):
+        try:
+            self.plugin_name = plugin_name
+            self.plugin_config = plugin_config
+            self.list = plugin.get_plugin_by_name(plugin_name).instance.get_list(plugin_config)
+        except AttributeError:
+            raise PluginError('Plugin %s does not support list interface' % plugin_name)
+        if self.list.immutable:
+            raise PluginError(self.list.immutable)
+
+    def add(self, entries):
+        log.verbose('adding entries from %s - %s', self.plugin_name, self.plugin_config)
+        self.list |= entries
+
+    def remove(self, entries):
+        log.verbose('removing entries from %s - %s', self.plugin_name, self.plugin_config)
+        self.list -= entries
+
+    def clear(self):
+        log.verbose('clearing all items from %s - %s', self.plugin_name, self.plugin_config)
+        self.list.clear()
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(ListFramework, __name__, api_ver=2, interfaces=[])

--- a/flexget/plugins/list/list_framework.py
+++ b/flexget/plugins/list/list_framework.py
@@ -7,8 +7,8 @@ from flexget import plugin
 from flexget.event import event
 from flexget.plugin import PluginError
 
-__name__ = 'list_framework'
-log = logging.getLogger(__name__)
+plugin_name = 'list_framework'
+log = logging.getLogger(plugin_name)
 
 
 class ListFramework(object):
@@ -38,4 +38,4 @@ class ListFramework(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(ListFramework, __name__, api_ver=2, interfaces=[])
+    plugin.register(ListFramework, plugin_name, api_ver=2, interfaces=[])

--- a/flexget/plugins/modify/list_clear.py
+++ b/flexget/plugins/modify/list_clear.py
@@ -36,16 +36,16 @@ class ListClear(object):
         for item in config['what']:
             for plugin_name, plugin_config in item.items():
                 try:
-                    the_list = plugin.get_plugin_by_name('list_framework').instance
-                    the_list.initialize(plugin_name, plugin_config)
+                    framework = plugin.get_plugin_by_name('list_framework').instance
+                    list_manager = framework.ListManager(plugin_name, plugin_config)
                 except PluginError as e:
                     log.error(e.value)
                     continue
                 if config['phase'] == task.current_phase:
-                    if task.manager.options.test and the_list.online:
+                    if task.manager.options.test and list_manager.list.online:
                         log.info('would have cleared all items from %s - %s', plugin_name, plugin_config)
                         continue
-                    the_list.clear()
+                    list_manager.clear()
 
 
 @event('plugin.register')

--- a/flexget/plugins/modify/list_clear.py
+++ b/flexget/plugins/modify/list_clear.py
@@ -36,7 +36,8 @@ class ListClear(object):
         for item in config['what']:
             for plugin_name, plugin_config in item.items():
                 try:
-                    the_list = plugin.get_plugin_by_name('list_framework').instance(plugin_name, plugin_config)
+                    the_list = plugin.get_plugin_by_name('list_framework').instance
+                    the_list.initialize(plugin_name, plugin_config)
                 except PluginError as e:
                     log.error(e.value)
                     continue

--- a/flexget/plugins/modify/list_clear.py
+++ b/flexget/plugins/modify/list_clear.py
@@ -36,17 +36,15 @@ class ListClear(object):
         for item in config['what']:
             for plugin_name, plugin_config in item.items():
                 try:
-                    thelist = plugin.get_plugin_by_name(plugin_name).instance.get_list(plugin_config)
-                except AttributeError:
-                    raise PluginError('Plugin %s does not support list interface' % plugin_name)
-                if thelist.immutable:
-                    raise plugin.PluginError(thelist.immutable)
+                    the_list = plugin.get_plugin_by_name('list_framework').instance(plugin_name, plugin_config)
+                except PluginError as e:
+                    log.error(e.value)
+                    continue
                 if config['phase'] == task.current_phase:
-                    if task.manager.options.test and thelist.online:
+                    if task.manager.options.test and the_list.online:
                         log.info('would have cleared all items from %s - %s', plugin_name, plugin_config)
                         continue
-                    log.verbose('clearing all items from %s - %s', plugin_name, plugin_config)
-                    thelist.clear()
+                    the_list.clear()
 
 
 @event('plugin.register')

--- a/flexget/plugins/output/list_add.py
+++ b/flexget/plugins/output/list_add.py
@@ -36,16 +36,16 @@ class ListAdd(object):
         for item in config:
             for plugin_name, plugin_config in item.items():
                 try:
-                    the_list = plugin.get_plugin_by_name('list_framework').instance
-                    the_list.initialize(plugin_name, plugin_config)
+                    framework = plugin.get_plugin_by_name('list_framework').instance
+                    list_manager = framework.ListManager(plugin_name, plugin_config)
                 except PluginError as e:
                     log.error(e.value)
                     continue
-                if task.manager.options.test and the_list.online:
+                if task.manager.options.test and list_manager.list.online:
                     log.info('`%s` is marked as an online plugin, would add accepted items outside of --test mode. '
                              'Skipping', plugin_name)
                     continue
-                the_list.add(task.accepted)
+                list_manager.add(task.accepted)
 
 
 @event('plugin.register')

--- a/flexget/plugins/output/list_add.py
+++ b/flexget/plugins/output/list_add.py
@@ -36,7 +36,8 @@ class ListAdd(object):
         for item in config:
             for plugin_name, plugin_config in item.items():
                 try:
-                    the_list = plugin.get_plugin_by_name('list_framework').instance(plugin_name, plugin_config)
+                    the_list = plugin.get_plugin_by_name('list_framework').instance
+                    the_list.initialize(plugin_name, plugin_config)
                 except PluginError as e:
                     log.error(e.value)
                     continue

--- a/flexget/plugins/output/list_remove.py
+++ b/flexget/plugins/output/list_remove.py
@@ -34,7 +34,8 @@ class ListRemove(object):
         for item in config:
             for plugin_name, plugin_config in item.items():
                 try:
-                    the_list = plugin.get_plugin_by_name('list_framework').instance(plugin_name, plugin_config)
+                    the_list = plugin.get_plugin_by_name('list_framework').instance
+                    the_list.initialize(plugin_name, plugin_config)
                 except PluginError as e:
                     log.error(e.value)
                     continue

--- a/flexget/plugins/output/list_remove.py
+++ b/flexget/plugins/output/list_remove.py
@@ -34,16 +34,16 @@ class ListRemove(object):
         for item in config:
             for plugin_name, plugin_config in item.items():
                 try:
-                    the_list = plugin.get_plugin_by_name('list_framework').instance
-                    the_list.initialize(plugin_name, plugin_config)
+                    framework = plugin.get_plugin_by_name('list_framework').instance
+                    list_manager = framework.ListManager(plugin_name, plugin_config)
                 except PluginError as e:
                     log.error(e.value)
                     continue
-                if task.manager.options.test and the_list.online:
+                if task.manager.options.test and list_manager.list.online:
                     log.info('`%s` is marked as an online plugin, would add accepted items outside of --test mode. '
                              'Skipping', plugin_name)
                     continue
-                the_list.remove(task.accepted)
+                list_manager.remove(task.accepted)
 
 
 @event('plugin.register')


### PR DESCRIPTION
### Motivation for changes:
This will enable creating generic API for list management
### Detailed changes:

- Moved logic form `list_add`, `list_clear` and `list_remove` to a new `list_framework` plugin
- Backwards compatible

#### To Do:

- [x] API 
- [ ] API Tests
- [x] Tweak `list_match` to use this as well (although its logic should not be move to the framework since its logic unique to the task interface (?)
