### PR TITLE
Refactor config hash management

### DIFF
--- a/flexget/plugins/filter/remember_rejected.py
+++ b/flexget/plugins/filter/remember_rejected.py
@@ -77,8 +77,8 @@ class FilterRememberRejected(object):
         entry.reject('message', remember=True)
     """
 
-    @plugin.priority(0)
-    def on_task_start(self, task, config):
+    @plugin.priority(-255)
+    def on_task_input(self, task, config):
         """Purge remembered entries if the config has changed."""
         with Session() as session:
             # See if the task has changed since last run
@@ -98,8 +98,6 @@ class FilterRememberRejected(object):
                     log.debug('%s entries have expired from remember_rejected table.' % deleted)
                     task.config_changed()
 
-    @plugin.priority(-255)
-    def on_task_input(self, task, config):
         for entry in task.all_entries:
             entry.on_reject(self.on_entry_reject)
 

--- a/flexget/plugins/filter/remember_rejected.py
+++ b/flexget/plugins/filter/remember_rejected.py
@@ -77,22 +77,30 @@ class FilterRememberRejected(object):
         entry.reject('message', remember=True)
     """
 
+    @plugin.priority(0)
+    def on_task_start(self, task, config):
+        with Session() as session:
+            remember_task = session.query(RememberTask).filter(RememberTask.name == task.name).first()
+            if not remember_task:
+                # Create this task in the db if not present
+                session.add(RememberTask(name=task.name))
+
     @plugin.priority(-255)
     def on_task_input(self, task, config):
         """Purge remembered entries if the config has changed."""
         with Session() as session:
             # See if the task has changed since last run
-            old_task = session.query(RememberTask).filter(RememberTask.name == task.name).first()
-            if not task.is_rerun and old_task and task.config_modified:
+            remember_task = session.query(RememberTask).filter(RememberTask.name == task.name).first()
+            if not task.is_rerun and remember_task and task.config_modified:
                 log.debug('Task config has changed since last run, purging remembered entries.')
-                session.delete(old_task)
-                old_task = None
-            if not old_task:
+                session.delete(remember_task)
+                remember_task = None
+            if not remember_task:
                 # Create this task in the db if not present
                 session.add(RememberTask(name=task.name))
             elif not task.is_rerun:
                 # Delete expired items if this is not a rerun
-                deleted = session.query(RememberEntry).filter(RememberEntry.task_id == old_task.id). \
+                deleted = session.query(RememberEntry).filter(RememberEntry.task_id == remember_task.id). \
                     filter(RememberEntry.expires < datetime.now()).delete()
                 if deleted:
                     log.debug('%s entries have expired from remember_rejected table.' % deleted)

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -2022,10 +2022,6 @@ class SeriesDBManager(FilterSeriesBase):
 
     @plugin.priority(0)
     def on_task_start(self, task, config):
-        if not task.config_modified:
-            log.trace('not task.config_modified, returning')
-            return
-
         # Clear all series from this task
         with Session() as session:
             session.query(SeriesTask).filter(SeriesTask.name == task.name).delete()

--- a/flexget/plugins/operate/configure_series.py
+++ b/flexget/plugins/operate/configure_series.py
@@ -94,9 +94,6 @@ class ConfigureSeries(FilterSeriesBase):
         # Merge our series config in with the base series config
         self.merge_config(task, series_config)
 
-        # Set the config_modified flag if the list of shows changed since last time
-        task.check_config_hash()
-
 
 @event('plugin.register')
 def register_plugin():

--- a/flexget/plugins/operate/configure_series.py
+++ b/flexget/plugins/operate/configure_series.py
@@ -14,15 +14,6 @@ from flexget.plugins.filter.series import FilterSeriesBase
 from flexget.utils.tools import get_config_hash
 
 log = logging.getLogger('configure_series')
-Base = db_schema.versioned_base('import_series', 0)
-
-
-class LastHash(Base):
-    __tablename__ = 'import_series_last_hash'
-
-    id = Column(Integer, primary_key=True)
-    task = Column(Unicode)
-    hash = Column(Unicode)
 
 
 class ConfigureSeries(FilterSeriesBase):
@@ -90,17 +81,6 @@ class ConfigureSeries(FilterSeriesBase):
                         else:
                             s[key] = entry['configure_series_' + key]
 
