### PR TITLE
fix a import error for python3

### DIFF
--- a/flexget/plugins/sites/freshon.py
+++ b/flexget/plugins/sites/freshon.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+from future.moves.urllib.parse import urlsplit, parse_qs
 
 import logging
 import re
 import urllib
-from urlparse import urlsplit, parse_qs
 
 from flexget import plugin
 from flexget.entry import Entry


### PR DESCRIPTION
### Motivation for changes:
fix an import error for python3
### Detailed changes:

- 

### Addressed issues:

- Fixes # .

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
```
paste output here
```

