### PR TITLE
add utcnow to if conditional evaluation

### DIFF
--- a/flexget/plugins/filter/if_condition.py
+++ b/flexget/plugins/filter/if_condition.py
@@ -42,6 +42,7 @@ class FilterIf(object):
         eval_locals = copy(entry)
         eval_locals.update({'has_field': lambda f: f in entry,
                             'timedelta': datetime.timedelta,
+                            'utcnow': datetime.datetime.utcnow(),
                             'now': datetime.datetime.now()})
         try:
             # Restrict eval namespace to have no globals and locals only from eval_locals


### PR DESCRIPTION
The "now()" function in Python is relative to your local timezone,
whereas the pubdate for most RSS feeds, and possibly many other sources
of input, are specified as UTC. So when comparing dates, similar to what
is shown in the documentation, it's a lot easier to use utcnow instead
of now.

### Motivation for changes:

This allows you to be able to compare dates in a like manner without having to do timezone offset tracking yourself when using the if plugin. While the current implementation of the "if" plugin already handles comparing local timezones with the "now" keyword. Adding the "utcnow" keyword would allow comparing UTC timezones.

### Detailed changes:

- add utcnow keyword to the list of keywords the if plugin understands

### Config usage if relevant (new plugin or updated schema):
```
    if:
      - rss_pubdate > utcnow - timedelta(hours=1): reject
```
### Log and/or tests output (preferably both):

I've tested this locally by making the change, installing it, and running it against the above configuration and it works correctly.