-        # Set the config_modified flag if the list of shows changed since last time
-        new_hash = str(get_config_hash(series))
-        with Session() as session:
-            last_hash = session.query(LastHash).filter(LastHash.task == task.name).first()
-            if not last_hash:
-                last_hash = LastHash(task=task.name)
-                session.add(last_hash)
-            if last_hash.hash != new_hash:
-                task.config_changed()
-            last_hash.hash = new_hash
-
         if not series:
             log.info('Did not get any series to generate series configuration')
             return
@@ -113,6 +93,9 @@ class ConfigureSeries(FilterSeriesBase):
             series_config['settings'] = {'generated_series': config['settings']}
         # Merge our series config in with the base series config
         self.merge_config(task, series_config)
+
+        # Set the config_modified flag if the list of shows changed since last time
+        task.check_config_hash()
 
 
 @event('plugin.register')

--- a/flexget/plugins/operate/include.py
+++ b/flexget/plugins/operate/include.py
@@ -55,7 +55,7 @@ class PluginInclude(object):
             log.debug('Merging %s into task %s', file, task.name)
             # merge
             try:
-                task.merge_config(include, plugin_name, details=file_name)
+                task.merge_config(include)
             except MergeException:
                 raise plugin.PluginError('Failed to merge include file to task %s, incompatible datatypes' % task.name)
 

--- a/flexget/plugins/operate/template.py
+++ b/flexget/plugins/operate/template.py
@@ -1,18 +1,15 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
-from past.builtins import basestring
 
 import logging
 
-from sqlalchemy import Column, Integer, String, Unicode
-
-from flexget import options, plugin, db_schema
-from flexget.event import event
+from flexget import options, plugin
 from flexget.config_schema import register_config_key
-from flexget.manager import Session
-from flexget.utils.tools import MergeException, merge_dict_from_to
+from flexget.event import event
+from flexget.utils.tools import MergeException
 
-log = logging.getLogger('template')
+plugin_name = 'template'
+log = logging.getLogger(plugin_name)
 
 
 class PluginTemplate(object):
@@ -58,7 +55,7 @@ class PluginTemplate(object):
     def prepare_config(self, config):
         if config is None or isinstance(config, bool):
             config = []
-        elif isinstance(config, basestring):
+        elif isinstance(config, str):
             config = [config]
         return config
 
@@ -111,7 +108,7 @@ class PluginTemplate(object):
 
             # Merge
             try:
-                task.merge_config(template_config)
+                task.merge_config(template_config, plugin_name, details=template)
             except MergeException as exc:
                 raise plugin.PluginError('Failed to merge template %s to task %s. Error: %s' %
                                          (template, task.name, exc.value))

--- a/flexget/plugins/operate/template.py
+++ b/flexget/plugins/operate/template.py
@@ -108,7 +108,7 @@ class PluginTemplate(object):
 
             # Merge
             try:
-                task.merge_config(template_config, plugin_name, details=template)
+                task.merge_config(template_config)
             except MergeException as exc:
                 raise plugin.PluginError('Failed to merge template %s to task %s. Error: %s' %
                                          (template, task.name, exc.value))

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -545,8 +545,8 @@ class Task(object):
         try:
             merge_dict_from_to(new_config, self.config)
             self.check_config_hash()
-        except MergeException:
-            raise PluginError('Failed to merge include file to task %s, incompatible datatypes' % self.name)
+        except MergeException as e:
+            raise PluginError('Failed to merge configs for task %s: %s' % (self.name, e))
 
     def check_config_hash(self):
         """

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -550,7 +550,7 @@ class Task(object):
         except MergeException as e:
             raise PluginError('Failed to merge configs for task %s: %s' % (self.name, e))
 
-    def check_config_hash(self, plugin_name, details):
+    def check_config_hash(self, plugin_name=None, details=None):
         """
         Checks the task's config hash and updates the hash if necessary.
         """
@@ -563,8 +563,9 @@ class Task(object):
             else:
                 log.error('BUG: No prepared_config on rerun, please report.')
         with Session() as session:
-            last_hash = session.query(TaskConfigHash).filter(TaskConfigHash.task == self.name).filter(
-                TaskConfigHash.plugin == plugin_name)
+            last_hash = session.query(TaskConfigHash).filter(TaskConfigHash.task == self.name)
+            if plugin_name:
+                last_hash = last_hash.filter(TaskConfigHash.plugin == plugin_name)
             if details:
                 last_hash.filter(TaskConfigHash.details == details)
             last_hash = last_hash.first()

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -22,7 +22,7 @@ from flexget.plugin import (
 from flexget.utils import requests
 from flexget.utils.database import with_session
 from flexget.utils.simple_persistence import SimpleTaskPersistence
-from flexget.utils.tools import get_config_hash
+from flexget.utils.tools import get_config_hash, MergeException, merge_dict_from_to
 from flexget.utils.template import render_from_task, FlexGetTemplate
 
 log = logging.getLogger('task')
@@ -541,15 +541,18 @@ class Task(object):
         """
         self.config_modified = True
 
