### PR TITLE
[add] parser - Support for DD+ audio and more channels

### DIFF
--- a/flexget/tests/test_qualities.py
+++ b/flexget/tests/test_qualities.py
@@ -100,7 +100,9 @@ class TestQualityParser(object):
         ('Test.File.DTSHD', 'dtshd'),
         ('Test.File.DTS', 'dts'),
         ('Test.File.truehd', 'truehd'),
-        ('Test.File.DTSHDMA', 'dtshd')
+        ('Test.File.DTSHDMA', 'dtshd'),
+        ('Test.File.DD2.0', 'dd5.1'),
+        ('Test.File.AC35.1', 'ac3')
     ])
     def test_quality_failures(self, parser, test_quality):
         quality = parser().parse_movie(test_quality[0]).quality
@@ -113,7 +115,11 @@ class TestQualityInternalParser(object):
     @pytest.mark.parametrize("test_quality", [
         ('Test.File.DD+5.1', 'dd+5.1'),
         ('Test.File.DDP5.1', 'dd+5.1'),
-        ('Test.File.DD5.1', 'dd5.1')
+        ('Test.File.DDP7.1', 'dd+5.1'),
+        ('Test.File.DD5.1', 'dd5.1'),
+        ('Test.File.DD4.0', 'dd5.1'),
+        ('Test.File.DD2.1', 'dd5.1'),
+        ('Test.File.FLAC1.0', 'flac'),
     ])
     def test_quality_failures(self, test_quality):
         quality = ParserInternal().parse_movie(test_quality[0]).quality

--- a/flexget/tests/test_qualities.py
+++ b/flexget/tests/test_qualities.py
@@ -100,13 +100,23 @@ class TestQualityParser(object):
         ('Test.File.DTSHD', 'dtshd'),
         ('Test.File.DTS', 'dts'),
         ('Test.File.truehd', 'truehd'),
-        ('Test.File.DTSHDMA', 'dtshd'),
+        ('Test.File.DTSHDMA', 'dtshd')
+    ])
+    def test_quality_failures(self, parser, test_quality):
+        quality = parser().parse_movie(test_quality[0]).quality
+        assert str(quality) == test_quality[1], ('`%s` quality should be `%s` not `%s`' % (
+            test_quality[0], test_quality[1], quality
+        ))
+
+
+class TestQualityInternalParser(object):
+    @pytest.mark.parametrize("test_quality", [
         ('Test.File.DD+5.1', 'dd+5.1'),
         ('Test.File.DDP5.1', 'dd+5.1'),
         ('Test.File.DD5.1', 'dd5.1')
     ])
-    def test_quality_failures(self, parser, test_quality):
-        quality = parser().parse_movie(test_quality[0]).quality
+    def test_quality_failures(self, test_quality):
+        quality = ParserInternal().parse_movie(test_quality[0]).quality
         assert str(quality) == test_quality[1], ('`%s` quality should be `%s` not `%s`' % (
             test_quality[0], test_quality[1], quality
         ))

--- a/flexget/tests/test_qualities.py
+++ b/flexget/tests/test_qualities.py
@@ -205,6 +205,7 @@ class TestQualityAudio(object):
             quality: "dd+5.1"
             mock:
               - {title: 'My Show S01E05 720p HDTV DD+7.1'}
+              - {title: 'My Show S01E05 720p HDTV DD+5.0'}
           test_dd_audio_min:
             quality: ">dd5.1"
             mock:
@@ -224,9 +225,12 @@ class TestQualityAudio(object):
         assert entry, 'Entry "My Show S01E05 720p HDTV DD+7.1" should not have been rejected'
         assert entry['quality'].audio == 'dd+5.1', 'audio "dd+7.1" should have been parsed as dd+5.1'
 
+        entry = task.find_entry('undecided', title='My Show S01E05 720p HDTV DD+5.0')
+        assert entry['quality'].audio == 'dd+5.1', 'audio "dd+5.0" should have been parsed as dd+5.1'
+
     def test_dd_audio_min(self, execute_task):
         task = execute_task('test_dd_audio_min')
-        #assert len(task.rejected) == 1, 'should have rejected one'
+        assert len(task.rejected) == 1, 'should have rejected one'
         entry = task.find_entry('undecided', title='My Show S01E05 720p HDTV DD+2.0')
         assert entry, 'Entry "My Show S01E05 720p HDTV DD+2.0" should not have been rejected'
         assert entry['quality'].audio == 'dd+5.1', 'audio should have been parsed as dd+5.1'

