### PR TITLE
[change] deluge - Render label

### DIFF
--- a/flexget/plugins/clients/deluge.py
+++ b/flexget/plugins/clients/deluge.py
@@ -716,7 +716,7 @@ class OutputDeluge(DelugePlugin):
                         dlist = []
                         for label in labels:
                             if label not in d_labels:
-                                log.debug('Adding the label `%s` to deluge' % label)
+                                log.debug('Adding the label `%s` to deluge', label)
                                 dlist.append(client.label.add(label))
                         return defer.DeferredList(dlist)
 

--- a/flexget/plugins/clients/deluge.py
+++ b/flexget/plugins/clients/deluge.py
@@ -690,9 +690,17 @@ class OutputDeluge(DelugePlugin):
         # dlist is a list of deferreds that must complete before we exit
         dlist = []
         # loop through entries to get a list of labels to add
-        labels = set([format_label(entry['label']) for entry in task.accepted if entry.get('label')])
-        if config.get('label'):
-            labels.add(format_label(config['label']))
+        labels = set()
+        for entry in task.accepted:
+            if entry.get('label', config.get('label')):
+                try:
+                    label = format_label(entry.render(entry.get('label', config.get('label'))))
+                    log.debug('Rendered label: %s', label)
+                except RenderError as e:
+                    log.error('Error rendering label `%s`: %s', label, e)
+                    continue
+                labels.add(label)
+                entry['label'] = label
         label_deferred = defer.succeed(True)
         if labels:
             # Make sure the label plugin is available and enabled, then add appropriate labels
@@ -708,7 +716,7 @@ class OutputDeluge(DelugePlugin):
                         dlist = []
                         for label in labels:
                             if label not in d_labels:
-                                log.debug('Adding the label %s to deluge' % label)
+                                log.debug('Adding the label `%s` to deluge' % label)
                                 dlist.append(client.label.add(label))
                         return defer.DeferredList(dlist)
 
@@ -804,13 +812,17 @@ class OutputDeluge(DelugePlugin):
                             add_opts['stop_at_ratio'] = True
                 # Make another set of options, that get set after the torrent has been added
                 modify_opts = {
-                    'label': format_label(entry.get('label', config['label'])),
                     'queuetotop': entry.get('queuetotop', config.get('queuetotop')),
                     'main_file_only': entry.get('main_file_only', config.get('main_file_only', False)),
                     'main_file_ratio': entry.get('main_file_ratio', config.get('main_file_ratio')),
                     'hide_sparse_files': entry.get('hide_sparse_files', config.get('hide_sparse_files', True)),
                     'keep_subs': entry.get('keep_subs', config.get('keep_subs', True))
                 }
+                try:
+                    label = entry.render(entry.get('label', config['label']))
+                    modify_opts['label'] = format_label(label)
+                except RenderError as e:
+                    log.error('Error setting label for `%s`: %s', entry['title'], e)
                 try:
                     movedone = entry.render(entry.get('movedone', config['movedone']))
                     modify_opts['movedone'] = pathscrub(os.path.expanduser(movedone))

--- a/flexget/plugins/clients/deluge.py
+++ b/flexget/plugins/clients/deluge.py
@@ -700,7 +700,6 @@ class OutputDeluge(DelugePlugin):
                     log.error('Error rendering label `%s`: %s', label, e)
                     continue
                 labels.add(label)
-                entry['label'] = label
         label_deferred = defer.succeed(True)
         if labels:
             # Make sure the label plugin is available and enabled, then add appropriate labels


### PR DESCRIPTION
### Motivation for changes:
Yet another step towards me not needing a custom `deluge` plugin anymore. (Also [it's a feature request](http://feathub.com/Flexget/Flexget/+23).)

### Detailed changes:
The `deluge` option `label` is now a jinja-rendered field.

### Implemented feature requests:
- feathub #[23](http://feathub.com/Flexget/Flexget/+23)