### PR TITLE
Enable notify plugin to use entry data when sending notification

### DIFF
--- a/flexget/plugins/notifiers/email.py
+++ b/flexget/plugins/notifiers/email.py
@@ -14,6 +14,7 @@ from flexget import plugin
 from flexget.config_schema import one_or_more
 from flexget.event import event
 from flexget.plugin import PluginWarning
+from flexget.utils.tools import merge_by_prefix
 
 plugin_name = 'email'
 log = logging.getLogger(plugin_name)
@@ -137,7 +138,7 @@ class EmailNotifier(object):
         'additionalProperties': False,
     }
 
-    def notify(self, title, message, config):
+    def notify(self, title, message, config, entry=None):
         """
         Send an email notification
 
@@ -145,6 +146,9 @@ class EmailNotifier(object):
         :param str title: message subject
         :param dict config: email plugin config
         """
+        if entry:
+            prefix = plugin_name + '_'
+            merge_by_prefix(prefix, dict(entry), config)
 
         if not isinstance(config['to'], list):
             config['to'] = [config['to']]

--- a/flexget/plugins/notifiers/email.py
+++ b/flexget/plugins/notifiers/email.py
@@ -147,8 +147,7 @@ class EmailNotifier(object):
         :param dict config: email plugin config
         """
         if entry:
-            prefix = plugin_name + '_'
-            merge_by_prefix(prefix, dict(entry), config)
+            merge_by_prefix(plugin_name + '_', dict(entry), config)
 
         if not isinstance(config['to'], list):
             config['to'] = [config['to']]

--- a/flexget/plugins/notifiers/join.py
+++ b/flexget/plugins/notifiers/join.py
@@ -3,12 +3,14 @@ from builtins import *  # pylint: disable=unused-import, redefined-builtin
 
 import logging
 
+from requests.exceptions import RequestException
+
 from flexget import plugin
+from flexget.config_schema import one_or_more
 from flexget.event import event
 from flexget.plugin import PluginWarning
-from flexget.config_schema import one_or_more
 from flexget.utils.requests import Session as RequestSession, TimedLimiter
-from requests.exceptions import RequestException
+from flexget.utils.tools import merge_by_prefix
 
 plugin_name = 'join'
 log = logging.getLogger(plugin_name)
@@ -54,10 +56,13 @@ class JoinNotifier(object):
         'additionalProperties': False
     }
 
-    def notify(self, title, message, config):
+    def notify(self, title, message, config, entry=None):
         """
         Send Join notifications.
         """
+        if entry:
+            prefix = plugin_name + '_'
+            merge_by_prefix(prefix, dict(entry), config)
         notification = {'title': title, 'text': message, 'url': config.get('url'),
                         'icon': config.get('icon'), 'priority': config.get('priority'), 'apikey': config['api_key']}
         if config.get('device'):

--- a/flexget/plugins/notifiers/join.py
+++ b/flexget/plugins/notifiers/join.py
@@ -61,8 +61,7 @@ class JoinNotifier(object):
         Send Join notifications.
         """
         if entry:
-            prefix = plugin_name + '_'
-            merge_by_prefix(prefix, dict(entry), config)
+            merge_by_prefix(plugin_name + '_', dict(entry), config)
         notification = {'title': title, 'text': message, 'url': config.get('url'),
                         'icon': config.get('icon'), 'priority': config.get('priority'), 'apikey': config['api_key']}
         if config.get('device'):

--- a/flexget/plugins/notifiers/notification_framework.py
+++ b/flexget/plugins/notifiers/notification_framework.py
@@ -78,7 +78,7 @@ def render_config(config, template_renderer, _path=''):
 
 
 class NotificationFramework(object):