-    def is_config_modified(self, last_hash):
-        """
-        Checks the task's config hash. Returns True/False depending on config has been modified and the config hash
+    def merge_config(self, new_config):
+        try:
+            merge_dict_from_to(new_config, self.config)
+            self.check_config_hash()
+        except MergeException:
+            raise PluginError('Failed to merge include file to task %s, incompatible datatypes' % self.name)
 
-        :param str last_hash:
-        :return bool, str: config modified and config hash
+    def check_config_hash(self):
+        """
+        Checks the task's config hash and updates the hash if necessary.
         """
         # Save current config hash and set config_modified flag
-        config_modified = False
         config_hash = get_config_hash(self.config)
         if self.is_rerun:
             # Restore the config to state right after start phase
@@ -557,15 +560,14 @@ class Task(object):
                 self.config = copy.deepcopy(self.prepared_config)
             else:
                 log.error('BUG: No prepared_config on rerun, please report.')
-                config_modified = False
-        elif not last_hash:
-            config_modified = True
-        elif last_hash.hash != config_hash:
-            config_modified = True
-            last_hash.hash = config_hash
-        else:
-            config_modified = False
-        return config_modified, config_hash
+        with Session() as session:
+            last_hash = session.query(TaskConfigHash).filter(TaskConfigHash.task == self.name).first()
+            if not last_hash:
+                session.add(TaskConfigHash(task=self.name, hash=config_hash))
+                self.config_changed()
+            elif last_hash.hash != config_hash:
+                last_hash.hash = config_hash
+                self.config_changed()
 
     def _execute(self):
         """Executes the task without rerunning."""
@@ -589,9 +591,12 @@ class Task(object):
 
         with Session() as session:
             last_hash = session.query(TaskConfigHash).filter(TaskConfigHash.task == self.name).first()
-            self.config_modified, config_hash = self.is_config_modified(last_hash)
+            config_hash = None
+            if not last_hash:
+                config_hash = last_hash.hash
+            self.config_modified, config_hash = self.check_config_hash(config_hash)
             if self.config_modified:
-                session.add(TaskConfigHash(task=self.name, hash=config_hash))
+                last_hash.hash = config_hash
 
         # run phases
         try:

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -36,8 +36,6 @@ class TaskConfigHash(Base):
 
     id = Column(Integer, primary_key=True)
     task = Column('name', Unicode, index=True, nullable=False)
-    plugin = Column('plugin', Unicode, index=True, nullable=False)
-    details = Column('plugin', Unicode)
     hash = Column('hash', String)
 
     def __repr__(self):

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -589,14 +589,7 @@ class Task(object):
             self.disable_phase('input')
             self.all_entries.extend(copy.deepcopy(self.options.inject))
 
-        with Session() as session:
-            last_hash = session.query(TaskConfigHash).filter(TaskConfigHash.task == self.name).first()
-            config_hash = None
-            if not last_hash:
-                config_hash = last_hash.hash
-            self.config_modified, config_hash = self.check_config_hash(config_hash)
-            if self.config_modified:
-                last_hash.hash = config_hash
+        self.check_config_hash()
 
         # run phases
         try:

--- a/flexget/tests/test_include.py
+++ b/flexget/tests/test_include.py
@@ -9,19 +9,27 @@ class TestInclude(object):
         tasks:
           include_test:
             include:
-            - {{ tmpfile }}
+            - {{ tmpfile_1 }}
+            - {{ tmpfile_2 }}
     """
 
     @pytest.fixture
     def config(self, tmpdir):
