### PR TITLE
change series - Expose identified_by and exact

### DIFF
--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1174,6 +1174,8 @@ def populate_entry_fields(entry, parser, config):
     entry['series_episodes'] = parser.episodes
     entry['series_id'] = parser.pack_identifier
     entry['series_id_type'] = parser.id_type
+    entry['series_identified_by'] = parser.identified_by
+    entry['series_exact'] = parser.strict_name
 
     # If a config is passed in, also look for 'path' and 'set' options to set more fields
     if config:


### PR DESCRIPTION
### Motivation for changes:
Exposing the ``identified_by`` and ``exact`` values allows other plugins to determine what their values were at the time of parsing. This allows, for example, the btn plugin to determine if the user wants a search done with the exact series name only, or if a second search (which strips any parenthetical information from the title) should also be run. It also allows the ``next_episode_*`` plugins to determine if an unknown series, or a series still being learned (i.e. set to ``identified_by: auto`` in the database) should be treated as ep or sequence ID type, or rejected.

### Detailed changes:
- Add the two values as ``series_identified_by`` and ``series_exact`` to the entry when its ``series_*`` fields are populated after parsing. ``series_identified_by`` will be one of the ID types or ``auto``. ``series_exact`` will be ``True`` or ``False``.

### Addressed issues:
- Fixes #1785 and addresses comments in #1787.

### Logs:
Note: irrelevant fields and lines were snipped from all logs.

Config 1 - ``exact`` not enabled by config or auto; ``identified_by`` is ``auto`` due to new series
```
  test_series_fields:
    series:
      - My Show:
          quality: 720p hdtv|webdl|webrip h264
```
Log 1 (irrelevant fields snipped)
```
→ flexget inject "My Show S01E01 720p hdtv h264" --tasks test_series_fields --dump
2017-04-18 00:10 VERBOSE  series        test_series_fields identified by is currently on `auto` for My Show. Multiple id types may be accepted until it locks in on the appropriate type.
...
-- Accepted: ---------------------------
title            : My Show S01E01 720p hdtv h264
series_exact     : False
series_id        : S01E01
series_id_type   : ep
series_identified_by: auto
```

Config 2 - auto enabling of ``exact``; ``identified_by`` is ``auto`` due to new series
```
  test_series_fields:
    series:
      - My Show:
          quality: 720p hdtv|webdl|webrip h264
      - 'My Show: The Spinoff':
          quality: 720p hdtv|webdl|webrip h264
```
Log 2:
```
→ flexget inject "My Show S01E01 720p hdtv h264" --tasks test_series_fields --dump
2017-04-18 00:15 VERBOSE  series        test_series_fields Auto enabling exact matching for series My Show (reason My Show: The Spinoff)
2017-04-18 00:15 VERBOSE  series        test_series_fields identified by is currently on `auto` for My Show. Multiple id types may be accepted until it locks in on the appropriate type.
...
-- Accepted: ---------------------------
title            : My Show S01E01 720p hdtv h264
series_exact     : True
series_id        : S01E01
series_id_type   : ep
series_identified_by: auto
```

Config 3 (after removing _My Show_ and _My Show: The Spinoff_ from the database) - explicit enabling of ``exact``; explicit setting of ``identified_by`` for a new series that would otherwise be ``auto``
```
  test_series_fields:
    series:
      - My Show:
          quality: 720p hdtv|webdl|webrip h264
          exact: yes
          identified_by: ep
```
Log 3:
```
→ flexget inject "My Show S01E01 720p hdtv h264" --tasks test_series_fields --dump
...
-- Accepted: ---------------------------
title            : My Show S01E01 720p hdtv h264
series_exact     : True
series_id        : S01E01
series_id_type   : ep
series_identified_by: ep