### PR TITLE
[add] t411 - add the possibility to obtain results matching a query

### DIFF
--- a/flexget/plugins/sites/t411.py
+++ b/flexget/plugins/sites/t411.py
@@ -40,6 +40,7 @@ class T411InputPlugin(object):
       category: <see available categories on "flexget t411 list-cats">
       terms: <see available terms on "flexget t411 list-terms --category <category name>"
       max_resutls: XXX
+      search: <search query>
     """
 
     def __init__(self):
@@ -49,6 +50,7 @@ class T411InputPlugin(object):
                 'category': {'type': 'string'},
                 'terms': one_or_more({'type': 'string'}),
                 'max_results': {'type': 'number', 'default': 100}
+                'search': {'type': 'string'},
             },
             'additionalProperties': False
         }
@@ -64,6 +66,7 @@ class T411InputPlugin(object):
         query.category_name = config.get('category')
         query.term_names = list(config.get('terms', []))
         query.max_results = config.get('max_results')
+        query.expression = config.get('search')
         return query
 
     @plugin.internet(log)

--- a/flexget/plugins/sites/t411.py
+++ b/flexget/plugins/sites/t411.py
@@ -49,8 +49,8 @@ class T411InputPlugin(object):
             'properties': {
                 'category': {'type': 'string'},
                 'terms': one_or_more({'type': 'string'}),
-                'max_results': {'type': 'number', 'default': 100}
-                'search': {'type': 'string'},
+                'max_results': {'type': 'number', 'default': 100},
+                'search': {'type': 'string'}
             },
             'additionalProperties': False
         }


### PR DESCRIPTION
## Add the possibility for the plugin to obtain results matching a query.

### Motivation for changes:
- Reduce useless entries 
- Reduce the api response size
- Increase the time available before a result is not longer in the results (100 results for a precise query vs 100 results for a full category)

### Detailed changes:
The api wrapper was already able to request results using a query.
I've just modified the plugin to be able to use the search query feature from the api.

### Config usage:
Added ability to set a query using `search`
```
  task:
    t411:
      search: <query>

```


