### PR TITLE
jinja2 filters CLI

### DIFF
--- a/flexget/plugins/cli/filters.py
+++ b/flexget/plugins/cli/filters.py
@@ -28,5 +28,7 @@ def do_cli(manager, options):
 @event('options.register')
 def register_parser_arguments():
     # Register subcommand
-    parser = options.register_command('filters', do_cli, help='View jinja2 filters and their description', parents=[table_parser])
+    parser = options.register_command('jinja-filters', do_cli,
+                                      help='View registered jinja2 filters and their description',
+                                      parents=[table_parser])
     parser.add_argument('--name', help='Filter results by filter name')

--- a/flexget/plugins/cli/filters.py
+++ b/flexget/plugins/cli/filters.py
@@ -5,14 +5,14 @@ import inspect
 
 from flexget import options
 from flexget.event import event
-from flexget.utils.template import list_filters
+from flexget.utils.template import get_filters
 from flexget.terminal import TerminalTable, TerminalTableError, table_parser, console
 
 
 def do_cli(manager, options):
     header = ['Name', 'Description']
     table_data = [header]
-    for filter_name, filter in list_filters():
+    for filter_name, filter in get_filters():
         if options.name and not options.name in filter_name:
             continue
         filter_doc = inspect.getdoc(filter) or ''
@@ -28,5 +28,5 @@ def do_cli(manager, options):
 @event('options.register')
 def register_parser_arguments():
     # Register subcommand
-    parser = options.register_command('filters', do_cli, help='View custom jinja2 filters', parents=[table_parser])
+    parser = options.register_command('filters', do_cli, help='View jinja2 filters and their description', parents=[table_parser])
     parser.add_argument('--name', help='Filter results by filter name')

--- a/flexget/plugins/cli/filters.py
+++ b/flexget/plugins/cli/filters.py
@@ -1,0 +1,32 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+import inspect
+
+from flexget import options
+from flexget.event import event
+from flexget.utils.template import list_filters
+from flexget.terminal import TerminalTable, TerminalTableError, table_parser, console
+
+
+def do_cli(manager, options):
+    header = ['Name', 'Description']
+    table_data = [header]
+    for filter_name, filter in list_filters():
+        if options.name and not options.name in filter_name:
+            continue
+        filter_doc = inspect.getdoc(filter) or ''
+        table_data.append([filter_name, filter_doc])
+    try:
+        table = TerminalTable(options.table_type, table_data)
+    except TerminalTableError as e:
+        console('ERROR: %s' % str(e))
+    else:
+        console(table.output)
+
+
+@event('options.register')
+def register_parser_arguments():
+    # Register subcommand
+    parser = options.register_command('filters', do_cli, help='View custom jinja2 filters', parents=[table_parser])
+    parser.add_argument('--name', help='Filter results by filter name')

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -162,9 +162,12 @@ def list_templates(extensions=None):
     return environment.list_templates(extensions=extensions)
 
 
-def list_filters():
+def get_filters():
+    """
+    Returns all built-in and custom Jinja filters in a dict, where the key is the name, and the value is the filter func
+    """
     if environment is None or not hasattr(environment, 'loader'):
-        return
+        return {}
     return environment.filters.items()
 
 

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -85,6 +85,7 @@ def filter_parsedate(val):
 
 
 def filter_date_suffix(date):
+    """Returns a date suffix for a given date"""
     day = int(date[-2:])
     if 4 <= day <= 20 or 24 <= day <= 30:
         suffix = "th"
@@ -114,13 +115,14 @@ def filter_pad(val, width, fillchar='0'):
 
 
 def filter_to_date(date_time_val):
+    """Returns the date from any date-time object"""
     if not isinstance(date_time_val, (datetime, date, time)):
         return date_time_val
     return date_time_val.date()
 
 
-# Override the built-in Jinja default filter to change the `boolean` param to True by default
 def filter_default(value, default_value='', boolean=True):
+    """Override the built-in Jinja default filter to change the `boolean` param to True by default"""
     return jinja2.filters.do_default(value, default_value, boolean)
 
 
@@ -158,6 +160,12 @@ def list_templates(extensions=None):
     if environment is None or not hasattr(environment, 'loader'):
         return
     return environment.list_templates(extensions=extensions)
+
+
+def list_filters():
+    if environment is None or not hasattr(environment, 'loader'):
+        return
+    return environment.filters.items()
 
 
 def get_template(template_name, scope='task'):


### PR DESCRIPTION
### Motivation for changes:
A detailed view of all jinja2 filters, native and our custom ones.

### Config usage if relevant (new plugin or updated schema):
`flexget filters`:
http://pastebin.com/Vfi6PH5V

