### PR TITLE
[add] trakt_next_episode - 'aired' context

### DIFF
--- a/flexget/plugins/input/next_trakt_episodes.py
+++ b/flexget/plugins/input/next_trakt_episodes.py
@@ -39,7 +39,7 @@ class NextTraktEpisodes(object):
             'username': {'type': 'string'},
             'account': {'type': 'string'},
             'position': {'type': 'string', 'enum': ['last', 'next'], 'default': 'next'},
-            'context': {'type': 'string', 'enum': ['watched', 'collected'], 'default': 'watched'},
+            'context': {'type': 'string', 'enum': ['watched', 'collected', 'aired'], 'default': 'watched'},
             'list': {'type': 'string'},
             'strip_dates': {'type': 'boolean', 'default': False}
         },
@@ -94,12 +94,22 @@ class NextTraktEpisodes(object):
             context = 'collection'
         entries = []
         for trakt_id, fields in listed_series.items():
-            url = get_api_url('shows', trakt_id, 'progress', context)
+            if context == 'aired':
+                url = get_api_url('shows', trakt_id, '{}_episode'.format(config['position']))
+            else:
+                url = get_api_url('shows', trakt_id, 'progress', context)
             try:
-                data = session.get(url).json()
+                response = session.get(url)
+                if response.status_code == 204:
+                    log.debug('No {} epsisode for {}'.format(config['position'], fields['series_name']))
+                    continue
+                data = response.json()
             except RequestException as e:
                 raise plugin.PluginError('An error has occurred looking up: Trakt_id: %s Error: %s' % (trakt_id, e))
-            if config['position'] == 'next' and data.get('next_episode'):
+            if context == 'aired':
+                eps = data['season']
+                epn = data['number']
+            elif config['position'] == 'next' and data.get('next_episode'):
                 # If the next episode is already in the trakt database, we'll get it here
                 eps = data['next_episode']['season']
                 epn = data['next_episode']['number']

--- a/flexget/plugins/input/next_trakt_episodes.py
+++ b/flexget/plugins/input/next_trakt_episodes.py
@@ -64,13 +64,13 @@ class NextTraktEpisodes(object):
         except RequestException as e:
             raise plugin.PluginError('Unable to get trakt list `%s`: %s' % (config['list'], e))
         if not data:
-            log.warning('The list "%s" is empty.' % config['list'])
+            log.warning('The list "%s" is empty.', config['list'])
             return
         for item in data:
             if item.get('show'):
                 if not item['show']['title']:
                     # Seems we can get entries with a blank show title sometimes
-                    log.warning('Found trakt list show with no series name.')
+                    log.warning('Found trakt list show without series name.')
                     continue
                 trakt_id = item['show']['ids']['trakt']
                 listed_series[trakt_id] = {
@@ -101,7 +101,7 @@ class NextTraktEpisodes(object):
             try:
                 response = session.get(url)
                 if response.status_code == 204:
-                    log.debug('No {} epsisode for {}'.format(config['position'], fields['series_name']))
+                    log.debug('No %s episode for %s', config['position'], fields['series_name'])
                     continue
                 data = response.json()
             except RequestException as e:


### PR DESCRIPTION
### Motivation for changes:
Someone was asking for a way to set begin episode to next airing ep, this would facilitate that.

### Detailed changes:
Adds 'aired' context to next_trakt_episodes. Allows emitting next or last aired eps based on trakt data.

### Config usage if relevant (new plugin or updated schema):
```
trakt_next_episode:
  account: my_account
  list: my series list
  context: aired
```
