### PR TITLE
[change] series begin - SXX accepted as ID / CLI --forget option

### DIFF
--- a/flexget/api/core/format_checker.py
+++ b/flexget/api/core/format_checker.py
@@ -21,7 +21,8 @@ class ObjectContainer(object):
             'file': {'type': 'string', 'format': 'file'},
             'path': {'type': 'string', 'format': 'path'},
             'url': {'type': 'string', 'format': 'url'},
-            'episode_identifier': {'type': 'string', 'format': 'episode_identifier'}
+            'episode_identifier': {'type': 'string', 'format': 'episode_identifier'},
+            'episode_or_season_identifier': {'type': 'string', 'format': 'episode_or_season_identifier'}
         }
     }
 

--- a/flexget/api/core/format_checker.py
+++ b/flexget/api/core/format_checker.py
@@ -22,7 +22,7 @@ class ObjectContainer(object):
             'path': {'type': 'string', 'format': 'path'},
             'url': {'type': 'string', 'format': 'url'},
             'episode_identifier': {'type': 'string', 'format': 'episode_identifier'},
-            'episode_or_season_identifier': {'type': 'string', 'format': 'episode_or_season_identifier'}
+            'episode_or_season_id': {'type': 'string', 'format': 'episode_or_season_id'}
         }
     }
 

--- a/flexget/api/plugins/series.py
+++ b/flexget/api/plugins/series.py
@@ -102,7 +102,7 @@ class ObjectsContainer(object):
         'type': 'object',
         'properties': {
             'begin_episode':
-                {'type': ['string', 'integer'], 'format': 'episode_or_season_identifier'},
+                {'type': ['string', 'integer'], 'format': 'episode_or_season_id'},
             'alternate_names': {'type': 'array', 'items': {'type': 'string'}}
         },
         'anyOf': [

--- a/flexget/api/plugins/series.py
+++ b/flexget/api/plugins/series.py
@@ -102,7 +102,7 @@ class ObjectsContainer(object):
         'type': 'object',
         'properties': {
             'begin_episode':
-                {'type': ['string', 'integer'], 'format': 'episode_identifier'},
+                {'type': ['string', 'integer'], 'format': 'episode_or_season_identifier'},
             'alternate_names': {'type': 'array', 'items': {'type': 'string'}}
         },
         'anyOf': [

--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -263,8 +263,8 @@ def is_episode_identifier(instance):
     return parse_episode_identifier(instance) is not None
 
 
-@format_checker.checks('episode_or_season_identifier', raises=ValueError)
-def is_episode_or_season_identifier(instance):
+@format_checker.checks('episode_or_season_id', raises=ValueError)
+def is_episode_or_season_id(instance):
     if not isinstance(instance, (str_types, int)):
         return True
     return parse_episode_identifier(instance, identify_season=True) is not None

--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -263,6 +263,13 @@ def is_episode_identifier(instance):
     return parse_episode_identifier(instance) is not None
 
 
+@format_checker.checks('episode_or_season_identifier', raises=ValueError)
+def is_episode_or_season_identifier(instance):
+    if not isinstance(instance, (str_types, int)):
+        return True
+    return parse_episode_identifier(instance, identify_season=True) is not None
+
+
 @format_checker.checks('file_template', raises=ValueError)
 def is_valid_template(instance):
     if not isinstance(instance, str_types):

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 import argparse
-import re
 from datetime import timedelta
 
 from colorclass.toggles import disable_all_colors

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -15,7 +15,7 @@ try:
     from flexget.plugins.filter.series import (Series, remove_series, remove_series_entity, set_series_begin,
                                                normalize_series_name, new_entities_after, get_latest_release,
                                                get_series_summary, shows_by_name, show_episodes, shows_by_exact_name,
-                                               get_all_entities, remove_series_begin)
+                                               get_all_entities)
 except ImportError:
     raise plugin.DependencyError(issued_by='cli_series', missing='series',
                                  message='Series commandline interface not loaded')

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -142,11 +142,11 @@ def begin(manager, options):
             else:
                 series = series[0]
             try:
-                set_series_begin(series, ep_id)
+                _, entity_type = set_series_begin(series, ep_id)
             except ValueError as e:
                 console(e)
             else:
-                if re.match(r'(?i)^S\d{1,4}$', ep_id):
+                if entity_type == 'season':
                     console('`%s` was identified as a season.' % ep_id)
                     ep_id += 'E01'
                 console('Releases for `%s` will be accepted starting with `%s`.' % (series.name, ep_id))

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -135,7 +135,7 @@ def begin(manager, options):
         except ValueError as e:
             console(e)
         else:
-            console('Episodes for `%s` will be accepted starting with `%s`' % (series.name, ep_id))
+            console('Releases for `%s` will be accepted starting with `%s`' % (series.name, ep_id))
             session.commit()
         manager.config_changed()
 
@@ -290,7 +290,8 @@ def register_parser_arguments():
                                          help='set the episode to start getting a series from')
     begin_parser.add_argument('episode_id', metavar='<episode ID>',
                               help='Episode ID to start getting the series from (e.g. S02E01, 2013-12-11, or 9, '
-                                   'depending on how the series is numbered)')
+                                   'depending on how the series is numbered). You can also enter a season ID such as '
+                                   ' S02.')
     forget_parser = subparsers.add_parser('forget', parents=[series_parser],
                                           help='Removes episodes or whole series from the entire database '
                                                '(including seen plugin)')

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -128,7 +128,7 @@ def begin(manager, options):
                 console('Series `%s` was not found in the database.' % series_name)
             else:
                 series = series[0]