-    def send_notification(self, title, message, notifiers, template_renderer=None):
+    def send_notification(self, title, message, notifiers, template_renderer=None, entry=None):
         """
         Send a notification out to the given `notifiers` with a given `title` and `message`.
         If `template_renderer` is specified, `title`, `message`, as well as any string options in a notifier's config
@@ -114,7 +114,7 @@ class NotificationFramework(object):
 
                 log.debug('Sending a notification to `%s`', notifier_name)
                 try:
-                    notifier.notify(title, message, rendered_config)  # TODO: Update notifiers for new api
+                    notifier.notify(title, message, rendered_config, entry)  # TODO: Update notifiers for new api
                 except PluginWarning as e:
                     log.warning('Error while sending notification to `%s`: %s', notifier_name, e.value)
                 else:

--- a/flexget/plugins/notifiers/notify.py
+++ b/flexget/plugins/notifiers/notify.py
@@ -126,7 +126,7 @@ class Notify(object):
                     message = config['entries']['message']
                 for entry in entries:
                     self.send_notification(config['entries']['title'], message, config['entries']['via'],
-                                           template_renderer=entry.render)
+                                           template_renderer=entry.render, entry=entry)
         if 'task' in config:
             if not (task.accepted or task.failed) and not config['task']['always_send']:
                 log.verbose('No accepted or failed entries, not sending a notification.')

--- a/flexget/plugins/notifiers/notifymyandroid.py
+++ b/flexget/plugins/notifiers/notifymyandroid.py
@@ -3,13 +3,15 @@ from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 import logging
 import xml.etree.ElementTree as ET
+
 import requests
+from requests.exceptions import RequestException
 
 from flexget import plugin
 from flexget.config_schema import one_or_more
 from flexget.event import event
 from flexget.plugin import PluginWarning
-from requests.exceptions import RequestException
+from flexget.utils.tools import merge_by_prefix
 
 plugin_name = 'notifymyandroid'
 log = logging.getLogger(plugin_name)
@@ -44,10 +46,13 @@ class NotifyMyAndroidNotifier(object):
         'additionalProperties': False
     }
 
-    def notify(self, title, message, config):
+    def notify(self, title, message, config, entry=None):
         """
         Send a Notifymyandroid notification
         """
+        if entry:
+            prefix = plugin_name + '_'
+            merge_by_prefix(prefix, dict(entry), config)
         notification = {'event': title, 'description': message, 'application': config.get('application'),
                         'priority': config.get('priority'), 'developerkey': config.get('developer_key'),
                         'url': config.get('url')}

--- a/flexget/plugins/notifiers/notifymyandroid.py
+++ b/flexget/plugins/notifiers/notifymyandroid.py
@@ -51,8 +51,7 @@ class NotifyMyAndroidNotifier(object):
         Send a Notifymyandroid notification
         """
         if entry:
-            prefix = plugin_name + '_'
-            merge_by_prefix(prefix, dict(entry), config)
+            merge_by_prefix(plugin_name + '_', dict(entry), config)
         notification = {'event': title, 'description': message, 'application': config.get('application'),
                         'priority': config.get('priority'), 'developerkey': config.get('developer_key'),
                         'url': config.get('url')}

--- a/flexget/plugins/notifiers/prowl.py
+++ b/flexget/plugins/notifiers/prowl.py
@@ -4,12 +4,14 @@ from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 import logging
 import xml.etree.ElementTree as ET
 
+from requests.exceptions import RequestException
+
 from flexget import plugin
 from flexget.config_schema import one_or_more
 from flexget.event import event
 from flexget.plugin import PluginWarning
 from flexget.utils.requests import Session as RequestSession, TimedLimiter
-from requests.exceptions import RequestException
+from flexget.utils.tools import merge_by_prefix
 
 plugin_name = 'prowl'
 log = logging.getLogger(plugin_name)
@@ -41,7 +43,7 @@ class ProwlNotifier(object):
             'application': {'type': 'string', 'default': 'FlexGet'},
             'priority': {'type': 'integer', 'minimum': -2, 'maximum': 2},
             'url': {'type': 'string'},
-            'provider_key':{'type': 'string'}
+            'provider_key': {'type': 'string'}
         },
         'required': ['api_key'],
         'additionalProperties': False
@@ -59,10 +61,8 @@ class ProwlNotifier(object):
         #
 
         if entry:
-            for key in entry:
-                if key.startswith(plugin_name + '_'):
-                    key_name = key[len(plugin_name) + 1:]
-                    config[key_name] = entry[key]
+            prefix = plugin_name + '_'
+            merge_by_prefix(prefix, dict(entry), config)
         notification = {'application': config.get('application'), 'event': title, 'description': message,
                         'url': config.get('url'), 'priority': config.get('priority'),
                         'providerkey': config.get('provider_key')}

--- a/flexget/plugins/notifiers/prowl.py
+++ b/flexget/plugins/notifiers/prowl.py
@@ -61,8 +61,7 @@ class ProwlNotifier(object):
         #
 
         if entry:
-            prefix = plugin_name + '_'
-            merge_by_prefix(prefix, dict(entry), config)
+            merge_by_prefix(plugin_name + '_', dict(entry), config)
         notification = {'application': config.get('application'), 'event': title, 'description': message,
                         'url': config.get('url'), 'priority': config.get('priority'),
                         'providerkey': config.get('provider_key')}

--- a/flexget/plugins/notifiers/prowl.py
+++ b/flexget/plugins/notifiers/prowl.py
@@ -47,10 +47,22 @@ class ProwlNotifier(object):
         'additionalProperties': False
     }
 
-    def notify(self, title, message, config):
+    def notify(self, title, message, config, entry=None):
         """
         Send a Prowl notification
         """
