### PR TITLE
New input plugin: trakt_calendar

### DIFF
--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 import jsonschema
 from jsonschema.compat import str_types, int_types
+from dateutil.parser import parse as dateutil_parse
 
 from flexget.event import fire_event
 from flexget.utils import qualities, template
@@ -159,6 +160,12 @@ def parse_size(size_input):
         return int(1024 ** prefixes.index(unit) * value)
 
 
+def parse_date(date_input):
+    try:
+        return dateutil_parse(date_input)
+    except ValueError:
+        raise ValueError("should be in ISO 8601 format eg. YYYY-MM-DD")
+
 # Public API end here, the rest should not be used outside this module
 
 
@@ -268,6 +275,13 @@ def is_valid_template(instance):
     if not isinstance(instance, str_types):
         return True
     return get_template(instance) is not None
+
+
+@format_checker.checks('date', raises=ValueError)
+def is_valid_date(date_string):
+    if not isinstance(date_string, str_types):
+        return True
+    return parse_date(date_string)
 
 
 def set_error_message(error):

--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -12,7 +12,6 @@ from datetime import datetime
 
 import jsonschema
 from jsonschema.compat import str_types, int_types
-from dateutil.parser import parse as dateutil_parse
 
 from flexget.event import fire_event
 from flexget.utils import qualities, template
@@ -160,12 +159,6 @@ def parse_size(size_input):
         return int(1024 ** prefixes.index(unit) * value)
 
 
-def parse_date(date_input):
-    try:
-        return dateutil_parse(date_input)
-    except ValueError:
-        raise ValueError("should be in ISO 8601 format eg. YYYY-MM-DD")
-
 # Public API end here, the rest should not be used outside this module
 
 
@@ -275,13 +268,6 @@ def is_valid_template(instance):
     if not isinstance(instance, str_types):
         return True
     return get_template(instance) is not None
-
-
-@format_checker.checks('date', raises=ValueError)
-def is_valid_date(date_string):
-    if not isinstance(date_string, str_types):
-        return True
-    return parse_date(date_string)
 
 
 def set_error_message(error):

--- a/flexget/plugins/input/trakt_calendar.py
+++ b/flexget/plugins/input/trakt_calendar.py
@@ -1,0 +1,114 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+import logging
+import datetime
+
+from flexget import plugin
+from flexget.entry import Entry
+from flexget.event import event
+from flexget.plugins.internal.api_trakt import get_api_url, get_session
+from flexget.utils.cached_input import cached
+
+from requests import RequestException
+
+log = logging.getLogger('trakt_calendar')
+
+
+class TraktCalendar(object):
+    schema = {
+        'type': 'object',
+        'properties': {
+            'start_date': {'type': 'string', 'format': 'date',
+                           'default': str(datetime.datetime.now().date() - datetime.timedelta(days=7))},
+            'days': {'type': 'integer', 'default': 7},
+            'account': {'type': 'string'},
+            'strip_year': {'type': 'boolean', 'default': False}
+        }
+    }
+
+    # Series info
+    series_map = {
+        'trakt_series_name': 'title',
+        'trakt_series_year': 'year',
+        'imdb_id': 'ids.imdb',
+        'tvdb_id': 'ids.tvdb',
+        'tmdb_id': 'ids.tmdb',
+        'trakt_show_id': 'ids.trakt',
+        'trakt_slug': 'ids.slug',
+        'tvrage_id': 'ids.tvrage',
+        'trakt_trailer': 'trailer',
+        'trakt_homepage': 'homepage',
+        'trakt_series_runtime': 'runtime',
+        'trakt_series_first_aired': 'first_aired',
+        'trakt_series_air_time': 'airs.time',
+        'trakt_series_air_day': 'airs.day',
+        'trakt_series_air_timezone': 'airs.timezone',
+        'trakt_series_content_rating': 'certification',
+        'trakt_genres': 'genres',
+        'trakt_series_network': 'network',
+        'imdb_url': lambda s: s['ids']['imdb'] and 'http://www.imdb.com/title/%s' % s['ids']['imdb'],
+        'trakt_series_url': lambda s: s['ids']['slug'] and 'https://trakt.tv/shows/%s' % s['ids']['slug'],
+        'trakt_series_country': 'country',
+        'trakt_series_status': 'status',
+        'trakt_series_overview': 'overview',
+        'trakt_series_rating': 'rating',
+        'trakt_series_votes': 'votes',
+        'trakt_series_language': 'language',
+        'trakt_series_aired_episodes': 'aired_episodes',
+        'trakt_languages': 'available_translations',
+        'trakt_series_updated_at': 'updated_at',
+    }
+
+    # Episode info
+    episode_map = {
+        'trakt_ep_name': 'title',
+        'trakt_ep_imdb_id': 'ids.imdb',
+        'trakt_ep_tvdb_id': 'ids.tvdb',
+        'trakt_ep_tmdb_id': 'ids.tmdb',
+        'trakt_ep_tvrage': 'ids.tvrage',
+        'trakt_episode_id': 'ids.trakt',
+        'trakt_ep_first_aired': 'first_aired',
+        'trakt_ep_overview': 'overview',
+        'trakt_ep_abs_number': 'number_abs',
+        'trakt_season': 'season',
+        'trakt_episode': 'number',
+        'trakt_ep_id': lambda ep: 'S%02dE%02d' % (ep['season'], ep['number']),
+        'trakt_ep_languages': 'available_translations',
+        'trakt_ep_runtime': 'runtime',
+        'trakt_ep_updated_at': 'updated_at',
+        'trakt_ep_rating': 'rating',
+        'trakt_ep_votes': 'votes'
+    }
+
+    @cached('trakt_calendar', persist='2 hours')
+    def on_task_input(self, task, config):
+        url = get_api_url('calendars', 'my' if config.get('account') else 'all', 'shows', config['start_date'],
+                          config['days'])
+
+        try:
+            results = get_session(config.get('account')).get(url, params={'extended': 'full'}).json()
+        except RequestException as e:
+            raise plugin.PluginError('Error while fetching calendar: {0}'.format(e))
+
+        entries = []
+        for result in results:
+            e = Entry()
+            e.update_using_map(self.series_map, result['show'])
+            e.update_using_map(self.episode_map, result['episode'])
+
+            e['title'] = e['trakt_series_name']
+            if not config['strip_year']:
+                e['title'] = '{0} ({1})'.format(e['title'], e['trakt_series_year'])
+            e['title'] = '{0} S{1:02d}E{2:02d}'.format(e['title'], e['trakt_season'], e['trakt_episode'])
+
+            e['url'] = '{0}/seasons/{1}/episodes/{2}'.format(e['trakt_series_url'], e['trakt_season'], e['trakt_episode'])
+
+            entries.append(e)
+
+        return entries
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(TraktCalendar, 'trakt_calendar', api_ver=2, interfaces=['task'])

