### PR TITLE
Update newpct.py

### DIFF
--- a/flexget/plugins/sites/newpct.py
+++ b/flexget/plugins/sites/newpct.py
@@ -65,7 +65,7 @@ class UrlRewriteNewPCT(object):
             torrent_id_prog = re.compile(r'descargar-torrent/(.+)/')
             torrent_ids = soup.findAll(href=torrent_id_prog)
         else:
-            torrent_id_prog = re.compile("'(?:torrentID|id)'\s*:\s*'(\d+)'")
+            torrent_id_prog = re.compile("'(?:torrentID|id=\'content-torrent\')'\s*:\s*'(\d+)'")
             torrent_ids = soup.findAll(text=torrent_id_prog)
 
         if len(torrent_ids) == 0:


### PR DESCRIPTION
### Motivation for changes:
Problem with another ID's in page

### Detailed changes:

-  Change the Regular expression

### Addressed issues:

- Fixes # .

### Log and/or tests output (preferably both):
```
<script type="text/javascript">
    (sc_adv_out = window.sc_adv_out || []).push({
        'id' : '344830', <--------------------------------- GET THIS ID
        'domain' : 'n.popclck.net',
        'click_domain' : 'n.popclck.com'
    });
</script>

But the ID is:

<a href='http://tumejorserie.com/descargar/index.php?link=torrents/091849.torrent' rel='nofollow' 
id='91849' <---------------------- CORRECT ID
 title='quantico-temporada-2-hdtv-720p-cap216-ac3-51-espanol-castellano' class='external-url' target='_blank'>
```
#### To Do:

- [ ] Stuff..

