### PR TITLE
New search plugin, FileList

### DIFF
--- a/flexget/plugins/sites/filelist.py
+++ b/flexget/plugins/sites/filelist.py
@@ -110,7 +110,7 @@ class SearchFileList(object):
 
         response = requests.get(url, params=params, cookies=cookies)
 
-        if BASE_URL + 'login.php' in response.url:
+        if BASE_URL + 'takelogin.php' in response.url:
             if self.errors:
                 raise plugin.PluginError('FileList.ro login cookie is invalid. Login page received?')
             self.errors = True

--- a/flexget/plugins/sites/filelist.py
+++ b/flexget/plugins/sites/filelist.py
@@ -25,6 +25,7 @@ requests.add_domain_limiter(TimedLimiter('filelist.tv', '5 seconds'))
 BASE_URL = 'https://filelist.ro/'
 
 CATEGORIES = {
+    'all': 0,
     'anime': 24,
     'audio': 11,
     'cartoons': 15,
@@ -85,7 +86,7 @@ class SearchFileList(object):
             'username': {'type': 'string'},
             'password': {'type': 'string'},
             'passkey': {'type': 'string'},
-            'category': {'type': 'string', 'enum': list(CATEGORIES.keys())},
+            'category': {'type': 'string', 'enum': list(CATEGORIES.keys()), 'default': 'all'},
             'order_by': {'type': 'string', 'enum': list(SORTING.keys()), 'default': 'hybrid'},
             'order_ascending': {'type': 'boolean', 'default': False},
             'search_in': {'type': 'boolean', 'enum': list(SEARCH_IN.keys())},
@@ -163,17 +164,17 @@ class SearchFileList(object):
     @plugin.internet(log)
     def search(self, task, entry, config):
         """
-            Search for entries on MoreThanTV
+            Search for entries on FileList.ro
         """
-        params = {}
-
-        if 'category' in config:
-            params['cat'] = CATEGORIES[config['category']]
-
         entries = set()
 
-        params.update({'incldead': int(config['include_dead']), 'order_by': SORTING[config['order_by']],
-                       'searchin': config.get('search_in', 0), 'asc': int(config['order_ascending'])})
+        params = {
+            'cat': CATEGORIES[config['category']],
+            'incldead': int(config['include_dead']),
+            'order_by': SORTING[config['order_by']],
+            'searchin': config.get('search_in', 0),
+            'asc': int(config['order_ascending'])
+        }
 
         for search_string in entry.get('search_strings', [entry['title']]):
             params['search'] = search_string

--- a/flexget/plugins/sites/filelist.py
+++ b/flexget/plugins/sites/filelist.py
@@ -20,7 +20,7 @@ log = logging.getLogger('filelist')
 Base = db_schema.versioned_base('filelist', 0)
 
 requests = RequestSession()
-requests.add_domain_limiter(TimedLimiter('filelist.tv', '5 seconds'))
+requests.add_domain_limiter(TimedLimiter('filelist.ro', '5 seconds'))
 
 BASE_URL = 'https://filelist.ro/'
 

--- a/flexget/plugins/sites/filelist.py
+++ b/flexget/plugins/sites/filelist.py
@@ -143,7 +143,7 @@ class SearchFileList(object):
             response = requests.post(url, data={'username': username, 'password': password, 'login': 'Log in',
                                                 'unlock': '1'}, timeout=30)
         except RequestException as e:
-            raise plugin.PluginError('FileList.ro login failed: %s', e)
+            raise plugin.PluginError('FileList.ro login failed: %s' % e)
 
         if 'https://filelist.ro/my.php' != response.url:
             raise plugin.PluginError('FileList.ro login failed: Your username or password was incorrect.')

--- a/flexget/plugins/sites/filelist.py
+++ b/flexget/plugins/sites/filelist.py
@@ -1,0 +1,234 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+import logging
+import datetime
+
+from sqlalchemy import Column, Unicode, DateTime
+
+from flexget import plugin, db_schema
+from flexget.entry import Entry
+from flexget.event import event
+from flexget.utils.requests import TimedLimiter, RequestException
+from flexget.manager import Session
+from flexget.utils.database import json_synonym
+from flexget.utils.soup import get_soup
+from flexget.config_schema import one_or_more
+from flexget.utils.tools import parse_filesize
+
+log = logging.getLogger('filelist')
+Base = db_schema.versioned_base('filelist', 0)
+
+BASE_URL = 'https://filelist.ro/'
+
+CATEGORIES = {
+    'anime': 24,
+    'audio': 11,
+    'cartoons': 15,
+    'docs': 16,
+    'games console': 10,
+    'games pc': 9,
+    'linux': 17,
+    'misc': 18,
+    'mobile': 22,
+    'movies 3d': 25,
+    'movies bluray': 20,
+    'movies dvd': 2,
+    'movies dvd-ro': 3,
+    'movies hd': 4,
+    'movies hd-ro': 19,
+    'movies sd': 1,
+    'series hd': 21,
+    'series sd': 23,
+    'software': 8,
+    'sport': 13,
+    'tv': 14,
+    'videoclip': 12,
+    'xxx': 7
+}
+
+SORTING = {
+    'hybrid': 0,
+    'relevance': 1,
+    'date': 2,
+    'size': 3,
+    'snatches': 4,
+    'peers': 5
+}
+
+SEARCH_IN = {
+    'title': 1,
+    'description': 2
+}
+
+
+class FileListCookie(Base):
+    __tablename__ = 'filelist_cookie'
+
+    username = Column(Unicode, primary_key=True)
+    _cookie = Column('cookie', Unicode)
+    cookie = json_synonym('_cookie')
+    expires = Column(DateTime)
+
+
+class SearchFileList(object):
+    """
+        FileList.ro search plugin.
+    """
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'username': {'type': 'string'},
+            'password': {'type': 'string'},
+            'passkey': {'type': 'string'},
+            'category': {'type': 'string', 'enum': list(CATEGORIES.keys())},
+            'order_by': {'type': 'string', 'enum': list(SORTING.keys()), 'default': 'hybrid'},
+            'order_ascending': {'type': 'boolean', 'default': False},
+            'search_in': {'type': 'boolean', 'enum': list(SEARCH_IN.keys())},
+            'include_dead': {'type': 'boolean', 'default': False}
+        },
+        'required': ['username', 'password', 'passkey'],
+        'additionalProperties': False
+    }
+
+    def on_task_start(self, task, config):
+        task.requests.add_domain_limiter(TimedLimiter('filelist.ro', '5 seconds'))
+
+    def get(self, url, params, username, password, requests, force=False):
+        """
+        Wrapper to allow refreshing the cookie if it is invalid for some reason
+
+        :param str url:
+        :param list params:
+        :param str username:
+        :param str password:
+        :param bool force: flag used to refresh the cookie forcefully ie. forgo DB lookup
+        :return:
+        """
+        cookies = self.get_login_cookie(username, password, requests, force=force)
+
+        response = requests.get(url, params=params, cookies=cookies)
+
+        if BASE_URL + 'login.php' in response.url:
+            if self.errors:
+                raise plugin.PluginError('FileList.ro login cookie is invalid. Login page received?')
+            self.errors = True
+            # try again
+            response = self.get(url, params, username, password, requests, force=True)
+        else:
+            self.errors = False
+
+        return response
+
+    def get_login_cookie(self, username, password, requests, force=False):
+        """
+        Retrieves login cookie
+
+        :param str username:
+        :param str password:
+        :param bool force: if True, then retrieve a fresh cookie instead of looking in the DB
+        :return:
+        """
+        if not force:
+            with Session() as session:
+                saved_cookie = session.query(FileListCookie).filter(FileListCookie.username == username.lower()).first()
+                log.error(saved_cookie)
+                if saved_cookie and saved_cookie.expires and saved_cookie.expires >= datetime.datetime.now():
+                    log.debug('Found valid login cookie')
+                    return saved_cookie.cookie
+
+        url = BASE_URL + 'takelogin.php'
+        try:
+            log.debug('Attempting to retrieve FileList.ro cookie')
+            response = requests.post(url, data={'username': username, 'password': password, 'login': 'Log in',
+                                                'unlock': '1'}, timeout=30)
+        except RequestException as e:
+            raise plugin.PluginError('FileList.ro login failed: %s', e)
+
+        if 'https://filelist.ro/my.php' != response.url:
+            raise plugin.PluginError('FileList.ro login failed: Your username or password was incorrect.')
+
+        with Session() as session:
+            expires = None
+            for c in requests.cookies:
+                if c.name == 'pass':
+                    expires = c.expires
+            if expires:
+                expires = datetime.datetime.fromtimestamp(expires)
+            log.debug('Saving or updating FileList.ro cookie in db')
+            cookie = FileListCookie(username=username.lower(), cookie=dict(requests.cookies), expires=expires)
+            session.merge(cookie)
+            return cookie.cookie
+
+    @plugin.internet(log)
+    def search(self, task, entry, config):
+        """
+            Search for entries on MoreThanTV
+        """
+        params = {}
+
+        if 'category' in config:
+            params['cat'] = CATEGORIES[config['category']]
+
+        entries = set()
+
+        params.update({'incldead': int(config['include_dead']), 'order_by': SORTING[config['order_by']],
+                       'searchin': config.get('search_in', 0), 'asc': int(config['order_ascending'])})
+
+        for search_string in entry.get('search_strings', [entry['title']]):
+            params['search'] = search_string
+            log.debug('Using search params: %s', params)
+            try:
+                page = self.get(BASE_URL + 'browse.php', params, config['username'], config['password'], task.requests)
+                log.debug('requesting: %s', page.url)
+            except RequestException as e:
+                log.error('FileList.ro request failed: %s', e)
+                continue
+
+            soup = get_soup(page.content)
+            for result in soup.findAll('div', attrs={'class': 'torrentrow'}):
+                e = Entry()
+
+                torrent_info = result.findAll('div', attrs={'class': 'torrenttable'})
+
+                # genres
+                genres = torrent_info[1].find('font')
+                if genres:
+                    genres = genres.text.lstrip('[').rstrip(']').replace(' ', '')
+                    genres = genres.split('|')
+
+                tags = torrent_info[1].findAll('img')
+                freeleech = False
+                internal = False
+                for tag in tags:
+                    if tag.get('alt', '').lower() == 'freeleech':
+                        freeleech = True
+                    if tag.get('alt', '').lower() == 'internal':
+                        internal = True
+
+                title = torrent_info[1].find('a').get('title', '')
+                if not title:
+                    title = torrent_info[1].find('b').text
+
+                e['title'] = title
+                e['url'] = BASE_URL + torrent_info[3].find('a')['href'] + '&passkey=' + config['passkey']
+                e['content_size'] = parse_filesize(torrent_info[6].find('font').text)
+
+                e['torrent_snatches'] = int(torrent_info[7].find('font').text.replace(' ', '').replace('times', '')
+                                            .replace(',', ''))
+                e['torrent_seeds'] = int(torrent_info[8].find('span').text)
+                e['torrent_leeches'] = int(torrent_info[9].find('span').text)
+                e['torrent_internal'] = internal
+                e['torrent_freeleech'] = freeleech
+                if genres:
+                    e['torrent_genres'] = genres
+
+                entries.add(e)
+
+        return entries
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(SearchFileList, 'filelist', interfaces=['search'], api_ver=2)


### PR DESCRIPTION
### Motivation for changes:
Request

### Config usage if relevant (new plugin or updated schema):
```
    schema = {
        'type': 'object',
        'properties': {
            'username': {'type': 'string'},
            'password': {'type': 'string'},
            'passkey': {'type': 'string'},
            'category': {'type': 'string', 'enum': list(CATEGORIES.keys())},
            'order_by': {'type': 'string', 'enum': list(SORTING.keys()), 'default': 'hybrid'},
            'order_ascending': {'type': 'boolean', 'default': False},
            'search_in': {'type': 'boolean', 'enum': list(SEARCH_IN.keys())},
            'include_dead': {'type': 'boolean', 'default': False}
        },
        'required': ['username', 'password', 'passkey'],
        'additionalProperties': False
    }
```

For some weird reason, the site only allows you to search in one category. Picking multiple categories and a search string makes it search in all categories.