+        # Enables using 'set' plugin to override plugin config, using plugin name and underscore as prefix
+        # Example:
+        #
+        # set:
+        #   pushover_url: http://newurl.com
+        #
+
+        if entry:
+            for key in entry:
+                if key.startswith(plugin_name + '_'):
+                    key_name = key[len(plugin_name) + 1:]
+                    config[key_name] = entry[key]
         notification = {'application': config.get('application'), 'event': title, 'description': message,
                         'url': config.get('url'), 'priority': config.get('priority'),
                         'providerkey': config.get('provider_key')}

--- a/flexget/plugins/notifiers/pushalot.py
+++ b/flexget/plugins/notifiers/pushalot.py
@@ -3,12 +3,14 @@ from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 import logging
 
+from requests.exceptions import RequestException
+
 from flexget import plugin
 from flexget.config_schema import one_or_more
 from flexget.event import event
 from flexget.plugin import PluginWarning
 from flexget.utils.requests import Session as RequestSession, TimedLimiter
-from requests.exceptions import RequestException
+from flexget.utils.tools import merge_by_prefix
 
 plugin_name = 'pushalot'
 log = logging.getLogger(plugin_name)
@@ -50,10 +52,13 @@ class PushalotNotifier(object):
               'required': ['api_key'],
               'additionalProperties': False}
 
-    def notify(self, title, message, config):
+    def notify(self, title, message, config, entry=None):
         """
         Send a Pushalot notification
         """
+        if entry:
+            prefix = plugin_name + '_'
+            merge_by_prefix(prefix, dict(entry), config)
         notification = {'Title': title, 'Body': message, 'LinkTitle': config.get('url_title'),
                         'Link': config.get('url'), 'IsImportant': config.get('important'),
                         'IsSilent': config.get('silent'), 'Image': config.get('image'), 'Source': config.get('source'),

--- a/flexget/plugins/notifiers/pushalot.py
+++ b/flexget/plugins/notifiers/pushalot.py
@@ -57,8 +57,7 @@ class PushalotNotifier(object):
         Send a Pushalot notification
         """
         if entry:
-            prefix = plugin_name + '_'
-            merge_by_prefix(prefix, dict(entry), config)
+            merge_by_prefix(plugin_name + '_', dict(entry), config)
         notification = {'Title': title, 'Body': message, 'LinkTitle': config.get('url_title'),
                         'Link': config.get('url'), 'IsImportant': config.get('important'),
                         'IsSilent': config.get('silent'), 'Image': config.get('image'), 'Source': config.get('source'),

--- a/flexget/plugins/notifiers/pushbullet.py
+++ b/flexget/plugins/notifiers/pushbullet.py
@@ -65,8 +65,7 @@ class PushbulletNotifier(object):
         Send a Pushbullet notification
         """
         if entry:
-            prefix = plugin_name + '_'
-            merge_by_prefix(prefix, dict(entry), config)
+            merge_by_prefix(plugin_name + '_', dict(entry), config)
         if config.get('device') and not isinstance(config['device'], list):
             config['device'] = [config['device']]
 

--- a/flexget/plugins/notifiers/pushbullet.py
+++ b/flexget/plugins/notifiers/pushbullet.py
@@ -1,16 +1,18 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
-import logging
 import base64
 import datetime
+import logging
+
+from requests.exceptions import RequestException
 
 from flexget import plugin
-from flexget.event import event
 from flexget.config_schema import one_or_more
+from flexget.event import event
 from flexget.plugin import PluginWarning
 from flexget.utils.requests import Session as RequestSession, TimedLimiter
-from requests.exceptions import RequestException
+from flexget.utils.tools import merge_by_prefix
 
 plugin_name = 'pushbullet'
 log = logging.getLogger(plugin_name)
@@ -58,10 +60,13 @@ class PushbulletNotifier(object):
         'additionalProperties': False
     }
 
-    def notify(self, title, message, config):
+    def notify(self, title, message, config, entry=None):
         """
         Send a Pushbullet notification
         """
+        if entry:
+            prefix = plugin_name + '_'
+            merge_by_prefix(prefix, dict(entry), config)
         if config.get('device') and not isinstance(config['device'], list):
             config['device'] = [config['device']]
 

--- a/flexget/plugins/notifiers/pushover.py
+++ b/flexget/plugins/notifiers/pushover.py
@@ -11,6 +11,8 @@ from flexget.plugin import PluginWarning
 from flexget.utils.requests import Session as RequestSession, TimedLimiter
 from requests.exceptions import RequestException
 
+from flexget.utils.tools import merge_dict_from_to
+
 plugin_name = 'pushover'
 log = logging.getLogger(plugin_name)
 
@@ -61,7 +63,7 @@ class PushoverNotifier(object):
         'additionalProperties': False
     }
 
-    def notify(self, title, message, config):
+    def notify(self, title, message, config, entry=None):
         """
         Sends a Pushover notification
 
@@ -69,6 +71,8 @@ class PushoverNotifier(object):
         :param str message: the message to send
         :param dict config: The pushover config
         """
