### PR TITLE
[added] btn - Search by season when the entry is a season pack

### DIFF
--- a/flexget/plugins/sites/btn.py
+++ b/flexget/plugins/sites/btn.py
@@ -27,14 +27,19 @@ class SearchBTN(object):
         searches = entry.get('search_strings', [entry['title']])
 
         if 'series_name' in entry:
-            search = {'category': 'Episode'}
+            if entry.get('season_pack_lookup', False):
+                search = {'category': 'Season'}
+            else:
+                search = {'category': 'Episode'}
             if 'tvdb_id' in entry:
                 search['tvdb'] = entry['tvdb_id']
             elif 'tvrage_id' in entry:
                 search['tvrage'] = entry['tvrage_id']
             else:
                 search['series'] = entry['series_name']
-            if 'series_id' in entry:
+            if entry.get('season_pack_lookup', False) and 'series_season' in entry:
+                search['name'] = 'Season %s' % entry['series_season']
+            elif 'series_id' in entry:
                 # BTN wants an ep style identifier even for sequence shows
                 if entry.get('series_id_type') == 'sequence':
                     search['name'] = 'S01E%02d' % entry['series_id']


### PR DESCRIPTION
### Motivation for changes:
The recent addition of season pack support to Flexget allows discovering by season, but the BTN search plugin is currently hardcoded to search for episodes. This change enables searching by season pack when appropriate.

### Detailed changes:
- Search in category "Season" when ``season_pack_lookup`` is in the entry (based on entries created by [new_series_seasons.py](https://github.com/Flexget/Flexget/blob/develop/flexget/plugins/input/next_series_seasons.py#L55))
- When the above is true, search for "Season X", which is BTN's required titling for season packs

### Config usage if relevant (new plugin or updated schema):
No change to config.

### Log and/or tests output (preferably both):
```
2017-04-06 19:56 DEBUG    utils.requests catchup_btn_search_seasons Fetching URL https://api.broadcasthe.net/ with args () and kwargs {'headers': {u'Content-type': u'application/json'}, 'json': None, 'data': '{"params": ["api-key", {"category": "Season", "series": "My Show", "name": "Season 1"}], "method": "getTorrents", "id": 1}', u'timeout': 30}
```
(There obviously is more log than this, but since it's used with the discover plugin, the rest of it isn't from the BTN plugin itself.)