### PR TITLE
[fix] api - Send Access-Control-Expose-Headers for pagination and ETag headers

### DIFF
--- a/flexget/api/app.py
+++ b/flexget/api/app.py
@@ -233,7 +233,7 @@ api_app.config['DEBUG'] = True
 api_app.config['ERROR_404_HELP'] = False
 api_app.url_map.strict_slashes = False
 
-CORS(api_app)
+CORS(api_app, expose_headers='Link, Total-Count, Count, ETag')
 Compress(api_app)
 
 api = API(


### PR DESCRIPTION
### Motivation for changes:
Outside of the [six "simple response headers"](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers), most headers returned by a cross-origin ``XMLHttpRequest`` are not available to JavaScript in browsers. In order to programmatically use in JavaScript the pagination and ETag headers returned by the Flexget API, the ``Access-Control-Expose-Headers`` header must be sent to the browser.

### Detailed changes:
Implements the Flask-CORS [``expose_headers`` option](http://flask-cors.readthedocs.io/en/latest/api.html#flask_cors.CORS) with the four additional headers Flexget sends (Link, Total-Count, Count, ETag). This causes the ``Access-Control-Expose-Headers`` header to be sent. This option should be updated if Flexget sends additional headers in the future. _Note the the presence of the header name here does not mean that it will be sent with every request, simply that it's possible it will be and if it is present, it should be considered safe to use._

### Log and/or tests output (preferably both):
**Example JavaScript function:**
```
var request = new XMLHttpRequest();
request.open('GET', 'http://localhost:5050/api/entry_list/1/entries/');
request.setRequestHeader('Authorization', 'Token ABCDEFGHIJKLMNOPQRSTUVWXYZ');
request.onreadystatechange = function () {
    if (this.readyState === 4) {
        if (this.status == '200') {
            console.log('Total-Count:', this.getResponseHeader('Total-Count'));
            console.log('ETag:', this.getResponseHeader('ETag'));
        }
    }
}
request.send();
```

**Chrome console output**
_Before changes_
```
Refused to get unsafe header "Total-Count"
Total-Count: null
Refused to get unsafe header "ETag"
ETag: null
```

_After changes_
```
Total-Count: 37
ETag: 1cf974de95c7c24879f9de9b6877945c
```