-                remove_series_begin(series)
+                series.begin = None
                 console('The begin episode for `%s` has been forgotten.' % series.name)
                 session.commit()
                 manager.config_changed()

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 import argparse
+import re
 from datetime import timedelta
 
 from colorclass.toggles import disable_all_colors
@@ -14,7 +15,7 @@ try:
     from flexget.plugins.filter.series import (Series, remove_series, remove_series_entity, set_series_begin,
                                                normalize_series_name, new_entities_after, get_latest_release,
                                                get_series_summary, shows_by_name, show_episodes, shows_by_exact_name,
-                                               get_all_entities)
+                                               get_all_entities, remove_series_begin)
 except ImportError:
     raise plugin.DependencyError(issued_by='cli_series', missing='series',
                                  message='Series commandline interface not loaded')
@@ -119,25 +120,38 @@ def display_summary(options):
 def begin(manager, options):
     series_name = options.series_name
     series_name = series_name.replace(r'\!', '!')
-    ep_id = options.episode_id
     normalized_name = normalize_series_name(series_name)
     with Session() as session:
         series = shows_by_exact_name(normalized_name, session)
-        if not series:
-            console('Series not yet in database, adding `%s`' % series_name)
-            series = Series()
-            series.name = series_name
-            session.add(series)
-        else:
-            series = series[0]
-        try:
-            set_series_begin(series, ep_id)
-        except ValueError as e:
-            console(e)
-        else:
-            console('Releases for `%s` will be accepted starting with `%s`' % (series.name, ep_id))
-            session.commit()
-        manager.config_changed()
+        if options.forget:
+            if not series:
+                console('Series `%s` was not found in the database.' % series_name)
+            else:
+                series = series[0]
+                remove_series_begin(series)
+                console('The begin episode for `%s` has been forgotten.' % series.name)
+                session.commit()
+                manager.config_changed()
+        elif options.episode_id:
+            ep_id = options.episode_id
+            if not series:
+                console('Series not yet in database. Adding `%s`.' % series_name)
+                series = Series()
+                series.name = series_name
+                session.add(series)
+            else:
+                series = series[0]
+            try:
+                set_series_begin(series, ep_id)
+            except ValueError as e:
+                console(e)
+            else:
+                if re.match(r'(?i)^S\d{1,4}$', ep_id):
+                    console('`%s` was identified as a season.' % ep_id)
+                    ep_id += 'E01'
+                console('Releases for `%s` will be accepted starting with `%s`.' % (series.name, ep_id))
+                session.commit()
+            manager.config_changed()
 
 
 def remove(manager, options, forget=False):
