### PR TITLE
New lostfilm plugin

### DIFF
--- a/flexget/plugins/sites/lostfilm.py
+++ b/flexget/plugins/sites/lostfilm.py
@@ -11,6 +11,7 @@ import feedparser
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
+from flexget.plugin import PluginError
 from flexget.utils.requests import RequestException
 from flexget.utils.soup import get_soup
 
@@ -22,7 +23,7 @@ EPISODE_REGEXP = re.compile(
     '.*lostfilm.tv/series/.*/season_(\d+)/episode_(\d+)/.*')
 LOSTFILM_ID_REGEXP = re.compile(
     '.*static.lostfilm.tv/Images/(\d+)/Posters/poster.jpg.*')
-TEXT_REGEXP = re.compile('^(\d+)\sсезон\s(\d+)\sсерия\.\s(.+)\s\((.+)\)$')
+TEXT_REGEXP = re.compile('^\d+\sсезон\s\d+\sсерия\.\s(.+)\s\((.+)\)$')
 
 quality_map = {
     'SD': ('480p', 'avi'),
@@ -66,10 +67,12 @@ class LostFilm(object):
         config = self.build_config(config)
         if config is False:
             return
-        rss = feedparser.parse(config['url'])
+        try:
+            rss = feedparser.parse(config['url'])
+        except:
+            raise PluginError('Cannot parse rss feed')
         if rss.get('status') != 200:
-            log.error('Received not 200 (OK) status')
-            return
+            raise PluginError('Received not 200 (OK) status')
         entries = []
         for item in rss.entries:
             if item.get('link') is None:
@@ -78,23 +81,27 @@ class LostFilm(object):
             if item.get('description') is None:
                 log.debug('Item doesn\'t have a description')
                 continue
-            match = LOSTFILM_ID_REGEXP.search(item['description'])
-            if match:
-                lostfilm_num = match.group(1)
-            else:
+            try:
+                lostfilm_num = LOSTFILM_ID_REGEXP.search(
+                    item['description']).groups()
+            except:
                 log.debug('Item doesn\'t have lostfilm id in description')
                 continue
-            match = EPISODE_REGEXP.match(item['link'])
-            if match:
-                season_num = int(match.group(1))
-                episode_num = int(match.group(2))
-            else:
+            try:
+                season_num, episode_num = \
+                    [int(x) for x in
+                     EPISODE_REGEXP.search(item['link']).groups()]
+            except:
                 log.debug('Item doesn\'t have episode id in link')
                 continue
-            redirect_url = 'http://www.lostfilm.tv/v_search.php?' \
-                'c={}&s={}&e={}'.format(lostfilm_num, season_num, episode_num)
+            params = {
+                'c': lostfilm_num,
+                's': season_num,
+                'e': episode_num
+            }
+            redirect_url = 'http://www.lostfilm.tv/v_search.php'
             try:
-                response = task.requests.get(redirect_url)
+                response = task.requests.get(redirect_url, params=params)
             except RequestException as e:
                 log.error('Could not connect to redirect url: {:s}'.format(e))
                 continue
@@ -114,49 +121,53 @@ class LostFilm(object):
 
             page = get_soup(response.content)
 
-            new_title_template = episode_name_rus = episode_name_eng \
-                = series_name_rus = series_name_eng = None
+            episode_name_rus = episode_name_eng = series_name_rus = \
+                series_name_eng = None
             try:
                 series_name_rus = page.find(
-                    'div', 'inner-box--title').text.strip() or None
+                    'div', 'inner-box--title').text.strip()
                 title_eng_div = page.find(
                     'div', 'inner-box--subtitle').text.strip() or None
-                series_name_eng = title_eng_div[:-8] \
-                    if title_eng_div.endswith(', сериал') else None
+                series_name_eng = (title_eng_div.endswith(', сериал')) \
+                    and title_eng_div[:-8] or None
                 text_div = page.find('div', 'inner-box--text').text.strip() \
                     or None
-                match = TEXT_REGEXP.match(text_div)
-                if match:
-                    season_num = int(match.group(1).strip())
-                    episode_num = int(match.group(2).strip())
-                    episode_name_rus = match.group(3).strip()
-                    episode_name_eng = match.group(4).strip()
-                if series_name_eng and season_num and episode_num:
-                    new_title_template = \
-                        '{}.S{:02d}E{:02d}.{{}}.rus.LostFilm.TV.{{}}.torrent'\
-                        .format(series_name_eng, season_num, episode_num)
+                episode_name_rus, episode_name_eng = \
+                    TEXT_REGEXP.findall(text_div).pop()
             except:
