### PR TITLE
[add] series CLI - --sort-by argument for series show

### DIFF
--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -202,7 +202,7 @@ def display_details(options):
                        ' {}'.format(name, ', '.join(s.name for s in matches[1:])))
             if not options.table_type == 'porcelain':
                 console(warning)
-        header = ['Entity ID', 'Latest age', 'Release titles', 'Release Quality', 'Proper']
+        header = ['Identifier', 'Last seen', 'Release titles', 'Release Quality', 'Proper']
         table_data = [header]
         entities = get_all_entities(series, session=session, sort_by=sort_by, reverse=reverse)
         for entity in entities:
@@ -241,9 +241,9 @@ def display_details(options):
                        ' during this time.')
         else:
             footer += '\n Series uses `%s` mode to identify episode numbering (identified_by).' % series.identified_by
-        footer += ' \n See option `identified_by` for more information.\n'
+        footer += ' \n See option `identified_by` for more information.'
         if series.begin:
-            footer += ' Begin episode for this series set to `%s`.' % series.begin.identifier
+            footer += ' \n Begin episode for this series set to `%s`.' % series.begin.identifier
     try:
         table = TerminalTable(options.table_type, table_data, table_title, drop_columns=[4, 3, 1])
         console(table.output)
@@ -286,8 +286,8 @@ def register_parser_arguments():
 
     show_parser = subparsers.add_parser('show', parents=[series_parser, table_parser],
                           help='Show the releases FlexGet has seen for a given series')
-    show_parser.add_argument('--sort-by', choices=('seen', 'entity'), default='seen',
-                             help='Choose releases list sort: last seen date (default) or entity ID')
+    show_parser.add_argument('--sort-by', choices=('age', 'identifier'), default='age',
+                             help='Choose releases list sort: age (default) or identifier')
     show_order = show_parser.add_mutually_exclusive_group(required=False)
     show_order.add_argument('--descending', dest='order', action='store_true', help='Sort in descending order')
     show_order.add_argument('--ascending', dest='order', action='store_false', help='Sort in ascending order')

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -183,6 +183,8 @@ def get_latest_status(episode):
 def display_details(options):
     """Display detailed series information, ie. series show NAME"""
     name = options.series_name
+    sort_by = options.sort_by
+    reverse = options.order
     with Session() as session:
         name = normalize_series_name(name)
         # Sort by length of name, so that partial matches always show shortest matching title
@@ -202,7 +204,7 @@ def display_details(options):
                 console(warning)
         header = ['Entity ID', 'Latest age', 'Release titles', 'Release Quality', 'Proper']
         table_data = [header]
-        entities = get_all_entities(series, session=session)
+        entities = get_all_entities(series, session=session, sort_by=sort_by, reverse=reverse)
         for entity in entities:
             if entity.identifier is None:
                 identifier = colorize(ERROR_COLOR, 'MISSING')
@@ -282,8 +284,14 @@ def register_parser_arguments():
     order.add_argument('--descending', dest='order', action='store_true', help='Sort in descending order')
     order.add_argument('--ascending', dest='order', action='store_false', help='Sort in ascending order')
 
-    subparsers.add_parser('show', parents=[series_parser, table_parser],
-                          help='Show the releases FlexGet has seen for a given series ')
+    show_parser = subparsers.add_parser('show', parents=[series_parser, table_parser],
+                          help='Show the releases FlexGet has seen for a given series')
+    show_parser.add_argument('--sort-by', choices=('seen', 'entity'), default='seen',
+                             help='Choose releases list sort: last seen date (default) or entity ID')
+    show_order = show_parser.add_mutually_exclusive_group(required=False)
+    show_order.add_argument('--descending', dest='order', action='store_true', help='Sort in descending order')
+    show_order.add_argument('--ascending', dest='order', action='store_false', help='Sort in ascending order')
+
     begin_parser = subparsers.add_parser('begin', parents=[series_parser],
                                          help='set the episode to start getting a series from')
     begin_parser.add_argument('episode_id', metavar='<episode ID>',

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1136,13 +1136,14 @@ def show_seasons(series, start=None, stop=None, count=False, descending=False, s
     return seasons.slice(start, stop).from_self().all()
 
 
-def get_all_entities(series, session, sort_by='seen', reverse=False):
+def get_all_entities(series, session, sort_by='age', reverse=False):
     episodes = show_episodes(series, session=session)
     seasons = show_seasons(series, session=session)
-    if sort_by == 'entity':
-        return sorted(episodes + seasons, key=lambda e: (e.identifier), reverse=reverse)
+    if sort_by == 'identifier':
+        key = lambda e: e.identifier
     else:
-        return sorted(episodes + seasons, key=lambda e: (e.first_seen or datetime.min, e.identifier), reverse=reverse)
+        key = lambda e: (e.first_seen or datetime.min, e.identifier)
+    return sorted(episodes + seasons, key=key, reverse=reverse)
 
 
 def get_releases(episode, downloaded=None, start=None, stop=None, count=False, descending=False, sort_by=None,

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1136,10 +1136,13 @@ def show_seasons(series, start=None, stop=None, count=False, descending=False, s
     return seasons.slice(start, stop).from_self().all()
 
 
-def get_all_entities(series, session):
+def get_all_entities(series, session, sort_by='seen', reverse=False):
     episodes = show_episodes(series, session=session)
     seasons = show_seasons(series, session=session)
-    return sorted(episodes + seasons, key=lambda e: (e.first_seen or datetime.min, e.identifier))
+    if sort_by == 'entity':
+        return sorted(episodes + seasons, key=lambda e: (e.identifier), reverse=reverse)
+    else:
+        return sorted(episodes + seasons, key=lambda e: (e.first_seen or datetime.min, e.identifier), reverse=reverse)
 
 
 def get_releases(episode, downloaded=None, start=None, stop=None, count=False, descending=False, sort_by=None,


### PR DESCRIPTION
### Motivation for changes:
I want to sort by entity ID.

### Detailed changes:
When using the `series show` CLI subcommand, you can now specify `--sort-by identifier` to sort by entity ID (aka season/episode) or `--sort-by age` for last seen date (default), and `--descending` or `--ascending` to specify the sort order.
`get_all_entities` now supports return entities sorted by `identifier` or age (default).
Renamed 'Entity ID' and 'Latest age' columns in `series show` output to 'Identifier' and 'Last seen', respectively.