+        if entry:
+            merge_dict_from_to(dict(entry), config, override=True)
         notification = {'token': config.get('api_key'), 'message': message, 'title': title,
                         'device': config.get('device'), 'priority': config.get('priority'), 'url': config.get('url'),
                         'url_title': config.get('url_title'), 'sound': config.get('sound'),

--- a/flexget/plugins/notifiers/pushover.py
+++ b/flexget/plugins/notifiers/pushover.py
@@ -81,8 +81,7 @@ class PushoverNotifier(object):
         #
 
         if entry:
-            prefix = plugin_name + '_'
-            merge_by_prefix(prefix, dict(entry), config)
+            merge_by_prefix(plugin_name + '_', dict(entry), config)
         notification = {'token': config.get('api_key'), 'message': message, 'title': title,
                         'device': config.get('device'), 'priority': config.get('priority'), 'url': config.get('url'),
                         'url_title': config.get('url_title'), 'sound': config.get('sound'),

--- a/flexget/plugins/notifiers/pushover.py
+++ b/flexget/plugins/notifiers/pushover.py
@@ -8,10 +8,9 @@ from flexget import plugin
 from flexget.config_schema import one_or_more
 from flexget.event import event
 from flexget.plugin import PluginWarning
+from flexget.utils.tools import merge_dict_from_to
 from flexget.utils.requests import Session as RequestSession, TimedLimiter
 from requests.exceptions import RequestException
-
-from flexget.utils.tools import merge_dict_from_to
 
 plugin_name = 'pushover'
 log = logging.getLogger(plugin_name)

--- a/flexget/plugins/notifiers/pushover.py
+++ b/flexget/plugins/notifiers/pushover.py
@@ -8,7 +8,6 @@ from flexget import plugin
 from flexget.config_schema import one_or_more
 from flexget.event import event
 from flexget.plugin import PluginWarning
-from flexget.utils.tools import merge_dict_from_to
 from flexget.utils.requests import Session as RequestSession, TimedLimiter
 from requests.exceptions import RequestException
 
@@ -69,9 +68,21 @@ class PushoverNotifier(object):
         :param str title: the message's title
         :param str message: the message to send
         :param dict config: The pushover config
+        :param Entry: Passed entry. Can be used to override config
         """
+
+        # Enables using 'set' plugin to override plugin config, using plugin name and underscore as prefix
+        # Example:
+        #
+        # set:
+        #   pushover_url: http://newurl.com
+        #
+
         if entry:
-            merge_dict_from_to(dict(entry), config, override=True)
+            for key in entry:
+                if key.startswith(plugin_name + '_'):
+                    key_name = key[len(plugin_name) + 1:]
+                    config[key_name] = entry[key]
         notification = {'token': config.get('api_key'), 'message': message, 'title': title,
                         'device': config.get('device'), 'priority': config.get('priority'), 'url': config.get('url'),
                         'url_title': config.get('url_title'), 'sound': config.get('sound'),

--- a/flexget/plugins/notifiers/pushover.py
+++ b/flexget/plugins/notifiers/pushover.py
@@ -4,12 +4,14 @@ from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 import datetime
 import logging
 
+from requests.exceptions import RequestException
+
 from flexget import plugin
 from flexget.config_schema import one_or_more
 from flexget.event import event
 from flexget.plugin import PluginWarning
 from flexget.utils.requests import Session as RequestSession, TimedLimiter
-from requests.exceptions import RequestException
+from flexget.utils.tools import merge_by_prefix
 
 plugin_name = 'pushover'
 log = logging.getLogger(plugin_name)
@@ -79,10 +81,8 @@ class PushoverNotifier(object):
         #
 
         if entry:
-            for key in entry:
-                if key.startswith(plugin_name + '_'):
-                    key_name = key[len(plugin_name) + 1:]
-                    config[key_name] = entry[key]
+            prefix = plugin_name + '_'
+            merge_by_prefix(prefix, dict(entry), config)
         notification = {'token': config.get('api_key'), 'message': message, 'title': title,
                         'device': config.get('device'), 'priority': config.get('priority'), 'url': config.get('url'),
                         'url_title': config.get('url_title'), 'sound': config.get('sound'),

--- a/flexget/plugins/notifiers/pushsafer.py
+++ b/flexget/plugins/notifiers/pushsafer.py
@@ -1,14 +1,15 @@
 from __future__ import unicode_literals, division, absolute_import
-from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 import logging
+
+from requests.exceptions import RequestException
 
 from flexget import plugin
 from flexget.config_schema import one_or_more
 from flexget.event import event
 from flexget.plugin import PluginWarning
 from flexget.utils.requests import Session as RequestSession, TimedLimiter
-from requests.exceptions import RequestException
+from flexget.utils.tools import merge_by_prefix
 
 plugin_name = 'pushsafer'
 log = logging.getLogger(plugin_name)
@@ -50,10 +51,13 @@ class PushsaferNotifier(object):
               'required': ['private_key'],
               'additionalProperties': False}
 
-    def notify(self, title, message, config):
+    def notify(self, title, message, config, entry=None):
         """
         Send a Pushsafer notification
         """
+        if entry:
+            prefix = plugin_name + '_'
+            merge_by_prefix(prefix, dict(entry), config)
         notification = {'t': title, 'm': message, 'ut': config.get('url_title'),
                         'u': config.get('url'), 's': config.get('sound'),
                         'i': config.get('icon'), 'v': config.get('vibration'),

--- a/flexget/plugins/notifiers/pushsafer.py
+++ b/flexget/plugins/notifiers/pushsafer.py
@@ -56,8 +56,7 @@ class PushsaferNotifier(object):
         Send a Pushsafer notification
         """
         if entry:
-            prefix = plugin_name + '_'
-            merge_by_prefix(prefix, dict(entry), config)
+            merge_by_prefix(plugin_name + '_', dict(entry), config)
         notification = {'t': title, 'm': message, 'ut': config.get('url_title'),
                         'u': config.get('url'), 's': config.get('sound'),
                         'i': config.get('icon'), 'v': config.get('vibration'),

--- a/flexget/plugins/notifiers/rapidpush.py
+++ b/flexget/plugins/notifiers/rapidpush.py
@@ -58,8 +58,7 @@ class RapidpushNotifier(object):
         Send a Rapidpush notification
         """
         if entry:
-            prefix = plugin_name + '_'
-            merge_by_prefix(prefix, dict(entry), config)
+            merge_by_prefix(plugin_name + '_', dict(entry), config)
         notification = {'title': title, 'message': message}
         if not isinstance(config['api_key'], list):
             config['api_key'] = [config['api_key']]

--- a/flexget/plugins/notifiers/rapidpush.py
+++ b/flexget/plugins/notifiers/rapidpush.py
@@ -1,15 +1,17 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
-import logging
 import json
+import logging
+
+from requests.exceptions import RequestException
 
 from flexget import plugin
-from flexget.event import event
 from flexget.config_schema import one_or_more
+from flexget.event import event
 from flexget.plugin import PluginWarning
 from flexget.utils.requests import Session as RequestSession, TimedLimiter
-from requests.exceptions import RequestException
+from flexget.utils.tools import merge_by_prefix
 
 plugin_name = 'rapidpush'
 log = logging.getLogger(plugin_name)
@@ -51,10 +53,13 @@ class RapidpushNotifier(object):
         'error_not': 'Cannot use \'channel\' with \'group\', \'category\' or \'priority\''
     }
 
-    def notify(self, title, message, config):
+    def notify(self, title, message, config, entry=None):
         """
         Send a Rapidpush notification
         """
+        if entry:
+            prefix = plugin_name + '_'
+            merge_by_prefix(prefix, dict(entry), config)
         notification = {'title': title, 'message': message}
         if not isinstance(config['api_key'], list):
             config['api_key'] = [config['api_key']]

--- a/flexget/plugins/notifiers/slack.py
+++ b/flexget/plugins/notifiers/slack.py
@@ -52,8 +52,7 @@ class SlackNotifier(object):
         Send a Slack notification
         """
         if entry:
-            prefix = plugin_name + '_'
-            merge_by_prefix(prefix, dict(entry), config)
+            merge_by_prefix(plugin_name + '_', dict(entry), config)
         notification = {'text': message, 'channel': config.get('channel'), 'username': config.get('username')}
         if config.get('icon_emoji'):
             notification['icon_emoji'] = ':%s:' % config['icon_emoji'].strip(':')

--- a/flexget/plugins/notifiers/slack.py
+++ b/flexget/plugins/notifiers/slack.py
@@ -3,11 +3,13 @@ from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 import logging
 
+from requests.exceptions import RequestException
+
 from flexget import plugin
 from flexget.event import event
 from flexget.plugin import PluginWarning
-from requests.exceptions import RequestException
 from flexget.utils.requests import Session as RequestSession
+from flexget.utils.tools import merge_by_prefix
 
 requests = RequestSession(max_retries=3)
 
@@ -45,10 +47,13 @@ class SlackNotifier(object):
         'additionalProperties': False
     }
 
-    def notify(self, title, message, config):
+    def notify(self, title, message, config, entry=None):
         """
         Send a Slack notification
         """
+        if entry:
+            prefix = plugin_name + '_'
+            merge_by_prefix(prefix, dict(entry), config)
         notification = {'text': message, 'channel': config.get('channel'), 'username': config.get('username')}
         if config.get('icon_emoji'):
             notification['icon_emoji'] = ':%s:' % config['icon_emoji'].strip(':')

--- a/flexget/plugins/notifiers/sms_ru.py
+++ b/flexget/plugins/notifiers/sms_ru.py
@@ -49,8 +49,7 @@ class SMSRuNotifier(object):
         Send an SMS RU notification
         """
         if entry:
-            prefix = plugin_name + '_'
-            merge_by_prefix(prefix, dict(entry), config)
+            merge_by_prefix(plugin_name + '_', dict(entry), config)
         try:
             token_response = requests.get(SMS_TOKEN_URL)
         except RequestException as e:

--- a/flexget/plugins/notifiers/sms_ru.py
+++ b/flexget/plugins/notifiers/sms_ru.py
@@ -1,14 +1,16 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
-import logging
 import hashlib
+import logging
+
+from requests.exceptions import RequestException
 
 from flexget import plugin
 from flexget.event import event
 from flexget.plugin import PluginWarning
 from flexget.utils.requests import Session as RequestSession, TimedLimiter
-from requests.exceptions import RequestException
+from flexget.utils.tools import merge_by_prefix
 
 plugin_name = 'sms_ru'
 log = logging.getLogger(plugin_name)
@@ -42,10 +44,13 @@ class SMSRuNotifier(object):
         'required': ['phone_number', 'password']
     }
 
-    def notify(self, title, message, config):
+    def notify(self, title, message, config, entry=None):
         """
         Send an SMS RU notification
         """
+        if entry:
+            prefix = plugin_name + '_'
+            merge_by_prefix(prefix, dict(entry), config)
         try:
             token_response = requests.get(SMS_TOKEN_URL)
         except RequestException as e:

--- a/flexget/plugins/notifiers/telegram.py
+++ b/flexget/plugins/notifiers/telegram.py
@@ -175,8 +175,7 @@ class TelegramNotifier(object):
         Send a Telegram notification
         """
         if entry:
-            prefix = _PLUGIN_NAME + '_'
-            merge_by_prefix(prefix, dict(entry), config)
+            merge_by_prefix(_PLUGIN_NAME + '_', dict(entry), config)
         chat_ids = self._real_init(Session(), config)
 
         if not chat_ids:

--- a/flexget/plugins/notifiers/telegram.py
+++ b/flexget/plugins/notifiers/telegram.py
@@ -10,6 +10,7 @@ from flexget import db_schema, plugin
 from flexget.event import event
 from flexget.manager import Session
 from flexget.plugin import PluginWarning, PluginError
+from flexget.utils.tools import merge_by_prefix
 
 try:
     import telegram
@@ -169,10 +170,13 @@ class TelegramNotifier(object):
         'additionalProperties': False,
     }
 
-    def notify(self, title, message, config):
+    def notify(self, title, message, config, entry=None):
         """
         Send a Telegram notification
         """
+        if entry:
+            prefix = _PLUGIN_NAME + '_'
+            merge_by_prefix(prefix, dict(entry), config)
         chat_ids = self._real_init(Session(), config)
 
         if not chat_ids:

--- a/flexget/plugins/notifiers/toast.py
+++ b/flexget/plugins/notifiers/toast.py
@@ -1,11 +1,13 @@
 from __future__ import unicode_literals, division, absolute_import
+
 import logging
-import sys
 import os
+import sys
 
 from flexget import plugin
 from flexget.event import event
 from flexget.plugin import PluginWarning, DependencyError
+from flexget.utils.tools import merge_by_prefix
 
 plugin_name = 'toast'
 
@@ -37,7 +39,10 @@ class NotifyToast(object):
         config.setdefault('url', '')
         return config
 
-    def mac_notify(self, title, message, config):
+    def mac_notify(self, title, message, config, entry=None):
+        if entry:
+            prefix = plugin_name + '_'
+            merge_by_prefix(prefix, dict(entry), config)
         config = self.prepare_config(config)
         try:
             from pync import Notifier
@@ -58,7 +63,10 @@ class NotifyToast(object):
         except Exception as e:
             raise PluginWarning('Cannot send a notification: %s' % e)
 
-    def linux_notify(self, title, message, config):
+    def linux_notify(self, title, message, config, entry=None):
+        if entry:
+            prefix = plugin_name + '_'
+            merge_by_prefix(prefix, dict(entry), config)
         config = self.prepare_config(config)
         try:
             from gi.repository import Notify
@@ -76,7 +84,10 @@ class NotifyToast(object):
         if not n.show():
             raise PluginWarning('Unable to send notification for %s' % title)
 
-    def windows_notify(self, title, message, config):
+    def windows_notify(self, title, message, config, entry=None):
+        if entry:
+            prefix = plugin_name + '_'
+            merge_by_prefix(prefix, dict(entry), config)
         config = self.prepare_config(config)
         try:
             from win32api import GetModuleHandle, PostQuitMessage
@@ -87,7 +98,7 @@ class NotifyToast(object):
                                   UpdateWindow, WNDCLASS)
         except ImportError:
             raise DependencyError(plugin_name, 'pypiwin32', 'pywin32 module is required for desktop notifications on '
-                                                         'windows. You can install it with `pip install pypiwin32`')
+                                                            'windows. You can install it with `pip install pypiwin32`')
 
         # Register the window class.
         wc = WNDCLASS()

