### PR TITLE
Extend movie-list Plugin to support DUBBED Movies

### DIFF
--- a/flexget/_version.py
+++ b/flexget/_version.py
@@ -7,4 +7,4 @@ The version should always be set to the <next release version>.dev
 The jenkins release job will automatically strip the .dev for release,
 and update the version again for continued development.
 """
-__version__ = '2.10.19'
+__version__ = '2.10.20.dev'


### PR DESCRIPTION
Extend existing Plugin to support DUBBED Movies from imdb_id, trakt_movie_id and tmdb_id


modify flexget/plugins/list/ and add the ability to handle dubbed movies.

add ISO 3166 that defines codes for the names of countries


Extended from the existing example on the wiki:

flexget movie-list add tmdb_id=127380 will add finding dory 

and add the dubbed movies lets say PL, RU, DE, FR, JP, IT so Maybe adding a new syntax like this

flexget movie-list add tmdb_id=127380 PL will add The Polish synchronized version Gdzie jest Dory
flexget movie-list add tmdb_id=127380 RU will add The Russian synchronized version В поисках Дори 
flexget movie-list add tmdb_id=127380 DE will add The German synchronized version Findet Dorie
flexget movie-list add tmdb_id=127380 FR will add The French synchronized version Le Monde de Dory
flexget movie-list add tmdb_id=127380 JP will add The Japanese synchronized version ファインディング・ドリー
flexget movie-list add tmdb_id=127380 IT will add The Italian synchronized version Alla ricerca di Dory

And so on .....