### PR TITLE
Change trakt URLs to TLS and plural collections.

### DIFF
--- a/flexget/plugins/input/next_trakt_episodes.py
+++ b/flexget/plugins/input/next_trakt_episodes.py
@@ -144,7 +144,7 @@ class NextTraktEpisodes(object):
         entry['series_id_type'] = 'ep'
         entry['series_id'] = 'S%02dE%02d' % (season, episode)
         entry['title'] = entry['series_name'] + ' ' + entry['series_id']
-        entry['url'] = 'http://trakt.tv/shows/%s/seasons/%s/episodes/%s' % (fields['trakt_id'], season, episode)
+        entry['url'] = 'https://trakt.tv/shows/%s/seasons/%s/episodes/%s' % (fields['trakt_id'], season, episode)
         return entry
 
 

--- a/flexget/plugins/internal/api_trakt.py
+++ b/flexget/plugins/internal/api_trakt.py
@@ -31,7 +31,7 @@ log = logging.getLogger('api_trakt')
 CLIENT_ID = '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af'
 CLIENT_SECRET = 'db4af7531e8df678b134dbc22445a2c04ebdbdd7213be7f5b6d17dfdfabfcdc2'
 API_URL = 'https://api.trakt.tv/'
-PIN_URL = 'http://trakt.tv/pin/346'
+PIN_URL = 'https://trakt.tv/pin/346'
 # Stores the last time we checked for updates for shows/movies
 updated = SimplePersistence('api_trakt')
 

--- a/flexget/plugins/list/trakt_list.py
+++ b/flexget/plugins/list/trakt_list.py
@@ -193,10 +193,10 @@ class TraktSet(MutableSet):
                     continue
                 entry = Entry()
                 if list_type == 'episode':
