### PR TITLE
[fix] next_series_seasons - Use latest download for rerun entry generation

### DIFF
--- a/flexget/plugins/input/next_series_seasons.py
+++ b/flexget/plugins/input/next_series_seasons.py
@@ -165,7 +165,7 @@ class NextSeriesSeasons(object):
                 else:
                     log.debug('%s %s was accepted, rerunning to look for next season.', entry['series_name'],
                               entry['series_id'])
-                    if not [entry for entry in self.rerun_entries if entry.get('series_season') == latest.season + 1]:
+                    if not any(e.get('series_season') == latest.season + 1 for e in self.rerun_entries):
                         self.rerun_entries.append(self.search_entry(series, latest.season + 1, task))
                     # Increase rerun limit by one if we have matches, this way
                     # we keep searching as long as matches are found!

--- a/flexget/plugins/input/next_series_seasons.py
+++ b/flexget/plugins/input/next_series_seasons.py
@@ -165,7 +165,8 @@ class NextSeriesSeasons(object):
                 else:
                     log.debug('%s %s was accepted, rerunning to look for next season.', entry['series_name'],
                               entry['series_id'])
-                    self.rerun_entries.append(self.search_entry(series, entry['series_season'] + 1, task))
+                    if not [entry for entry in self.rerun_entries if entry.get('series_season') == latest.season + 1]:
+                        self.rerun_entries.append(self.search_entry(series, latest.season + 1, task))
                     # Increase rerun limit by one if we have matches, this way
                     # we keep searching as long as matches are found!
                     # TODO: this should ideally be in discover so it would be more generic


### PR DESCRIPTION
### Motivation for changes:
Fixes a bug with erroneously-generated rerun entries. I realize it's small - I submitted it as a PR to ensure this is the FlexGet way to make sure there's no duplicate entry in `self.rerun_entries`.

### Detailed changes:
Given begin episode of S2014E01, S2017 downloaded in history, and backfill enabled, `next_series_seasons` will emit S2014, S2015, S2016, and S2018.

If those are accepted and it’s allowed to rerun, it will then look for S2015, S2016, S2018, and S2019, because when each of the previous seasons was accepted, a rerun entry was created for the season immediately after the accepted season regardless of whether that “next” season was also accepted in that run. This is further compounded by the fact that rerun entries are generated without the normal review process in the `latest_season` -> `low_season` loop and are assumed to be correct.

In other words:
```
S2014 -> search -> accept -> generate S2015 rerun (despite it being accepted during this run)
S2015 -> search -> accept -> generate S2016 rerun (despite it being accepted during this run)
S2016 -> search -> accept -> generate S2017 rerun (despite it being a downloaded entity prior to this run)
S2018 -> search -> accept -> generate S2019 rerun (this is the only valid one)
```

After this change:
```
S2014 -> search -> accept -> generate S2019 rerun -> added to self.rerun_entries
S2015 -> search -> accept -> generate S2019 rerun -> not added to self.rerun_entries since it's a duplicate
S2016 -> search -> accept -> generate S2019 rerun -> ditto
S2018 -> search -> accept -> generate S2019 rerun -> ditto
```

This change uses the latest downloaded season instead to determine the next season to search.