### PR TITLE
 Multiples changes for t411 domain name change : from .ai to .al

### DIFF
--- a/flexget/plugins/internal/api_t411.py
+++ b/flexget/plugins/internal/api_t411.py
@@ -120,7 +120,7 @@ class FriendlySearchQuery(object):
         self.term_names.append("Episode %02d" % episode)
 
 
-T411API_DOMAIN_URL = "api.t411.ai"
+T411API_DOMAIN_URL = "api.t411.al"
 T411API_CATEGORY_TREE_PATH = "/categories/tree/"
 T411API_AUTH_PATH = "/auth"
 T411API_TERMS_PATH = "/terms/tree/"

--- a/flexget/plugins/sites/torrent411.py
+++ b/flexget/plugins/sites/torrent411.py
@@ -222,7 +222,7 @@ class t411Auth(AuthBase):
 
     #   RETREIVING LOGIN COOKIES ONLY ONCE A DAY
     def get_login_cookies(self, username, password):
-        url_auth = 'http://www.t411.ai/users/login'
+        url_auth = 'https://www.t411.al/users/login'
         db_session = Session()
         account = db_session.query(torrent411Account).filter(
             torrent411Account.username == username).first()
@@ -336,16 +336,16 @@ class UrlRewriteTorrent411(object):
 
             -- RSS DOWNLOAD WITH LOGIN
             rss:
-              url: http://www.t411.ai/rss/?cat=210
+              url: https://www.t411.al/rss/?cat=210
               username: ****
               password: ****
 
             - OR -
 
