### PR TITLE
[add] sort_by - Option to ignore leading articles

### DIFF
--- a/flexget/plugins/modify/sort_by.py
+++ b/flexget/plugins/modify/sort_by.py
@@ -10,6 +10,7 @@ import re
 
 log = logging.getLogger('sort_by')
 
+RE_ARTICLES = '^(the|a|an)\s'
 
 class PluginSortBy(object):
     """
@@ -52,8 +53,7 @@ class PluginSortBy(object):
     }
 
     def on_task_filter(self, task, config):
-        re_articles = '^(the|a|an)\s'
-        if isinstance(config, basestring):
+        if isinstance(config, str):
             field = config
             reverse = False
             ignore_articles = False
@@ -68,8 +68,7 @@ class PluginSortBy(object):
             task.all_entries.reverse()
             return
         
-        if not isinstance(ignore_articles, bool):
-            re_articles = ignore_articles
+        re_articles = ignore_articles if not isinstance(ignore_articles, bool) else RE_ARTICLES
 
         if ignore_articles:
             task.all_entries.sort(key=lambda e: re.sub(re_articles, '', e.get(field, 0), flags=re.IGNORECASE),

--- a/flexget/tests/test_sort_by.py
+++ b/flexget/tests/test_sort_by.py
@@ -1,17 +1,18 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
+import pytest
 
 class TestSortBy(object):
     config = """
         tasks:
-          test1:
+          test_title:
             sort_by: title
             mock:
               - {title: 'B C D', url: 'http://localhost/1'}
               - {title: 'A B C', url: 'http://localhost/2'}
               - {title: 'A P E', url: 'http://localhost/3'}
-          test2:
+          test_title_reverse:
             sort_by:
               field: title
               reverse: true
@@ -19,7 +20,7 @@ class TestSortBy(object):
               - {title: 'B C D', url: 'http://localhost/1'}
               - {title: 'A B C', url: 'http://localhost/2'}
               - {title: 'A P E', url: 'http://localhost/3'}
-          test3:
+          test_reverse:
             sort_by:
                 reverse: true
             mock:
@@ -34,29 +35,56 @@ class TestSortBy(object):
               - {title: 'Test.720p'}
               - {title: 'Test.hdtv'}
               - {title: 'Test.1080p'}
-
+          test_ignore_articles:
+            sort_by:
+              field: title
+              ignore_articles: yes
+            mock:
+              - {title: 'New Series 2', url: 'http://localhost/2'}
+              - {title: 'An Owl Looked Back', url: 'http://localhost/4'}
+              - {title: 'A New Series', url: 'http://localhost/1'}
+              - {title: 'Owl Looked Back Goes to College', url: 'http://localhost/5'}
+              - {title: 'The Cat Who Looked Back', url: 'http://localhost/3'}
+          test_ignore_articles_custom:
+            sort_by:
+              field: title
+              ignore_articles: '^(the|a)\s'
+            mock:
+              - {title: 'The Cat Who Looked Back', url: 'http://localhost/3'}
+              - {title: 'A New Series', url: 'http://localhost/1'}
+              - {title: 'Owl Looked Back Goes to College', url: 'http://localhost/5'}
+              - {title: 'New Series 2', url: 'http://localhost/2'}
+              - {title: 'An Owl Looked Back', url: 'http://localhost/4'}
     """
 
-    def test_sort_by_title(self, execute_task):
-        task = execute_task('test1')
-        assert task.entries[0]['title'] == 'A B C', 'Entries sorted alphabetically by title'
-        assert task.entries[1]['title'] == 'A P E', 'Entries sorted alphabetically by title'
-        assert task.entries[2]['title'] == 'B C D', 'Entries sorted alphabetically by title'
+    def generate_test_ids(param):
+        if param[0:5] == 'test_' or not isinstance(param, list):
+            return param
+        return '|'
 
-    def test_sort_by_title_reverse(self, execute_task):
-        task = execute_task('test2')
-        assert task.entries[0]['title'] == 'B C D', 'Entries sorted alphabetically by title'
-        assert task.entries[1]['title'] == 'A P E', 'Entries sorted alphabetically by title'
-        assert task.entries[2]['title'] == 'A B C', 'Entries sorted alphabetically by title'
-
-    def test_sort_by_reverse(self, execute_task):
-        task = execute_task('test3')
-        assert task.entries[0]['title'] == 'A P E', 'Entries sorted alphabetically by title'
-        assert task.entries[1]['title'] == 'A B C', 'Entries sorted alphabetically by title'
-        assert task.entries[2]['title'] == 'B C D', 'Entries sorted alphabetically by title'
-
-    def test_quality_sort(self, execute_task):
-        task = execute_task('test_quality')
-        assert task.entries[0]['title'] == 'Test.1080p', 'Entries should be sorted by descending quality'
-        assert task.entries[1]['title'] == 'Test.720p', 'Entries should be sorted by descending quality'
-        assert task.entries[2]['title'] == 'Test.hdtv', 'Entries should be sorted by descending quality'
+    @pytest.mark.parametrize('task_name,result_titles,fail_reason', [
+        ('test_title',
+            ['A B C', 'A P E', 'B C D'],
+            'Entries should be sorted alphabetically by title'),
+        ('test_title_reverse',
+            ['B C D', 'A P E', 'A B C'],
+            'Entries should be sorted alphabetically by title'),
+        ('test_reverse',
+            ['A P E', 'A B C', 'B C D'],
+            'Entries should be sorted alphabetically by title'),
+        ('test_quality',
+            ['Test.1080p', 'Test.720p', 'Test.hdtv'],
+            'Entries should be sorted by descending quality'),
+        ('test_ignore_articles',
+            ['The Cat Who Looked Back', 'A New Series', 'New Series 2', 'An Owl Looked Back',
+             'Owl Looked Back Goes to College'],
+            'Entries should be sorted ignoring articles `a`, `an`, and `the`'),
+        ('test_ignore_articles_custom',
+            ['An Owl Looked Back', 'The Cat Who Looked Back', 'A New Series', 'New Series 2',
+             'Owl Looked Back Goes to College'],
+            'Entries should be sorted ignoring articles `a` and `the`')
+    ], ids=generate_test_ids)
+    def test_sort_by(self, execute_task, task_name, result_titles, fail_reason):
+        task = execute_task(task_name)
+        for count, title in enumerate(result_titles):
+            assert task.entries[count]['title'] == title, fail_reason


### PR DESCRIPTION
### Motivation for changes:
I wanted to sort my series without regard to leading articles.

### Detailed changes:
- Adds an additional option, `ignore_articles`:
  - When set to yes, the sort will ignore the English articles ‘the’, ‘a’, and ‘an’ when they appear as the first word in the field to be sorted.
  - Alternatively, you can specify a custom regular expression to be used, for use with other languages or to otherwise customize the articles that are ignored.
- Added tests for both bool and custom regex forms of `ignore_articles` options.
- All tests now run from one function through use of `@pytest.mark.parametrize`.

### Config usage if relevant (new plugin or updated schema):
```
sort_by:
  field: title
  ignore_articles: yes

sort_by:
  field: title
  ignore_articles: '^(ignore|other|words)\s'
```

### Tests
Added two tests to test_sort_by.py for `ignore_articles: yes` and `ignore_articles: '^(the|a)\s'`.