--- a/flexget/plugins/input/trakt_calendar.py
+++ b/flexget/plugins/input/trakt_calendar.py
@@ -11,6 +11,7 @@ from flexget.plugins.internal.api_trakt import get_api_url, get_session
 from flexget.utils.cached_input import cached
 
 from requests import RequestException
+from dateutil.parser import parse as dateutil_parse
 
 log = logging.getLogger('trakt_calendar')
 
@@ -83,8 +84,8 @@ class TraktCalendar(object):
 
     @cached('trakt_calendar', persist='2 hours')
     def on_task_input(self, task, config):
-        url = get_api_url('calendars', 'my' if config.get('account') else 'all', 'shows', config['start_date'],
-                          config['days'])
+        start_date = str(dateutil_parse(config['start_date']).date())
+        url = get_api_url('calendars', 'my' if config.get('account') else 'all', 'shows', start_date, config['days'])
 
         try:
             results = get_session(config.get('account')).get(url, params={'extended': 'full'}).json()

--- a/flexget/plugins/input/trakt_calendar.py
+++ b/flexget/plugins/input/trakt_calendar.py
@@ -21,11 +21,14 @@ class TraktCalendar(object):
         'type': 'object',
         'properties': {
             'start_date': {'type': 'string', 'format': 'date',
-                           'default': str(datetime.datetime.now().date() - datetime.timedelta(days=7))},
+                           'default': str(datetime.datetime.now().date())},
             'days': {'type': 'integer', 'default': 7},
             'account': {'type': 'string'},
-            'strip_year': {'type': 'boolean', 'default': False}
-        }
+            'strip_year': {'type': 'boolean', 'default': False},
+            'type': {'type': 'string', 'enum': ['shows', 'episodes']}
+        },
+        'required': ['type'],
+        'additionalProperties': False
     }
 
     # Series info
@@ -97,16 +100,21 @@ class TraktCalendar(object):
         for result in results:
             e = Entry()
             e.update_using_map(self.series_map, result['show'])
-            e.update_using_map(self.episode_map, result['episode'])
+            if config['type'] == 'episodes':
+                e.update_using_map(self.episode_map, result['episode'])
 
             e['title'] = e['trakt_series_name']
             if not config['strip_year']:
                 e['title'] = '{0} ({1})'.format(e['title'], e['trakt_series_year'])