-            -- RSS NORMAL URL REWRITE (i.e.: http://www.t411.ai/torrents/download/?id=12345678)
+            -- RSS NORMAL URL REWRITE (i.e.: https://www.t411.al/torrents/download/?id=12345678)
             -- WARNING: NEED CUSTOM COOKIES NOT HANDLE BY THIS PLUGIN
             rss:
-              url: http://www.t411.ai/rss/?cat=210
+              url: https://www.t411.al/rss/?cat=210
 
         ---
             SEARCH WITHIN SITE
@@ -422,7 +422,7 @@ class UrlRewriteTorrent411(object):
             if match:
                 torrent_id = match.group(1)
                 log.debug("Got the Torrent ID: %s" % torrent_id)
-                entry['url'] = 'https://www.t411.ai/torrents/download/?id=' + torrent_id
+                entry['url'] = 'https://www.t411.al/torrents/download/?id=' + torrent_id
                 if 'download_auth' in entry:
                     auth_handler = t411Auth(*entry['download_auth'])
                     entry['download_auth'] = auth_handler
@@ -434,7 +434,7 @@ class UrlRewriteTorrent411(object):
         """
         Search for name from torrent411.
         """
-        url_base = 'http://www.t411.ai'
+        url_base = 'https://www.t411.al'
 
         if not isinstance(config, dict):
             config = {}
@@ -489,12 +489,12 @@ class UrlRewriteTorrent411(object):
                 if nfo_link_res is not None:
                     tid = nfo_link_res.group(1)
                 title_res = re.search(
-                    '<a href=\"//www.t411.ai/torrents/([-A-Za-z0-9+&@#/%|?=~_|!:,.;]+)\" title="([^"]*)">',
+                    '<a href=\"//www.t411.al/torrents/([-A-Za-z0-9+&@#/%|?=~_|!:,.;]+)\" title="([^"]*)">',
                     str(tr))
                 if title_res is not None:
                     entry['title'] = native_str_to_text(title_res.group(2), encoding='utf-8')
                 size = tr('td')[5].contents[0]
-                entry['url'] = 'http://www.t411.ai/torrents/download/?id=%s' % tid
+                entry['url'] = 'https://www.t411.al/torrents/download/?id=%s' % tid
                 entry['torrent_seeds'] = tr('td')[7].contents[0]
                 entry['torrent_leeches'] = tr('td')[8].contents[0]
                 entry['search_sort'] = torrent_availability(entry['torrent_seeds'],

--- a/flexget/tests/cassettes/test_t411.TestRestClient.test_auth
+++ b/flexget/tests/cassettes/test_t411.TestRestClient.test_auth
@@ -8,7 +8,7 @@ interactions:
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [!!python/unicode 'FlexGet/1.2.379.dev (www.flexget.com)']
     method: POST
-    uri: https://api.t411.ai/auth
+    uri: https://api.t411.al/auth
   response:
     body: {string: !!python/unicode '{"token":"12345:123:ASDZXCQWEPOILKJMNB"}'}
     headers:

--- a/flexget/tests/cassettes/test_t411.TestRestClient.test_error_message_handler
+++ b/flexget/tests/cassettes/test_t411.TestRestClient.test_error_message_handler
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [!!python/unicode 'FlexGet/1.2.415.dev (www.flexget.com)']
     method: GET
-    uri: https://api.t411.ai/torrents/details/666666
+    uri: https://api.t411.al/torrents/details/666666
   response:
     body: {string: !!python/unicode '{"error":"Invalid token","code":202}'}
     headers:
@@ -17,7 +17,7 @@ interactions:
       date: ['Tue, 26 Jan 2016 20:45:57 GMT']
       server: [cloudflare-nginx]
       set-cookie: ['__cfduid=d7298a571b0b0d2dac2faae901d4b95061453841157; expires=Wed,
-          25-Jan-17 20:45:57 GMT; path=/; domain=.t411.ai; HttpOnly']
+          25-Jan-17 20:45:57 GMT; path=/; domain=.t411.al; HttpOnly']
       t411-node: [webus1]
       vary: [Accept-Encoding]
       x-powered-by: [PHP/5.5.30-1+deb.sury.org~trusty+1]

--- a/flexget/tests/cassettes/test_t411.TestRestClient.test_malformed_search_response
+++ b/flexget/tests/cassettes/test_t411.TestRestClient.test_malformed_search_response
@@ -7,7 +7,7 @@ interactions:
         Connection: [keep-alive]
         User-Agent: [FlexGet/1.2.379.dev (www.flexget.com)]
       method: GET
-      uri: https://api.t411.ai/torrents/search/
+      uri: https://api.t411.al/torrents/search/
     response:
       body: {string: '<div class="errorMessage">Missing argument 1 for App\Api\Controllers\TorrentsController::searchAction()</div>
 
@@ -40,7 +40,7 @@ interactions:
         date: ['Tue, 24 Nov 2015 22:07:05 GMT']
         server: [cloudflare-nginx]
         set-cookie: ['__cfduid=d01cd88b10233fbcc956c5d87224d74f61448402824; expires=Wed,
-            23-Nov-16 22:07:04 GMT; path=/; domain=.t411.ai; HttpOnly']
+            23-Nov-16 22:07:04 GMT; path=/; domain=.t411.al; HttpOnly']
         t411-node: [webus1]
         transfer-encoding: [chunked]
         vary: [Accept-Encoding]

--- a/flexget/tests/cassettes/test_t411.TestRestClient.test_retrieve_categories
+++ b/flexget/tests/cassettes/test_t411.TestRestClient.test_retrieve_categories
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [!!python/unicode 'FlexGet/1.2.379.dev (www.flexget.com)']
     method: GET
-    uri: https://api.t411.ai/categories/tree/
+    uri: https://api.t411.al/categories/tree/
   response:
     body: {string: !!python/unicode '{"210":{"id":"210","pid":"0","name":"Film\/Vid\u00e9o","cats":{"402":{"id":"402","pid":"210","name":"Vid\u00e9o-clips"},"433":{"id":"433","pid":"210","name":"S\u00e9rie
         TV"},"455":{"id":"455","pid":"210","name":"Animation"},"631":{"id":"631","pid":"210","name":"Film"},"633":{"id":"633","pid":"210","name":"Concert"},"634":{"id":"634","pid":"210","name":"Documentaire"},"635":{"id":"635","pid":"210","name":"Spectacle"},"636":{"id":"636","pid":"210","name":"Sport"},"637":{"id":"637","pid":"210","name":"Animation

--- a/flexget/tests/cassettes/test_t411.TestRestClient.test_retrieve_terms
+++ b/flexget/tests/cassettes/test_t411.TestRestClient.test_retrieve_terms
@@ -7,7 +7,7 @@ interactions:
         Connection: [keep-alive]
         User-Agent: [FlexGet/1.2.379.dev (www.flexget.com)]
       method: GET
-      uri: https://api.t411.ai/terms/tree/
+      uri: https://api.t411.al/terms/tree/
     response:
       body: {string: '{"234":{"11":{"type":"Application - Genre","mode":"single","terms":{"190":"Utilitaire","158":"Edition
           multim\u00e9dia","126":"Administration","137":"Aspiration de site","169":"Lecteur
@@ -727,7 +727,7 @@ interactions:
         date: ['Tue, 24 Nov 2015 22:09:17 GMT']
         server: [cloudflare-nginx]
         set-cookie: ['__cfduid=d1519d402486c941d0309da7e9c3bafb41448402957; expires=Wed,
-            23-Nov-16 22:09:17 GMT; path=/; domain=.t411.ai; HttpOnly']
+            23-Nov-16 22:09:17 GMT; path=/; domain=.t411.al; HttpOnly']
         t411-node: [webus1]
         transfer-encoding: [chunked]
         vary: [Accept-Encoding]


### PR DESCRIPTION
According to t411 website : 
Il faudra donc tout faire passer du .ai au .al
L'adresse du site est https://www.t411.al/  (à mettre en favoris) 

Commit modify both plugins : api_t411 (+tests) and torrent411 