+                log.debug('Cannot parse head info')
                 pass
 
             for item in page.findAll('div', 'inner-box--item'):
-                torrent_link = item.find(
-                    'div', 'inner-box--link sub').a['href'] or None
-                quality = item.find('div', 'inner-box--label').text.strip() \
-                    or None
-                if torrent_link is None or quality is None:
+                torrent_link = quality = None
+                try:
+                    torrent_link = \
+                        item.find('div', 'inner-box--link sub').a['href']
+                    quality = \
+                        item.find('div', 'inner-box--label').text.strip()
+                except:
+                    log.debug('Item doesn\'t have a link or quality')
                     continue
-                if new_title_template:
-                    new_title = new_title_template.format(
-                        quality_map.get(quality, (quality, None))[0],
-                        quality_map.get(quality, (None, 'avi'))[1]
-                        ).replace(' ', '.')
+                if torrent_link is None or quality is None:
+                    log.debug('Item doesn\'t have a link or quality')
+                    continue
+                if series_name_eng:
+                    new_title = \
+                        '.'.join([
+                            series_name_eng,
+                            'S{:02d}E{:02d}'.format(season_num, episode_num),
+                            quality_map.get(quality, (quality, 0))[0],
+                            'rus.LostFilm.TV',
+                            quality_map.get(quality, (0, 'avi'))[1],
+                            'torrent'
+                                  ]).replace(' ', '.')
                 else:
                     if item.get('title') is not None:
-                        new_title = '%s %s'.format(
+                        new_title = '{} {}'.format(
                             item['title'],
-                            quality_map.get(quality, (quality, None))[0])
+                            quality_map.get(quality, (quality, 0))[0])
                     else:
-                        log.error('Item doesn\'t have a title')
+                        log.debug('Item doesn\'t have a title')
                         continue
                 new_entry = Entry()
                 new_entry['url'] = torrent_link

