### PR TITLE
Fix non-check of bytes sent over Unix socket

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,12 +1,18 @@
 <!---
-Before opening an issue, verify these:
+Before opening an issue, verify:
 
-- Search if the issue already exist
-- Running daemon? Restart it completely
-- This issue template is there for a reason. Please do not ignore it and fill it correctly no matter how irrelevant you think it may be
+- Is this a feature request? Post it on https://feathub.com/Flexget/Flexget
+- Did you recently upgrade? Look at the Change Log and Upgrade Actions to make sure that you don't need to make any changes to your config https://flexget.com/ChangeLog https://flexget.com/UpgradeActions
+- Are you running FlexGet as a daemon? Stop it completely and then start it again https://flexget.com/CLI/daemon
+- Did you search to see if the issue already exists? https://github.com/Flexget/Flexget/issues
+- Did you fill out the issue template as completely as possible?
 
+The issue template is here because it helps to ensure you submitted all the necessary information the first time, and allows us to more quickly review issues. Please fill it out correctly and do not ignore it, no matter how irrelevant you think it may be. Thanks in advance for your help with this!
 --->
 ### Expected behaviour:
+<!---
+Please don't just say "it doesn't crash" or "it works". Explain what the expected result is.
+--->
 
 ### Actual behaviour:
 
@@ -16,32 +22,35 @@ Before opening an issue, verify these:
 #### Config:
 ```
 paste relevant config
-use paste service if config is too long
+use paste service like http://dpaste.de or http://pastebin.com if config is too long
 ```
   
 #### Log:
 ```
 paste log output
-use paste service if log is too long
+use paste service like http://dpaste.de or http://pastebin.com if log is too long
 ```
 
 ### Additional information:
 
-- Flexget Version:
-- Python Version:
+- FlexGet version:
+- Python version:
 - Installation method:
-- Using Daemon? 
+- Using daemon (yes/no):
 - OS and version:
 - Link to crash log:
 
 <!---
+In config and debug/crash logs, remember to redact any personal or sensitive information such as passwords, API keys, private URLs and so on.
+
 Please verify that the following data is present before submitting your issue:
 
-- Paste or link to a paste service (http://pastebin.com/ for example) of relevant config (preferably full config including templates if present. Remember to redact any personal information! Please make sure the paste does not expire, if possible.
-- Paste or link to a paste service of debug level logs of relevant task/s. Use `flexget -L debug execute --tasks <Task_name>`
-- Flexget version (Use `flexget -V` to get it).
-- Full Python version (`2.7.11` for example). Run `python -V` to get it.
-- Installation method (pip, git install, etc.)
-- OS and version
-- Attach crash log if available
+- Link to a paste service or paste above the relevant config (preferably full config, including templates if present). Please make sure the paste does not expire, if possible.
+- Link to a paste service or paste above debug-level logs of the relevant task/s (use `flexget -L debug execute --tasks <Task_name>`).
+- FlexGet version (use `flexget -V` to get it).
+- Full Python version, for example `2.7.11` (use `python -V` to get it). Note that FlexGet is not supported for use with Python v3.0, 3.1, 3.2 or 3.6.
+- Installation method (pip, git install, etc).
+- Whether or not you're running FlexGet as a daemon.
+- OS and version.
+- Attach crash log if one was generated, in addition to the debug-level log. It can be found in the directory with your config file.
 --->


### PR DESCRIPTION
I noticed a very strange issue with rTorrent; payloads/torrent encoded payloads bigger than 16256 bytes were failing.  I put some logging around this `sock.send` line.  Here's a working example:

```2017-05-11 20:27 VERBOSE  rtorrent      task   Calling load.raw()
2017-05-11 20:27 INFO     rtorrent      task   Sending body of len: 11344
2017-05-11 20:27 INFO     rtorrent      task   Actually sent len: 11344
2017-05-11 20:27 INFO     rtorrent      task   Sending body of len: 1026
2017-05-11 20:27 INFO     rtorrent      task   Actually sent len: 1026
2017-05-11 20:27 INFO     rtorrent      task   some.torrent.title added to rtorrent
```

And this is a broken example:

```2017-05-11 13:20 INFO     rtorrent      task Sending body of len: 5734
2017-05-11 13:20 INFO     rtorrent      task Actually sent len: 5734
2017-05-11 13:20 INFO     rtorrent      task Sending body of len: 18164
2017-05-11 13:20 INFO     rtorrent      task Actually sent len: 16256
2017-05-11 13:20 ERROR    rtorrent      task timed out
```

... and is then followed by an exception.

Using `socket.sendall` may not be the ideal solution, but it seems good enough for me.