@@ -240,10 +254,12 @@ def display_details(options):
                        ' Few duplicate downloads can happen with different numbering schemes\n'
                        ' during this time.')
         else:
-            footer += '\n Series uses `%s` mode to identify episode numbering (identified_by).' % series.identified_by
-        footer += ' \n See option `identified_by` for more information.\n'
+            footer += '\n `%s` uses `%s` mode to identify episode numbering.' % (series.name, series.identified_by)
+        begin_text = 'option'
         if series.begin:
-            footer += ' Begin episode for this series set to `%s`.' % series.begin.identifier
+            footer += ' \n Begin for `%s` is set to `%s`.' % (series.name, series.begin.identifier)
+            begin_text = 'and `begin` options'
+        footer += ' \n See `identified_by` %s for more information.' % begin_text
     try:
         table = TerminalTable(options.table_type, table_data, table_title, drop_columns=[4, 3, 1])
         console(table.output)
@@ -288,10 +304,12 @@ def register_parser_arguments():
                           help='Show the releases FlexGet has seen for a given series ')
     begin_parser = subparsers.add_parser('begin', parents=[series_parser],
                                          help='set the episode to start getting a series from')
-    begin_parser.add_argument('episode_id', metavar='<episode ID>',
+    begin_opts = begin_parser.add_mutually_exclusive_group(required=True)
+    begin_opts.add_argument('--forget', dest='forget', action='store_true', help='Forget begin episode', required=False)
+    begin_opts.add_argument('episode_id', metavar='<episode ID>',
                               help='Episode ID to start getting the series from (e.g. S02E01, 2013-12-11, or 9, '
                                    'depending on how the series is numbered). You can also enter a season ID such as '
-                                   ' S02.')
+                                   ' S02.', nargs='?', default='')
     forget_parser = subparsers.add_parser('forget', parents=[series_parser],
                                           help='Removes episodes or whole series from the entire database '
                                                '(including seen plugin)')

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -968,6 +968,7 @@ def set_series_begin(series, ep_id):
     :param Series series: Series instance
     :param ep_id: Integer for sequence mode, SxxEyy for episodic and yyyy-mm-dd for date.
     :raises ValueError: If malformed ep_id or series in different mode
+    :return: tuple containing identified_by and identity_type
     """
     # If identified_by is not explicitly specified, auto-detect it based on begin identifier
     # TODO: use some method of series parser to do the identifier parsing
@@ -1001,6 +1002,7 @@ def set_series_begin(series, ep_id):
         # Need to flush to get an id on new Episode before assigning it as series begin
         session.flush()
     series.begin = episode
+    return (identified_by, entity_type)
 
 
 def remove_series(name, forget=False):

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1002,6 +1002,13 @@ def set_series_begin(series, ep_id):
         session.flush()
     series.begin = episode
 
+def remove_series_begin(series):
+    """
+    Remove begin episode link for series
+    
+    :param Series series: series instance
+    """
+    series.begin = None
 
 def remove_series(name, forget=False):
     """
@@ -1262,7 +1269,7 @@ class FilterSeriesBase(object):
                 # Strict naming
                 'exact': {'type': 'boolean'},
                 # Begin takes an ep, sequence or date identifier
-                'begin': {'type': ['string', 'integer'], 'format': 'episode_identifier'},
+                'begin': {'type': ['string', 'integer'], 'format': 'episode_or_season_identifier'},
                 'from_group': one_or_more({'type': 'string'}),
                 'parse_only': {'type': 'boolean'},
                 'special_ids': one_or_more({'type': 'string'}),

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -972,10 +972,10 @@ def set_series_begin(series, ep_id):
     # If identified_by is not explicitly specified, auto-detect it based on begin identifier
     # TODO: use some method of series parser to do the identifier parsing
     session = Session.object_session(series)
-    identified_by = parse_episode_identifier(ep_id, identify_season=True)
+    identified_by, entity_type = parse_episode_identifier(ep_id, identify_season=True)
     if identified_by == 'ep':
         ep_id = ep_id.upper()