--- a/flexget/plugins/notifiers/toast.py
+++ b/flexget/plugins/notifiers/toast.py
@@ -41,8 +41,7 @@ class NotifyToast(object):
 
     def mac_notify(self, title, message, config, entry=None):
         if entry:
-            prefix = plugin_name + '_'
-            merge_by_prefix(prefix, dict(entry), config)
+            merge_by_prefix(plugin_name + '_', dict(entry), config)
         config = self.prepare_config(config)
         try:
             from pync import Notifier
@@ -65,8 +64,7 @@ class NotifyToast(object):
 
     def linux_notify(self, title, message, config, entry=None):
         if entry:
-            prefix = plugin_name + '_'
-            merge_by_prefix(prefix, dict(entry), config)
+            merge_by_prefix(plugin_name + '_', dict(entry), config)
         config = self.prepare_config(config)
         try:
             from gi.repository import Notify
@@ -86,8 +84,7 @@ class NotifyToast(object):
 
     def windows_notify(self, title, message, config, entry=None):
         if entry:
-            prefix = plugin_name + '_'
-            merge_by_prefix(prefix, dict(entry), config)
+            merge_by_prefix(plugin_name + '_', dict(entry), config)
         config = self.prepare_config(config)
         try:
             from win32api import GetModuleHandle, PostQuitMessage

