### PR TITLE
[change] series CLI - Hide unseen episodes

### DIFF
--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -204,6 +204,8 @@ def display_details(options):
         table_data = [header]
         entities = get_all_entities(series, session=session)
         for entity in entities:
+            if not entity.releases:
+                continue
             if entity.identifier is None:
                 identifier = colorize(ERROR_COLOR, 'MISSING')
                 age = ''


### PR DESCRIPTION
### Motivation for changes:
Unseen episodes shouldn't be listed in the `series show` table, whether they are the `begin` episode or not.

### Detailed changes:
Episodes which have never been seen by FlexGet are now hidden when using the `series show <show_name>` subcommand. This includes the `begin` episode if that episode was never seen by FlexGet. The `begin` episode is still listed below the table, if it is set.