-        if 'E' not in ep_id:
+        if entity_type == 'season':
             ep_id += 'E01'
     if series.identified_by not in ['auto', '', None]:
         if identified_by != series.identified_by:
@@ -1002,13 +1002,6 @@ def set_series_begin(series, ep_id):
         session.flush()
     series.begin = episode
 
-def remove_series_begin(series):
-    """
-    Remove begin episode link for series
-    
-    :param Series series: series instance
-    """
-    series.begin = None
 
 def remove_series(name, forget=False):
     """
@@ -1269,7 +1262,7 @@ class FilterSeriesBase(object):
                 # Strict naming
                 'exact': {'type': 'boolean'},
                 # Begin takes an ep, sequence or date identifier
-                'begin': {'type': ['string', 'integer'], 'format': 'episode_or_season_identifier'},
+                'begin': {'type': ['string', 'integer'], 'format': 'episode_or_season_id'},
                 'from_group': one_or_more({'type': 'string'}),
                 'parse_only': {'type': 'boolean'},
                 'special_ids': one_or_more({'type': 'string'}),

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -972,9 +972,11 @@ def set_series_begin(series, ep_id):
     # If identified_by is not explicitly specified, auto-detect it based on begin identifier
     # TODO: use some method of series parser to do the identifier parsing
     session = Session.object_session(series)
-    identified_by = parse_episode_identifier(ep_id)
+    identified_by = parse_episode_identifier(ep_id, identify_season=True)
     if identified_by == 'ep':
         ep_id = ep_id.upper()
+        if 'E' not in ep_id:
+            ep_id += 'E01'
     if series.identified_by not in ['auto', '', None]:
         if identified_by != series.identified_by:
             raise ValueError('`begin` value `%s` does not match identifier type for identified_by `%s`' %

--- a/flexget/plugins/sites/iptorrents.py
+++ b/flexget/plugins/sites/iptorrents.py
@@ -152,7 +152,7 @@ class UrlRewriteIPTorrents(object):
                     continue
                 if torrent.find('td', {'colspan': '99'}):
                     log.debug('No results found for search %s', search_string)
-                    return
+                    break
                 entry = Entry()
                 link = torrent.find('a', href=re.compile('download'))['href']
                 entry['url'] = "{base}{link}?torrent_pass={key}".format(

--- a/flexget/tests/api_tests/test_format_checker_api.py
+++ b/flexget/tests/api_tests/test_format_checker_api.py
@@ -217,3 +217,22 @@ class TestFormatChecker(object):
 
         errors = schema_match(base_message, data)
         assert not errors
+
+    def test_episode_or_season_identifier(self, api_client, schema_match):
+        payload1 = {'episode_or_season_identifier': 's01'}
+
+        rsp = api_client.json_post('/format_check/', data=json.dumps(payload1))
+        assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(base_message, data)
+        assert not errors
+
+        payload2 = {'episode_or_season_identifier': 'bla'}
+
+        rsp = api_client.json_post('/format_check/', data=json.dumps(payload2))
+        assert rsp.status_code == 422, 'Response code is %s' % rsp.status_code
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(base_message, data)
+        assert not errors

--- a/flexget/tests/api_tests/test_format_checker_api.py
+++ b/flexget/tests/api_tests/test_format_checker_api.py
@@ -218,8 +218,8 @@ class TestFormatChecker(object):
         errors = schema_match(base_message, data)
         assert not errors
 
-    def test_episode_or_season_identifier(self, api_client, schema_match):
-        payload1 = {'episode_or_season_identifier': 's01'}
+    def test_episode_or_season_id(self, api_client, schema_match):
+        payload1 = {'episode_or_season_id': 's01'}
 
         rsp = api_client.json_post('/format_check/', data=json.dumps(payload1))
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
@@ -228,7 +228,7 @@ class TestFormatChecker(object):
         errors = schema_match(base_message, data)
         assert not errors
 
-        payload2 = {'episode_or_season_identifier': 'bla'}
+        payload2 = {'episode_or_season_id': 'bla'}
 
         rsp = api_client.json_post('/format_check/', data=json.dumps(payload2))
         assert rsp.status_code == 422, 'Response code is %s' % rsp.status_code

--- a/flexget/tests/test_series.py
+++ b/flexget/tests/test_series.py
@@ -1478,6 +1478,13 @@ class TestBegin(object):
               - {title: 'WTest.S02E03.HDTV.XViD-FlexGet'}
               - {title: 'W2Test.S02E03.HDTV.XViD-FlexGet'}
         tasks:
+          season_id_test:
+            template: eps
+            series:
+              - WTest:
+                  begin: S02
+              - W2Test:
+                  begin: S03
           before_ep_test:
             template: eps
             series:
@@ -1546,6 +1553,13 @@ class TestBegin(object):
                 begin: S03E01
 
     """