--- a/flexget/plugins/notifiers/xmpp.py
+++ b/flexget/plugins/notifiers/xmpp.py
@@ -7,6 +7,7 @@ from flexget import plugin
 from flexget.event import event
 from flexget.config_schema import one_or_more
 from flexget.plugin import DependencyError, PluginWarning
+from flexget.utils.tools import merge_by_prefix
 
 plugin_name = 'xmpp'
 
@@ -27,7 +28,10 @@ class XMPPNotifier(object):
 
     __version__ = '1.0'
 
-    def notify(self, title, message, config):
+    def notify(self, title, message, config, entry=None):
+        if entry:
+            prefix = plugin_name + '_'
+            merge_by_prefix(prefix, dict(entry), config)
         try:
             import sleekxmpp  # noqa
         except ImportError as e:

--- a/flexget/plugins/notifiers/xmpp.py
+++ b/flexget/plugins/notifiers/xmpp.py
@@ -30,8 +30,7 @@ class XMPPNotifier(object):
 
     def notify(self, title, message, config, entry=None):
         if entry:
-            prefix = plugin_name + '_'
-            merge_by_prefix(prefix, dict(entry), config)
+            merge_by_prefix(plugin_name + '_', dict(entry), config)
         try:
             import sleekxmpp  # noqa
         except ImportError as e:

--- a/flexget/tests/notifiers/conftest.py
+++ b/flexget/tests/notifiers/conftest.py
@@ -1,11 +1,13 @@
 from __future__ import unicode_literals, division, absolute_import
-from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 import pytest
 
 from flexget import plugin
 from flexget.event import event
 from flexget.plugin import get_plugin_by_name
+from flexget.utils.tools import merge_by_prefix
+
+plugin_name = 'debug_notification'
 
 
 class DebugNotification(object):
@@ -15,15 +17,17 @@ class DebugNotification(object):
         self.notifications = []
 
     def notify(self, title, message, config, entry=None):
+        if entry:
+            merge_by_prefix(plugin_name + '_', dict(entry), config)
         self.notifications.append((title, message, config))
 
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(DebugNotification, 'debug_notification', interfaces=['notifiers'], api_ver=2, debug=True)
+    plugin.register(DebugNotification, plugin_name, interfaces=['notifiers'], api_ver=2, debug=True)
 
 
 @pytest.fixture()
 def debug_notifications(manager):
-    notifications = get_plugin_by_name('debug_notification').instance.notifications = []
+    notifications = get_plugin_by_name(plugin_name).instance.notifications = []
     return notifications

--- a/flexget/tests/notifiers/conftest.py
+++ b/flexget/tests/notifiers/conftest.py
@@ -14,7 +14,7 @@ class DebugNotification(object):
     def __init__(self):
         self.notifications = []
 
-    def notify(self, title, message, config):
+    def notify(self, title, message, config, entry=None):
         self.notifications.append((title, message, config))
 
 