-            e['title'] = '{0} S{1:02d}E{2:02d}'.format(e['title'], e['trakt_season'], e['trakt_episode'])
+                
+            e['url'] = e['trakt_series_url']
+            
+            if config['type'] == 'episodes':
+                e['title'] = '{0} S{1:02d}E{2:02d}'.format(e['title'], e['trakt_season'], e['trakt_episode'])
 
-            e['url'] = '{0}/seasons/{1}/episodes/{2}'.format(e['trakt_series_url'],
-                                                             e['trakt_season'],
-                                                             e['trakt_episode'])
+                e['url'] = '{0}/seasons/{1}/episodes/{2}'.format(e['url'],
+                                                                 e['trakt_season'],
+                                                                 e['trakt_episode'])
 
             entries.append(e)
 

--- a/flexget/plugins/input/trakt_calendar.py
+++ b/flexget/plugins/input/trakt_calendar.py
@@ -103,7 +103,9 @@ class TraktCalendar(object):
                 e['title'] = '{0} ({1})'.format(e['title'], e['trakt_series_year'])
             e['title'] = '{0} S{1:02d}E{2:02d}'.format(e['title'], e['trakt_season'], e['trakt_episode'])
 
-            e['url'] = '{0}/seasons/{1}/episodes/{2}'.format(e['trakt_series_url'], e['trakt_season'], e['trakt_episode'])
+            e['url'] = '{0}/seasons/{1}/episodes/{2}'.format(e['trakt_series_url'],
+                                                             e['trakt_season'],
+                                                             e['trakt_episode'])
 
             entries.append(e)
 

--- a/flexget/plugins/input/trakt_calendar.py
+++ b/flexget/plugins/input/trakt_calendar.py
@@ -97,7 +97,7 @@ class TraktCalendar(object):
         except RequestException as e:
             raise plugin.PluginError('Error while fetching calendar: {0}'.format(e))
 
-        entries = []
+        entries = set()
         for result in results:
             e = Entry()
             e.update_using_map(self.series_map, result['show'])
@@ -117,9 +117,9 @@ class TraktCalendar(object):
                                                                  e['trakt_season'],
                                                                  e['trakt_episode'])
 
-            entries.append(e)
+            entries.add(e)
 
-        return entries
+        return list(entries)
 
 
 @event('plugin.register')

--- a/flexget/plugins/input/trakt_calendar.py
+++ b/flexget/plugins/input/trakt_calendar.py
@@ -22,7 +22,7 @@ class TraktCalendar(object):
             'start_day': {'type': 'integer', 'default': 0},
             'days': {'type': 'integer', 'default': 7},
             'account': {'type': 'string'},
-            'strip_year': {'type': 'boolean', 'default': False},
+            'strip_dates': {'type': 'boolean', 'default': False},
             'type': {'type': 'string', 'enum': ['shows', 'episodes']}
         },
         'required': ['type'],
@@ -105,7 +105,7 @@ class TraktCalendar(object):
                 e.update_using_map(self.episode_map, result['episode'])
 
             e['title'] = e['trakt_series_name']
-            if not config['strip_year']:
+            if not config['strip_dates']:
                 e['title'] = '{0} ({1})'.format(e['title'], e['trakt_series_year'])
                 
             e['url'] = e['trakt_series_url']

--- a/flexget/plugins/input/trakt_calendar.py
+++ b/flexget/plugins/input/trakt_calendar.py
@@ -84,7 +84,8 @@ class TraktCalendar(object):
 
     @cached('trakt_calendar', persist='2 hours')
     def on_task_input(self, task, config):
-        start_date = str(dateutil_parse(config['start_date']).date())
+        start_date = dateutil_parse(config['start_date']).date()
+
         url = get_api_url('calendars', 'my' if config.get('account') else 'all', 'shows', start_date, config['days'])
 
         try:


### PR DESCRIPTION
### Motivation for changes:
Dunno

### Config usage if relevant (new plugin or updated schema):
```
  trakt_calendar:
    account: myaccount
    start_day: -7  # number of days from today
    days: 10
    strip_dates: yes
    type: episodes
```

### TODO
- [x] Test with `what` in discover plugin
~- [ ] Structural pytest?~
- [x] Make sure a "you missed an episode X days ago" task is feasible

### Example "you missed an episode X days ago" task
```YAML
tasks:
  notify_missed:
    disable: seen  # we do not want seen to interfere
    metainfo_series: yes
    notify: bla bla
    trakt_calendar:
      type: episodes
      account: asdas
      start_day: -7
      days: 6  # Grab episodes in the last 6 days (not including today)
    if:
      - "trakt_collected or trakt_watched": reject
      - "series_season == 0": reject
    trakt_lookup:
      account: dsadsa
    crossmatch:
      from:
        - trakt_list:
            account: dsadsa
            type: shows
            list: ddsadasdas
      action: accept
      fields: [trakt_series_name]
```
