### PR TITLE
Extend Slack notification to support attachments

### DIFF
--- a/flexget/plugins/notifiers/slack.py
+++ b/flexget/plugins/notifiers/slack.py
@@ -26,6 +26,7 @@ class SlackNotifier(object):
         [username: <string>] (override username)
         [icon_emoji: <string>] (override emoji icon)
         [icon_url: <string>] (override emoji icon)
+        [attachments: <array>[<object>]] (send a more complex 'message' as part of the notification)
 
     """
     schema = {
@@ -35,7 +36,74 @@ class SlackNotifier(object):
             'channel': {'type': 'string'},
             'username': {'type': 'string', 'default': 'Flexget'},
             'icon_emoji': {'type': 'string'},
-            'icon_url': {'type': 'string', 'format': 'url'}
+            'icon_url': {'type': 'string', 'format': 'url'},
+            'attachments': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'fallback': {
+                            'type': 'string'
+                        },
+                        'color': {
+                            'type': 'string'
+                        },
+                        'pretext': {
+                            'type': 'string'
+                        },
+                        'author_name': {
+                            'type': 'string'
+                        },
+                        'author_link': {
+                            'type': 'string'
+                        },
+                        'author_icon': {
+                            'type': 'string'
+                        },
+                        'title': {
+                            'type': 'string'
+                        },
+                        'title_link': {
+                            'type': 'string'
+                        },
+                        'text': {
+                            'type': 'string'
+                        },
+                        'fields': {
+                            'type': 'array',
+                            'items': {
+                                'type': 'object',
+                                'properties': {
+                                    'title': {
+                                        'type': 'string'
+                                    },
+                                    'value': {
+                                        'type': 'string'
+                                    },
+                                    'short': {
+                                        'type': 'boolean'
+                                    }
+                                }
+                            }
+                        },
+                        'image_url': {
+                            'type': 'string'
+                        },
+                        'thumb_url': {
+                            'type': 'string'
+                        },
+                        'footer': {
+                            'type': 'string'
+                        },
+                        'footer_icon': {
+                            'type': 'string'
+                        },
+                        'ts': {
+                            'type': 'number'
+                        }
+                    }
+                }
+            }
         },
         'not': {
             'required': ['icon_emoji', 'icon_url']
@@ -49,7 +117,10 @@ class SlackNotifier(object):
         """
         Send a Slack notification
         """
-        notification = {'text': message, 'channel': config.get('channel'), 'username': config.get('username')}
+        notification = {'text': message,
+                        'attachments': config.get('attachments'),
+                        'channel': config.get('channel'),
+                        'username': config.get('username')}
         if config.get('icon_emoji'):
             notification['icon_emoji'] = ':%s:' % config['icon_emoji'].strip(':')
         if config.get('icon_url'):


### PR DESCRIPTION
### Motivation for changes:

- Extend existing Slack notification to support [message attachments](https://api.slack.com/docs/message-attachments)  

### Detailed changes:

- modify `flexget/plugins/notifiers/slack.py` and add the additional `attachments` schema.
- send the new attachment field in the notification payload

### Config usage:
Extended from the existing example on the wiki:
```
tasks:
  move-test:
    rss: <redacted>
    imdb_lookup: yes
    imdb:
      min_year: 2016
    notify:
      entries:
        message: >
          {{task}} - Download started:
          {%- if imdb_name is defined %}
          {%- if imdb_url is defined %}
          <{{imdb_url}}|{{imdb_name}} {{imdb_year}}>
          {%- else %}
          {{imdb_name}} {{imdb_year}}
          {%- endif %}
          - {{quality}}
          {%- else -%}
          {{title}}
          {%- endif %}
        via:
          - slack:
              web_hook_url: <redacted>
              attachments:
                - image_url: '{{imdb_photo}}'
                - title: '{{imdb_name}} ({{imdb_year}})'
                  title_link: '{{imdb_url}}'
                  fallback: '{{imdb_name}} {{imdb_year}}'
                  text: '{{imdb_plot_outline}}'
                  color: "#3AA3E3"
                  footer: Flexget download
                  footer_icon: 'https://flexget.com/attachments/LogoContest/PastedGraphic-3.png'
                  fields:
                    - title: Votes
                      value: '{{imdb_votes}}'
                      short: true
                    - title: Score
                      value: '{{imdb_score}}'
                      short: true
                    - title: Genres
                      value: '{{imdb_genres|join(", ")}}'
                      short: true
                    - title: Rating
                      value: '{{imdb_mpaa_rating}}'
                      short: true
                    - title: Actors
                      value: >
                        {% for key, value in imdb_actors.iteritems() %}
                        {{value}}{% if not loop.last %},{% endif %}
                        {% endfor %}
                      short: false
```
###  Output:
A picture of the above config's output in slack:
<img width="597" alt="screen shot 2017-03-04 at 3 48 00 pm" src="https://cloud.githubusercontent.com/assets/327286/23576478/1a32d0a2-00f2-11e7-9750-6c77d5e84393.png">
#### To Do:

- Update the [notifications documentation](https://flexget.com/Plugins/Notifiers/slack) to explain how the attachment field works as well as include some example configuration.
