### PR TITLE
[add] auth plugin - Enable generic basic and digest auth

### DIFF
--- a/flexget/plugins/output/auth.py
+++ b/flexget/plugins/output/auth.py
@@ -49,7 +49,7 @@ class RequestAuth(object):
                 continue
             for host_config in config:
                 for host, auth_config in host_config.items():
-                    if re.match(host, entry['url']):
+                    if re.search(host, entry['url'], re.IGNORECASE):
                         auth_type = auth_config['type']
                         username = auth_config['username']
                         password = auth_config['password']

--- a/flexget/plugins/output/auth.py
+++ b/flexget/plugins/output/auth.py
@@ -1,0 +1,49 @@
+from __future__ import unicode_literals, division, absolute_import
+
+import logging
+
+from requests.auth import HTTPBasicAuth, HTTPDigestAuth
+
+from flexget import plugin
+from flexget.event import event
+
+PLUGIN_NAME = 'auth'
+
+log = logging.getLogger(PLUGIN_NAME)
+
+
+class RequestAuth(object):
+    schema = {
+        'type': 'object',
+        'properties': {
+            'username': {'type': 'string'},
+            'password': {'type': 'string'},
+            'type': {'type': 'string', 'enum': ['basic', 'digest'], 'default': 'basic'}
+        },
+        'required': ['username', 'password'],
+        'additionalProperties': False
+    }
+
+    auth_mapper = {
+        'basic': HTTPBasicAuth,
+        'digest': HTTPDigestAuth
+    }
+
+    # Run before all downloads
+    @plugin.priority(255)
+    def on_task_download(self, task, config):
+        auth_type = config['type']
+        username = config['username']
+        password = config['password']
+
+        for entry in task.accepted:
+            if entry.get('download_auth'):
+                log.verbose('entry %s already has auth set, skipping', entry)
+                continue
+            log.debug('setting auth type %s with username %s', auth_type, username)
+            entry['download_auth'] = self.auth_mapper[auth_type](username, password)
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(RequestAuth, PLUGIN_NAME, api_ver=2)

--- a/flexget/plugins/output/auth.py
+++ b/flexget/plugins/output/auth.py
@@ -45,7 +45,7 @@ class RequestAuth(object):
     def on_task_download(self, task, config):
         for entry in task.accepted:
             if entry.get('download_auth'):
-                log.verbose('entry %s already has auth set, skipping', entry)
+                log.debug('entry %s already has auth set, skipping', entry)
                 continue
             for host_config in config:
                 for host, auth_config in host_config.items():

--- a/flexget/plugins/output/download_auth.py
+++ b/flexget/plugins/output/download_auth.py
@@ -8,12 +8,12 @@ from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 from flexget import plugin
 from flexget.event import event
 
-PLUGIN_NAME = 'auth'
+PLUGIN_NAME = 'download_auth'
 
 log = logging.getLogger(PLUGIN_NAME)
 
 