-        f = tmpdir.mkdir('include').join('foo.yml')
-        f.write("""
+        test_dir = tmpdir.mkdir('include')
+        file_1 = test_dir.join('foo.yml')
+        file_2 = test_dir.join('baz.yml')
+        file_1.write("""
             mock:
             - title: foo
         """)
-        return Template(self._config).render({'tmpfile': f.strpath})
+        file_2.write("""
+            mock:
+            - title: baz
+        """)
+        return Template(self._config).render({'tmpfile_1': file_1.strpath, 'tmpfile_2': file_2.strpath})
 
     def test_include(self, execute_task):
         task = execute_task('include_test')
-        assert len(task.all_entries) == 1
+        assert len(task.all_entries) == 2
         assert task.find_entry(title='foo')
+        assert task.find_entry(title='baz')

--- a/flexget/tests/test_include.py
+++ b/flexget/tests/test_include.py
@@ -33,3 +33,57 @@ class TestInclude(object):
         assert len(task.all_entries) == 2
         assert task.find_entry(title='foo')
         assert task.find_entry(title='baz')
+
+
+class TestIncludeChange(object):
+    _config = """
+        tasks:
+          include_test:
+            include:
+            - {{ tmpfile_1 }}
+    """
+
+    @pytest.fixture
+    def config(self, tmpdir):
+        test_dir = tmpdir.mkdir('include')
+        file_1 = test_dir.join('foo.yml')
+        file_1.write("""
+            mock:
+            - title: foo
+        """)
+        return Template(self._config).render({'tmpfile_1': file_1.strpath})
+
+    def test_include_update(self, execute_task, manager, tmpdir):
+        task = execute_task('include_test')
+        assert len(task.all_entries) == 1
+        assert task.find_entry(title='foo')
+
+        # Run without change. verify task hasn't changed
+        task = execute_task('include_test')
+        assert not task.config_modified
+
+        # Change file name
+        test_dir = tmpdir.mkdir('include_changed')
+        file_1 = test_dir.join('foo.yml')
+        file_1.write("""
+            mock:
+            - title: foo_change_1
+        """)
+        new_file = Template('{{ tmpfile_1 }}').render({'tmpfile_1': file_1.strpath})
+        manager.config['tasks']['include_test']['include'].pop()
+        manager.config['tasks']['include_test']['include'].append(new_file)
+
+        task = execute_task('include_test')
+        assert len(task.all_entries) == 1
+        assert task.find_entry(title='foo_change_1')
+        assert task.config_modified
+
+        # Change file contents
+        file_1.write("""
+            mock:
+            - title: foo_change_2
+        """)
+        task = execute_task('include_test')
+        assert len(task.all_entries) == 1
+        assert task.find_entry(title='foo_change_2')
+        assert task.config_modified

--- a/flexget/tests/test_include.py
+++ b/flexget/tests/test_include.py
@@ -1,0 +1,27 @@
+from __future__ import unicode_literals, division, absolute_import
+
+import pytest
+from jinja2 import Template
+
+
+class TestInclude(object):
+    _config = """
+        tasks:
+          include_test:
+            include:
+            - {{ tmpfile }}
+    """
+
+    @pytest.fixture
+    def config(self, tmpdir):
+        f = tmpdir.mkdir('include').join('foo.yml')
+        f.write("""
+            mock:
+            - title: foo
+        """)
+        return Template(self._config).render({'tmpfile': f.strpath})
+
+    def test_include(self, execute_task):
+        task = execute_task('include_test')
+        assert len(task.all_entries) == 1
+        assert task.find_entry(title='foo')

--- a/flexget/tests/test_template.py
+++ b/flexget/tests/test_template.py
@@ -104,3 +104,26 @@ class TestTemplateRerun(object):
     def test_rerun(self, execute_task):
         task = execute_task('test_rerun')
         assert len(task.config['series']) == 1
+
+
+class TestTemplateChange(object):
+    config = """
+        templates:
+          a:
+            mock:
+            - title: foo
+        tasks:
+          test_config_change:
+            mock:
+            - title: bar
+            template: a
+    """
+
+    def test_template_change_trigger_config_change(self, execute_task, manager):
+        task = execute_task('test_config_change')
+        assert len(task.all_entries) == 2
+
+        manager.config['templates']['a']['mock'].append({'title': 'baz}'})
+        task = execute_task('test_config_change')
+        assert task.config_modified
+        assert len(task.all_entries) == 3


### PR DESCRIPTION
### Motivation for changes:
It's ugly
### Detailed changes:

- Removed specific plugins hash table, hash table check is now global per task
- Config is checked after start phase so all changes on that phase can cause a new hash to be created 

### TODO
- [x] Think of a better solution that doesn't break shit...
- [x] Fix issue with remember rejected plugin 
- [x] Test all series since it changes config on metainfo phase 
- [x] Add hash specifc checks (include, configure_series and template plugins)