### PR TITLE
[fix] couchpotato_list minor fix in debug logging

### DIFF
--- a/flexget/plugins/list/couchpotato_list.py
+++ b/flexget/plugins/list/couchpotato_list.py
@@ -208,7 +208,7 @@ class CouchPotatoSet(MutableSet):
         if not self._find_entry(entry):
             self._movies = None
             movie = CouchPotatoBase.add_movie(self.config, entry)
-            log.verbose('Successfully added movie %s to CouchPotato', movie['movie']['info']['original_title'])
+            log.verbose('Successfully added movie %s to CouchPotato', movie['info']['original_title'])
         else:
             log.debug('entry %s already exists in couchpotato list', entry)
 


### PR DESCRIPTION
### Motivation for changes:
Error after successful adding movie to couchpotato list

### Detailed changes:

CouchPotatoBase.add_movie returns json with no _movies_ key. We should  get film name directly from _info_ dict ([source](https://github.com/Flexget/Flexget/blob/develop/flexget/plugins/list/couchpotato_list.py#L156)).

### Log
```
2017-04-22 15:48 VERBOSE  couchpotato_list TrakttoCP       Connection to CouchPotato to add a movie to list.
2017-04-22 15:48 CRITICAL task          TrakttoCP       BUG: Unhandled error in plugin list_add: u'movie'
Traceback (most recent call last):
  File "/home/qk4l/progs/flexget/local/lib/python2.7/site-packages/flexget/task.py", line 483, in __run_plugin
    return method(*args, **kwargs)
  File "/home/qk4l/progs/flexget/local/lib/python2.7/site-packages/flexget/event.py", line 23, in __call__
    return self.func(*args, **kwargs)
  File "/home/qk4l/progs/flexget/local/lib/python2.7/site-packages/flexget/plugins/output/list_add.py", line 54, in on_task_output
    thelist |= task.accepted
  File "/home/qk4l/progs/flexget/lib/python2.7/_abcoll.py", line 311, in __ior__
    self.add(value)
  File "/home/qk4l/progs/flexget/local/lib/python2.7/site-packages/flexget/plugins/list/couchpotato_list.py", line 211, in add
    log.verbose('Successfully added movie %s to CouchPotato', movie['movie']['info']['original_title'])
KeyError: u'movie'

```

