### PR TITLE
rutracker - always use https

### DIFF
--- a/flexget/plugins/sites/rutracker.py
+++ b/flexget/plugins/sites/rutracker.py
@@ -25,6 +25,8 @@ __author__ = 'asm0dey'
 log = logging.getLogger('rutracker_auth')
 Base = versioned_base('rutracker_auth', 0)
 
+domain_url = None
+
 
 class JSONEncodedDict(TypeDecorator):
     """Represents an immutable structure as a json-encoded string.
@@ -59,13 +61,14 @@ class RutrackerAccount(Base):
 
 class RutrackerAuth(AuthBase):
     """Supports downloading of torrents from 'rutracker' tracker
-       if you pass cookies (CookieJar) to constructor then authentication will be bypassed and cookies will be just set
+       if you pass cookies (CookieJar) to constructor then authentication will
+       be bypassed and cookies will be just set
     """
 
     def try_authenticate(self, payload):
         for _ in range(5):
             s = RSession()
-            s.post("http://rutracker.org/forum/login.php", data=payload)
+            s.post('{}/forum/login.php'.format(domain_url), data=payload)
             if s.cookies and len(s.cookies) > 0:
                 return s.cookies
             else:
@@ -95,15 +98,17 @@ class RutrackerAuth(AuthBase):
     def __call__(self, r):
         url = r.url
         id = re.findall(r'\d+', url)[0]
-        data = 't=' + id
+        data = 't={}'.format(id)
         headers = {
-            'referer': "http://rutracker.org/forum/viewtopic.php?t=" + id,
-            "Content-Type": "application/x-www-form-urlencoded", "t": id, 'Origin': 'http://rutracker.org',
+            'referer': '{}/forum/viewtopic.php?t={}'.format(domain_url, id),
+            'Content-Type': 'application/x-www-form-urlencoded', 't': id,
+            'Origin': domain_url,
             'Accept-Encoding': 'gzip,deflate,sdch'}
         r.prepare_body(data=data, files=None)
         r.prepare_method('POST')
         r.prepare_url(
-            url='http://rutracker.org/forum/dl.php?t=' + id, params=None)
+            url='{}/forum/dl.php?t={}'.format(domain_url, id),
+            params=None)
         r.prepare_headers(headers)
         r.prepare_cookies(self.cookies_)
         return r
@@ -115,18 +120,29 @@ class RutrackerUrlrewrite(object):
     rutracker_auth:
       username: 'username_here'
       password: 'password_here'
+
+      For using https add use_ssl
+
+    rutracker_auth:
+      username: 'username_here'
+      password: 'password_here'
+      use_ssl: yes
     """
     schema = {'type': 'object',
               'properties': {
                   'username': {'type': 'string'},
-                  'password': {'type': 'string'}
+                  'password': {'type': 'string'},
+                  'use_ssl': {'type': 'boolean', 'default': False}
               },
-              "additionalProperties": False}
+              'additionalProperties': False}
 
     auth_cache = {}
 
     @plugin.priority(127)
     def on_task_urlrewrite(self, task, config):
+        global domain_url
+        domain_url = 'http{}://rutracker.org'.format(
+            's' if config['use_ssl'] else '')
         username = config['username']
         db_session = Session()
         cookies = self.try_find_cookie(db_session, username)
@@ -137,7 +153,8 @@ class RutrackerUrlrewrite(object):
         else:
             auth_handler = self.auth_cache[username]
         for entry in task.accepted:
-            if entry['url'].startswith('http://rutracker.org/forum/viewtopic.php'):
+            if entry['url'].startswith(
+                    '{}/forum/viewtopic.php'.format(domain_url)):
                 entry['download_auth'] = auth_handler
 
     def try_find_cookie(self, db_session, username):

--- a/flexget/plugins/sites/rutracker.py
+++ b/flexget/plugins/sites/rutracker.py
@@ -61,8 +61,7 @@ class RutrackerAccount(Base):
 
 class RutrackerAuth(AuthBase):
     """Supports downloading of torrents from 'rutracker' tracker
-       if you pass cookies (CookieJar) to constructor then authentication will
-       be bypassed and cookies will be just set
+       if you pass cookies (CookieJar) to constructor then authentication will be bypassed and cookies will be just set
     """
 
     def try_authenticate(self, payload):
@@ -97,17 +96,16 @@ class RutrackerAuth(AuthBase):
 
     def __call__(self, r):
         url = r.url
-        id = re.findall(r'\d+', url)[0]
-        data = 't={}'.format(id)
+        t_id = re.findall(r'\d+', url)[0]
+        data = 't={}'.format(t_id)
         headers = {
-            'referer': '{}/forum/viewtopic.php?t={}'.format(BASE_URL, id),
-            'Content-Type': 'application/x-www-form-urlencoded', 't': id,
+            'referer': '{}/forum/viewtopic.php?t={}'.format(BASE_URL, t_id),
+            'Content-Type': 'application/x-www-form-urlencoded', 't': t_id,
             'Origin': BASE_URL,
             'Accept-Encoding': 'gzip,deflate,sdch'}
         r.prepare_body(data=data, files=None)
         r.prepare_method('POST')
-        r.prepare_url(
-            url='{}/forum/dl.php?t={}'.format(BASE_URL, id),
+        r.prepare_url(url='{}/forum/dl.php?t={}'.format(BASE_URL, t_id),
             params=None)
         r.prepare_headers(headers)
         r.prepare_cookies(self.cookies_)
@@ -142,8 +140,7 @@ class RutrackerUrlrewrite(object):
         else:
             auth_handler = self.auth_cache[username]
         for entry in task.accepted:
-            if entry['url'].startswith(
-                    '{}/forum/viewtopic.php'.format(BASE_URL)):
+            if entry['url'].startswith('{}/forum/viewtopic.php'.format(BASE_URL)):
                 entry['download_auth'] = auth_handler
 
     def try_find_cookie(self, db_session, username):


### PR DESCRIPTION
### Motivation for changes:

Sometimes rutracker.org available only throw https

### Detailed changes:

- Add new property use_ssl(boolean)
- Small code changes

### Addressed issues:

- None

### Config usage if relevant (new plugin or updated schema):
```
    rutracker_auth:
      username: 'username_here'
      password: 'password_here'
      use_ssl: yes
```
### Log and/or tests output (preferably both):

- None


