### PR TITLE
Created unique plugin

### DIFF
--- a/flexget/plugins/filter/unique.py
+++ b/flexget/plugins/filter/unique.py
@@ -1,0 +1,83 @@
+from __future__ import unicode_literals, division, absolute_import
+import logging
+
+from flexget import plugin
+from flexget.event import event
+from flexget.config_schema import one_or_more
+
+log = logging.getLogger('unique')
+
+
+class Unique(object):
+    """
+    Take action on entries with duplicate fields, except for the first item
+
+    Reject the second+ instance of every movie:
+
+      unique:
+        field:
+          - imdb_id
+          - movie_name
+        action: reject
+    """
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'field': one_or_more({'type': 'string'}),
+            'action': {'enum': ['accept', 'reject']},
+        },
+        'required': ['field'],
+        'additionalProperties': False
+    }
+
+    def prepare_config(self, config):
+        if isinstance(config, bool) or config is None:
+            config = {}
+        config.setdefault('action', 'reject')
+        if not isinstance(config['field'], list):
+            config['field'] = [config['field']]
+        return config
+
+    def extract_fields(self, entry, field_names):
+        return [ entry[field] for field in field_names ]
+
+    def should_ignore(self, item, action):
+        return item.accepted and action == 'accept' or item.rejected and action == 'reject'
+
+    def on_task_filter(self, task, config):
+        config = self.prepare_config(config)
+        field_names = config['field']
+        entries = list(task.entries)
+        for i, entry in enumerate(entries):
+            # Ignore already processed entries
+            if self.should_ignore(entry, config['action']):
+                continue
+            try:
+                entry_fields = self.extract_fields(entry,field_names)
+            # Ignore if a field is missing
+            except KeyError:
+                continue
+            # Iterate over next items, try to find a similar item
+            for prospect in entries[i+1:]:
+                # Ignore processed prospects
+                if self.should_ignore(prospect, config['action']):
+                    continue
+                try:
+                    prospect_fields = self.extract_fields(prospect,field_names)
+                # Ignore if a field is missing
+                except KeyError:
+                    continue
+                if entry_fields and entry_fields == prospect_fields:
+                    msg = 'Field {} value {} equals on {} and {}'.format(
+                        field_names, entry_fields, entry['title'], prospect['title'])
+                    # Mark prospect
+                    if config['action'] == 'accept':
+                        prospect.accept(msg)
+                    else:
+                        prospect.reject(msg)
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(Unique, 'unique', api_ver=2)

--- a/flexget/tests/test_unique.py
+++ b/flexget/tests/test_unique.py
@@ -1,0 +1,60 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+class TestUniques(object):
+    config = """
+        templates:
+          global:
+            # just cleans log a bit ..
+            disable:
+              - seen
+
+        tasks:
+          single_field:
+            mock:
+              - {title: 'bla1', episode_id: 1, series_id: 1, quality: '720p'}
+              - {title: 'bla2', episode_id: 1, series_id: 1}
+              - {title: 'bla3', episode_id: 1, series_id: 2, quality: '720p'}
+            unique:
+              action: reject
+              field: episode_id
+
+          multi_field:
+            mock:
+              - {title: 'bla1', episode_id: 1, series_id: 1, quality: '720p'}
+              - {title: 'bla2', episode_id: 1, series_id: 1}
+              - {title: 'bla3', episode_id: 1, series_id: 2, quality: '720p'}
+            unique:
+              field:
+              - episode_id
+              - series_id
+
+          missing_field:
+            mock:
+              - {title: 'bla1', episode_id: 1, series_id: 1, quality: '720p'}
+              - {title: 'bla2', episode_id: 1, series_id: 1}
+              - {title: 'bla3', episode_id: 1, series_id: 2, quality: '720p'}
+            unique:
+              field:
+              - episode_id
+              - quality
+
+    """
+
+    def test_single_field(self, execute_task):
+        """Unique plugin: Filter by single field"""
+        task = execute_task('single_field')
+        assert len(task.rejected) == 2, 'Should reject 2 entries'
+        assert [e['title'] for e in task.rejected] == ['bla2', 'bla3'], 'should reject bla2,bla3'
+
+    def test_multi_field(self, execute_task):
+        """Unique plugin: Filter by multiple fields"""
+        task = execute_task('multi_field')
+        assert len(task.rejected) == 1, 'should reject 1 entries'
+        assert task.rejected[0]['title'] == 'bla2', 'should reject bla2'
+
+    def test_missing_field(self, execute_task):
+        """Unique plugin: Ensure we ignore entries with missing fields"""
+        task = execute_task('missing_field')
+        assert len(task.rejected) == 1, 'should reject 1 entires'
+        assert task.rejected[0]['title'] == 'bla3', 'should reject bla3'


### PR DESCRIPTION
Takes action on all duplicates, except for the first

### Motivation for changes:
Redoing #1231 in a separate plugin
Allowing to create unique lists by rejecting second+ items based on a list of fields.
Also created tests

### Detailed changes:

New plugin "unique":
```
unique:
  field: imdb_id

unique:
  field: 
  - series_episode
  - series_name
```

### Addressed issues:

(no tickets)
Personal usecase - select only one entry of each kind (e.g. only one torrent for a movie)

### Config usage if relevant (new plugin or updated schema):

New plugin as described above.
Nothing else

### Log and/or tests output (preferably both):
```
nitz@mars:~/projects/flexget/virtualenv (master *+%)$ bin/py.test ~/projects/flexget/flexget/flexget/tests/test_unique.py 
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.11+, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/nitz/projects/flexget/flexget, inifile: setup.cfg
plugins: xdist-1.14, cov-2.2.1, capturelog-0.7
collected 6 items 

../flexget/flexget/tests/test_unique.py ......
```