### PR TITLE
[fix] next_series_seasons - Limit size of emit in one run

### DIFF
--- a/flexget/plugins/input/next_series_seasons.py
+++ b/flexget/plugins/input/next_series_seasons.py
@@ -115,6 +115,19 @@ class NextSeriesSeasons(object):
                 else:
                     latest_season = low_season + 1
 
+                if (latest_season - low_season > 15 and not series.begin) or (series.begin and
+                    latest_season - series.begin.season > 30):
+                    if series.begin:
+                        log.error('Series `%s` has a begin episode set (`%s`), but the season currently being processed '
+                                  '(%s) is %s seasons later than it. To prevent emitting incorrect seasons, this ' 
+                                  'series will not emit unless the begin episode is adjusted to a season that is less '
+                                  'than 30 seasons from season %s.', series.name, series.begin.identifier, latest_season,
+                                  (latest_season - series.begin.season), latest_season)
+                    else:
+                        log.error('Series `%s` does not have a begin episode set and continuing this task would result '                                   'in more than 15 seasons being emitted. To prevent emitting incorrect seasons, this '
+                                  'series will not emit unless the begin episode is set in your series config or by '
+                                  'using the CLI subcommand `series begin "%s" <SxxExx>`.', series.name, series.name)
+                    continue
                 for season in range(latest_season, low_season, -1):
                     if season in series.completed_seasons:
                         log.debug('season %s is marked as completed, skipping', season)
@@ -136,9 +149,9 @@ class NextSeriesSeasons(object):
                         if config.get('from_start') or config.get('backfill'):
                             entries.append(self.search_entry(series, season, task))
                         else:
-                            log.verbose('Series `%s` has no history. Set begin option, '
-                                        'or use CLI `series begin` '
-                                        'subcommand to set first episode to emit', series.name)
+                            log.verbose('Series `%s` has no history. Set the begin option in your config, '
+                                        'or use the CLI subcommand `series begin "%s" <SxxExx>` '
+                                        'to set the first episode to emit', series.name, series.name)
                             break
                     # Skip older seasons if we are not in backfill mode
                     if not config.get('backfill'):

--- a/flexget/plugins/input/next_series_seasons.py
+++ b/flexget/plugins/input/next_series_seasons.py
@@ -71,6 +71,8 @@ class NextSeriesSeasons(object):
         if isinstance(config, bool):
             config = {}
 
+        DIFF_NO_SERIES_BEGIN = 15
+        DIFF_GAP_TOO_BIG = 30
         if task.is_rerun:
             # Just return calculated next eps on reruns
             entries = self.rerun_entries
@@ -115,8 +117,8 @@ class NextSeriesSeasons(object):
                 else:
                     latest_season = low_season + 1
 
-                if (latest_season - low_season > 15 and not series.begin) or (series.begin and
-                    latest_season - series.begin.season > 30):
+                if (latest_season - low_season > DIFF_NO_SERIES_BEGIN and not series.begin) or (series.begin and
+                    latest_season - series.begin.season > DIFF_GAP_TOO_BIG):
                     if series.begin:
                         log.error('Series `%s` has a begin episode set (`%s`), but the season currently being processed '
                                   '(%s) is %s seasons later than it. To prevent emitting incorrect seasons, this ' 


### PR DESCRIPTION
### Motivation for changes:
Given a season identifier of S2014 and backfill enabled, it is possible for `next_series_seasons` to emit all the way down to S01 in one run.

### Detailed changes:
This change prevents it from emitting if `begin` is not set and the group of seasons to review is more than 15, or if `begin` is set and the difference between the latest season to review and `begin` is more than 30. In both cases the user will be required to set or adjust `begin` before any emit will occur.

### Addressed issues:
- Fixes issue originally raised by @jawilson [here](https://github.com/Flexget/Flexget/commit/30751df7da16bdc12781411cdec9f51d9e02a890#commitcomment-22161686).