--- a/flexget/tests/notifiers/test_notify_entry.py
+++ b/flexget/tests/notifiers/test_notify_entry.py
@@ -1,8 +1,6 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
-import mock
-
 
 class TestNotifyEntry(object):
     config = """
@@ -19,12 +17,33 @@ class TestNotifyEntry(object):
                 via:
                   - debug_notification:
                       api_key: apikey
+          test_set_override:
+            mock:
+            - title: foo
+              url: http://bla.com
+            accept_all: yes
+            set:
+              debug_notification_url: http://changed.com
+            notify:
+              entries:
+                title: "{{title}}"
+                message: "{{url}}"
+                via:
+                  - debug_notification:
+                      api_key: apikey
         """
 
     def test_basic_notify(self, debug_notifications, execute_task):
         expected = [('foo', 'http://bla.com', {'api_key': 'apikey'}),
                     ('bar', 'http://bla2.com', {'api_key': 'apikey'})]
         task = execute_task('test_basic_notify')
+
+        assert len(task.accepted) == 2
+        assert debug_notifications == expected
+
+    def test_set_override_notify(self, debug_notifications, execute_task):
+        expected = [('foo', 'http://changed.com', {'api_key': 'apikey'})]
+        task = execute_task('test_set_override')
 
         assert len(task.accepted) == 2
         assert debug_notifications == expected

--- a/flexget/tests/notifiers/test_notify_entry.py
+++ b/flexget/tests/notifiers/test_notify_entry.py
@@ -45,5 +45,5 @@ class TestNotifyEntry(object):
         expected = [('foo', 'http://changed.com', {'api_key': 'apikey'})]
         task = execute_task('test_set_override')
 
-        assert len(task.accepted) == 2
+        assert len(task.accepted) == 1
         assert debug_notifications == expected

--- a/flexget/tests/notifiers/test_pushover.py
+++ b/flexget/tests/notifiers/test_pushover.py
@@ -1,10 +1,7 @@
 from __future__ import unicode_literals, division, absolute_import
 
-from time import sleep
-
-from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
-
 import pytest
+
 from flexget.plugin import PluginWarning
 from flexget.plugins.notifiers.pushover import PushoverNotifier
 

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -151,7 +151,7 @@ def _xmlcharref_encode(unicode_data, encoding):
     return ''.join(chars)
 
 
-def merge_dict_from_to(d1, d2):
+def merge_dict_from_to(d1, d2, override=False):
     """Merges dictionary d1 into dictionary d2. d1 will remain in original form."""
     for k, v in list(d1.items()):
         if k in d2:
@@ -161,7 +161,10 @@ def merge_dict_from_to(d1, d2):
                 elif isinstance(v, list):
                     d2[k].extend(copy.deepcopy(v))
                 elif isinstance(v, (basestring, bool, int, float, type(None))):
-                    pass
+                    if not override:
+                        pass
+                    else:
+                        d2[k] = copy.deepcopy(v)
                 else:
                     raise Exception('Unknown type: %s value: %s in dictionary' % (type(v), repr(v)))
             elif (isinstance(v, (basestring, bool, int, float, type(None))) and

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -178,6 +178,24 @@ def merge_dict_from_to(d1, d2, override=False):
             d2[k] = copy.deepcopy(v)
 
 
+def merge_by_prefix(prefix, dict1, dict2, override=True):
+    """
+    Merges keys from dict1 into dict2 if prefix match.
+
+    :param prefix: Prefix to validate
+    :param dict1: Base dict
+    :param dict2: Target dict
+    :param override: Flag to indicate if to force a copy of field exist in both dict
+    """
+    for key in dict1:
+        if key.startswith(prefix):
+            key_name = key[len(prefix):]
+            if override:
+                dict2[key_name] = dict1[key]
+            else:
+                dict2.setdefault(key_name, dict1[key])
+
+
 class SmartRedirectHandler(request.HTTPRedirectHandler):
     def http_error_301(self, req, fp, code, msg, headers):
         result = request.HTTPRedirectHandler.http_error_301(self, req, fp, code, msg, headers)


### PR DESCRIPTION
### Motivation for changes:

Default behavior used to be so that entry data takes precedence as a rule of thumb. That ability was lost in a recent refactor, this PR brings it back.

### Detailed changes:

- Going over entry fields and trying to match `plugin_name_` as a key prefix
- This will be applied only when using `entries` scope notifications.
- Updated `pushover` plugin to use this.

### Usage:
```yaml
tasks:
  not_task:
    set:
      pushover_url: http://new.url.com
    mock:
    - title: bla
    accept_all: yes
    notify:
      entries:
        via:
        - pushover:
             api_key: token
             url: http://old.url.com
```

### Addressed issues:

- Fixes #1767

