### PR TITLE
Season packs phase 2

### DIFF
--- a/flexget/api/plugins/series.py
+++ b/flexget/api/plugins/series.py
@@ -440,7 +440,7 @@ class SeriesEpisodesAPI(APIResource):
         args = delete_parser.parse_args()
         forget = args.get('forget')
         for episode in show.episodes:
-            series.remove_series_episode(show.name, episode.identifier, forget)
+            series.remove_series_entity(show.name, episode.identifier, forget)
         return success_response('successfully removed all series %s episodes from DB' % show_id)
 
 
@@ -489,7 +489,7 @@ class SeriesEpisodeAPI(APIResource):
             raise BadRequest('episode with id %s does not belong to show %s' % (ep_id, show_id))
 
         args = delete_parser.parse_args()
-        series.remove_series_episode(show.name, episode.identifier, args.get('forget'))
+        series.remove_series_entity(show.name, episode.identifier, args.get('forget'))
 
         return success_response('successfully removed episode %s from show %s' % (ep_id, show_id))
 

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -11,7 +11,7 @@ from flexget.manager import Session
 from flexget.terminal import TerminalTable, TerminalTableError, table_parser, colorize, console
 
 try:
-    from flexget.plugins.filter.series import (Series, remove_series, remove_series_episode, set_series_begin,
+    from flexget.plugins.filter.series import (Series, remove_series, remove_series_entity, set_series_begin,
                                                normalize_series_name, new_entities_after, get_latest_release,
                                                get_series_summary, shows_by_name, show_episodes, shows_by_exact_name,
                                                get_all_entities)
@@ -146,7 +146,7 @@ def remove(manager, options, forget=False):
         # remove by id
         identifier = options.episode_id
         try:
-            remove_series_episode(name, identifier, forget)
+            remove_series_entity(name, identifier, forget)
         except ValueError as e:
             console(e.args[0])
         else:

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -146,7 +146,7 @@ def remove(manager, options, forget=False):
         for identifier in options.episode_id:
             try:
                 remove_series_entity(name, identifier, forget)
-            except (ValueError, LookupError) as e:
+            except ValueError as e:
                 console(e.args[0])
             else:
                 console('Removed entities(s) matching `%s` from series `%s`.' % (identifier, name.capitalize()))

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -143,14 +143,13 @@ def begin(manager, options):
 def remove(manager, options, forget=False):
     name = options.series_name
     if options.episode_id:
-        # remove by id
-        identifier = options.episode_id
-        try:
-            remove_series_entity(name, identifier, forget)
-        except ValueError as e:
-            console(e.args[0])
-        else:
-            console('Removed entities(s) matching `%s` from series `%s`.' % (identifier, name.capitalize()))
+        for identifier in options.episode_id:
+            try:
+                remove_series_entity(name, identifier, forget)
+            except ValueError as e:
+                console(e.args[0])
+            else:
+                console('Removed entities(s) matching `%s` from series `%s`.' % (identifier, name.capitalize()))
     else:
         # remove whole series
         try:
@@ -293,7 +292,7 @@ def register_parser_arguments():
     forget_parser = subparsers.add_parser('forget', parents=[series_parser],
                                           help='Removes episodes or whole series from the entire database '
                                                '(including seen plugin)')
-    forget_parser.add_argument('episode_id', nargs='?', default=None, help='episode ID to forget (optional)')
+    forget_parser.add_argument('episode_id', nargs='*', default=None, help='Entity ID(s) to forget (optional)')
     delete_parser = subparsers.add_parser('remove', parents=[series_parser],
                                           help='Removes episodes or whole series from the series database only')
     delete_parser.add_argument('episode_id', nargs='?', default=None, help='Episode ID to forget (optional)')

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -146,7 +146,7 @@ def remove(manager, options, forget=False):
         for identifier in options.episode_id:
             try:
                 remove_series_entity(name, identifier, forget)
-            except ValueError as e:
+            except (ValueError, LookupError) as e:
                 console(e.args[0])
             else:
                 console('Removed entities(s) matching `%s` from series `%s`.' % (identifier, name.capitalize()))

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -150,7 +150,7 @@ def remove(manager, options, forget=False):
         except ValueError as e:
             console(e.args[0])
         else:
-            console('Removed episode(s) matching `%s` from series `%s`.' % (identifier, name.capitalize()))
+            console('Removed entities(s) matching `%s` from series `%s`.' % (identifier, name.capitalize()))
     else:
         # remove whole series
         try:

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1010,8 +1010,8 @@ def remove_series(name, forget=False):
         if series:
             for s in series:
                 if forget:
-                    for episode in s.episodes:
-                        for release in episode.downloaded_releases:
+                    for entity in (s.episodes + s.seasons):
+                        for release in entity.downloaded_releases:
                             downloaded_releases.append(release.title)
                 session.delete(s)
             session.commit()
@@ -1046,7 +1046,7 @@ def remove_series_entity(name, identifier, forget=False):
         name_to_parse = '{} {}'.format(series.name, identifier)
         parsed = get_plugin_by_name('parsing').instance.parse_series(name_to_parse, name=series.name)
         if not parsed.valid:
-            raise LookupError('Invalid identifier for series {}: {}'.format(series.name, identifier))
+            raise ValueError('Invalid identifier for series {}: {}'.format(series.name, identifier))
 
         removed = False
         if parsed.season_pack:

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1024,7 +1024,7 @@ def remove_series(name, forget=False):
 
 def remove_series_entity(name, identifier, forget=False):
     """
-    Remove all entitires by `identifier` from series `name` from database.
+    Remove all entities by `identifier` from series `name` from database.
 
     :param name: Name of series to be removed
     :param identifier: Series identifier to be deleted,
@@ -1049,15 +1049,15 @@ def remove_series_entity(name, identifier, forget=False):
             raise LookupError('Invalid identifier for series {}: {}'.format(series.name, identifier))
 
         removed = False
-        if parsed.season_pack:
+        if parsed.is_season_pack:
             season = session.query(Season).filter(Season.season == parsed.season).filter(
                 Season.series_id == series.id).first()
             if season:
                 removed = True
                 downloaded_releases = remove_entity(season)
         else:
-            episode = session.query(Episode).filter(Episode.identifier == identifier). \
-                filter(Episode.series_id == series.id).first()
+            episode = session.query(Episode).filter(Episode.season == parsed.season).filter(
+                Episode.number == parsed.episode).filter(Episode.series_id == series.id).first()
             if episode:
                 removed = True
                 downloaded_releases = remove_entity(episode)

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1135,7 +1135,7 @@ def show_seasons(series, start=None, stop=None, count=False, descending=False, s
 def get_all_entities(series, session):
     episodes = show_episodes(series, session=session)
     seasons = show_seasons(series, session=session)
-    return episodes + seasons
+    return sorted(episodes + seasons, key=lambda e: (e.age, e.identifier), reverse=True)
 
 
 def get_releases(episode, downloaded=None, start=None, stop=None, count=False, descending=False, sort_by=None,

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1049,7 +1049,7 @@ def remove_series_entity(name, identifier, forget=False):
             raise LookupError('Invalid identifier for series {}: {}'.format(series.name, identifier))
 
         removed = False
-        if parsed.is_season_pack:
+        if parsed.season_pack:
             season = session.query(Season).filter(Season.season == parsed.season).filter(
                 Season.series_id == series.id).first()
             if season:

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1147,7 +1147,7 @@ def show_seasons(series, start=None, stop=None, count=False, descending=False, s
 def get_all_entities(series, session):
     episodes = show_episodes(series, session=session)
     seasons = show_seasons(series, session=session)
-    return sorted(episodes + seasons, key=lambda e: (e.first_seen, e.identifier), reverse=True)
+    return sorted(episodes + seasons, key=lambda e: (e.first_seen or datetime.min, e.identifier), reverse=True)
 
 
 def get_releases(episode, downloaded=None, start=None, stop=None, count=False, descending=False, sort_by=None,

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1135,7 +1135,7 @@ def show_seasons(series, start=None, stop=None, count=False, descending=False, s
 def get_all_entities(series, session):
     episodes = show_episodes(series, session=session)
     seasons = show_seasons(series, session=session)
-    return sorted(episodes + seasons, key=lambda e: (e.age, e.identifier), reverse=True)
+    return sorted(episodes + seasons, key=lambda e: (e.first_seen, e.identifier), reverse=True)
 
 
 def get_releases(episode, downloaded=None, start=None, stop=None, count=False, descending=False, sort_by=None,

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -316,18 +316,6 @@ class Series(Base):
     def completed_seasons(self):
         return [season.season for season in self.seasons if season.completed]
 
-    @property
-    def has_season_downloads(self):
-        return any(season.downloaded_releases for season in self.seasons)
-
-    @property
-    def has_episode_downloads(self):
-        return any(episode.downloaded_releases for episode in self.episodes)
-
-    @property
-    def has_history(self):
-        return self.has_season_downloads or self.has_episode_downloads
-
 
 class Season(Base):
     __tablename__ = 'series_seasons'

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -316,6 +316,18 @@ class Series(Base):
     def completed_seasons(self):
         return [season.season for season in self.seasons if season.completed]
 
+    @property
+    def has_season_downloads(self):
+        return any(season.downloaded_releases for season in self.seasons)
+
+    @property
+    def has_episode_downloads(self):
+        return any(episode.downloaded_releases for episode in self.episodes)
+
+    @property
+    def has_history(self):
+        return self.has_season_downloads or self.has_episode_downloads
+
 
 class Season(Base):
     __tablename__ = 'series_seasons'

--- a/flexget/plugins/input/next_series_episodes.py
+++ b/flexget/plugins/input/next_series_episodes.py
@@ -114,8 +114,12 @@ class NextSeriesEpisodes(object):
                 check_downloaded = not config.get('backfill')
                 latest_season = get_latest_release(series, downloaded=check_downloaded)
                 if latest_season:
-                    latest_season = latest_season.season + 1 if latest_season.season in series.completed_seasons \
-                        else latest_season.season
+                    if latest_season.season in series.completed_seasons:
+                        latest_season = new_season = latest_season.season + 1
+                    else:
+                        latest_season = latest_season.season
+                        new_season = None
+
                 else:
                     latest_season = low_season + 1
 
@@ -166,8 +170,11 @@ class NextSeriesEpisodes(object):
                         else:
                             # No episode means that latest is a season pack, emit episode 1
                             entries.append(self.search_entry(series, season, 1, task))
+                    # First iteration of a new season with no show begin and show has downloads
+                    elif new_season and season == new_season and series.has_history:
+                        entries.append(self.search_entry(series, season, 1, task))
                     else:
-                        if config.get('from_start') or config.get('backfill') or series.has_history:
+                        if config.get('from_start') or config.get('backfill'):
                             entries.append(self.search_entry(series, season, 1, task))
                         else:
                             log.verbose('Series `%s` has no history. Set begin option, '

--- a/flexget/plugins/input/next_series_episodes.py
+++ b/flexget/plugins/input/next_series_episodes.py
@@ -110,22 +110,22 @@ class NextSeriesEpisodes(object):
                     continue
 
                 low_season = 0 if series.identified_by == 'ep' else -1
+                # Don't look for seasons older than begin ep
+                if series.begin and series.begin.season:
+                    low_season = series.begin.season
 
                 new_season = None
                 check_downloaded = not config.get('backfill')
                 latest_season = get_latest_release(series, downloaded=check_downloaded)
                 if latest_season:
-                    if latest_season.season in series.completed_seasons:
+                    if latest_season.season <= low_season:
+                        latest_season = new_season = low_season + 1
+                    elif latest_season.season in series.completed_seasons:
                         latest_season = new_season = latest_season.season + 1
                     else:
                         latest_season = latest_season.season
-
                 else:
                     latest_season = low_season + 1
-
-                # Don't look for seasons older than begin ep
-                if series.begin and series.begin.season < latest_season:
-                    low_season = series.begin.season
 
                 for season in range(latest_season, low_season, -1):
                     if season in series.completed_seasons:

--- a/flexget/plugins/input/next_series_episodes.py
+++ b/flexget/plugins/input/next_series_episodes.py
@@ -111,7 +111,7 @@ class NextSeriesEpisodes(object):
 
                 low_season = 0 if series.identified_by == 'ep' else -1
                 # Don't look for seasons older than begin ep
-                if series.begin and series.begin.season:
+                if series.begin and series.begin.season and series.begin.season > 1:
                     low_season = series.begin.season
 
                 new_season = None

--- a/flexget/plugins/input/next_series_episodes.py
+++ b/flexget/plugins/input/next_series_episodes.py
@@ -110,6 +110,9 @@ class NextSeriesEpisodes(object):
                     continue
 
                 low_season = 0 if series.identified_by == 'ep' else -1
+                # Don't look for seasons older than begin ep
+                if series.begin:
+                    low_season = series.begin.season
 
                 new_season = None
                 check_downloaded = not config.get('backfill')
@@ -124,13 +127,10 @@ class NextSeriesEpisodes(object):
                     latest_season = low_season + 1
 
                 for season in range(latest_season, low_season, -1):
-                    # Don't look for seasons older than begin ep
-                    if series.begin and series.begin.season < season:
-                        break
                     if season in series.completed_seasons:
                         log.debug('season %s is marked as completed, skipping', season)
                         continue
-                    log.trace('Adding episodes for series %s season %d', series.name, season)
+                    log.trace('Evaluating episodes for series %s, season %d', series.name, season)
                     latest = get_latest_release(series, season=season, downloaded=check_downloaded)
                     if series.begin and (not latest or latest < series.begin):
                         # In case series.begin season is already completed, look in next available season

--- a/flexget/plugins/input/next_series_episodes.py
+++ b/flexget/plugins/input/next_series_episodes.py
@@ -124,6 +124,9 @@ class NextSeriesEpisodes(object):
                     latest_season = low_season + 1
 
                 for season in range(latest_season, low_season, -1):
+                    # Don't look for seasons older than begin ep
+                    if series.begin and series.begin.season < season:
+                        break
                     if season in series.completed_seasons:
                         log.debug('season %s is marked as completed, skipping', season)
                         continue
@@ -183,9 +186,6 @@ class NextSeriesEpisodes(object):
                             break
                     # Skip older seasons if we are not in backfill mode
                     if not config.get('backfill'):
-                        break
-                    # Don't look for seasons older than begin ep
-                    if series.begin and series.begin.season >= season:
                         break
 
         for reason, series in impossible.items():

--- a/flexget/plugins/input/next_series_episodes.py
+++ b/flexget/plugins/input/next_series_episodes.py
@@ -166,9 +166,8 @@ class NextSeriesEpisodes(object):
                         else:
                             # No episode means that latest is a season pack, emit episode 1
                             entries.append(self.search_entry(series, season, 1, task))
-
                     else:
-                        if config.get('from_start') or config.get('backfill'):
+                        if config.get('from_start') or config.get('backfill') or series.has_history:
                             entries.append(self.search_entry(series, season, 1, task))
                         else:
                             log.verbose('Series `%s` has no history. Set begin option, '

--- a/flexget/plugins/input/next_series_episodes.py
+++ b/flexget/plugins/input/next_series_episodes.py
@@ -111,6 +111,7 @@ class NextSeriesEpisodes(object):
 
                 low_season = 0 if series.identified_by == 'ep' else -1
 
+                new_season = None
                 check_downloaded = not config.get('backfill')
                 latest_season = get_latest_release(series, downloaded=check_downloaded)
                 if latest_season:
@@ -118,7 +119,6 @@ class NextSeriesEpisodes(object):
                         latest_season = new_season = latest_season.season + 1
                     else:
                         latest_season = latest_season.season
-                        new_season = None
 
                 else:
                     latest_season = low_season + 1

--- a/flexget/plugins/input/next_series_episodes.py
+++ b/flexget/plugins/input/next_series_episodes.py
@@ -171,7 +171,7 @@ class NextSeriesEpisodes(object):
                             # No episode means that latest is a season pack, emit episode 1
                             entries.append(self.search_entry(series, season, 1, task))
                     # First iteration of a new season with no show begin and show has downloads
-                    elif new_season and season == new_season and series.has_history:
+                    elif new_season and season == new_season:
                         entries.append(self.search_entry(series, season, 1, task))
                     else:
                         if config.get('from_start') or config.get('backfill'):

--- a/flexget/plugins/input/next_series_episodes.py
+++ b/flexget/plugins/input/next_series_episodes.py
@@ -110,9 +110,6 @@ class NextSeriesEpisodes(object):
                     continue
 
                 low_season = 0 if series.identified_by == 'ep' else -1
-                # Don't look for seasons older than begin ep
-                if series.begin:
-                    low_season = series.begin.season
 
                 new_season = None
                 check_downloaded = not config.get('backfill')
@@ -125,6 +122,10 @@ class NextSeriesEpisodes(object):
 
                 else:
                     latest_season = low_season + 1
+
+                # Don't look for seasons older than begin ep
+                if series.begin and series.begin.season < latest_season:
+                    low_season = series.begin.season
 
                 for season in range(latest_season, low_season, -1):
                     if season in series.completed_seasons:

--- a/flexget/plugins/input/next_series_episodes.py
+++ b/flexget/plugins/input/next_series_episodes.py
@@ -112,7 +112,8 @@ class NextSeriesEpisodes(object):
                 low_season = 0 if series.identified_by == 'ep' else -1
                 # Don't look for seasons older than begin ep
                 if series.begin and series.begin.season and series.begin.season > 1:
-                    low_season = series.begin.season
+                    # begin-1 or the range() loop will never get to the begin season
+                    low_season = max(series.begin.season - 1, 0)
 
                 new_season = None
                 check_downloaded = not config.get('backfill')
@@ -133,7 +134,7 @@ class NextSeriesEpisodes(object):
                         continue
                     log.trace('Evaluating episodes for series %s, season %d', series.name, season)
                     latest = get_latest_release(series, season=season, downloaded=check_downloaded)
-                    if series.begin and (not latest or latest < series.begin):
+                    if series.begin and season == series.begin.season and (not latest or latest < series.begin):
                         # In case series.begin season is already completed, look in next available season
                         lookup_season = series.begin.season
                         ep_number = series.begin.number
@@ -187,6 +188,7 @@ class NextSeriesEpisodes(object):
                             break
                     # Skip older seasons if we are not in backfill mode
                     if not config.get('backfill'):
+                        log.debug('backfill is not enabled; skipping older seasons')
                         break
 
         for reason, series in impossible.items():

--- a/flexget/plugins/input/next_series_seasons.py
+++ b/flexget/plugins/input/next_series_seasons.py
@@ -121,8 +121,8 @@ class NextSeriesSeasons(object):
                     elif latest:
                         entries.append(self.search_entry(series, latest.season, task))
                     else:
-                        if config.get('from_start') or config.get('backfill'):
-                            entries.append(self.search_entry(series, season, 1, task))
+                        if config.get('from_start') or config.get('backfill') or series.has_history:
+                            entries.append(self.search_entry(series, season, task))
                         else:
                             log.verbose('Series `%s` has no history. Set begin option, '
                                         'or use CLI `series begin` '

--- a/flexget/plugins/input/next_series_seasons.py
+++ b/flexget/plugins/input/next_series_seasons.py
@@ -125,7 +125,7 @@ class NextSeriesSeasons(object):
                     elif latest:
                         entries.append(self.search_entry(series, latest.season, task))
                     # First iteration of a new season with no show begin and show has downloads
-                    elif new_season and season == new_season and series.has_history:
+                    elif new_season and season == new_season:
                         entries.append(self.search_entry(series, season, task))
                     else:
                         if config.get('from_start') or config.get('backfill'):

--- a/flexget/plugins/input/next_series_seasons.py
+++ b/flexget/plugins/input/next_series_seasons.py
@@ -98,6 +98,7 @@ class NextSeriesSeasons(object):
 
                 low_season = 0
 
+                new_season = None
                 check_downloaded = not config.get('backfill')
                 latest_season = get_latest_release(series, downloaded=check_downloaded)
                 if latest_season:
@@ -105,7 +106,7 @@ class NextSeriesSeasons(object):
                         latest_season = new_season = latest_season.season + 1
                     else:
                         latest_season = latest_season.season
-                        new_season = None
+
                 else:
                     latest_season = low_season + 1
 

--- a/flexget/plugins/input/next_series_seasons.py
+++ b/flexget/plugins/input/next_series_seasons.py
@@ -111,6 +111,9 @@ class NextSeriesSeasons(object):
                     latest_season = low_season + 1
 
                 for season in range(latest_season, low_season, -1):
+                    # Don't look for seasons older than begin ep
+                    if series.begin and series.begin.season < season:
+                        break
                     if season in series.completed_seasons:
                         log.debug('season %s is marked as completed, skipping', season)
                         continue
@@ -137,9 +140,6 @@ class NextSeriesSeasons(object):
                             break
                     # Skip older seasons if we are not in backfill mode
                     if not config.get('backfill'):
-                        break
-                    # Don't look for seasons older than begin ep
-                    if series.begin and series.begin.season >= season:
                         break
 
         for reason, series in impossible.items():

--- a/flexget/plugins/input/next_series_seasons.py
+++ b/flexget/plugins/input/next_series_seasons.py
@@ -101,8 +101,11 @@ class NextSeriesSeasons(object):
                 check_downloaded = not config.get('backfill')
                 latest_season = get_latest_release(series, downloaded=check_downloaded)
                 if latest_season:
-                    latest_season = latest_season.season + 1 if latest_season.season in series.completed_seasons \
-                        else latest_season.season
+                    if latest_season.season in series.completed_seasons:
+                        latest_season = new_season = latest_season.season + 1
+                    else:
+                        latest_season = latest_season.season
+                        new_season = None
                 else:
                     latest_season = low_season + 1
 
@@ -120,8 +123,11 @@ class NextSeriesSeasons(object):
                         entries.append(self.search_entry(series, lookup_season, task))
                     elif latest:
                         entries.append(self.search_entry(series, latest.season, task))
+                    # First iteration of a new season with no show begin and show has downloads
+                    elif new_season and season == new_season and series.has_history:
+                        entries.append(self.search_entry(series, season, task))
                     else:
-                        if config.get('from_start') or config.get('backfill') or series.has_history:
+                        if config.get('from_start') or config.get('backfill'):
                             entries.append(self.search_entry(series, season, task))
                         else:
                             log.verbose('Series `%s` has no history. Set begin option, '

--- a/flexget/plugins/input/next_series_seasons.py
+++ b/flexget/plugins/input/next_series_seasons.py
@@ -98,7 +98,7 @@ class NextSeriesSeasons(object):
 
                 low_season = 0
                 # Don't look for seasons older than begin ep
-                if series.begin and series.begin.season:
+                if series.begin and series.begin.season and series.begin.season > 1:
                     low_season = series.begin.season
 
                 new_season = None

--- a/flexget/plugins/input/next_series_seasons.py
+++ b/flexget/plugins/input/next_series_seasons.py
@@ -97,9 +97,6 @@ class NextSeriesSeasons(object):
                     continue
 
                 low_season = 0
-                # Don't look for seasons older than begin ep
-                if series.begin:
-                    low_season = series.begin.season
 
                 new_season = None
                 check_downloaded = not config.get('backfill')
@@ -112,6 +109,10 @@ class NextSeriesSeasons(object):
 
                 else:
                     latest_season = low_season + 1
+
+                # Don't look for seasons older than begin ep
+                if series.begin and series.begin.season < latest_season:
+                    low_season = series.begin.season
 
                 for season in range(latest_season, low_season, -1):
                     if season in series.completed_seasons:

--- a/flexget/plugins/input/next_series_seasons.py
+++ b/flexget/plugins/input/next_series_seasons.py
@@ -97,6 +97,9 @@ class NextSeriesSeasons(object):
                     continue
 
                 low_season = 0
+                # Don't look for seasons older than begin ep
+                if series.begin:
+                    low_season = series.begin.season
 
                 new_season = None
                 check_downloaded = not config.get('backfill')
@@ -111,13 +114,10 @@ class NextSeriesSeasons(object):
                     latest_season = low_season + 1
 
                 for season in range(latest_season, low_season, -1):
-                    # Don't look for seasons older than begin ep
-                    if series.begin and series.begin.season < season:
-                        break
                     if season in series.completed_seasons:
                         log.debug('season %s is marked as completed, skipping', season)
                         continue
-                    log.trace('Adding episodes for series %s season %d', series.name, season)
+                    log.trace('Evaluating season %s for series %s', season, series.name)
                     latest = get_latest_release(series, season=season, downloaded=check_downloaded)
                     if series.begin and (not latest or latest < series.begin):
                         # In case series.begin season is already completed, look in next available season

--- a/flexget/plugins/input/next_series_seasons.py
+++ b/flexget/plugins/input/next_series_seasons.py
@@ -99,7 +99,7 @@ class NextSeriesSeasons(object):
                 low_season = 0
                 # Don't look for seasons older than begin ep
                 if series.begin and series.begin.season and series.begin.season > 1:
-                    low_season = series.begin.season
+                    low_season = max(series.begin.season - 1, 0)
 
                 new_season = None
                 check_downloaded = not config.get('backfill')
@@ -120,7 +120,7 @@ class NextSeriesSeasons(object):
                         continue
                     log.trace('Evaluating season %s for series %s', season, series.name)
                     latest = get_latest_release(series, season=season, downloaded=check_downloaded)
-                    if series.begin and (not latest or latest < series.begin):
+                    if series.begin and season == series.begin.season and (not latest or latest < series.begin):
                         # In case series.begin season is already completed, look in next available season
                         lookup_season = series.begin.season
                         while lookup_season in series.completed_seasons:
@@ -141,6 +141,7 @@ class NextSeriesSeasons(object):
                             break
                     # Skip older seasons if we are not in backfill mode
                     if not config.get('backfill'):
+                        log.debug('backfill is not enabled; skipping older seasons')
                         break
 
         for reason, series in impossible.items():

--- a/flexget/plugins/input/next_series_seasons.py
+++ b/flexget/plugins/input/next_series_seasons.py
@@ -97,22 +97,22 @@ class NextSeriesSeasons(object):
                     continue
 
                 low_season = 0
+                # Don't look for seasons older than begin ep
+                if series.begin and series.begin.season:
+                    low_season = series.begin.season
 
                 new_season = None
                 check_downloaded = not config.get('backfill')
                 latest_season = get_latest_release(series, downloaded=check_downloaded)
                 if latest_season:
-                    if latest_season.season in series.completed_seasons:
+                    if latest_season.season <= low_season:
+                        latest_season = new_season = low_season + 1
+                    elif latest_season.season in series.completed_seasons:
                         latest_season = new_season = latest_season.season + 1
                     else:
                         latest_season = latest_season.season
-
                 else:
                     latest_season = low_season + 1
-
-                # Don't look for seasons older than begin ep
-                if series.begin and series.begin.season < latest_season:
-                    low_season = series.begin.season
 
                 for season in range(latest_season, low_season, -1):
                     if season in series.completed_seasons:

--- a/flexget/plugins/metainfo/thetvdb_lookup.py
+++ b/flexget/plugins/metainfo/thetvdb_lookup.py
@@ -181,8 +181,11 @@ class PluginThetvdbLookup(object):
 
                 # If there is season and ep info as well, register episode lazy fields
                 if entry.get('series_id_type') in ('ep', 'sequence', 'date'):
-                    lazy_episode_lookup = partial(self.lazy_episode_lookup, language=language)
-                    entry.register_lazy_func(lazy_episode_lookup, self.episode_map)
+                    if entry.get('season_pack'):
+                        log.verbose('TheTVDB API does not support season lookup at this time, skipping %s', entry)
+                    else:
+                        lazy_episode_lookup = partial(self.lazy_episode_lookup, language=language)
+                        entry.register_lazy_func(lazy_episode_lookup, self.episode_map)
 
     @property
     def series_identifier(self):

--- a/flexget/plugins/output/series_forget.py
+++ b/flexget/plugins/output/series_forget.py
@@ -7,7 +7,7 @@ from flexget import plugin
 from flexget.event import event
 
 try:
-    from flexget.plugins.filter.series import remove_series_episode
+    from flexget.plugins.filter.series import remove_series_entity
 except ImportError:
     raise plugin.DependencyError(issued_by='series_remove', missing='series',
                                  message='series_forget plugin need series plugin to work')
@@ -24,7 +24,7 @@ class OutputSeriesRemove(object):
         for entry in task.accepted:
             if 'series_name' in entry and 'series_id' in entry:
                 try:
-                    remove_series_episode(entry['series_name'], entry['series_id'])
+                    remove_series_entity(entry['series_name'], entry['series_id'])
                     log.info('Removed episode `%s` from series `%s` download history.' %
                              (entry['series_id'], entry['series_name']))
                 except ValueError:

--- a/flexget/tests/test_discover.py
+++ b/flexget/tests/test_discover.py
@@ -205,7 +205,18 @@ class TestEmitSeriesInDiscover(object):
                 begin: s02e01
                 identified_by: ep
                 season_packs: yes
-            max_reruns: 0          
+            max_reruns: 0     
+          test_next_series_episodes_without_begin:
+            max_reruns: 0
+            discover:
+              release_estimations: ignore
+              what:
+              - next_series_episodes: yes
+              from:
+              - test_search: yes
+            series:
+            - My Show 2:
+                identified_by: ep
     """
 
     def test_next_series_episodes_backfill(self, execute_task):
@@ -240,4 +251,8 @@ class TestEmitSeriesInDiscover(object):
         task = execute_task('test_next_series_seasons')
         assert task.find_entry(title='My Show 2 S03')
 
-
+    def test_next_series_episodes_without_being(self, execute_task):
+        execute_task('inject_series',
+                     options={'inject': [Entry(title='My Show 2 S01', url='')]})
+        task = execute_task('test_next_series_episodes_without_begin')
+        assert task.find_entry(title='My Show 2 S02E01')

--- a/flexget/tests/test_discover.py
+++ b/flexget/tests/test_discover.py
@@ -205,30 +205,7 @@ class TestEmitSeriesInDiscover(object):
                 begin: s02e01
                 identified_by: ep
                 season_packs: yes
-            max_reruns: 0     
-          test_next_series_episodes_without_begin:
-            max_reruns: 0
-            discover:
-              release_estimations: ignore
-              what:
-              - next_series_episodes: yes
-              from:
-              - test_search: yes
-            series:
-            - My Show 2:
-                identified_by: ep
-          test_next_series_seasons_without_begin:
-            max_reruns: 0
-            discover:
-              release_estimations: ignore
-              what:
-              - next_series_seasons: yes
-              from:
-              - test_search: yes
-            series:
-            - My Show 2:
-                identified_by: ep
-                season_packs: yes
+            max_reruns: 0          
     """
 
     def test_next_series_episodes_backfill(self, execute_task):
@@ -263,14 +240,4 @@ class TestEmitSeriesInDiscover(object):
         task = execute_task('test_next_series_seasons')
         assert task.find_entry(title='My Show 2 S03')
 
-    def test_next_series_episodes_without_begin(self, execute_task):
-        execute_task('inject_series',
-                     options={'inject': [Entry(title='My Show 2 S01', url='')]})
-        task = execute_task('test_next_series_episodes_without_begin')
-        assert task.find_entry(title='My Show 2 S02E01')
 
-    def test_next_series_seasons_without_begin(self, execute_task):
-        execute_task('inject_series',
-                     options={'inject': [Entry(title='My Show 2 S01', url='')]})
-        task = execute_task('test_next_series_seasons_without_begin')
-        assert task.find_entry(title='My Show 2 S02')

--- a/flexget/tests/test_discover.py
+++ b/flexget/tests/test_discover.py
@@ -217,6 +217,18 @@ class TestEmitSeriesInDiscover(object):
             series:
             - My Show 2:
                 identified_by: ep
+          test_next_series_seasons_without_begin:
+            max_reruns: 0
+            discover:
+              release_estimations: ignore
+              what:
+              - next_series_seasons: yes
+              from:
+              - test_search: yes
+            series:
+            - My Show 2:
+                identified_by: ep
+                season_packs: yes
     """
 
     def test_next_series_episodes_backfill(self, execute_task):
@@ -251,8 +263,14 @@ class TestEmitSeriesInDiscover(object):
         task = execute_task('test_next_series_seasons')
         assert task.find_entry(title='My Show 2 S03')
 
-    def test_next_series_episodes_without_being(self, execute_task):
+    def test_next_series_episodes_without_begin(self, execute_task):
         execute_task('inject_series',
                      options={'inject': [Entry(title='My Show 2 S01', url='')]})
         task = execute_task('test_next_series_episodes_without_begin')
         assert task.find_entry(title='My Show 2 S02E01')
+
+    def test_next_series_seasons_without_begin(self, execute_task):
+        execute_task('inject_series',
+                     options={'inject': [Entry(title='My Show 2 S01', url='')]})
+        task = execute_task('test_next_series_seasons_without_begin')
+        assert task.find_entry(title='My Show 2 S02')

--- a/flexget/tests/test_next_series_episodes.py
+++ b/flexget/tests/test_next_series_episodes.py
@@ -220,3 +220,83 @@ class TestNextSeriesEpisodes(object):
         task = execute_task('test_next_series_episodes_alternate_name')
         s2 = len(task.mock_output[0].get('search_strings'))
         assert s2 > s1, 'Alternate names did not create sufficient search strings.'
+
+class TestNextSeriesEpisodesSeasonPack(object):
+    _config = """
+        templates:
+          global:
+            parsing:
+              series: internal
+        tasks:
+          inject_series:
+            series:
+              - Test Series 1:
+                  season_packs: always
+              - Test Series 2:
+                  season_packs: always
+              - Test Series 3:
+                  season_packs: always
+          test_next_series_episodes_season_pack:
+            next_series_episodes: yes
+            series:
+            - Test Series 1:
+                identified_by: ep
+            max_reruns: 0
+          test_next_series_episodes_season_pack_backfill:
+            next_series_episodes:
+              backfill: yes
+            series:
+            - Test Series 2:
+                identified_by: ep
+                tracking: backfill
+            max_reruns: 0
+          test_next_series_episodes_season_pack_backfill_and_begin:
+            next_series_episodes:
+              backfill: yes
+            series:
+            - Test Series 3:
+                identified_by: ep
+                begin: S02E01
+                tracking: backfill
+            max_reruns: 0
+    """
+
+    @pytest.fixture()
+    def config(self):
+        """Season packs aren't supported by guessit yet."""
+        return self._config
+
+    def inject_series(self, execute_task, release_name):
+        execute_task('inject_series', options={'inject': [Entry(title=release_name, url='')], 'disable_tracking': True})
+
+    def test_next_series_episodes_season_pack(self, execute_task):
+        self.inject_series(execute_task, 'Test Series 1 S02')
+        task = execute_task('test_next_series_episodes_season_pack')
+        assert task.find_entry(title='Test Series 1 S03E01')
+        assert len(task.all_entries) == 1
+        self.inject_series(execute_task, 'Test Series 2 S03E01')
+        task = execute_task('test_next_series_episodes_season_pack')
+        assert task.find_entry(title='Test Series 1 S03E02')
+        assert len(task.all_entries) == 1
+
+    def test_next_series_episodes_season_pack_backfill(self, execute_task):
+        self.inject_series(execute_task, 'Test Series 2 S02')
+        task = execute_task('test_next_series_episodes_season_pack_backfill')
+        assert task.find_entry(title='Test Series 2 S01E01')
+        assert task.find_entry(title='Test Series 2 S03E01')
+        assert len(task.all_entries) == 2
+        self.inject_series(execute_task, 'Test Series 2 S03E01')
+        task = execute_task('test_next_series_episodes_season_pack_backfill')
+        assert task.find_entry(title='Test Series 2 S01E01')
+        assert task.find_entry(title='Test Series 2 S03E02')
+        assert len(task.all_entries) == 2
+
+    def test_next_series_episodes_season_pack_backfill_and_begin(self, execute_task):
+        self.inject_series(execute_task, 'Test Series 3 S02')
+        task = execute_task('test_next_series_episodes_season_pack_backfill_and_begin')
+        assert task.find_entry(title='Test Series 3 S03E01')
+        assert len(task.all_entries) == 1
+        self.inject_series(execute_task, 'Test Series 3 S03E01')
+        task = execute_task('test_next_series_episodes_season_pack_backfill_and_begin')
+        assert task.find_entry(title='Test Series 3 S03E02')
+        assert len(task.all_entries) == 1

--- a/flexget/tests/test_next_series_episodes.py
+++ b/flexget/tests/test_next_series_episodes.py
@@ -236,17 +236,37 @@ class TestNextSeriesEpisodesSeasonPack(object):
                   season_packs: always
               - Test Series 3:
                   season_packs: always
+              - Test Series 4:
+                  season_packs: always
+              - Test Series 5:
+                  season_packs: always
+              - Test Series 6:
+                  season_packs: always
           test_next_series_episodes_season_pack:
             next_series_episodes: yes
             series:
             - Test Series 1:
                 identified_by: ep
             max_reruns: 0
+          test_next_series_episodes_season_pack_and_ep:
+            next_series_episodes: yes
+            series:
+            - Test Series 2:
+                identified_by: ep
+            max_reruns: 0
           test_next_series_episodes_season_pack_backfill:
             next_series_episodes:
               backfill: yes
             series:
-            - Test Series 2:
+            - Test Series 3:
+                identified_by: ep
+                tracking: backfill
+            max_reruns: 0
+          test_next_series_episodes_season_pack_and_ep_backfill:
+            next_series_episodes:
+              backfill: yes
+            series:
+            - Test Series 4:
                 identified_by: ep
                 tracking: backfill
             max_reruns: 0
@@ -254,7 +274,16 @@ class TestNextSeriesEpisodesSeasonPack(object):
             next_series_episodes:
               backfill: yes
             series:
-            - Test Series 3:
+            - Test Series 5:
+                identified_by: ep
+                begin: S02E01
+                tracking: backfill
+            max_reruns: 0
+          test_next_series_episodes_season_pack_and_ep_backfill_and_begin:
+            next_series_episodes:
+              backfill: yes
+            series:
+            - Test Series 6:
                 identified_by: ep
                 begin: S02E01
                 tracking: backfill
@@ -274,29 +303,38 @@ class TestNextSeriesEpisodesSeasonPack(object):
         task = execute_task('test_next_series_episodes_season_pack')
         assert task.find_entry(title='Test Series 1 S03E01')
         assert len(task.all_entries) == 1
+
+    def test_next_series_episodes_season_pack_and_ep(self, execute_task):
+        self.inject_series(execute_task, 'Test Series 2 S02')
         self.inject_series(execute_task, 'Test Series 2 S03E01')
-        task = execute_task('test_next_series_episodes_season_pack')
-        assert task.find_entry(title='Test Series 1 S03E02')
+        task = execute_task('test_next_series_episodes_season_pack_and_ep')
+        assert task.find_entry(title='Test Series 2 S03E02')
         assert len(task.all_entries) == 1
 
     def test_next_series_episodes_season_pack_backfill(self, execute_task):
-        self.inject_series(execute_task, 'Test Series 2 S02')
+        self.inject_series(execute_task, 'Test Series 3 S02')
         task = execute_task('test_next_series_episodes_season_pack_backfill')
-        assert task.find_entry(title='Test Series 2 S01E01')
-        assert task.find_entry(title='Test Series 2 S03E01')
+        assert task.find_entry(title='Test Series 3 S01E01')
+        assert task.find_entry(title='Test Series 3 S03E01')
         assert len(task.all_entries) == 2
-        self.inject_series(execute_task, 'Test Series 2 S03E01')
-        task = execute_task('test_next_series_episodes_season_pack_backfill')
-        assert task.find_entry(title='Test Series 2 S01E01')
-        assert task.find_entry(title='Test Series 2 S03E02')
+
+    def test_next_series_episodes_season_pack_and_ep_backfill(self, execute_task):
+        self.inject_series(execute_task, 'Test Series 4 S02')
+        self.inject_series(execute_task, 'Test Series 4 S03E01')
+        task = execute_task('test_next_series_episodes_season_pack_and_ep_backfill')
+        assert task.find_entry(title='Test Series 4 S01E01')
+        assert task.find_entry(title='Test Series 4 S03E02')
         assert len(task.all_entries) == 2
 
     def test_next_series_episodes_season_pack_backfill_and_begin(self, execute_task):
-        self.inject_series(execute_task, 'Test Series 3 S02')
+        self.inject_series(execute_task, 'Test Series 5 S02')
         task = execute_task('test_next_series_episodes_season_pack_backfill_and_begin')
-        assert task.find_entry(title='Test Series 3 S03E01')
+        assert task.find_entry(title='Test Series 5 S03E01')
         assert len(task.all_entries) == 1
-        self.inject_series(execute_task, 'Test Series 3 S03E01')
-        task = execute_task('test_next_series_episodes_season_pack_backfill_and_begin')
-        assert task.find_entry(title='Test Series 3 S03E02')
+
+    def test_next_series_episodes_season_pack_and_ep_backfill_and_begin(self, execute_task):
+        self.inject_series(execute_task, 'Test Series 6 S02')
+        self.inject_series(execute_task, 'Test Series 6 S03E01')
+        task = execute_task('test_next_series_episodes_season_pack_and_ep_backfill_and_begin')
+        assert task.find_entry(title='Test Series 6 S03E02')
         assert len(task.all_entries) == 1

--- a/flexget/tests/test_next_series_episodes.py
+++ b/flexget/tests/test_next_series_episodes.py
@@ -227,74 +227,220 @@ class TestNextSeriesEpisodesSeasonPack(object):
           global:
             parsing:
               series: internal
+          anchors:
+            _nse_backfill: &nse_backfill
+              next_series_episodes:
+                backfill: yes
+            _nse_from_start: &nse_from_start
+              next_series_episodes:
+                from_start: yes
+            _nse_backfill_from_start: &nse_backfill_from_start
+              next_series_episodes:
+                backfill: yes
+                from_start: yes
+            _series_ep_tracking: &series_ep_tracking
+              identified_by: ep
+              tracking: backfill
+            _series_ep_tracking_begin_s02e01: &series_ep_tracking_begin_s02e01
+              identified_by: ep
+              tracking: backfill
+              begin: s02e01
+            _series_ep_tracking_begin_s04e01: &series_ep_tracking_begin_s04e01
+              identified_by: ep
+              tracking: backfill
+              begin: s04e01
         tasks:
           inject_series:
             series:
-              - Test Series 1:
+              settings:
+                test_series:
                   season_packs: always
-              - Test Series 2:
-                  season_packs: always
-              - Test Series 3:
-                  season_packs: always
-              - Test Series 4:
-                  season_packs: always
-              - Test Series 5:
-                  season_packs: always
-              - Test Series 6:
-                  season_packs: always
-              - Test Series 7:
-                  season_packs: always
+              test_series:
+              - Test Series 1
+              - Test Series 2
+              - Test Series 3
+              - Test Series 4
+              - Test Series 5
+              - Test Series 6
+              - Test Series 7
+              - Test Series 8
+              - Test Series 9
+              - Test Series 10
+              - Test Series 11
+              - Test Series 12
+              - Test Series 13
+              - Test Series 14
+              - Test Series 15
+              - Test Series 16
+              - Test Series 17
+              - Test Series 18
+              - Test Series 19
+              - Test Series 20
+              - Test Series 21
+              - Test Series 22
+              - Test Series 23
+              - Test Series 24
+              - Test Series 25
+              - Test Series 50
+              - Test Series 100
           test_next_series_episodes_season_pack:
             next_series_episodes: yes
             series:
             - Test Series 1:
                 identified_by: ep
             max_reruns: 0
-          test_next_series_episodes_season_pack_and_ep:
-            next_series_episodes: yes
+          test_next_series_episodes_season_pack_backfill:
+            <<: *nse_backfill
             series:
             - Test Series 2:
-                identified_by: ep
+                <<: *series_ep_tracking
             max_reruns: 0
-          test_next_series_episodes_season_pack_backfill:
-            next_series_episodes:
-              backfill: yes
+          test_next_series_episodes_season_pack_backfill_and_begin:
+            <<: *nse_backfill
             series:
             - Test Series 3:
-                identified_by: ep
-                tracking: backfill
+                <<: *series_ep_tracking_begin_s02e01
             max_reruns: 0
-          test_next_series_episodes_season_pack_and_ep_backfill:
-            next_series_episodes:
-              backfill: yes
+          test_next_series_episodes_season_pack_from_start:
+            <<: *nse_from_start
             series:
             - Test Series 4:
                 identified_by: ep
-                tracking: backfill
             max_reruns: 0
-          test_next_series_episodes_season_pack_backfill_and_begin:
-            next_series_episodes:
-              backfill: yes
+          test_next_series_episodes_season_pack_from_start_backfill:
+            <<: *nse_backfill_from_start
             series:
             - Test Series 5:
-                identified_by: ep
-                begin: S02E01
-                tracking: backfill
+                <<: *series_ep_tracking
             max_reruns: 0
-          test_next_series_episodes_season_pack_and_ep_backfill_and_begin:
-            next_series_episodes:
-              backfill: yes
+          test_next_series_episodes_season_pack_from_start_backfill_and_begin:
+            <<: *nse_backfill_from_start
             series:
             - Test Series 6:
+                <<: *series_ep_tracking_begin_s02e01
+            max_reruns: 0
+          test_next_series_episodes_season_pack_and_ep:
+            next_series_episodes: yes
+            series:
+            - Test Series 7:
+                identified_by: ep
+            max_reruns: 0
+          test_next_series_episodes_season_pack_and_ep_backfill:
+            <<: *nse_backfill
+            series:
+            - Test Series 8:
+                <<: *series_ep_tracking
+            max_reruns: 0
+          test_next_series_episodes_season_pack_and_ep_backfill_and_begin:
+            <<: *nse_backfill
+            series:
+            - Test Series 9:
+                <<: *series_ep_tracking_begin_s02e01
+            max_reruns: 0
+          test_next_series_episodes_season_pack_and_ep_from_start:
+            <<: *nse_from_start
+            series:
+            - Test Series 10:
+                identified_by: ep
+            max_reruns: 0
+          test_next_series_episodes_season_pack_and_ep_from_start_backfill:
+            <<: *nse_backfill_from_start
+            series:
+            - Test Series 11:
+                <<: *series_ep_tracking
+            max_reruns: 0
+          test_next_series_episodes_season_pack_and_ep_from_start_backfill_and_begin:
+            <<: *nse_backfill_from_start
+            series:
+            - Test Series 12:
+                <<: *series_ep_tracking_begin_s02e01
+            max_reruns: 0
+          test_next_series_episodes_season_pack_gap:
+            next_series_episodes: yes
+            series:
+            - Test Series 13:
+                identified_by: ep
+            max_reruns: 0
+          test_next_series_episodes_season_pack_gap_backfill:
+            <<: *nse_backfill
+            series:
+            - Test Series 14:
+                <<: *series_ep_tracking
+            max_reruns: 0
+          test_next_series_episodes_season_pack_gap_backfill_and_begin:
+            <<: *nse_backfill
+            series:
+            - Test Series 15:
+                <<: *series_ep_tracking_begin_s04e01
+            max_reruns: 0
+          test_next_series_episodes_season_pack_gap_from_start:
+            <<: *nse_from_start
+            series:
+            - Test Series 16:
+                identified_by: ep
+            max_reruns: 0
+          test_next_series_episodes_season_pack_gap_from_start_backfill:
+            <<: *nse_backfill_from_start
+            series:
+            - Test Series 17:
+                <<: *series_ep_tracking
+            max_reruns: 0
+          test_next_series_episodes_season_pack_gap_from_start_backfill_and_begin:
+            <<: *nse_backfill_from_start
+            series:
+            - Test Series 18:
+                <<: *series_ep_tracking_begin_s04e01
+            max_reruns: 0
+          test_next_series_episodes_season_pack_and_ep_gap:
+            next_series_episodes: yes
+            series:
+            - Test Series 19:
+                identified_by: ep
+            max_reruns: 0
+          test_next_series_episodes_season_pack_and_ep_gap_backfill:
+            <<: *nse_backfill
+            series:
+            - Test Series 20:
+                <<: *series_ep_tracking
+            max_reruns: 0
+          test_next_series_episodes_season_pack_and_ep_gap_backfill_and_begin:
+            <<: *nse_backfill
+            series:
+            - Test Series 21:
+                <<: *series_ep_tracking_begin_s04e01
+            max_reruns: 0
+          test_next_series_episodes_season_pack_and_ep_gap_from_start:
+            <<: *nse_from_start
+            series:
+            - Test Series 22:
+                identified_by: ep
+            max_reruns: 0
+          test_next_series_episodes_season_pack_and_ep_gap_from_start_backfill:
+            <<: *nse_backfill_from_start
+            series:
+            - Test Series 23:
+                <<: *series_ep_tracking
+            max_reruns: 0
+          test_next_series_episodes_season_pack_and_ep_gap_from_start_backfill_and_begin:
+            <<: *nse_backfill_from_start
+            series:
+            - Test Series 24:
+                <<: *series_ep_tracking_begin_s04e01
+            max_reruns: 0
+
+          test_next_series_episodes_season_pack_begin_completed:
+            next_series_episodes: yes
+            series:
+            - Test Series 50:
                 identified_by: ep
                 begin: S02E01
-                tracking: backfill
             max_reruns: 0
-          test_next_series_episodes_season_pack_from_start:
+
+          test_next_series_episodes_season_pack_from_start_multirun:
             next_series_episodes:
                 from_start: yes
             series:
-            - Test Series 7:
+            - Test Series 100:
                 identified_by: ep
             max_reruns: 0
     """
@@ -311,21 +457,82 @@ class TestNextSeriesEpisodesSeasonPack(object):
         ('test_next_series_episodes_season_pack',
             ['Test Series 1 S02'],
             ['Test Series 1 S03E01']),
-        ('test_next_series_episodes_season_pack_and_ep',
-            ['Test Series 2 S02', 'Test Series 2 S03E01'],
-            ['Test Series 2 S03E02']),
         ('test_next_series_episodes_season_pack_backfill',
-            ['Test Series 3 S02'],
-            ['Test Series 3 S01E01', 'Test Series 3 S03E01']),
-        ('test_next_series_episodes_season_pack_and_ep_backfill',
-            ['Test Series 4 S02', 'Test Series 4 S03E01'],
-            ['Test Series 4 S01E01', 'Test Series 4 S03E02']),
+            ['Test Series 2 S02'],
+            ['Test Series 2 S01E01', 'Test Series 2 S03E01']),
         ('test_next_series_episodes_season_pack_backfill_and_begin',
+            ['Test Series 3 S02'],
+            ['Test Series 3 S03E01']),
+        ('test_next_series_episodes_season_pack_from_start',
+            ['Test Series 4 S02'],
+            ['Test Series 4 S03E01']),
+        ('test_next_series_episodes_season_pack_from_start_backfill',
             ['Test Series 5 S02'],
-            ['Test Series 5 S03E01']),
+            ['Test Series 5 S03E01', 'Test Series 5 S01E01']),
+        ('test_next_series_episodes_season_pack_from_start_backfill_and_begin',
+            ['Test Series 6 S02'],
+            ['Test Series 6 S03E01']),
+        ('test_next_series_episodes_season_pack_and_ep',
+            ['Test Series 7 S02', 'Test Series 7 S03E01'],
+            ['Test Series 7 S03E02']),
+        ('test_next_series_episodes_season_pack_and_ep_backfill',
+            ['Test Series 8 S02', 'Test Series 8 S03E01'],
+            ['Test Series 8 S01E01', 'Test Series 8 S03E02']),
         ('test_next_series_episodes_season_pack_and_ep_backfill_and_begin',
-            ['Test Series 6 S02', 'Test Series 6 S03E01'],
-            ['Test Series 6 S03E02'])
+            ['Test Series 9 S02', 'Test Series 9 S03E01'],
+            ['Test Series 9 S03E02']),
+        ('test_next_series_episodes_season_pack_and_ep_from_start',
+            ['Test Series 10 S02', 'Test Series 10 S03E01'],
+            ['Test Series 10 S03E02']),
+        ('test_next_series_episodes_season_pack_and_ep_from_start_backfill',
+            ['Test Series 11 S02', 'Test Series 11 S03E01'],
+            ['Test Series 11 S03E02', 'Test Series 11 S01E01']),
+        ('test_next_series_episodes_season_pack_and_ep_from_start_backfill_and_begin',
+            ['Test Series 12 S02', 'Test Series 12 S03E01'],
+            ['Test Series 12 S03E02']),
+        ('test_next_series_episodes_season_pack_gap',
+            ['Test Series 13 S02', 'Test Series 13 S06'],
+            ['Test Series 13 S07E01']),
+        ('test_next_series_episodes_season_pack_gap_backfill',
+            ['Test Series 14 S02', 'Test Series 14 S06'],
+            ['Test Series 14 S07E01', 'Test Series 14 S05E01', 'Test Series 14 S04E01', 'Test Series 14 S03E01',
+             'Test Series 14 S01E01']),
+        ('test_next_series_episodes_season_pack_gap_backfill_and_begin',
+            ['Test Series 15 S02', 'Test Series 15 S06'],
+            ['Test Series 15 S07E01', 'Test Series 15 S05E01', 'Test Series 15 S04E01']),
+        ('test_next_series_episodes_season_pack_gap_from_start',
+            ['Test Series 16 S02', 'Test Series 16 S06'],
+            ['Test Series 16 S07E01']),
+        ('test_next_series_episodes_season_pack_gap_from_start_backfill',
+            ['Test Series 17 S02', 'Test Series 17 S06'],
+            ['Test Series 17 S07E01', 'Test Series 17 S05E01', 'Test Series 17 S04E01', 'Test Series 17 S03E01',
+             'Test Series 17 S01E01']),
+        ('test_next_series_episodes_season_pack_gap_from_start_backfill_and_begin',
+            ['Test Series 18 S02', 'Test Series 18 S06'],
+            ['Test Series 18 S07E01', 'Test Series 18 S05E01', 'Test Series 18 S04E01']),
+        ('test_next_series_episodes_season_pack_and_ep_gap',
+            ['Test Series 19 S02', 'Test Series 19 S06', 'Test Series 19 S07E01'],
+            ['Test Series 19 S07E02']),
+        ('test_next_series_episodes_season_pack_and_ep_gap_backfill',
+            ['Test Series 20 S02', 'Test Series 20 S06', 'Test Series 20 S07E01'],
+            ['Test Series 20 S07E02', 'Test Series 20 S05E01', 'Test Series 20 S04E01', 'Test Series 20 S03E01',
+             'Test Series 20 S01E01']),
+        ('test_next_series_episodes_season_pack_and_ep_gap_backfill_and_begin',
+            ['Test Series 21 S02', 'Test Series 21 S06', 'Test Series 21 S07E01'],
+            ['Test Series 21 S07E02', 'Test Series 21 S05E01', 'Test Series 21 S04E01']),
+        ('test_next_series_episodes_season_pack_and_ep_gap_from_start',
+            ['Test Series 22 S02', 'Test Series 22 S03E01', 'Test Series 22 S06'],
+            ['Test Series 22 S07E01']),
+        ('test_next_series_episodes_season_pack_and_ep_gap_from_start_backfill',
+            ['Test Series 23 S02', 'Test Series 23 S03E01', 'Test Series 23 S06'],
+            ['Test Series 23 S07E01', 'Test Series 23 S05E01', 'Test Series 23 S04E01', 'Test Series 23 S03E02',
+             'Test Series 23 S01E01']),
+        ('test_next_series_episodes_season_pack_and_ep_gap_from_start_backfill_and_begin',
+            ['Test Series 24 S02', 'Test Series 24 S03E01', 'Test Series 24 S06'],
+            ['Test Series 24 S07E01', 'Test Series 24 S05E01', 'Test Series 24 S04E01']),
+        ('test_next_series_episodes_season_pack_begin_completed',
+            ['Test Series 50 S02'],
+            ['Test Series 50 S03E01'])
     ])
     def test_next_series_episodes_season_pack(self, execute_task, task_name, inject, result_find):
         for entity_id in inject:
@@ -339,12 +546,12 @@ class TestNextSeriesEpisodesSeasonPack(object):
     # Each run_parameter is a tuple of lists: [task name, list of series ID(s) to inject, list of result(s) to find]
     @pytest.mark.parametrize("run_parameters", [
         (
-         ['test_next_series_episodes_season_pack_from_start',
+         ['test_next_series_episodes_season_pack_from_start_multirun',
             [],
-            ['Test Series 7 S01E01']],
-         ['test_next_series_episodes_season_pack_from_start',
+            ['Test Series 100 S01E01']],
+         ['test_next_series_episodes_season_pack_from_start_multirun',
             [],
-            ['Test Series 7 S01E02']]
+            ['Test Series 100 S01E02']]
         )
     ])
     def test_next_series_episodes_season_pack_multirun(self, execute_task, run_parameters):

--- a/flexget/tests/test_next_series_seasons.py
+++ b/flexget/tests/test_next_series_seasons.py
@@ -28,7 +28,9 @@ class TestNextSeriesSeasonSeasonsPack(object):
                   season_packs: always
               - Test Series 6:
                   season_packs: always
-          test_next_series_seasons_season_pack:
+              - Test Series 7:
+                  season_packs: always
+          test_next_series_seasons:
             next_series_seasons: yes
             series:
             - Test Series 1:
@@ -37,7 +39,7 @@ class TestNextSeriesSeasonSeasonsPack(object):
                     threshold: 1000
                     reject_eps: yes
             max_reruns: 0
-          test_next_series_seasons_season_pack_and_ep:
+          test_next_series_seasons_ep_history:
             next_series_seasons: yes
             series:
             - Test Series 2:
@@ -46,7 +48,7 @@ class TestNextSeriesSeasonSeasonsPack(object):
                     threshold: 1000
                     reject_eps: yes
             max_reruns: 0
-          test_next_series_seasons_season_pack_backfill:
+          test_next_series_seasons_backfill:
             next_series_seasons:
               backfill: yes
             series:
@@ -57,7 +59,7 @@ class TestNextSeriesSeasonSeasonsPack(object):
                     threshold: 1000
                     reject_eps: yes
             max_reruns: 0
-          test_next_series_seasons_season_pack_and_ep_backfill:
+          test_next_series_seasons_ep_history_backfill:
             next_series_seasons:
               backfill: yes
             series:
@@ -68,7 +70,7 @@ class TestNextSeriesSeasonSeasonsPack(object):
                     threshold: 1000
                     reject_eps: yes
             max_reruns: 0
-          test_next_series_seasons_season_pack_backfill_and_begin:
+          test_next_series_seasons_backfill_and_begin:
             next_series_seasons:
               backfill: yes
             series:
@@ -80,7 +82,7 @@ class TestNextSeriesSeasonSeasonsPack(object):
                     threshold: 1000
                     reject_eps: yes
             max_reruns: 0
-          test_next_series_seasons_season_pack_and_ep_backfill_and_begin:
+          test_next_series_seasons_ep_history_backfill_and_begin:
             next_series_seasons:
               backfill: yes
             series:
@@ -88,6 +90,16 @@ class TestNextSeriesSeasonSeasonsPack(object):
                 identified_by: ep
                 tracking: backfill
                 begin: S02E01
+                season_packs:
+                    threshold: 1000
+                    reject_eps: yes
+            max_reruns: 0
+          test_next_series_seasons_from_start:
+            next_series_seasons:
+                from_start: yes
+            series:
+            - Test Series 7:
+                identified_by: ep
                 season_packs:
                     threshold: 1000
                     reject_eps: yes
@@ -102,43 +114,57 @@ class TestNextSeriesSeasonSeasonsPack(object):
     def inject_series(self, execute_task, release_name):
         execute_task('inject_series', options={'inject': [Entry(title=release_name, url='')], 'disable_tracking': True})
 
-    def test_next_series_seasons_season_pack(self, execute_task):
-        self.inject_series(execute_task, 'Test Series 1 S02')
-        task = execute_task('test_next_series_seasons_season_pack')
-        assert task.find_entry(title='Test Series 1 S03')
-        assert len(task.all_entries) == 1
+    @pytest.mark.parametrize("task_name,inject,result_find,result_length", [
+        ('test_next_series_seasons',
+            ['Test Series 1 S02'],
+            ['Test Series 1 S03'],
+            1),
+        ('test_next_series_seasons_ep_history',
+            ['Test Series 2 S02', 'Test Series 2 S03E01'],
+            ['Test Series 2 S03'],
+            1),
+        ('test_next_series_seasons_backfill',
+            ['Test Series 3 S02'],
+            ['Test Series 3 S01', 'Test Series 3 S03'],
+            2),
+        ('test_next_series_seasons_ep_history_backfill',
+            ['Test Series 4 S02', 'Test Series 4 S03E01'],
+            ['Test Series 4 S01', 'Test Series 4 S03'],
+            2),
+        ('test_next_series_seasons_backfill_and_begin',
+            ['Test Series 5 S02'],
+            ['Test Series 5 S03'],
+            1),
+        ('test_next_series_seasons_ep_history_backfill_and_begin',
+            ['Test Series 6 S02', 'Test Series 6 S03E01'],
+            ['Test Series 6 S03'],
+            1)
+    ])
+    def test_next_series_seasons(self, execute_task, task_name, inject, result_find, result_length):
+        for entity_id in inject:
+            self.inject_series(execute_task, entity_id)
+        task = execute_task(task_name)
+        for result_title in result_find:
+            assert task.find_entry(title=result_title)
+        assert len(task.all_entries) == result_length
 
-    def test_next_series_seasons_season_pack_and_ep(self, execute_task):
-        self.inject_series(execute_task, 'Test Series 2 S02')
-        self.inject_series(execute_task, 'Test Series 2 S03E01')
-        task = execute_task('test_next_series_seasons_season_pack_and_ep')
-        assert task.find_entry(title='Test Series 2 S03')
-        assert len(task.all_entries) == 1
-
-    def test_next_series_seasons_season_pack_backfill(self, execute_task):
-        self.inject_series(execute_task, 'Test Series 3 S02')
-        task = execute_task('test_next_series_seasons_season_pack_backfill')
-        assert task.find_entry(title='Test Series 3 S01')
-        assert task.find_entry(title='Test Series 3 S03')
-        assert len(task.all_entries) == 2
-
-    def test_next_series_seasons_season_pack_and_ep_backfill(self, execute_task):
-        self.inject_series(execute_task, 'Test Series 4 S02')
-        self.inject_series(execute_task, 'Test Series 4 S03E01')
-        task = execute_task('test_next_series_seasons_season_pack_and_ep_backfill')
-        assert task.find_entry(title='Test Series 4 S01')
-        assert task.find_entry(title='Test Series 4 S03')
-        assert len(task.all_entries) == 2
-
-    def test_next_series_seasons_season_pack_backfill_and_begin(self, execute_task):
-        self.inject_series(execute_task, 'Test Series 5 S02')
-        task = execute_task('test_next_series_seasons_season_pack_backfill_and_begin')
-        assert task.find_entry(title='Test Series 5 S03')
-        assert len(task.all_entries) == 1
-
-    def test_next_series_seasons_season_pack_and_ep_backfill_and_begin(self, execute_task):
-        self.inject_series(execute_task, 'Test Series 6 S02')
-        self.inject_series(execute_task, 'Test Series 6 S03E01')
-        task = execute_task('test_next_series_seasons_season_pack_and_ep_backfill_and_begin')
-        assert task.find_entry(title='Test Series 6 S03')
-        assert len(task.all_entries) == 1
+    # Tests which require multiple tasks to be executed in order
+    # Each run_parameter is a tuple of lists: [task name, list of series ID(s) to inject, list of result(s) to find]
+    @pytest.mark.parametrize("run_parameters", [
+        (
+         ['test_next_series_seasons_from_start',
+            [],
+            ['Test Series 7 S01']],
+         ['test_next_series_seasons_from_start',
+            [],
+            ['Test Series 7 S02']]
+        )
+    ])
+    def test_next_series_seasons_multirun(self, execute_task, run_parameters):
+        for this_test in run_parameters:
+            for entity_id in this_test[1]:
+                self.inject_series(execute_task, entity_id)
+            task = execute_task(this_test[0])
+            for result_title in this_test[2]:
+                assert task.find_entry(title=result_title)
+            assert len(task.all_entries) == len(this_test[2])

--- a/flexget/tests/test_next_series_seasons.py
+++ b/flexget/tests/test_next_series_seasons.py
@@ -22,6 +22,12 @@ class TestNextSeriesSeasonSeasonsPack(object):
                   season_packs: always
               - Test Series 3:
                   season_packs: always
+              - Test Series 4:
+                  season_packs: always
+              - Test Series 5:
+                  season_packs: always
+              - Test Series 6:
+                  season_packs: always
           test_next_series_seasons_season_pack:
             next_series_seasons: yes
             series:
@@ -29,11 +35,27 @@ class TestNextSeriesSeasonSeasonsPack(object):
                 identified_by: ep
                 season_packs: only
             max_reruns: 0
+          test_next_series_seasons_season_pack_and_ep:
+            next_series_seasons: yes
+            series:
+            - Test Series 2:
+                identified_by: ep
+                season_packs: only
+            max_reruns: 0
           test_next_series_seasons_season_pack_backfill:
             next_series_seasons:
               backfill: yes
             series:
-            - Test Series 2:
+            - Test Series 3:
+                identified_by: ep
+                tracking: backfill
+                season_packs: only
+            max_reruns: 0
+          test_next_series_seasons_season_pack_and_ep_backfill:
+            next_series_seasons:
+              backfill: yes
+            series:
+            - Test Series 4:
                 identified_by: ep
                 tracking: backfill
                 season_packs: only
@@ -42,7 +64,17 @@ class TestNextSeriesSeasonSeasonsPack(object):
             next_series_seasons:
               backfill: yes
             series:
-            - Test Series 3:
+            - Test Series 5:
+                identified_by: ep
+                tracking: backfill
+                begin: S02E01
+                season_packs: only
+            max_reruns: 0
+          test_next_series_seasons_season_pack_and_ep_backfill_and_begin:
+            next_series_seasons:
+              backfill: yes
+            series:
+            - Test Series 6:
                 identified_by: ep
                 tracking: backfill
                 begin: S02E01
@@ -63,29 +95,38 @@ class TestNextSeriesSeasonSeasonsPack(object):
         task = execute_task('test_next_series_seasons_season_pack')
         assert task.find_entry(title='Test Series 1 S03')
         assert len(task.all_entries) == 1
-        self.inject_series(execute_task, 'Test Series 1 S03E01')
-        task = execute_task('test_next_series_seasons_season_pack')
-        assert task.find_entry(title='Test Series 1 S03')
+
+    def test_next_series_seasons_season_pack_and_ep(self, execute_task):
+        self.inject_series(execute_task, 'Test Series 2 S02')
+        self.inject_series(execute_task, 'Test Series 2 S03E01')
+        task = execute_task('test_next_series_seasons_season_pack_and_ep')
+        assert task.find_entry(title='Test Series 2 S03')
         assert len(task.all_entries) == 1
 
     def test_next_series_seasons_season_pack_backfill(self, execute_task):
-        self.inject_series(execute_task, 'Test Series 2 S02')
+        self.inject_series(execute_task, 'Test Series 3 S02')
         task = execute_task('test_next_series_seasons_season_pack_backfill')
-        assert task.find_entry(title='Test Series 2 S01')
-        assert task.find_entry(title='Test Series 2 S03')
+        assert task.find_entry(title='Test Series 3 S01')
+        assert task.find_entry(title='Test Series 3 S03')
         assert len(task.all_entries) == 2
-        self.inject_series(execute_task, 'Test Series 2 S03E01')
-        task = execute_task('test_next_series_seasons_season_pack_backfill')
-        assert task.find_entry(title='Test Series 2 S01')
-        assert task.find_entry(title='Test Series 2 S03')
+
+    def test_next_series_seasons_season_pack_and_ep_backfill(self, execute_task):
+        self.inject_series(execute_task, 'Test Series 4 S02')
+        self.inject_series(execute_task, 'Test Series 4 S03E01')
+        task = execute_task('test_next_series_seasons_season_pack_and_ep_backfill')
+        assert task.find_entry(title='Test Series 4 S01')
+        assert task.find_entry(title='Test Series 4 S03')
         assert len(task.all_entries) == 2
 
     def test_next_series_seasons_season_pack_backfill_and_begin(self, execute_task):
-        self.inject_series(execute_task, 'Test Series 3 S02')
+        self.inject_series(execute_task, 'Test Series 5 S02')
         task = execute_task('test_next_series_seasons_season_pack_backfill_and_begin')
-        assert task.find_entry(title='Test Series 3 S03')
+        assert task.find_entry(title='Test Series 5 S03')
         assert len(task.all_entries) == 1
-        self.inject_series(execute_task, 'Test Series 3 S03E01')
-        task = execute_task('test_next_series_seasons_season_pack_backfill_and_begin')
-        assert task.find_entry(title='Test Series 3 S03')
+
+    def test_next_series_seasons_season_pack_and_ep_backfill_and_begin(self, execute_task):
+        self.inject_series(execute_task, 'Test Series 6 S02')
+        self.inject_series(execute_task, 'Test Series 6 S03E01')
+        task = execute_task('test_next_series_seasons_season_pack_and_ep_backfill_and_begin')
+        assert task.find_entry(title='Test Series 6 S03')
         assert len(task.all_entries) == 1

--- a/flexget/tests/test_next_series_seasons.py
+++ b/flexget/tests/test_next_series_seasons.py
@@ -13,96 +13,239 @@ class TestNextSeriesSeasonSeasonsPack(object):
           global:
             parsing:
               series: internal
+          anchors:
+            _nss_backfill: &nss_backfill
+              next_series_seasons:
+                backfill: yes
+            _nss_from_start: &nss_from_start
+              next_series_seasons:
+                from_start: yes
+            _nss_backfill_from_start: &nss_backfill_from_start
+              next_series_seasons:
+                backfill: yes
+                from_start: yes
+            _series_ep_pack: &series_ep_pack
+              identified_by: ep
+              tracking: backfill
+              season_packs:
+                threshold: 1000
+                reject_eps: yes
+            _series_ep_tracking_pack: &series_ep_tracking_pack
+              identified_by: ep
+              tracking: backfill
+              season_packs:
+                threshold: 1000
+                reject_eps: yes
+            _series_ep_tracking_begin_s02e01: &series_ep_tracking_pack_begin_s02e01
+              identified_by: ep
+              tracking: backfill
+              begin: s02e01
+              season_packs:
+                threshold: 1000
+                reject_eps: yes
+            _series_ep_tracking_begin_s04e01: &series_ep_tracking_pack_begin_s04e01
+              identified_by: ep
+              tracking: backfill
+              begin: s04e01
+              season_packs:
+                threshold: 1000
+                reject_eps: yes
         tasks:
           inject_series:
             series:
-              - Test Series 1:
+              settings:
+                test_series:
                   season_packs: always
-              - Test Series 2:
-                  season_packs: always
-              - Test Series 3:
-                  season_packs: always
-              - Test Series 4:
-                  season_packs: always
-              - Test Series 5:
-                  season_packs: always
-              - Test Series 6:
-                  season_packs: always
-              - Test Series 7:
-                  season_packs: always
-          test_next_series_seasons:
+              test_series:
+              - Test Series 1
+              - Test Series 2
+              - Test Series 3
+              - Test Series 4
+              - Test Series 5
+              - Test Series 6
+              - Test Series 7
+              - Test Series 8
+              - Test Series 9
+              - Test Series 10
+              - Test Series 11
+              - Test Series 12
+              - Test Series 13
+              - Test Series 14
+              - Test Series 15
+              - Test Series 16
+              - Test Series 17
+              - Test Series 18
+              - Test Series 19
+              - Test Series 20
+              - Test Series 21
+              - Test Series 22
+              - Test Series 23
+              - Test Series 24
+              - Test Series 25
+              - Test Series 50
+              - Test Series 100
+          test_next_series_seasons_season_pack:
             next_series_seasons: yes
             series:
             - Test Series 1:
-                identified_by: ep
-                season_packs:
-                    threshold: 1000
-                    reject_eps: yes
+                <<: *series_ep_pack
             max_reruns: 0
-          test_next_series_seasons_ep_history:
-            next_series_seasons: yes
+          test_next_series_seasons_season_pack_backfill:
+            <<: *nss_backfill
             series:
             - Test Series 2:
-                identified_by: ep
-                season_packs:
-                    threshold: 1000
-                    reject_eps: yes
+                <<: *series_ep_tracking_pack
             max_reruns: 0
-          test_next_series_seasons_backfill:
-            next_series_seasons:
-              backfill: yes
+          test_next_series_seasons_season_pack_backfill_and_begin:
+            <<: *nss_backfill
             series:
             - Test Series 3:
-                identified_by: ep
-                tracking: backfill
-                season_packs:
-                    threshold: 1000
-                    reject_eps: yes
+                <<: *series_ep_tracking_pack_begin_s02e01
             max_reruns: 0
-          test_next_series_seasons_ep_history_backfill:
-            next_series_seasons:
-              backfill: yes
+          test_next_series_seasons_season_pack_from_start:
+            <<: *nss_from_start
             series:
             - Test Series 4:
-                identified_by: ep
-                tracking: backfill
-                season_packs:
-                    threshold: 1000
-                    reject_eps: yes
+                <<: *series_ep_pack
             max_reruns: 0
-          test_next_series_seasons_backfill_and_begin:
-            next_series_seasons:
-              backfill: yes
+          test_next_series_seasons_season_pack_from_start_backfill:
+            <<: *nss_backfill_from_start
             series:
             - Test Series 5:
-                identified_by: ep
-                tracking: backfill
-                begin: S02E01
-                season_packs:
-                    threshold: 1000
-                    reject_eps: yes
+                <<: *series_ep_tracking_pack
             max_reruns: 0
-          test_next_series_seasons_ep_history_backfill_and_begin:
-            next_series_seasons:
-              backfill: yes
+          test_next_series_seasons_season_pack_from_start_backfill_and_begin:
+            <<: *nss_backfill_from_start
             series:
             - Test Series 6:
+                <<: *series_ep_tracking_pack_begin_s02e01
+            max_reruns: 0
+          test_next_series_seasons_season_pack_and_ep:
+            next_series_seasons: yes
+            series:
+            - Test Series 7:
+                <<: *series_ep_pack
+            max_reruns: 0
+          test_next_series_seasons_season_pack_and_ep_backfill:
+            <<: *nss_backfill
+            series:
+            - Test Series 8:
+                <<: *series_ep_tracking_pack
+            max_reruns: 0
+          test_next_series_seasons_season_pack_and_ep_backfill_and_begin:
+            <<: *nss_backfill
+            series:
+            - Test Series 9:
+                <<: *series_ep_tracking_pack_begin_s02e01
+            max_reruns: 0
+          test_next_series_seasons_season_pack_and_ep_from_start:
+            <<: *nss_from_start
+            series:
+            - Test Series 10:
+                <<: *series_ep_pack
+            max_reruns: 0
+          test_next_series_seasons_season_pack_and_ep_from_start_backfill:
+            <<: *nss_backfill_from_start
+            series:
+            - Test Series 11:
+                <<: *series_ep_tracking_pack
+            max_reruns: 0
+          test_next_series_seasons_season_pack_and_ep_from_start_backfill_and_begin:
+            <<: *nss_backfill_from_start
+            series:
+            - Test Series 12:
+                <<: *series_ep_tracking_pack_begin_s02e01
+            max_reruns: 0
+          test_next_series_seasons_season_pack_gap:
+            next_series_seasons: yes
+            series:
+            - Test Series 13:
+                <<: *series_ep_pack
+            max_reruns: 0
+          test_next_series_seasons_season_pack_gap_backfill:
+            <<: *nss_backfill
+            series:
+            - Test Series 14:
+                <<: *series_ep_tracking_pack
+            max_reruns: 0
+          test_next_series_seasons_season_pack_gap_backfill_and_begin:
+            <<: *nss_backfill
+            series:
+            - Test Series 15:
+                <<: *series_ep_tracking_pack_begin_s04e01
+            max_reruns: 0
+          test_next_series_seasons_season_pack_gap_from_start:
+            <<: *nss_from_start
+            series:
+            - Test Series 16:
+                <<: *series_ep_pack
+            max_reruns: 0
+          test_next_series_seasons_season_pack_gap_from_start_backfill:
+            <<: *nss_backfill_from_start
+            series:
+            - Test Series 17:
+                <<: *series_ep_tracking_pack
+            max_reruns: 0
+          test_next_series_seasons_season_pack_gap_from_start_backfill_and_begin:
+            <<: *nss_backfill_from_start
+            series:
+            - Test Series 18:
+                <<: *series_ep_tracking_pack_begin_s04e01
+            max_reruns: 0
+          test_next_series_seasons_season_pack_and_ep_gap:
+            next_series_seasons: yes
+            series:
+            - Test Series 19:
+                <<: *series_ep_pack
+            max_reruns: 0
+          test_next_series_seasons_season_pack_and_ep_gap_backfill:
+            <<: *nss_backfill
+            series:
+            - Test Series 20:
+                <<: *series_ep_tracking_pack
+            max_reruns: 0
+          test_next_series_seasons_season_pack_and_ep_gap_backfill_and_begin:
+            <<: *nss_backfill
+            series:
+            - Test Series 21:
+                <<: *series_ep_tracking_pack_begin_s04e01
+            max_reruns: 0
+          test_next_series_seasons_season_pack_and_ep_gap_from_start:
+            <<: *nss_from_start
+            series:
+            - Test Series 22:
+                <<: *series_ep_pack
+            max_reruns: 0
+          test_next_series_seasons_season_pack_and_ep_gap_from_start_backfill:
+            <<: *nss_backfill_from_start
+            series:
+            - Test Series 23:
+                <<: *series_ep_tracking_pack
+            max_reruns: 0
+          test_next_series_seasons_season_pack_and_ep_gap_from_start_backfill_and_begin:
+            <<: *nss_backfill_from_start
+            series:
+            - Test Series 24:
+                <<: *series_ep_tracking_pack_begin_s04e01
+            max_reruns: 0
+
+          test_next_series_seasons_season_pack_begin_completed:
+            next_series_seasons: yes
+            series:
+            - Test Series 50:
                 identified_by: ep
-                tracking: backfill
                 begin: S02E01
                 season_packs:
-                    threshold: 1000
-                    reject_eps: yes
+                  threshold: 1000
+                  reject_eps: yes
             max_reruns: 0
-          test_next_series_seasons_from_start:
+
+          test_next_series_seasons_season_pack_from_start_multirun:
             next_series_seasons:
                 from_start: yes
             series:
-            - Test Series 7:
-                identified_by: ep
-                season_packs:
-                    threshold: 1000
-                    reject_eps: yes
+            - Test Series 100:
+                <<: *series_ep_pack
             max_reruns: 0
     """
 
@@ -114,50 +257,105 @@ class TestNextSeriesSeasonSeasonsPack(object):
     def inject_series(self, execute_task, release_name):
         execute_task('inject_series', options={'inject': [Entry(title=release_name, url='')], 'disable_tracking': True})
 
-    @pytest.mark.parametrize("task_name,inject,result_find,result_length", [
-        ('test_next_series_seasons',
+    @pytest.mark.parametrize("task_name,inject,result_find", [
+        ('test_next_series_seasons_season_pack',
             ['Test Series 1 S02'],
-            ['Test Series 1 S03'],
-            1),
-        ('test_next_series_seasons_ep_history',
-            ['Test Series 2 S02', 'Test Series 2 S03E01'],
-            ['Test Series 2 S03'],
-            1),
-        ('test_next_series_seasons_backfill',
+            ['Test Series 1 S03']),
+        ('test_next_series_seasons_season_pack_backfill',
+            ['Test Series 2 S02'],
+            ['Test Series 2 S01', 'Test Series 2 S03']),
+        ('test_next_series_seasons_season_pack_backfill_and_begin',
             ['Test Series 3 S02'],
-            ['Test Series 3 S01', 'Test Series 3 S03'],
-            2),
-        ('test_next_series_seasons_ep_history_backfill',
-            ['Test Series 4 S02', 'Test Series 4 S03E01'],
-            ['Test Series 4 S01', 'Test Series 4 S03'],
-            2),
-        ('test_next_series_seasons_backfill_and_begin',
+            ['Test Series 3 S03']),
+        ('test_next_series_seasons_season_pack_from_start',
+            ['Test Series 4 S02'],
+            ['Test Series 4 S03']),
+        ('test_next_series_seasons_season_pack_from_start_backfill',
             ['Test Series 5 S02'],
-            ['Test Series 5 S03'],
-            1),
-        ('test_next_series_seasons_ep_history_backfill_and_begin',
-            ['Test Series 6 S02', 'Test Series 6 S03E01'],
-            ['Test Series 6 S03'],
-            1)
+            ['Test Series 5 S03', 'Test Series 5 S01']),
+        ('test_next_series_seasons_season_pack_from_start_backfill_and_begin',
+            ['Test Series 6 S02'],
+            ['Test Series 6 S03']),
+        ('test_next_series_seasons_season_pack_and_ep',
+            ['Test Series 7 S02', 'Test Series 7 S03E01'],
+            ['Test Series 7 S03']),
+        ('test_next_series_seasons_season_pack_and_ep_backfill',
+            ['Test Series 8 S02', 'Test Series 8 S03E01'],
+            ['Test Series 8 S01', 'Test Series 8 S03']),
+        ('test_next_series_seasons_season_pack_and_ep_backfill_and_begin',
+            ['Test Series 9 S02', 'Test Series 9 S03E01'],
+            ['Test Series 9 S03']),
+        ('test_next_series_seasons_season_pack_and_ep_from_start',
+            ['Test Series 10 S02', 'Test Series 10 S03E01'],
+            ['Test Series 10 S03']),
+        ('test_next_series_seasons_season_pack_and_ep_from_start_backfill',
+            ['Test Series 11 S02', 'Test Series 11 S03E01'],
+            ['Test Series 11 S03', 'Test Series 11 S01']),
+        ('test_next_series_seasons_season_pack_and_ep_from_start_backfill_and_begin',
+            ['Test Series 12 S02', 'Test Series 12 S03E01'],
+            ['Test Series 12 S03']),
+        ('test_next_series_seasons_season_pack_gap',
+            ['Test Series 13 S02', 'Test Series 13 S06'],
+            ['Test Series 13 S07']),
+        ('test_next_series_seasons_season_pack_gap_backfill',
+            ['Test Series 14 S02', 'Test Series 14 S06'],
+            ['Test Series 14 S07', 'Test Series 14 S05', 'Test Series 14 S04', 'Test Series 14 S03',
+             'Test Series 14 S01']),
+        ('test_next_series_seasons_season_pack_gap_backfill_and_begin',
+            ['Test Series 15 S02', 'Test Series 15 S06'],
+            ['Test Series 15 S07', 'Test Series 15 S05', 'Test Series 15 S04']),
+        ('test_next_series_seasons_season_pack_gap_from_start',
+            ['Test Series 16 S02', 'Test Series 16 S06'],
+            ['Test Series 16 S07']),
+        ('test_next_series_seasons_season_pack_gap_from_start_backfill',
+            ['Test Series 17 S02', 'Test Series 17 S06'],
+            ['Test Series 17 S07', 'Test Series 17 S05', 'Test Series 17 S04', 'Test Series 17 S03',
+             'Test Series 17 S01']),
+        ('test_next_series_seasons_season_pack_gap_from_start_backfill_and_begin',
+            ['Test Series 18 S02', 'Test Series 18 S06'],
+            ['Test Series 18 S07', 'Test Series 18 S05', 'Test Series 18 S04']),
+        ('test_next_series_seasons_season_pack_and_ep_gap',
+            ['Test Series 19 S02', 'Test Series 19 S06', 'Test Series 19 S07E01'],
+            ['Test Series 19 S07']),
+        ('test_next_series_seasons_season_pack_and_ep_gap_backfill',
+            ['Test Series 20 S02', 'Test Series 20 S06', 'Test Series 20 S07E01'],
+            ['Test Series 20 S07', 'Test Series 20 S05', 'Test Series 20 S04', 'Test Series 20 S03',
+             'Test Series 20 S01']),
+        ('test_next_series_seasons_season_pack_and_ep_gap_backfill_and_begin',
+            ['Test Series 21 S02', 'Test Series 21 S06', 'Test Series 21 S07E01'],
+            ['Test Series 21 S07', 'Test Series 21 S05', 'Test Series 21 S04']),
+        ('test_next_series_seasons_season_pack_and_ep_gap_from_start',
+            ['Test Series 22 S02', 'Test Series 22 S03E01', 'Test Series 22 S06'],
+            ['Test Series 22 S07']),
+        ('test_next_series_seasons_season_pack_and_ep_gap_from_start_backfill',
+            ['Test Series 23 S02', 'Test Series 23 S03E01', 'Test Series 23 S06'],
+            ['Test Series 23 S07', 'Test Series 23 S05', 'Test Series 23 S04', 'Test Series 23 S03',
+             'Test Series 23 S01']),
+        ('test_next_series_seasons_season_pack_and_ep_gap_from_start_backfill_and_begin',
+            ['Test Series 24 S02', 'Test Series 24 S03E01', 'Test Series 24 S06'],
+            ['Test Series 24 S07', 'Test Series 24 S05', 'Test Series 24 S04']),
+        ('test_next_series_seasons_season_pack_begin_completed',
+            ['Test Series 50 S02'],
+            ['Test Series 50 S03'])
     ])
-    def test_next_series_seasons(self, execute_task, task_name, inject, result_find, result_length):
+    def test_next_series_seasons(self, execute_task, task_name, inject, result_find):
         for entity_id in inject:
             self.inject_series(execute_task, entity_id)
         task = execute_task(task_name)
         for result_title in result_find:
             assert task.find_entry(title=result_title)
-        assert len(task.all_entries) == result_length
+        assert len(task.all_entries) == len(result_find)
 
     # Tests which require multiple tasks to be executed in order
     # Each run_parameter is a tuple of lists: [task name, list of series ID(s) to inject, list of result(s) to find]
     @pytest.mark.parametrize("run_parameters", [
         (
-         ['test_next_series_seasons_from_start',
+         ['test_next_series_seasons_season_pack_from_start_multirun',
             [],
-            ['Test Series 7 S01']],
-         ['test_next_series_seasons_from_start',
+            ['Test Series 100 S01']],
+         ['test_next_series_seasons_season_pack_from_start_multirun',
             [],
-            ['Test Series 7 S02']]
+            ['Test Series 100 S02']]
         )
     ])
     def test_next_series_seasons_multirun(self, execute_task, run_parameters):

--- a/flexget/tests/test_next_series_seasons.py
+++ b/flexget/tests/test_next_series_seasons.py
@@ -1,0 +1,91 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+import pytest
+
+from flexget.entry import Entry
+
+
+#TODO Add more standard tests
+class TestNextSeriesSeasonSeasonsPack(object):
+    _config = """
+        templates:
+          global:
+            parsing:
+              series: internal
+        tasks:
+          inject_series:
+            series:
+              - Test Series 1:
+                  season_packs: always
+              - Test Series 2:
+                  season_packs: always
+              - Test Series 3:
+                  season_packs: always
+          test_next_series_seasons_season_pack:
+            next_series_seasons: yes
+            series:
+            - Test Series 1:
+                identified_by: ep
+                season_packs: only
+            max_reruns: 0
+          test_next_series_seasons_season_pack_backfill:
+            next_series_seasons:
+              backfill: yes
+            series:
+            - Test Series 2:
+                identified_by: ep
+                tracking: backfill
+                season_packs: only
+            max_reruns: 0
+          test_next_series_seasons_season_pack_backfill_and_begin:
+            next_series_seasons:
+              backfill: yes
+            series:
+            - Test Series 3:
+                identified_by: ep
+                tracking: backfill
+                begin: S02E01
+                season_packs: only
+            max_reruns: 0
+    """
+
+    @pytest.fixture()
+    def config(self):
+        """Season packs aren't supported by guessit yet."""
+        return self._config
+
+    def inject_series(self, execute_task, release_name):
+        execute_task('inject_series', options={'inject': [Entry(title=release_name, url='')], 'disable_tracking': True})
+
+    def test_next_series_seasons_season_pack(self, execute_task):
+        self.inject_series(execute_task, 'Test Series 1 S02')
+        task = execute_task('test_next_series_seasons_season_pack')
+        assert task.find_entry(title='Test Series 1 S03')
+        assert len(task.all_entries) == 1
+        self.inject_series(execute_task, 'Test Series 1 S03E01')
+        task = execute_task('test_next_series_seasons_season_pack')
+        assert task.find_entry(title='Test Series 1 S03')
+        assert len(task.all_entries) == 1
+
+    def test_next_series_seasons_season_pack_backfill(self, execute_task):
+        self.inject_series(execute_task, 'Test Series 2 S02')
+        task = execute_task('test_next_series_seasons_season_pack_backfill')
+        assert task.find_entry(title='Test Series 2 S01')
+        assert task.find_entry(title='Test Series 2 S03')
+        assert len(task.all_entries) == 2
+        self.inject_series(execute_task, 'Test Series 2 S03E01')
+        task = execute_task('test_next_series_seasons_season_pack_backfill')
+        assert task.find_entry(title='Test Series 2 S01')
+        assert task.find_entry(title='Test Series 2 S03')
+        assert len(task.all_entries) == 2
+
+    def test_next_series_seasons_season_pack_backfill_and_begin(self, execute_task):
+        self.inject_series(execute_task, 'Test Series 3 S02')
+        task = execute_task('test_next_series_seasons_season_pack_backfill_and_begin')
+        assert task.find_entry(title='Test Series 3 S03')
+        assert len(task.all_entries) == 1
+        self.inject_series(execute_task, 'Test Series 3 S03E01')
+        task = execute_task('test_next_series_seasons_season_pack_backfill_and_begin')
+        assert task.find_entry(title='Test Series 3 S03')
+        assert len(task.all_entries) == 1

--- a/flexget/tests/test_next_series_seasons.py
+++ b/flexget/tests/test_next_series_seasons.py
@@ -33,14 +33,18 @@ class TestNextSeriesSeasonSeasonsPack(object):
             series:
             - Test Series 1:
                 identified_by: ep
-                season_packs: only
+                season_packs:
+                    threshold: 1000
+                    reject_eps: yes
             max_reruns: 0
           test_next_series_seasons_season_pack_and_ep:
             next_series_seasons: yes
             series:
             - Test Series 2:
                 identified_by: ep
-                season_packs: only
+                season_packs:
+                    threshold: 1000
+                    reject_eps: yes
             max_reruns: 0
           test_next_series_seasons_season_pack_backfill:
             next_series_seasons:
@@ -49,7 +53,9 @@ class TestNextSeriesSeasonSeasonsPack(object):
             - Test Series 3:
                 identified_by: ep
                 tracking: backfill
-                season_packs: only
+                season_packs:
+                    threshold: 1000
+                    reject_eps: yes
             max_reruns: 0
           test_next_series_seasons_season_pack_and_ep_backfill:
             next_series_seasons:
@@ -58,7 +64,9 @@ class TestNextSeriesSeasonSeasonsPack(object):
             - Test Series 4:
                 identified_by: ep
                 tracking: backfill
-                season_packs: only
+                season_packs:
+                    threshold: 1000
+                    reject_eps: yes
             max_reruns: 0
           test_next_series_seasons_season_pack_backfill_and_begin:
             next_series_seasons:
@@ -68,7 +76,9 @@ class TestNextSeriesSeasonSeasonsPack(object):
                 identified_by: ep
                 tracking: backfill
                 begin: S02E01
-                season_packs: only
+                season_packs:
+                    threshold: 1000
+                    reject_eps: yes
             max_reruns: 0
           test_next_series_seasons_season_pack_and_ep_backfill_and_begin:
             next_series_seasons:
@@ -78,7 +88,9 @@ class TestNextSeriesSeasonSeasonsPack(object):
                 identified_by: ep
                 tracking: backfill
                 begin: S02E01
-                season_packs: only
+                season_packs:
+                    threshold: 1000
+                    reject_eps: yes
             max_reruns: 0
     """
 

--- a/flexget/utils/titles/series.py
+++ b/flexget/utils/titles/series.py
@@ -138,10 +138,6 @@ class SeriesParser(TitleParser):
     def is_movie(self):
         return False
 
-    @property
-    def is_season_pack(self):
-        return self.season_pack is True
-
     def _reset(self):
         # parse produces these
         self.season = None


### PR DESCRIPTION
### Motivation for changes:

More stuff to do

### Detailed changes:

- Added season pack support to `forget` CLI
- Added ability to forget multiple entities per command `series forget foo s01 s02e01 s03e01`
- Fixed sorting bug with `series show`
- TheTVDB lookup (Just a log message, not support for season packs from tvdb)
- Trakt lookup (Done by @cvium)
- Fixed issue where `next_series_X` didn't emit the next entity if the last one was a season pack with not series begin set.
- Fixed `series show` sort bug
- Fixed issue where `next_series_X` emitted the begin episode in error if there was a gap in series history
- Lots of additional tests