--- a/flexget/tests/test_series.py
+++ b/flexget/tests/test_series.py
@@ -2317,3 +2317,65 @@ class TestSeriesSeasonPack(object):
 
         task = execute_task('test_with_dict_config_2')
         assert task.find_entry('accepted', title='bro.s02.720p.HDTV-Flexget')
+
+
+class TestSeriesDDAudio(object):
+    _config = """
+      templates:
+        global:
+          parsing:
+            series: internal
+      tasks:
+        min_quality:
+          mock:
+            - {title: 'MinQATest.S01E01.720p.XViD.DD5.1-FlexGet'}
+            - {title: 'MinQATest.S01E01.720p.XViD.DDP5.1-FlexGet'}
+          series:
+            - MinQATest:
+                quality: ">dd5.1"
+
+        max_quality:
+          mock:
+            - {title: 'MaxQATest.S01E01.720p.XViD.DD5.1-FlexGet'}
+            - {title: 'MaxQATest.S01E01.720p.XViD.DD+5.1-FlexGet'}
+          series:
+            - MaxQATest:
+                quality: "<=dd5.1"
+
+        test_channels:
+          mock:
+            - {title: 'Channels.S01E01.1080p.HDTV.DD+2.0-FlexGet'}
+            - {title: 'Channels.S01E01.1080p.HDTV.DD+5.1-FlexGet'}
+            - {title: 'Channels.S01E01.1080p.HDTV.DD+7.1-FlexGet'}
+          series:
+            - Channels:
+                quality: dd+5.1
+
+
+    """
+
+    @pytest.fixture()
+    def config(self):
+        """Overrides outer config fixture since season pack support does not work with guessit parser"""
+        return self._config
+
+    def test_min_quality(self, execute_task):
+        """Series plugin: min_quality"""
+        task = execute_task('min_quality')
+        assert task.find_entry('accepted', title='MinQATest.S01E01.720p.XViD.DDP5.1-FlexGet'), \
+            'MinQATest.S01E01.720p.XViD.DDP5.1-FlexGet should have been accepted'
+        assert len(task.accepted) == 1, 'should have accepted only two'
+
+    def test_max_quality(self, execute_task):
+        """Series plugin: max_quality"""
+        task = execute_task('max_quality')
+        assert task.find_entry('accepted', title='MaxQATest.S01E01.720p.XViD.DD5.1-FlexGet'), \
+            'MaxQATest.S01E01.720p.XViD.DD5.1-FlexGet should have been accepted'
+        assert len(task.accepted) == 1, 'should have accepted only one'
+
+    def test_channels(self, execute_task):
+        """Series plugin: max_quality"""
+        task = execute_task('test_channels')
+        assert task.find_entry(title='Channels.S01E01.1080p.HDTV.DD+7.1-FlexGet'), \
+            'Channels.S01E01.1080p.HDTV.DD+7.1-FlexGet should have been accepted'
+        assert len(task.accepted) == 1, 'should have accepted only one'

--- a/flexget/tests/test_series.py
+++ b/flexget/tests/test_series.py
@@ -2356,7 +2356,7 @@ class TestSeriesDDAudio(object):
 
     @pytest.fixture()
     def config(self):
-        """Overrides outer config fixture since season pack support does not work with guessit parser"""
+        """Overrides outer config fixture since DD+ and arbitrary channels support does not work with guessit parser"""
         return self._config
 
     def test_min_quality(self, execute_task):

--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -157,15 +157,15 @@ _codecs = [
     QualityComponent('codec', 40, 'h265', '[hx].?265|hevc'),
     QualityComponent('codec', 50, '10bit', '10.?bit|hi10p')
 ]