-class RequestAuth(object):
+class DownloadAuth(object):
     host_schema = {
         'additionalProperties': {
             'type': 'object',
@@ -59,4 +59,4 @@ class RequestAuth(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(RequestAuth, PLUGIN_NAME, api_ver=2)
+    plugin.register(DownloadAuth, PLUGIN_NAME, api_ver=2)

--- a/flexget/tests/cassettes/test_download.TestDownloadAuth.test_download_auth
+++ b/flexget/tests/cassettes/test_download.TestDownloadAuth.test_download_auth
@@ -1,0 +1,121 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept: ['*/*']
+        Accept-Encoding: ['gzip, deflate']
+        Connection: [keep-alive]
+        User-Agent: [!!python/unicode 'FlexGet/2.10.39.dev (www.flexget.com)']
+      method: GET
+      uri: https://httpbin.org/digest-auth/auth/user/passwd/MD5
+    response:
+      body: {string: !!python/unicode ''}
+      headers:
+        access-control-allow-credentials: ['true']
+        access-control-allow-origin: ['*']
+        connection: [keep-alive]
+        content-length: ['0']
+        content-type: [text/html; charset=utf-8]
+        date: ['Thu, 27 Apr 2017 09:15:43 GMT']
+        server: [gunicorn/19.7.1]
+        set-cookie: [fake=fake_value]
+        via: [1.1 vegur]
+        www-authenticate: ['Digest realm="me@kennethreitz.com", nonce="e10ceded18adcdaa498bfa1f69a735f4",
+            algorithm=MD5, qop="auth", opaque="0ade88773fd3a104a4f13b11ceaa0377"']
+      status: {code: 401, message: UNAUTHORIZED}
+  - request:
+      body: null
+      headers:
+        Accept: ['*/*']
+        Accept-Encoding: ['gzip, deflate']
+        Connection: [keep-alive]
+        User-Agent: [!!python/unicode 'FlexGet/2.10.39.dev (www.flexget.com)']
+      method: GET
+      uri: https://httpbin.org/basic-auth/user/passwd
+    response:
+      body: {string: !!python/unicode ''}
+      headers:
+        access-control-allow-credentials: ['true']
+        access-control-allow-origin: ['*']
+        connection: [keep-alive]
+        content-length: ['0']
+        date: ['Thu, 27 Apr 2017 09:15:43 GMT']
+        server: [gunicorn/19.7.1]
+        via: [1.1 vegur]
+        www-authenticate: [Basic realm="Fake Realm"]
+      status: {code: 401, message: UNAUTHORIZED}
+  - request:
+      body: null
+      headers:
+        Accept: ['*/*']
+        Accept-Encoding: ['gzip, deflate']
+        Connection: [keep-alive]
+        User-Agent: [!!python/unicode 'FlexGet/2.10.39.dev (www.flexget.com)']
+      method: GET
+      uri: https://httpbin.org/digest-auth/auth/user/passwd/MD5
+    response:
+      body: {string: !!python/unicode ''}
+      headers:
+        access-control-allow-credentials: ['true']
+        access-control-allow-origin: ['*']
+        connection: [keep-alive]
+        content-length: ['0']
+        content-type: [text/html; charset=utf-8]
+        date: ['Thu, 27 Apr 2017 09:15:44 GMT']
+        server: [gunicorn/19.7.1]
+        set-cookie: [fake=fake_value]
+        via: [1.1 vegur]
+        www-authenticate: ['Digest algorithm=MD5, qop="auth", nonce="90f0fb894a49f0ab99791daa5084c813",
+            opaque="5facaa3ec10d661665be9d75e4ee6e29", realm="me@kennethreitz.com"']
+      status: {code: 401, message: UNAUTHORIZED}
+  - request:
+      body: null
+      headers:
+        Accept: ['*/*']
+        Accept-Encoding: ['gzip, deflate']
+        Authorization: [!!python/unicode 'Digest username="user", realm="me@kennethreitz.com",
+            nonce="90f0fb894a49f0ab99791daa5084c813", uri="/digest-auth/auth/user/passwd/MD5",
+            response="ec7aadb65af8e9fa610ca640a68f8246", opaque="5facaa3ec10d661665be9d75e4ee6e29",
+            algorithm="MD5", qop="auth", nc=00000001, cnonce="7342fef9bdcebaa3"']
+        Connection: [keep-alive]
+        Cookie: [fake=fake_value]
+        User-Agent: [!!python/unicode 'FlexGet/2.10.39.dev (www.flexget.com)']
+      method: GET
+      uri: https://httpbin.org/digest-auth/auth/user/passwd/MD5
+    response:
+      body: {string: !!python/unicode "{\n  \"authenticated\": true, \n  \"user\"\
+          : \"user\"\n}\n"}
+      headers:
+        access-control-allow-credentials: ['true']
+        access-control-allow-origin: ['*']
+        connection: [keep-alive]
+        content-length: ['47']
+        content-type: [application/json]
+        date: ['Thu, 27 Apr 2017 09:15:44 GMT']
+        server: [gunicorn/19.7.1]
+        via: [1.1 vegur]
+      status: {code: 200, message: OK}
+  - request:
+      body: null
+      headers:
+        Accept: ['*/*']
+        Accept-Encoding: ['gzip, deflate']
+        Authorization: [Basic dXNlcjpwYXNzd2Q=]
+        Connection: [keep-alive]
+        User-Agent: [!!python/unicode 'FlexGet/2.10.39.dev (www.flexget.com)']
+      method: GET
+      uri: https://httpbin.org/basic-auth/user/passwd
+    response:
+      body: {string: !!python/unicode "{\n  \"authenticated\": true, \n  \"user\"\
+          : \"user\"\n}\n"}
+      headers:
+        access-control-allow-credentials: ['true']
+        access-control-allow-origin: ['*']
+        connection: [keep-alive]
+        content-length: ['47']
+        content-type: [application/json]
+        date: ['Thu, 27 Apr 2017 09:15:44 GMT']
+        server: [gunicorn/19.7.1]
+        via: [1.1 vegur]
+      status: {code: 200, message: OK}
+version: 1


### PR DESCRIPTION
### Motivation for changes:
#1240
### Detailed changes:

- Added support for base and digest auth

### Addressed issues:

- Fixes #1240 

### Config usage if relevant (new plugin or updated schema):
```yaml
  auth_test:
    mock:
    - title: bla
      url: https://httpbin.org/digest-auth/auth/user/passwd/MD5
    download_auth:
    - https://httpbin.org:
        username: user
        password: passwd
        type: digest
    accept_all: yes
    download: ~/
    disable: seen
```
#### To Do:

- [ ] Tests

