### PR TITLE
[fix] notifiers - Fix notifier plugins documentation

### DIFF
--- a/flexget/plugins/notifiers/email.py
+++ b/flexget/plugins/notifiers/email.py
@@ -40,44 +40,57 @@ class EmailNotifier(object):
 
     Config basic example::
 
-      email:
-        from: xxx@xxx.xxx
-        to: xxx@xxx.xxx
-        smtp_host: smtp.host.com
+      notify:
+        entries:
+          via:
+            - email:
+                from: xxx@xxx.xxx
+                to: xxx@xxx.xxx
+                smtp_host: smtp.host.com
 
     Config example with smtp login::
 
-      email:
-        from: xxx@xxx.xxx
-        to: xxx@xxx.xxx
-        smtp_host: smtp.host.com
-        smtp_port: 25
-        smtp_login: true
-        smtp_username: my_smtp_login
-        smtp_password: my_smtp_password
-        smtp_tls: true
+      notify:
+        entries:
+          via:
+            - email:
+                from: xxx@xxx.xxx
+                to: xxx@xxx.xxx
+                smtp_host: smtp.host.com
+                smtp_port: 25
+                smtp_login: true
+                smtp_username: my_smtp_login
+                smtp_password: my_smtp_password
+                smtp_tls: true
 
     GMAIL example::
 
-      from: from@gmail.com
-      to: to@gmail.com
-      smtp_host: smtp.gmail.com
-      smtp_port: 587
-      smtp_login: true
-      smtp_username: gmailUser
-      smtp_password: gmailPassword
-      smtp_tls: true
+      notify:
+        entries:
+          via:
+            - email:
+                from: from@gmail.com
+                to: to@gmail.com
+                smtp_host: smtp.gmail.com
+                smtp_port: 587
+                smtp_login: true
+                smtp_username: gmailUser
+                smtp_password: gmailPassword
+                smtp_tls: true
 
     Default values for the config elements::
 
-      email:
-        smtp_host: localhost
-        smtp_port: 25
-        smtp_login: False
-        smtp_username:
-        smtp_password:
-        smtp_tls: False
-        smtp_ssl: False
+      notify:
+        entries:
+          via:
+            - email:
+                smtp_host: localhost
+                smtp_port: 25
+                smtp_login: False
+                smtp_username:
+                smtp_password:
+                smtp_tls: False
+                smtp_ssl: False
     """
 
     def __init__(self):

--- a/flexget/plugins/notifiers/join.py
+++ b/flexget/plugins/notifiers/join.py
@@ -23,13 +23,16 @@ class JoinNotifier(object):
     """
     Example::
 