-channels = '(?:(?:[\W_]?5[\W_]?1)|(?:[\W_]?2[\W_]?(?:0|ch)))'
+channels = '(?:(?:[^\w+]?5[\W_]?1)|(?:[\W_]?2[\W_]?(?:0|ch)))'
 _audios = [
     QualityComponent('audio', 10, 'mp3'),
     # TODO: No idea what order these should go in or if we need different regexps
     QualityComponent('audio', 20, 'aac', 'aac%s?' % channels),
     # Because of the 'channels' regex, DD+5.1 is attempted first such that the + sign is not ignored
-    QualityComponent('audio', 45, 'dd+5.1', 'dd[p+]%s' % channels),
     QualityComponent('audio', 30, 'dd5.1', 'dd%s' % channels),
     QualityComponent('audio', 40, 'ac3', 'ac3%s?' % channels),
+    QualityComponent('audio', 45, 'dd+5.1', 'dd[p+]%s' % channels),
     QualityComponent('audio', 50, 'flac', 'flac%s?' % channels),
     # The DTSs are a bit backwards, but the more specific one needs to be parsed first
     QualityComponent('audio', 60, 'dtshd', 'dts[\W_]?hd(?:[\W_]?ma)?'),

--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -162,6 +162,8 @@ _audios = [
     QualityComponent('audio', 10, 'mp3'),
     # TODO: No idea what order these should go in or if we need different regexps
     QualityComponent('audio', 20, 'aac', 'aac%s?' % channels),
+    # Because of the 'channels' regex, DD+5.1 is attempted first such that the + sign is not ignored
+    QualityComponent('audio', 35, 'dd+5.1', 'dd[p+]%s' % channels),
     QualityComponent('audio', 30, 'dd5.1', 'dd%s' % channels),
     QualityComponent('audio', 40, 'ac3', 'ac3%s?' % channels),
     QualityComponent('audio', 50, 'flac', 'flac%s?' % channels),

--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -157,7 +157,7 @@ _codecs = [
     QualityComponent('codec', 40, 'h265', '[hx].?265|hevc'),
     QualityComponent('codec', 50, '10bit', '10.?bit|hi10p')
 ]
-channels = '(?:(?:[^\w+]?7[\W_]?1)|(?:[^\w+]?5[\W_]?1)|(?:[^\w+]?2[\W_]?(?:0|ch)))'
+channels = '(?:(?:[^\w+]?[1-7][\W_]?(?:0|1|ch)))'
 _audios = [
     QualityComponent('audio', 10, 'mp3'),
     # TODO: No idea what order these should go in or if we need different regexps

--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -162,7 +162,6 @@ _audios = [
     QualityComponent('audio', 10, 'mp3'),
     # TODO: No idea what order these should go in or if we need different regexps
     QualityComponent('audio', 20, 'aac', 'aac%s?' % channels),
-    # Because of the 'channels' regex, DD+5.1 is attempted first such that the + sign is not ignored
     QualityComponent('audio', 30, 'dd5.1', 'dd%s' % channels),
     QualityComponent('audio', 40, 'ac3', 'ac3%s?' % channels),
     QualityComponent('audio', 45, 'dd+5.1', 'dd[p+]%s' % channels),

--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -157,7 +157,7 @@ _codecs = [
     QualityComponent('codec', 40, 'h265', '[hx].?265|hevc'),
     QualityComponent('codec', 50, '10bit', '10.?bit|hi10p')
 ]
-channels = '(?:(?:[^\w+]?5[\W_]?1)|(?:[\W_]?2[\W_]?(?:0|ch)))'
+channels = '(?:(?:[^\w+]?7[\W_]?1)|(?:[^\w+]?5[\W_]?1)|(?:[^\w+]?2[\W_]?(?:0|ch)))'
 _audios = [
     QualityComponent('audio', 10, 'mp3'),
     # TODO: No idea what order these should go in or if we need different regexps

--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -163,7 +163,7 @@ _audios = [
     # TODO: No idea what order these should go in or if we need different regexps
     QualityComponent('audio', 20, 'aac', 'aac%s?' % channels),
     # Because of the 'channels' regex, DD+5.1 is attempted first such that the + sign is not ignored
-    QualityComponent('audio', 35, 'dd+5.1', 'dd[p+]%s' % channels),
+    QualityComponent('audio', 45, 'dd+5.1', 'dd[p+]%s' % channels),
     QualityComponent('audio', 30, 'dd5.1', 'dd%s' % channels),
     QualityComponent('audio', 40, 'ac3', 'ac3%s?' % channels),
     QualityComponent('audio', 50, 'flac', 'flac%s?' % channels),


### PR DESCRIPTION
### Motivation for changes:
DD+ audio is becoming more common. It stands for Dolby Digital Plus aka Enhanced AC-3 and it is therefore better than both DD and AC-3. It supports up to 7.1 channels and a more efficient compression.
### Detailed changes:

- Added dd+/ddp to qualities.py
- Added tests for series and quality filter
- Added support for parsing x.{0,1} audio eg. 7.1, 5.0 etc.