+
+    def test_season_id(self, execute_task):
+        task = execute_task('season_id_test')
+        assert task.find_entry('accepted', title='WTest.S02E03.HDTV.XViD-FlexGet'), 'Entry should have been ' \
+               'accepted, it\'s after the begin episode'
+        assert task.find_entry('rejected', title='W2Test.S02E03.HDTV.XViD-FlexGet'), 'Entry should have been ' \
+               'rejected, it\'s before the begin episode'
 
     def test_before_ep(self, execute_task):
         task = execute_task('before_ep_test')

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -476,7 +476,7 @@ def get_config_hash(config):
         return hashlib.md5(str(config).encode('utf-8')).hexdigest()
 
 
-def parse_episode_identifier(ep_id):
+def parse_episode_identifier(ep_id, identify_season=False):
     """
     Parses series episode identifier, raises ValueError if it fails
 
@@ -491,6 +491,8 @@ def parse_episode_identifier(ep_id):
             error = 'sequence type episode must be higher than 0'
         identified_by = 'sequence'
     elif re.match(r'(?i)^S\d{1,4}E\d{1,3}$', ep_id):
+        identified_by = 'ep'
+    elif re.match(r'(?i)^S\d{1,4}$', ep_id) and identify_season:
         identified_by = 'ep'
     elif re.match(r'\d{4}-\d{2}-\d{2}', ep_id):
         identified_by = 'date'

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -486,6 +486,7 @@ def parse_episode_identifier(ep_id, identify_season=False):
     """
     error = None
     identified_by = None
+    entity_type = 'episode'
     if isinstance(ep_id, int):
         if ep_id <= 0:
             error = 'sequence type episode must be higher than 0'
@@ -494,6 +495,7 @@ def parse_episode_identifier(ep_id, identify_season=False):
         identified_by = 'ep'
     elif re.match(r'(?i)^S\d{1,4}$', ep_id) and identify_season:
         identified_by = 'ep'
+        entity_type = 'season'
     elif re.match(r'\d{4}-\d{2}-\d{2}', ep_id):
         identified_by = 'date'
     else:
@@ -507,4 +509,4 @@ def parse_episode_identifier(ep_id, identify_season=False):
             error = '`%s` is not a valid episode identifier.' % ep_id
     if error:
         raise ValueError(error)
-    return identified_by
+    return (identified_by, entity_type)


### PR DESCRIPTION
### Motivation for changes:
Be able to use `S02` as a `begin` identifier, and also forget a `begin` episode link without removing the history of the episode itself.

### Detailed changes:
Two changes relating to `begin`:
- Behind the scenes, appends ‘E01’ when an identifier of the type SXX is used as the begin episode. This can be done via CLI `series begin SXX`, config with series plugin, or API. To make this work, an additional config format validator of `episode_or_season_identifier` was added which calls `parse_episode_identifier` with the new parameter `identify_season` set to `True`. When this is not wanted, continue to use the existing `episode_identifier` config format validator.
- CLI `series begin <show> --forget` argument to remove begin episode association in series table. 

### Implemented feature requests:
- feathub #[18](http://feathub.com/Flexget/Flexget/+18)

### Log and/or tests output (preferably both):
When using an identifier of the format `SXX` while setting begin via CLI:
```
`S05` was identified as a season.
Releases for `My Show` will be accepted starting with `S05E01`
```

When using the `--forget` argument:
```
The begin episode for `My Show` has been forgotten.
```