-      join:
-        [api_key: <API_KEY> (your join api key. Only required for 'group' notifications)]
-        [group: <GROUP_NAME> (name of group of join devices to notify. 'all', 'android', etc.)
-        [device: <DEVICE_ID> (can also be a list of device ids)]
-        [url: <NOTIFICATION_URL>]
-        [sms_number: <NOTIFICATION_SMS_NUMBER>]
-        [icon: <NOTIFICATION_ICON>]
+      notify:
+        entries:
+          via:
+            - join:
+                [api_key: <API_KEY> (your join api key. Only required for 'group' notifications)]
+                [group: <GROUP_NAME> (name of group of join devices to notify. 'all', 'android', etc.)
+                [device: <DEVICE_ID> (can also be a list of device ids)]
+                [url: <NOTIFICATION_URL>]
+                [sms_number: <NOTIFICATION_SMS_NUMBER>]
+                [icon: <NOTIFICATION_ICON>]
     """
     schema = {
         'type': 'object',

--- a/flexget/plugins/notifiers/notifymyandroid.py
+++ b/flexget/plugins/notifiers/notifymyandroid.py
@@ -21,11 +21,14 @@ class NotifyMyAndroidNotifier(object):
     """
     Example::
 
-      notifymyandroid:
-        apikey: xxxxxxx
-        [application: application name, default FlexGet]
-        [event: event title, default New Release]
-        [priority: -2 - 2 (2 = highest), default 0]
+      notify:
+        entries:
+          via:
+            - notifymyandroid:
+                apikey: xxxxxxx
+                [application: application name, default FlexGet]
+                [event: event title, default New Release]
+                [priority: -2 - 2 (2 = highest), default 0]
 
     Configuration parameters are also supported from entries (eg. through set).
     """

--- a/flexget/plugins/notifiers/prowl.py
+++ b/flexget/plugins/notifiers/prowl.py
@@ -26,12 +26,15 @@ class ProwlNotifier(object):
 
     Example::
 
-      prowl:
-        api_key: xxxxxxx
-        [application: application name, default FlexGet]
-        [event: event title, default New Release]
-        [priority: -2 - 2 (2 = highest), default 0]
-        [description: notification to send]
+      notify:
+        entries:
+          via:
+            - prowl:
+                api_key: xxxxxxx
+                [application: application name, default FlexGet]
+                [event: event title, default New Release]
+                [priority: -2 - 2 (2 = highest), default 0]
+                [description: notification to send]
 
     """
     schema = {

--- a/flexget/plugins/notifiers/pushalot.py
+++ b/flexget/plugins/notifiers/pushalot.py
@@ -23,18 +23,18 @@ class PushalotNotifier(object):
     """
     Example::
 
-      pushalot:
-        token: <string> Authorization token (can also be a list of tokens) - Required
-        title: <string> (default: task name)
-        body: <string> (default: '{{series_name}} {{series_id}}' )
-        link: <string> (default: '{{imdb_url}}')
-        linktitle: <string> (default: (none))
-        important: <boolean> (default is False)
-        silent: <boolean< (default is False)
-        image: <string> (default: (none))
-        source: <string> (default is 'FlexGet')
-        timetolive: <integer>
-
+      notify:
+        entries:
+          via:
+            - pushalot:
+                token: <string> Authorization token (can also be a list of tokens) - Required
+                link: <string> (default: '{{imdb_url}}')
+                linktitle: <string> (default: (none))
+                important: <boolean> (default is False)
+                silent: <boolean< (default is False)
+                image: <string> (default: (none))
+                source: <string> (default is 'FlexGet')
+                timetolive: <integer>
     """
     schema = {'type': 'object',
               'properties': {

--- a/flexget/plugins/notifiers/pushbullet.py
+++ b/flexget/plugins/notifiers/pushbullet.py
@@ -25,13 +25,14 @@ class PushbulletNotifier(object):
     """
     Example::
 
-      pushbullet:
-        apikey: <API_KEY>
-        [device: <DEVICE_IDEN> (can also be a list of device idens, or don't specify any idens to send to all devices)]
-        [email: <EMAIL_ADDRESS> (can also be a list of user email addresses)]
-        [channel: <CHANNEL_TAG> (you can only specify device / email or channel tag. cannot use both.)]
-        [title: <MESSAGE_TITLE>] (default: "{{task}} - Download started" -- accepts Jinja2)
-        [body: <MESSAGE_BODY>] (default: "{{series_name}} {{series_id}}" -- accepts Jinja2)
+    notify:
+      entries:
+        via:
+          pushbullet:
+            apikey: <API_KEY>
+            [device: <DEVICE_IDEN> (can also be a list of device ids, or don't specify any ids to send to all devices)]
+            [email: <EMAIL_ADDRESS> (can also be a list of user email addresses)]
+            [channel: <CHANNEL_TAG> (you can only specify device / email or channel tag, cannot use both)]
 
     Configuration parameters are also supported from entries (eg. through set).
     """
@@ -41,8 +42,6 @@ class PushbulletNotifier(object):
             'api_key': one_or_more({'type': 'string'}),
             'device': one_or_more({'type': 'string'}),
             'email': one_or_more({'type': 'string', 'format': 'email'}),
-            'title': {'type': 'string'},
-            'message': {'type': 'string'},
             'url': {'type': 'string'},
             'channel': {'type': 'string'},
             'file_template': {'type': 'string'},

--- a/flexget/plugins/notifiers/pushover.py
+++ b/flexget/plugins/notifiers/pushover.py
@@ -24,20 +24,21 @@ class PushoverNotifier(object):
     """
     Example::
 
-      pushover:
-        user_key: <USER_KEY> (can also be a list of userkeys)
-        token: <TOKEN>
-        [device: <DEVICE_STRING>]
-        [title: <MESSAGE_TITLE>]
-        [message: <MESSAGE_BODY>]
-        [priority: <PRIORITY>]
-        [url: <URL>]
-        [url_title: <URL_TITLE>]
-        [sound: <SOUND>]
-        [retry]: <RETRY>]
-        [expire]: <EXPIRE>]
-        [callback]: <CALLBACK>]
-        [html]: <HTML>]
+      notify:
+        entries:
+          via:
+            - pushover:
+                user_key: <USER_KEY> (can also be a list of userkeys)
+                token: <TOKEN>
+                [device: <DEVICE_STRING>]
+                [priority: <PRIORITY>]
+                [url: <URL>]
+                [url_title: <URL_TITLE>]
+                [sound: <SOUND>]
+                [retry]: <RETRY>]
+                [expire]: <EXPIRE>]
+                [callback]: <CALLBACK>]
+                [html]: <HTML>]
     """
 
     schema = {

--- a/flexget/plugins/notifiers/pushsafer.py
+++ b/flexget/plugins/notifiers/pushsafer.py
@@ -23,17 +23,18 @@ class PushsaferNotifier(object):
     """
     Example::
 
-      pushsafer:
-        private_key: <string> your private key (can also be a alias key) - Required
-        title: <string> (default: task name)
-        body: <string> (default: '{{series_name}} {{series_id}}' )
-        url: <string> (default: '{{imdb_url}}')
-        url_title: <string> (default: (none))
-        device: <string> ypur device or device group id (default: (none))
-        icon: <integer> (default is 1)
-        sound: <integer> (default is (none))
-        vibration: <integer> (default is 0)
-        timetolive: <integer> (default: (none))
+      notify:
+        entries:
+          via:
+            - pushsafer:
+                private_key: <string> your private key (can also be a alias key) - Required
+                url: <string> (default: '{{imdb_url}}')
+                url_title: <string> (default: (none))
+                device: <string> ypur device or device group id (default: (none))
+                icon: <integer> (default is 1)
+                sound: <integer> (default is (none))
+                vibration: <integer> (default is 0)
+                timetolive: <integer> (default: (none))
 
     """
     schema = {'type': 'object',

--- a/flexget/plugins/notifiers/rapidpush.py
+++ b/flexget/plugins/notifiers/rapidpush.py
@@ -24,13 +24,16 @@ class RapidpushNotifier(object):
     """
     Example::
 
-      rapidpush:
-        apikey: xxxxxxx (can also be a list of api keys)
-        [category: category, default FlexGet]
-        [group: device group, default no group]
-        [channel: the broadcast notification channel, if provided it will be send to the channel subscribers instead of
-            your devices, default no channel]
-        [priority: 0 - 6 (6 = highest), default 2 (normal)]
+      notify:
+        entries:
+          via:
+            - rapidpush:
+                apikey: xxxxxxx (can also be a list of api keys)
+                [category: category, default FlexGet]
+                [group: device group, default no group]
+                [channel: the broadcast notif. channel; if provided it will be send to the channel subscribers instead of
+                    your devices, default no channel]
+                [priority: 0 - 6 (6 = highest), default 2 (normal)]
     """
     schema = {
         'type': 'object',

--- a/flexget/plugins/notifiers/slack.py
+++ b/flexget/plugins/notifiers/slack.py
@@ -20,12 +20,15 @@ class SlackNotifier(object):
     """
     Example:
 
-      slack:
-        web_hook_url: <string>
-        [channel: <string>] (override channel, use "@username" or "#channel")
-        [username: <string>] (override username)
-        [icon_emoji: <string>] (override emoji icon)
-        [icon_url: <string>] (override emoji icon)
+      notify:
+        entries:
+          via:
+            - slack:
+                web_hook_url: <string>
+                [channel: <string>] (override channel, use "@username" or "#channel")
+                [username: <string>] (override username)
+                [icon_emoji: <string>] (override emoji icon)
+                [icon_url: <string>] (override emoji icon)
 
     """
     schema = {

--- a/flexget/plugins/notifiers/sms_ru.py
+++ b/flexget/plugins/notifiers/sms_ru.py
@@ -27,9 +27,12 @@ class SMSRuNotifier(object):
 
     Example:
 
-      sms_ru:
-        phone_number: <PHONE_NUMBER> (accepted format example: '79997776655')
-        password: <PASSWORD>
+      notify:
+        entries:
+          via:
+            - sms_ru:
+                phone_number: <PHONE_NUMBER> (accepted format example: '79997776655')
+                password: <PASSWORD>
 
     """
     schema = {

--- a/flexget/plugins/notifiers/telegram.py
+++ b/flexget/plugins/notifiers/telegram.py
@@ -74,16 +74,20 @@ class TelegramNotifier(object):
     Configuration example::
 
     my-task:
-      telegram:
-        bot_token: token
-        template: {{title}}
-        use_markdown: no
-        recipients:
-          - username: my-user-name
-          - group: my-group-name
-          - fullname:
-              first: my-first-name
-              sur: my-sur-name
+      notify:
+        title: {{title}}
+        message: {{title}}
+        entries:
+          via:
+            telegram:
+              bot_token: token
+              use_markdown: no
+              recipients:
+                - username: my-user-name
+                - group: my-group-name
+                - fullname:
+                    first: my-first-name
+                    sur: my-sur-name
 
 
     Bootstrapping and testing the bot::
@@ -98,9 +102,6 @@ class TelegramNotifier(object):
 
     You may use any combination of recipients types (`username`, `group` or `fullname`) - 0 or more of each (but you
     need at least one total...).
-
-    `template`::
-    Optional. The template from the example is the default.
 
     `parse_mode`::
     Optional. Whether the template uses `markdown` or `html` formatting.

--- a/flexget/plugins/notifiers/toast.py
+++ b/flexget/plugins/notifiers/toast.py
@@ -13,6 +13,23 @@ log = logging.getLogger(plugin_name)
 
 
 class NotifyToast(object):
+    """
+    Sends messages via local notification system. You must have a notification system like dbus for Linux.
+    Preliminary support for Windows notifications. Not heavily tested yet.
+
+    Examples:
+
+      notify:
+        entries:
+          via:
+            - toast: yes
+
+      notify:
+        entries:
+          via:
+            - toast:
+                timeout: 5
+    """
     schema = {
         'anyOf': [
             {'type': 'boolean', 'enum': [True]},

--- a/flexget/plugins/notifiers/xmpp.py
+++ b/flexget/plugins/notifiers/xmpp.py
@@ -14,6 +14,22 @@ log = logging.getLogger(plugin_name)
 
 
 class XMPPNotifier(object):
+    """
+    Sends messages via XMPP. The sleekxmpp library is required to be installed.
+    Install it with: `pip install sleekxmpp`
+
+    All fields are required.
+
+    Example:
+
+      notify:
+        entries:
+          via:
+            - xmpp:
+                sender: sender's JID
+                password: sender's password
+                recipients: recipient's JID or list of JIDs
+    """
     schema = {
         'type': 'object',
         'properties': {


### PR DESCRIPTION
### Motivation for changes:
Title and message now belong in the `notify` plugin. Some of the documentation still included these (and at least one plugin still had them in its config). Examples didn't make clear that these are sub-plugins of `notify`, and some plugins didn't have examples.

### Detailed changes:
- Remove `message` and `title` from all examples.
- Remove `message` and `title` from `pushbullet` config options.
- Fix all examples to reflect these are sub-plugins of `notify`'s `via` key.
- Add brief documentation and examples for `xmpp` and `toast`.
