### PR TITLE
[change] Extend series list help message. (#1720)

### DIFF
--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -71,7 +71,7 @@ def display_summary(options):
         for index, value in enumerate(header):
             if value.lower() == options.sort_by:
                 header[index] = colorize(SORT_COLUMN_COLOR, value)
-        footer = 'Use `flexget series show NAME` to get detailed information'
+
         table_data = [header]
         for series in query:
             name_column = series.name
@@ -109,7 +109,10 @@ def display_summary(options):
         console('ERROR: %s' % str(e))
         return
     if not porcelain:
-        console(footer)
+        if not query.count():
+            console('Use `flexget series list all` to view all known series.')
+        else:
+            console('Use `flexget series show NAME` to get detailed information.')
 
 
 def begin(manager, options):


### PR DESCRIPTION
### Motivation for changes:
See #1720 

### Detailed changes:

- Added 1 line of helpful text.

### Addressed issues:

- Fixes #1720.

#### To Do:

When 'implementing' this I noticed that most of the CLI plugins don't return anything when no additional CLI arguments are given. For example `flexget series` just returns as does `flexget archive`. `flexget regex` crashes (because it uses a map). That's rather confusing (for me at least).
I believe it would be helpful to print the help page with a leader like 'no option selected'. Would you agree?