### PR TITLE
Fix bad entry url dues to parse_qs values being lists

### DIFF
--- a/flexget/plugins/sites/freshon.py
+++ b/flexget/plugins/sites/freshon.py
@@ -186,7 +186,7 @@ class SearchFreshon(object):
             return None
 
         details_url = res.find('a', {'class': 'torrent_name_link'})['href']
-        torrent_id = parse_qs(urlsplit(details_url).query)['id']
+        torrent_id = parse_qs(urlsplit(details_url).query)['id'][0]
         params = {
             'type': 'rss',
             'id': torrent_id,


### PR DESCRIPTION
### Motivation for changes:
Generated entry URL was wrong due to the fact that `urlparse.parse_qs` returns a dict wich values are lists.


My bad.
