### PR TITLE
[change] next_series_* - Emit following season if latest download is a season pack

### DIFF
--- a/flexget/plugins/input/next_series_episodes.py
+++ b/flexget/plugins/input/next_series_episodes.py
@@ -110,12 +110,14 @@ class NextSeriesEpisodes(object):
                     continue
 
                 low_season = 0 if series.identified_by == 'ep' else -1
+                latest_season_inc = False
 
                 check_downloaded = not config.get('backfill')
                 latest_season = get_latest_release(series, downloaded=check_downloaded)
                 if latest_season:
                     latest_season = latest_season.season + 1 if latest_season.season in series.completed_seasons \
                         else latest_season.season
+                    latest_season_inc = True
                 else:
                     latest_season = low_season + 1
 
@@ -161,6 +163,8 @@ class NextSeriesEpisodes(object):
                         # If we have already downloaded the latest known episode, try the next episode
                         if latest_ep_this_season.releases:
                             entries.append(self.search_entry(series, season, latest_ep_this_season.number + 1, task))
+                    elif latest_season_inc and season == latest_season:
+                        entries.append(self.search_entry(series, season, 1, task))
                     else:
                         if config.get('from_start') or config.get('backfill'):
                             entries.append(self.search_entry(series, season, 1, task))

--- a/flexget/plugins/input/next_series_seasons.py
+++ b/flexget/plugins/input/next_series_seasons.py
@@ -97,12 +97,14 @@ class NextSeriesSeasons(object):
                     continue
 
                 low_season = 0
+                latest_season_inc = False
 
                 check_downloaded = not config.get('backfill')
                 latest_season = get_latest_release(series, downloaded=check_downloaded)
                 if latest_season:
                     latest_season = latest_season.season + 1 if latest_season.season in series.completed_seasons \
                         else latest_season.season
+                    latest_season_inc = True
                 else:
                     latest_season = low_season + 1
 
@@ -120,9 +122,11 @@ class NextSeriesSeasons(object):
                         entries.append(self.search_entry(series, lookup_season, task))
                     elif latest:
                         entries.append(self.search_entry(series, latest.season, task))
+                    elif latest_season_inc and season == latest_season:
+                        entries.append(self.search_entry(series, season, task))
                     else:
                         if config.get('from_start') or config.get('backfill'):
-                            entries.append(self.search_entry(series, season, 1, task))
+                            entries.append(self.search_entry(series, season, task))
                         else:
                             log.verbose('Series `%s` has no history. Set begin option, '
                                         'or use CLI `series begin` '

--- a/flexget/tests/test_discover.py
+++ b/flexget/tests/test_discover.py
@@ -206,6 +206,18 @@ class TestEmitSeriesInDiscover(object):
                 identified_by: ep
                 season_packs: yes
             max_reruns: 0          
+          test_next_series_seasons_no_begin:
+            discover:
+              release_estimations: ignore
+              what:
+              - next_series_seasons: yes
+              from:
+              - test_search: yes
+            series:
+            - My Show 2:
+                identified_by: ep
+                season_packs: yes
+            max_reruns: 0          
     """
 
     def test_next_series_episodes_backfill(self, execute_task):
@@ -225,6 +237,12 @@ class TestEmitSeriesInDiscover(object):
         task = execute_task('test_next_series_episodes')
         assert task.find_entry(title='My Show 2 S03E01')
 
+    def test_next_series_episodes_with_completed_season_no_begin(self, execute_task):
+        execute_task('inject_series',
+                     options={'inject': [Entry(title='My Show 2 S02', url=''), Entry(title='My Show 2 S01', url='')]})
+        task = execute_task('test_next_series_episodes_no_begin')
+        assert task.find_entry(title='My Show 2 S03E01')
+
     def test_next_series_episodes_with_uncompleted_season(self, execute_task):
         execute_task('inject_series', options={'inject': [Entry(title='My Show 1 S02 480p', url='')]})
         task = execute_task('test_next_series_episodes_with_unaccepted_season')
@@ -240,4 +258,9 @@ class TestEmitSeriesInDiscover(object):
         task = execute_task('test_next_series_seasons')
         assert task.find_entry(title='My Show 2 S03')
 
+    def test_next_series_seasons_with_completed_seasons_no_begin(self, execute_task):
+        execute_task('inject_series',
+                     options={'inject': [Entry(title='My Show 2 S02', url=''), Entry(title='My Show 2 S01', url='')]})
+        task = execute_task('test_next_series_seasons_no_begin')
+        assert task.find_entry(title='My Show 2 S03')
 

--- a/flexget/tests/test_discover.py
+++ b/flexget/tests/test_discover.py
@@ -206,6 +206,17 @@ class TestEmitSeriesInDiscover(object):
                 identified_by: ep
                 season_packs: yes
             max_reruns: 0          
+          test_next_series_episodes_no_begin:
+            discover:
+              release_estimations: ignore
+              what:
+              - next_series_episodes: yes
+              from:
+              - test_search: yes
+            series:
+            - My Show 2:
+                identified_by: ep
+            max_reruns: 0          
           test_next_series_seasons_no_begin:
             discover:
               release_estimations: ignore


### PR DESCRIPTION
### Motivation for changes:
Align behavior when the last release in series history is a season to what has always occurred when the last release in series history is an episode.

### Detailed changes:
- Given a last release in series history of a season pack S02, now emits S03 for ``next_series_seasons`` or S03E01 for ``next_series_episodes``, as opposed to not emitting anything.
- If the latest known season is completed in the database, ``next_series_*`` tries to review the following season for emit. Currently in this scenario it will emit nothing if ``from_start`` or ``backfill`` is not set. This change causes it to emit the following season.
- Also fixed a tiny bug in ``next_series_seasons`` on line 129 (``search_entry`` does not take an episode number in ``next_series_seasons``).

### Addressed issues:
Resolves #1782.

### Log and/or tests output (preferably both):
Given a series download history of S03 and S06 for My Show...
``next_series_seasons``:
```
2017-04-17 18:19 DEBUG    series        catchup_btn_search_seasons connecting series My Show to task catchup_btn_search_seasons
2017-04-17 18:19 DEBUG    series        catchup_btn_search_seasons no downloaded episodes found for series 'My Show', season: None, downloaded: True
2017-04-17 18:19 DEBUG    series        catchup_btn_search_seasons no downloaded episodes found for series 'My Show', season: 7, downloaded: True
2017-04-17 18:19 DEBUG    series        catchup_btn_search_seasons no downloaded season packs found for series 'My Show', season: 7, downloaded: True
2017-04-17 18:19 VERBOSE  discover      catchup_btn_search_seasons Discovering 1 titles ...
2017-04-17 18:19 DEBUG    discover      catchup_btn_search_seasons My Show S07 -> No previous run recorded
```
``next_series_episodes``:
```
2017-04-17 18:19 DEBUG    series        catchup_btn_search_eps connecting series My Show to task catchup_btn_search_eps
2017-04-17 18:19 DEBUG    series        catchup_btn_search_eps no downloaded episodes found for series 'My Show', season: None, downloaded: True
2017-04-17 18:19 DEBUG    series        catchup_btn_search_eps no downloaded episodes found for series 'My Show', season: 7, downloaded: True
2017-04-17 18:19 DEBUG    series        catchup_btn_search_eps no downloaded season packs found for series 'My Show', season: 7, downloaded: True
2017-04-17 18:19 VERBOSE  discover      catchup_btn_search_eps Discovering 1 titles ...
2017-04-17 18:19 DEBUG    discover      catchup_btn_search_eps My Show S07E01 -> No previous run recorded
```