--- a/flexget/plugins/sites/lostfilm.py
+++ b/flexget/plugins/sites/lostfilm.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+import logging
+import re
+
+from flexget import plugin
+from flexget.entry import Entry
+from flexget.event import event
+from flexget.utils.requests import RequestException
+from flexget.utils.soup import get_soup
+
+__author__ = 'danfocus'
+
+log = logging.getLogger('lostfilm')
+
+
+class LostFilm(object):
+    """
+    Change new lostfilm's rss links
+
+    Example::
+
+      lostfilm: yes
+    """
+
+    schema = {'type': 'boolean'}
+
+    episode_reg = re.compile(
+        '.*lostfilm.tv/series/.*/season_(\d+)/episode_(\d+)/.*')
+    lostfilm_reg = re.compile(
+        '.*static.lostfilm.tv/Images/(\d+)/Posters/poster.jpg.*')
+    text_reg = re.compile('^(\d+)\sсезон\s(\d+)\sсерия\.\s(.+)\s\((.+)\)$')
+
+    quality_map = {
+        'SD': ('480p', 'avi'),
+        '1080': ('1080p', 'mkv'),
+        'MP4': ('720p', 'mp4'),
+        'HD': ('720p', 'mkv')
+    }
+
+    @plugin.priority(-1)
+    def on_task_input(self, task, config):
+        if config is False:
+            return
+        entries = []
+        for entry in task.entries:
+            if entry.get('url') is None:
+                entry.reject('Entry doesn\'t have a url')
+                continue
+            if entry.get('description') is None:
+                entry.reject('Entry doesn\'t have a description')
+                continue
+            match = self.lostfilm_reg.search(entry['description'])
+            if match:
+                lostfilm_num = match.group(1)
+            else:
+                entry.reject('Entry doesn\'t have lostfilm id in description')
+                continue
+            match = self.episode_reg.match(entry['url'])
+            if match:
+                season_num = match.group(1)
+                episode_num = match.group(2)
+            else:
+                entry.reject('Entry doesn\'t have episode id in link')
+                continue
+            redirect_url = 'https://www.lostfilm.tv/v_search.php?' \
+                'c=%s&s=%s&e=%s' % (lostfilm_num, season_num, episode_num)
+            try:
+                response = task.requests.get(redirect_url,
+                                             headers=task.requests.headers)
+            except RequestException as e:
+                entry.reject('Could not connect to redirect url: %s' % e)
+                continue
+
+            page = get_soup(response.content)
+            try:
+                redirect_url = page.head.meta['content'].split("url=")[1]
+            except:
+                entry.reject('Missing redirect')
+                continue
+
+            try:
+                response = task.requests.get(redirect_url,
+                                             headers=task.requests.headers)
+            except RequestException as e:
+                entry.reject('Could not connect to redirect url 2: %s' % e)
+                continue
+
+            page = get_soup(response.content)
+
+            new_title_template = episode_name_rus = episode_name_eng \
+                = series_name_rus = series_name_eng = None
+            try:
+                series_name_rus = page.find(
+                    'div', 'inner-box--title').text.strip() or None
+                title_eng_div = page.find(
+                    'div', 'inner-box--subtitle').text.strip() or None
+                series_name_eng = title_eng_div[:-8] \
+                    if title_eng_div.endswith(", сериал") else None
+                text_div = page.find('div', 'inner-box--text').text.strip() \
+                    or None
+                match = self.text_reg.match(text_div)
+                if match:
+                    season_num = int(match.group(1).strip())
+                    episode_num = int(match.group(2).strip())
+                    episode_name_rus = match.group(3).strip()
+                    episode_name_eng = match.group(4).strip()
+                if series_name_eng and season_num and episode_num:
+                    new_title_template = \
+                        "{}.S{:02d}E{:02d}.{{}}.rus.LostFilm.TV.{{}}.torrent"\
+                        .format(series_name_eng, season_num, episode_num)
+            except:
+                pass
+
+            for item in page.findAll('div', 'inner-box--item'):
+                torrent_link = item.find(
+                    'div', 'inner-box--link sub').a['href'] or None
+                quality = item.find('div', 'inner-box--label').text.strip() \
+                    or None
+                if torrent_link is None or quality is None:
+                    continue
+                if new_title_template:
+                    new_title = new_title_template.format(
+                        self.quality_map.get(quality)[0] or quality,
+                        self.quality_map.get(quality)[1] or 'avi'
+                        ).replace(' ', '.')
+                else:
+                    new_title = entry['title'] + " " \
+                        + self.quality_map.get(quality)[0] or quality
+                new_entry = Entry()
+                new_entry['url'] = torrent_link
+                new_entry['title'] = new_title.strip()
+                if series_name_rus:
+                    new_entry['series_name_rus'] = series_name_rus
+                if episode_name_rus:
+                    new_entry['episode_name_rus'] = episode_name_rus
+                if series_name_eng:
+                    new_entry['series_name_eng'] = series_name_eng
+                if episode_name_eng:
+                    new_entry['episode_name_eng'] = episode_name_eng
+                entries.append(new_entry)
+            entry.reject("Original entry rejected")
+
+        return entries
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(LostFilm, 'lostfilm', api_ver=2)


### PR DESCRIPTION
original rss feed has link to episode page on site
this plugin make right links to torrent files

### Motivation for changes:

lostfilm.tv change rss-feed

### Detailed changes:

- New site plugin lostfilm.py

### Addressed issues:

-

### Config usage if relevant (new plugin or updated schema):
```
lostfilm: yes

or

lostfilm:
  url: <url>
```
### Log and/or tests output (preferably both):
```
...
2017-02-10 22:33 DEBUG    input_cache   lostfilm        storing to cache rss_90da24530a4756cb92568e3143af42a4 15 entries
2017-02-10 22:33 DEBUG    utils.requests lostfilm        Fetching URL https://www.lostfilm.tv/v_search.php?c=277&s=2&e=3 with args () and kwargs {'headers': {'Connection': 'keep-alive', u'cookie': u'uid=XXXXXX;
pass=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX; usess=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX; lf_session=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', u'User-Agent': u'FlexGet/2.9.18 (
www.flexget.com)'}, 'allow_redirects': True, u'timeout': 30}
2017-02-10 22:33 DEBUG    utils.requests lostfilm        Fetching URL http://retre.org/v3/?c=277&s=2&e=3&u=XXXXXX&h=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX&n=1 with args () and kwargs {'headers': {'Connection': 'keep-a
live', u'cookie': u'uid=XXXXXX; pass=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX; usess=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX; lf_session=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', u
'User-Agent': u'FlexGet/2.9.18 (www.flexget.com)'}, 'allow_redirects': True, u'timeout': 30}
...
```

