### PR TITLE
[fix] api - Accept OPTIONS requests without authentication to satisfy preflight browser cross-origin requests

### DIFF
--- a/flexget/api/core/authentication.py
+++ b/flexget/api/core/authentication.py
@@ -58,7 +58,8 @@ def load_user(username, session=None):
 def check_valid_login():
     # Allow access to root, login and swagger documentation without authentication
     if request.path == '/' or request.path.startswith('/auth/login') or \
-            request.path.startswith('/auth/logout') or request.path.startswith('/swagger'):
+            request.path.startswith('/auth/logout') or request.path.startswith('/swagger') or \
+            request.method == 'OPTIONS':
         return
 
     if not current_user.is_authenticated:


### PR DESCRIPTION
### Motivation for changes:
When sending cross-origin requests to the Flexget API server initiated via JavaScript, clients (web browsers) follow the [W3C Recommendation CORS section 7.1.5](https://www.w3.org/TR/cors/#cross-origin-request-with-preflight-0) and do preflight checks “to ensure that the resource is aware of this specification”. User credentials must be excluded from the request.

These requests are sent via the OPTIONS method. Currently, because of the lack of authentication details in the request, Flexget responds with status code 401 (unauthorized), causing the preflight request to fail in the browser, and therefore the subsequent request with authentication information is never sent. This prevents all endpoints except /auth/login/ and /auth/logout/ from being accessible via JavaScript, _even after successfully logging in or when sending an Authorization Token header_. This change resolves that by allowing all OPTIONS requests without authentication, regardless of endpoint.

I will state this is after a day of trying to figure this out, having never even heard of the CORS spec and preflight OPTIONS requests before yesterday, so this may not be the best way to go about this. I just know it resolves the issue and allows cross-origin requests to the API to succeed in my testing, whereas they failed every time previously (again except the /auth/ endpoints).

### Detailed changes:
- Responds to requests sent via method OPTIONS without requiring user authentication

### Config usage if relevant (new plugin or updated schema):
n/a