### PR TITLE
- restore freshon search plugin from 8636793fe6532fee086ec6664eefb844…

### DIFF
--- a/flexget/plugins/sites/freshon.py
+++ b/flexget/plugins/sites/freshon.py
@@ -9,9 +9,20 @@ from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
 from flexget.utils.soup import get_soup
+from flexget.utils.tools import parse_filesize
 from flexget.utils.search import normalize_unicode
 
 log = logging.getLogger('search_freshon')
+
+BASE_URL = 'https://freshon.tv'
+SEARCH_FRAGMENT = 'browse.php?search=%s&tab=%s&incldead=%s'
+DL_FRAGMENT = 'download.php?type=rss&id=%s&passkey=%s'
+LOGIN_FRAGMENT = 'login.php?action=makelogin'
+LEECHSTATUS = {
+    'all': 0,
+    'free': 3,
+    'half': 4
+}
 
 
 class SearchFreshon(object):
@@ -31,7 +42,7 @@ class SearchFreshon(object):
             'freeleech': {
                 'type': 'string',
                 'default': 'all',
-                'enum': ['free', 'half', 'all']
+                'enum': list(LEECHSTATUS.keys())
             },
         },
         'required': ['username', 'password', 'passkey'],
@@ -69,120 +80,121 @@ class SearchFreshon(object):
             free
             half
         """
-
-        base_url = 'https://freshon.tv'
-        search_fragment = 'browse.php?search=%s&tab=%s&incldead=%s'
-        dl_fragment = 'download.php?type=rss&id=%s&passkey=%s'
-        login_fragment = 'login.php?action=makelogin'
+        self.config = config
 
         if not task.requests.cookies:
-            log.debug('Logging in to Freshon.tv...')
-            params = {'username': config['username'],
-                      'password': config['password'],
-                      'login': 'Do it!'}
-            urlstr = (base_url, login_fragment)
-            lsrc = task.requests.post('/'.join(urlstr), data=params)
-            if str(config['username']) in lsrc.text:
-                log.debug('Login to FreshonTV was successful')
-            elif str('Username does not exist in the userbase') in lsrc.text:
-                log.error('Invalid username or password for FreshonTV; Check your settings')
-                raise plugin.PluginError("Invalid username or Password for FreshonTV.")
-            else:
-                log.error('Login to FreshonTV was NOT successful')
-                raise plugin.PluginError("Login to FreshonTV was NOT successful")
+            self.login(task)
 
-        if config['freeleech'] == 'all':
-            freeleech = 0
-        elif config['freeleech'] == 'free':
-            freeleech = 3
-        elif config['freeleech'] == 'half':
-            freeleech = 4
+        freeleech = LEECHSTATUS[config['freeleech']]
 
         entries = set()
         for search_string in entry.get('search_strings', [entry['title']]):
             query = normalize_unicode(search_string.replace(' ', '+'))
-            query_url_fragment = urllib.quote_plus(query.encode('utf-8'))
-            str_url = (base_url, search_fragment)
-            url = '/'.join(str_url) % (query_url_fragment, config['category'], str(freeleech))
-            log.debug('Search url: %s' % url)
-            page = task.requests.get(url).content
+            query = urllib.quote_plus(query.encode('utf-8'))
+            url = (BASE_URL, SEARCH_FRAGMENT)
+            url = '/'.join(url) % (query, config['category'], freeleech)
+            log.debug('Search url: %s', url)
+            try:
+                page = task.requests.get(url).content
+            except RequestsException:
+                log.error('Could not get page %s, skipping' % url)
+                continue
             soup = get_soup(page)
-            if soup.findAll(text=re.compile('Nothing found. Try again with a refined search string.')):
+            if soup.findAll(text=re.compile('Nothing found. Try again with '
+                                            'a refined search string.')):
                 log.debug('Search returned no results')
             else:
-                max_page_number = 0
-                # Check to see if there is more than 1 page of results
-                pager = soup.find('div', {'class': 'pager'})
-                if pager:
-                    page_links = pager.find_all('a', href=True)
-                else:
-                    page_links = []
-                if len(page_links) > 0:
-                    for lnk in page_links:
-                        link_text = lnk.text.strip()
-                        if link_text.isdigit():
-                            page_int = int(link_text)
-                            if page_int > max_page_number:
-                                max_page_number = page_int
-                else:
-                    max_page_number = 1
-
-                # limit to 10 pages
-                if max_page_number > 10:
-                    max_page_number = 10
+                page_number = self.get_page_number(soup)
 
                 # pages are 0 based
                 nextpage = 0
-                while (nextpage < max_page_number):
+                while (nextpage < page_number):
                     if (nextpage > 0):
                         newurl = url + '&page=' + str(nextpage)
-                        log.debug('-----> NEXT PAGE : %s' % newurl)
+                        log.debug('-----> NEXT PAGE : %s', newurl)
                         f1 = task.requests.get(newurl).content
                         soup = get_soup(f1)
-                    for res in soup.findAll('tr', {'class': re.compile('torrent_[0-9]*')}):
-                        entry = Entry()
-                        # skip if nuked
-                        if res.find('img', alt='Nuked') != None:
-                            continue
-
-                        link = res.find('a', attrs={'href': re.compile('dl-torrent')})
-
-                        entry['title'] = res.find('a', {'class': 'torrent_name_link'})['title']
-
-                        details_url = res.find('a', {'class': 'torrent_name_link'})['href']
-                        id = int((re.match('.*?([0-9]+)$', details_url).group(1)).strip())
-                        str_url = (base_url, dl_fragment)
-                        entry['url'] = '/'.join(str_url) % (str(id), config['passkey'])
-
-                        log.debug('Title: %s | DL LINK: %s' % (entry['title'], entry['url']))
-
-                        seeds = int(res.find('td', {'class': 'table_seeders'}).find('span').text.strip())
-                        leechers = int(res.find('td', {'class': 'table_leechers'}).find('a').text.strip())
-                        entry['torrent_seeds'] = seeds
-                        entry['torrent_leeches'] = leechers
-
-                        size = res.find('td', attrs={'class': re.compile('table_size')}).text
-                        size = re.search('(\d+(?:[.,]\d+)*)\s?([KMG]B)', size)
-
-                        if size:
-                            if size.group(2) == 'GB':
-                                entry['content_size'] = int(float(size.group(1)) * 1000 ** 3 / 1024 ** 2)
-                            elif size.group(2) == 'MB':
-                                entry['content_size'] = int(float(size.group(1)) * 1000 ** 2 / 1024 ** 2)
-                            elif size.group(2) == 'KB':
-                                entry['content_size'] = int(float(size.group(1)) * 1000 / 1024 ** 2)
-                            else:
-                                entry['content_size'] = int(float(size.group(1)) / 1024 ** 2)
-
-                        if (int(entry['torrent_seeds']) > 0):
+                    results = soup.findAll('tr', {
+                        'class': re.compile('torrent_[0-9]*')
+                    })
+                    for res in results:
+                        entry = self.parse_entry(res)
+                        if entry:
                             entries.add(entry)
-                        else:
-                            log.debug('0 SEEDS, not adding entry')
+
                     nextpage += 1
 
         return entries
 
+    def login(self, task):
+        log.debug('Logging in to Freshon.tv...')
+        params = {
+            'username': self.config['username'],
+            'password': self.config['password'],
+            'login': 'Do it!'
+        }
+        url = "%s/%s" % (BASE_URL, LOGIN_FRAGMENT)
+        lsrc = task.requests.post(url, data=params)
+        if self.config['username'] in lsrc.text:
+            log.debug('Login to FreshonTV was successful')
+        elif 'Username does not exist in the userbase' in lsrc.text:
+            log.error('Invalid credentials FreshonTV')
+            raise plugin.PluginError("Invalid credentials for FreshonTV.")
+        else:
+            log.error('Login to FreshonTV was NOT successful')
+            raise plugin.PluginError("Login to FreshonTV was NOT successful")
+
+    def get_page_number(self, html_soup):
+        page_number = 0
+        # Check to see if there is more than 1 page of results
+        pager = html_soup.find('div', {'class': 'pager'})
+        if pager:
+            page_links = pager.find_all('a', href=True)
+        else:
+            page_links = []
+        if len(page_links) > 0:
+            for lnk in page_links:
+                link_text = lnk.text.strip()
+                if link_text.isdigit():
+                    page_int = int(link_text)
+                    if page_int > page_number:
+                        page_number = page_int
+        else:
+            page_number = 1
+
+        # limit to 10 pages
+        if page_number > 10:
+            page_number = 10
+
+    def parse_entry(self, res):
+        entry = Entry()
+
+        entry['title'] = res.find('a', {'class': 'torrent_name_link'})['title']
+        # skip if nuked
+        if res.find('img', alt='Nuked'):
+            log.info('Skipping entry %s (nuked)' % entry['title'])
+            return None
+
+        details_url = res.find('a', {'class': 'torrent_name_link'})['href']
+        id = int((re.match('.*?([0-9]+)$', details_url).group(1)).strip())
+        url = (BASE_URL, DL_FRAGMENT)
+        entry['url'] = '/'.join(url) % (id, self.config['passkey'])
+
+        log.debug('Title: %s | DL LINK: %s', (entry['title'], entry['url']))
+
+        seeds = res.find('td', {'class': 'table_seeders'}) \
+            .find('span').text.strip()
+        leechers = res.find('td', {'class': 'table_leechers'}) \
+            .find('a').text.strip()
+        entry['torrent_seeds'] = int(seeds)
+        entry['torrent_leeches'] = int(leechers)
+
+        size = res.find('td', attrs={'class': re.compile('table_size')}).text
+        entry['content_size'] = parse_filesize(size)
+
+        return entry
+
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(SearchFreshon, 'freshon', groups=['search'], api_ver=2)
+    plugin.register(SearchFreshon, 'freshon', interfaces=['search'], api_ver=2)

--- a/flexget/plugins/sites/freshon.py
+++ b/flexget/plugins/sites/freshon.py
@@ -44,6 +44,7 @@ class SearchFreshon(object):
                 'default': 'all',
                 'enum': list(LEECHSTATUS.keys())
             },
+            'page_limit': {'type': 'integer', 'default': 10},
         },
         'required': ['username', 'password', 'passkey'],
         'additionalProperties': False
@@ -162,9 +163,7 @@ class SearchFreshon(object):
         else:
             page_number = 1
 
-        # limit to 10 pages
-        if page_number > 10:
-            page_number = 10
+        return min(page_number, self.config['page_limit'])
 
     def parse_entry(self, res):
         entry = Entry()

--- a/flexget/plugins/sites/freshon.py
+++ b/flexget/plugins/sites/freshon.py
@@ -4,6 +4,7 @@ from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 import logging
 import re
 import urllib
+from urlparse import urlsplit, parse_qs
 
 from flexget import plugin
 from flexget.entry import Entry
@@ -185,10 +186,10 @@ class SearchFreshon(object):
             return None
 
         details_url = res.find('a', {'class': 'torrent_name_link'})['href']
-        id = int((re.match('.*?([0-9]+)$', details_url).group(1)).strip())
+        torrent_id = parse_qs(urlsplit(details_url).query)['id']
         params = {
             'type': 'rss',
-            'id': id,
+            'id': torrent_id,
             'passkey': self.config['passkey']
         }
         url = '%s/%s?%s' % (BASE_URL, DL_PAGE, urllib.urlencode(params))

--- a/flexget/plugins/sites/freshon.py
+++ b/flexget/plugins/sites/freshon.py
@@ -102,7 +102,7 @@ class SearchFreshon(object):
             try:
                 page = task.requests.get(url, params=params).content
             except RequestsException:
-                log.error('Could not get page %s, skipping' % url)
+                log.error('Could not get page %s, %s, skipping',  url, params)
                 continue
             soup = get_soup(page)
             if soup.findAll(text=re.compile('Nothing found. Try again with '
@@ -117,7 +117,12 @@ class SearchFreshon(object):
                     if (nextpage > 0):
                         params['page'] = nextpage
                         log.debug('-----> NEXT PAGE : %s %s', url, params)
-                        f1 = task.requests.get(url, params=params).content
+                        try:
+                            f1 = task.requests.get(url, params=params).content
+                        except RequestsException:
+                            log.error('Could not get page %s, %s, skipping',
+                                      url, params)
+                            continue
                         soup = get_soup(f1)
                     results = soup.findAll('tr', {
                         'class': re.compile('torrent_[0-9]*')
@@ -133,7 +138,7 @@ class SearchFreshon(object):
 
     def login(self, task):
         log.debug('Logging in to Freshon.tv...')
-        params = { 'action': 'makelogin' }
+        params = {'action': 'makelogin'}
         data = {
             'username': self.config['username'],
             'password': self.config['password'],
@@ -176,7 +181,7 @@ class SearchFreshon(object):
         entry['title'] = res.find('a', {'class': 'torrent_name_link'})['title']
         # skip if nuked
         if res.find('img', alt='Nuked'):
-            log.info('Skipping entry %s (nuked)' % entry['title'])
+            log.info('Skipping entry %s (nuked)', entry['title'])
             return None
 
         details_url = res.find('a', {'class': 'torrent_name_link'})['href']

--- a/flexget/plugins/sites/freshon.py
+++ b/flexget/plugins/sites/freshon.py
@@ -1,0 +1,188 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+import logging
+import re
+import urllib
+
+from flexget import plugin
+from flexget.entry import Entry
+from flexget.event import event
+from flexget.utils.soup import get_soup
+from flexget.utils.search import normalize_unicode
+
+log = logging.getLogger('search_freshon')
+
+
+class SearchFreshon(object):
+
+    schema = {
+        'type': 'object',
+        'properties':
+        {
+            'username': {'type': 'string'},
+            'password': {'type': 'string'},
+            'passkey': {'type': 'string'},
+            'category': {
+                'type': 'string',
+                'default': 'all',
+                'enum': ['hd', 'webdl', 'all']
+            },
+            'freeleech': {
+                'type': 'string',
+                'default': 'all',
+                'enum': ['free', 'half', 'all']
+            },
+        },
+        'required': ['username', 'password', 'passkey'],
+        'additionalProperties': False
+    }
+
+    @plugin.internet(log)
+    def search(self, task, entry, config):
+        """Freshon.tv search plugin
+
+        Config example:
+        tv_search_freshon:
+            discover:
+              what:
+                 - trakt_list:
+                     username: xxxxxxx
+                     password: xxxxxxx
+                     list: somelist
+                     type: shows
+                  from:
+                    - freshon:
+                        username: xxxxxx
+                        password: xxxxxx
+                        passkey: xxxxx
+                  interval: 1 day
+                  ignore_estimations: yes
+
+        Category is one of:
+            all
+            hd
+            webdl
+
+        Freeleech is one of:
+            all
+            free
+            half
+        """
+
+        base_url = 'https://freshon.tv'
+        search_fragment = 'browse.php?search=%s&tab=%s&incldead=%s'
+        dl_fragment = 'download.php?type=rss&id=%s&passkey=%s'
+        login_fragment = 'login.php?action=makelogin'
+
+        if not task.requests.cookies:
+            log.debug('Logging in to Freshon.tv...')
+            params = {'username': config['username'],
+                      'password': config['password'],
+                      'login': 'Do it!'}
+            urlstr = (base_url, login_fragment)
+            lsrc = task.requests.post('/'.join(urlstr), data=params)
+            if str(config['username']) in lsrc.text:
+                log.debug('Login to FreshonTV was successful')
+            elif str('Username does not exist in the userbase') in lsrc.text:
+                log.error('Invalid username or password for FreshonTV; Check your settings')
+                raise plugin.PluginError("Invalid username or Password for FreshonTV.")
+            else:
+                log.error('Login to FreshonTV was NOT successful')
+                raise plugin.PluginError("Login to FreshonTV was NOT successful")
+
+        if config['freeleech'] == 'all':
+            freeleech = 0
+        elif config['freeleech'] == 'free':
+            freeleech = 3
+        elif config['freeleech'] == 'half':
+            freeleech = 4
+
+        entries = set()
+        for search_string in entry.get('search_strings', [entry['title']]):
+            query = normalize_unicode(search_string.replace(' ', '+'))
+            query_url_fragment = urllib.quote_plus(query.encode('utf-8'))
+            str_url = (base_url, search_fragment)
+            url = '/'.join(str_url) % (query_url_fragment, config['category'], str(freeleech))
+            log.debug('Search url: %s' % url)
+            page = task.requests.get(url).content
+            soup = get_soup(page)
+            if soup.findAll(text=re.compile('Nothing found. Try again with a refined search string.')):
+                log.debug('Search returned no results')
+            else:
+                max_page_number = 0
+                # Check to see if there is more than 1 page of results
+                pager = soup.find('div', {'class': 'pager'})
+                if pager:
+                    page_links = pager.find_all('a', href=True)
+                else:
+                    page_links = []
+                if len(page_links) > 0:
+                    for lnk in page_links:
+                        link_text = lnk.text.strip()
+                        if link_text.isdigit():
+                            page_int = int(link_text)
+                            if page_int > max_page_number:
+                                max_page_number = page_int
+                else:
+                    max_page_number = 1
+
+                # limit to 10 pages
+                if max_page_number > 10:
+                    max_page_number = 10
+
+                # pages are 0 based
+                nextpage = 0
+                while (nextpage < max_page_number):
+                    if (nextpage > 0):
+                        newurl = url + '&page=' + str(nextpage)
+                        log.debug('-----> NEXT PAGE : %s' % newurl)
+                        f1 = task.requests.get(newurl).content
+                        soup = get_soup(f1)
+                    for res in soup.findAll('tr', {'class': re.compile('torrent_[0-9]*')}):
+                        entry = Entry()
+                        # skip if nuked
+                        if res.find('img', alt='Nuked') != None:
+                            continue
+
+                        link = res.find('a', attrs={'href': re.compile('dl-torrent')})
+
+                        entry['title'] = res.find('a', {'class': 'torrent_name_link'})['title']
+
+                        details_url = res.find('a', {'class': 'torrent_name_link'})['href']
+                        id = int((re.match('.*?([0-9]+)$', details_url).group(1)).strip())
+                        str_url = (base_url, dl_fragment)
+                        entry['url'] = '/'.join(str_url) % (str(id), config['passkey'])
+
+                        log.debug('Title: %s | DL LINK: %s' % (entry['title'], entry['url']))
+
+                        seeds = int(res.find('td', {'class': 'table_seeders'}).find('span').text.strip())
+                        leechers = int(res.find('td', {'class': 'table_leechers'}).find('a').text.strip())
+                        entry['torrent_seeds'] = seeds
+                        entry['torrent_leeches'] = leechers
+
+                        size = res.find('td', attrs={'class': re.compile('table_size')}).text
+                        size = re.search('(\d+(?:[.,]\d+)*)\s?([KMG]B)', size)
+
+                        if size:
+                            if size.group(2) == 'GB':
+                                entry['content_size'] = int(float(size.group(1)) * 1000 ** 3 / 1024 ** 2)
+                            elif size.group(2) == 'MB':
+                                entry['content_size'] = int(float(size.group(1)) * 1000 ** 2 / 1024 ** 2)
+                            elif size.group(2) == 'KB':
+                                entry['content_size'] = int(float(size.group(1)) * 1000 / 1024 ** 2)
+                            else:
+                                entry['content_size'] = int(float(size.group(1)) / 1024 ** 2)
+
+                        if (int(entry['torrent_seeds']) > 0):
+                            entries.add(entry)
+                        else:
+                            log.debug('0 SEEDS, not adding entry')
+                    nextpage += 1
+
+        return entries
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(SearchFreshon, 'freshon', groups=['search'], api_ver=2)


### PR DESCRIPTION
### Motivation for changes:
Freshon.tv search plugin is documented but was not available.
I guess it has not been ported when the python3 compatibility has been done.

### Detailed changes:

- I restored the plugin from commit 8636793fe6532fee086ec6664eefb844
- moved the file from `flexget/plugins/search_freshon.py` to `flexget/plugins/sites/freshon.py` 
- As advised in https://flexget.com/Developers#python23-compatibility I added from the original file
```python
from builtins import *
```
- Only change from original plugin is that I removed `verify=False` the post request

### Config usage if relevant (new plugin or updated schema):
```
tv_search_freshon:
    discover:
      what:
         - trakt_list:
             username: xxxxxxx
             password: xxxxxxx
             list: somelist
             type: shows
          from:
            - freshon:
                username: xxxxxx
                password: xxxxxx
                passkey: xxxxx
```
Note: `passkey` is not present in documentation but is/was mandatory (cf. https://flexget.com/Searches/freshon )

