### PR TITLE
Entry list search

### DIFF
--- a/flexget/plugins/list/entry_list.py
+++ b/flexget/plugins/list/entry_list.py
@@ -187,10 +187,6 @@ class EntryList(object):
     def on_task_input(self, task, config):
         return list(DBEntrySet(config))
 
-
-class EntryListSearch(object):
-    schema = {'type': 'string'}
-
     def search(self, task, entry, config=None):
         entries = []
         with Session() as session:
@@ -210,8 +206,7 @@ class EntryListSearch(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(EntryList, 'entry_list', api_ver=2, interfaces=['task', 'list'])
-    plugin.register(EntryListSearch, 'entry_list_search', api_ver=2, interfaces=['search'])
+    plugin.register(EntryList, 'entry_list', api_ver=2, interfaces=['task', 'list', 'search'])
 
 
 @with_session

--- a/flexget/plugins/list/entry_list.py
+++ b/flexget/plugins/list/entry_list.py
@@ -201,8 +201,9 @@ class EntryListSearch(object):
             else:
                 for search_string in entry.get('search_strings', [entry['title']]):
                     log.debug('searching for entry that matches %s in entry_list %s', search_string, config)
+                    search_string = search_string.replace(' ', '%').replace('.', '%')
                     query = entry_list.entries.filter(EntryListEntry.title.like('%' + search_string + '%'))
-                    entries = [e.entry for e in query.all()]
+                    entries += [e.entry for e in query.all()]
             finally:
                 return entries
 

--- a/flexget/tests/test_entry_list.py
+++ b/flexget/tests/test_entry_list.py
@@ -17,6 +17,17 @@ class TestEntryListSearch(object):
                     - {title: 'test title'}
                   from:
                   - entry_list_search: 'Test list'
+              entry_list_with_series:
+                max_reruns: 0
+                series:
+                - foo:
+                    begin: s01e01
+                discover:
+                  release_estimations: ignore
+                  what:
+                    - next_series_episodes: yes
+                  from:
+                    - entry_list_search: series list
 
             """
 
@@ -32,8 +43,25 @@ class TestEntryListSearch(object):
             session.commit()
 
             db_entry = EntryListEntry(entry, entry_list.id)
-
             entry_list.entries.append(db_entry)
 
         task = execute_task('entry_list_discover')
         assert len(task.entries) > 0
+        assert task.find_entry(title='test title')
+
+    def test_entry_list_with_next_series_episodes(self, execute_task):
+        entry = Entry()
+        entry['title'] = 'foo.s01e01.720p.hdtv-flexget'
+        entry['url'] = ''
+
+        with Session() as session:
+            entry_list = EntryListList()
+            entry_list.name = 'series list'
+            session.add(entry_list)
+            session.commit()
+
+            db_entry = EntryListEntry(entry, entry_list.id)
+            entry_list.entries.append(db_entry)
+
+        task = execute_task('entry_list_with_series')
+        assert task.find_entry('accepted', title='foo.s01e01.720p.hdtv-flexget')

--- a/flexget/tests/test_entry_list.py
+++ b/flexget/tests/test_entry_list.py
@@ -1,0 +1,39 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+from flexget.entry import Entry
+from flexget.manager import Session
+from flexget.plugins.list.entry_list import EntryListList, EntryListEntry
+
+
+class TestEntryListSearch(object):
+    config = """
+            tasks:
+              entry_list_discover:
+                discover:
+                  release_estimations: ignore
+                  what:
+                  - mock:
+                    - {title: 'test title'}
+                  from:
+                  - entry_list_search: 'Test list'
+
+            """
+
+    def test_entry_list_search(self, execute_task):
+        entry = Entry()
+        entry['title'] = 'test title'
+        entry['url'] = ''
+
+        with Session() as session:
+            entry_list = EntryListList()
+            entry_list.name = 'Test list'
+            session.add(entry_list)
+            session.commit()
+
+            db_entry = EntryListEntry(entry, entry_list.id)
+
+            entry_list.entries.append(db_entry)
+
+        task = execute_task('entry_list_discover')
+        assert len(task.entries) > 0

--- a/flexget/tests/test_entry_list.py
+++ b/flexget/tests/test_entry_list.py
@@ -16,7 +16,7 @@ class TestEntryListSearch(object):
                   - mock:
                     - {title: 'test title'}
                   from:
-                  - entry_list_search: 'Test list'
+                  - entry_list: 'Test list'
               entry_list_with_series:
                 max_reruns: 0
                 series:
@@ -27,7 +27,7 @@ class TestEntryListSearch(object):
                   what:
                     - next_series_episodes: yes
                   from:
-                    - entry_list_search: series list
+                    - entry_list: series list
 
             """
 


### PR DESCRIPTION
### Motivation for changes:
Added search capability to `entry_list`

### Config usage if relevant (new plugin or updated schema):
```yaml
            tasks:
              entry_list_discover:
                discover:
                  release_estimations: ignore
                  what:
                  - mock:
                    - {title: 'test title'}
                  from:
                  - entry_list: 'Test list'
```


