### PR TITLE
Preparing for no files key when magnetizing

### DIFF
--- a/flexget/plugins/clients/deluge.py
+++ b/flexget/plugins/clients/deluge.py
@@ -741,7 +741,7 @@ class OutputDeluge(DelugePlugin):
                         except Exception as err:
                             log.error('wait_for_metadata Error: %s' % err)
                             break
-                        if len(status['files']) > 0:
+                        if status.get('files'):
                             log.info('"%s" magnetization successful' % (entry['title']))
                             break
                     else:


### PR DESCRIPTION
### Motivation for changes:

- I had torrent adding exceptions when waiting on magnetization. Torrent was actually added, so it's not showstopping, but feature is still defective.

### Detailed changes:

- Will supply default value of `[]` when trying to access `status['files']`, which might not exist.
- Also made line a bit more Pythonic

### Addressed issues:

This is the error I had.
```
2017-03-24 10:23 INFO     deluge        download_tv     REDACTED was not added to deluge! [Failure instance: Traceback: <type 'exceptions.KeyError'>: u'files'\n/usr/lib/python2.7/dist-packages/twisted/internet/defer.py:393:callback\n/usr/lib/python2.7/dist-packages/twisted/internet/defer.py:501:_startRunCallbacks\n/usr/lib/python2.7/dist-packages/twisted/internet/defer.py:588:_runCallbacks\n/usr/lib/python2.7/dist-packages/twisted/internet/defer.py:1184:gotResult\n--- <exception caught here> ---\n/usr/lib/python2.7/dist-packages/twisted/internet/defer.py:1128:_inlineCallbacks\n/srv/seedbox/flexget-venv/local/lib/python2.7/site-packages/flexget/plugins/clients/deluge.py:744:_wait_for_metadata\n]

```
### TODO
Line can also be:
```
if ('files' in status) and len(status['files']):
```
I have no strong opinion in either way.	