-                    entry['url'] = 'http://trakt.tv/shows/%s/seasons/%s/episodes/%s' % (
+                    entry['url'] = 'https://trakt.tv/shows/%s/seasons/%s/episodes/%s' % (
                         item['show']['ids']['slug'], item['episode']['season'], item['episode']['number'])
                 else:
-                    entry['url'] = 'http://trakt.tv/%s/%s' % (list_type, item[list_type]['ids'].get('slug'))
+                    entry['url'] = 'https://trakt.tv/%ss/%s' % (list_type, item[list_type]['ids'].get('slug'))
                 entry.update_using_map(field_maps[list_type], item)
                 # Override the title if strip_dates is on. TODO: a better way?
                 if self.config.get('strip_dates'):

--- a/flexget/plugins/metainfo/trakt_lookup.py
+++ b/flexget/plugins/metainfo/trakt_lookup.py
@@ -84,7 +84,7 @@ class PluginTraktLookup(object):
         'trakt_genres': lambda i: [db_genre.name for db_genre in i.genres],
         'trakt_series_network': 'network',
         'imdb_url': lambda series: series.imdb_id and 'http://www.imdb.com/title/%s' % series.imdb_id,
-        'trakt_series_url': lambda series: series.slug and 'http://trakt.tv/shows/%s' % series.slug,
+        'trakt_series_url': lambda series: series.slug and 'https://trakt.tv/shows/%s' % series.slug,
         'trakt_series_country': 'country',
         'trakt_series_status': 'status',
         'trakt_series_overview': 'overview',

--- a/flexget/tests/test_trakt_list_interface.py
+++ b/flexget/tests/test_trakt_list_interface.py
@@ -68,8 +68,8 @@ class TestTraktList(object):
         assert entries == sorted([
             {
                 'trakt_show_slug': 'castle',
-                'original_url': 'http://trakt.tv/shows/castle/seasons/8/episodes/15',
-                'url': 'http://trakt.tv/shows/castle/seasons/8/episodes/15',
+                'original_url': 'https://trakt.tv/shows/castle/seasons/8/episodes/15',
+                'url': 'https://trakt.tv/shows/castle/seasons/8/episodes/15',
                 'series_season': 8,
                 'tvdb_id': 83462,
                 'series_name': 'Castle (2009)',
@@ -86,10 +86,10 @@ class TestTraktList(object):
             },
             {
                 'movie_name': 'Deadpool',
-                'original_url': 'http://trakt.tv/movie/deadpool-2016',
+                'original_url': 'https://trakt.tv/movies/deadpool-2016',
                 'tmdb_id': 293660,
                 'title': 'Deadpool (2016)',
-                'url': 'http://trakt.tv/movie/deadpool-2016',
+                'url': 'https://trakt.tv/movies/deadpool-2016',
                 'trakt_movie_id': 190430,
                 'trakt_movie_name': 'Deadpool',
                 'imdb_id': 'tt1431045',
@@ -101,8 +101,8 @@ class TestTraktList(object):
                 'trakt_show_slug': 'the-walking-dead',
                 'tmdb_id': 1402,
                 'title': 'The Walking Dead (2010)',
-                'url': 'http://trakt.tv/show/the-walking-dead',
-                'original_url': 'http://trakt.tv/show/the-walking-dead',
+                'url': 'https://trakt.tv/shows/the-walking-dead',
+                'original_url': 'https://trakt.tv/shows/the-walking-dead',
                 'series_name': 'The Walking Dead (2010)',
                 'trakt_show_id': 1393,
                 'tvdb_id': 153021,
@@ -140,8 +140,8 @@ class TestTraktList(object):
         trakt_set.clear()
 
         entry = Entry(**{u'trakt_show_slug': u'game-of-thrones',
-                         u'original_url': u'http://trakt.tv/shows/game-of-thrones/seasons/4/episodes/5',
-                         u'url': u'http://trakt.tv/shows/game-of-thrones/seasons/4/episodes/5', u'series_season': 4,
+                         u'original_url': u'https://trakt.tv/shows/game-of-thrones/seasons/4/episodes/5',
+                         u'url': u'https://trakt.tv/shows/game-of-thrones/seasons/4/episodes/5', u'series_season': 4,
                          u'tvdb_id': 121361, u'series_name': u'Game of Thrones (2011)', u'imdb_id': u'tt0944947',
                          u'series_id': u'S04E05', u'series_episode': 5, u'trakt_episode_id': 73674,
                          u'title': u'Game of Thrones (2011) S04E05 First of His Name', u'trakt_show_id': 1390,

--- a/flexget/ui/tests-mock-data/history.js
+++ b/flexget/ui/tests-mock-data/history.js
@@ -23,7 +23,7 @@ var mockHistoryData = (function () {
 					'task': 'FillMovieQueue',
 					'time': '2016-05-24T03:52:01.924238',
 					'title': 'Autumn (2009)',
-					'url': 'http://trakt.tv/movie/autumn-2009'
+					'url': 'https://trakt.tv/movies/autumn-2009'
 				},
 				{
 					'details': 'Accepted by list_accept',
@@ -32,7 +32,7 @@ var mockHistoryData = (function () {
 					'task': 'RemoveCollectedMovies',
 					'time': '2016-05-24T03:00:09.372575',
 					'title': 'The Cell 2 (2009)',
-					'url': 'http://trakt.tv/movie/the-cell-2-2009'
+					'url': 'https://trakt.tv/movies/the-cell-2-2009'
 				}
 			],
 			'pages': 114

--- a/flexget/ui/tests-mock-data/seen.js
+++ b/flexget/ui/tests-mock-data/seen.js
@@ -65,7 +65,7 @@ var mockSeenData = (function () {
 							'field_id': 5586,
 							'field_name': 'url',
 							'seen_entry_id': 2978,
-							'value': 'http://trakt.tv/movie/ice-age-collision-course-2016'
+							'value': 'https://trakt.tv/movies/ice-age-collision-course-2016'
 						}
 					],
 					'id': 2978,
@@ -130,7 +130,7 @@ var mockSeenData = (function () {
 							'field_id': 5581,
 							'field_name': 'url',
 							'seen_entry_id': 2975,
-							'value': 'http://trakt.tv/movie/the-hunger-games-mockingjay-part-2-2015'
+							'value': 'https://trakt.tv/movies/the-hunger-games-mockingjay-part-2-2015'
 						}
 					],
 					'id': 2975,


### PR DESCRIPTION
### Motivation for changes:
The URLs generate by flexget in various places still used http as
protocol. This was changed by Trakt to https some time ago. The commit
reflects that fact.

Several URLs have changed from using `serie` and `movie` in the path to
their plural form. Trakt.tv redirected these singular forms to the
canonical plural form.

### Detailed changes:

In essence this was a search and replace exercise.

### Addressed issues:

None. All the 'wrong' URLs are correctly redirected by Trakt.tv. They might stop doing that at some point.
