### PR TITLE
[FIX] newpct - Login problem

### DIFF
--- a/flexget/plugins/operate/formlogin.py
+++ b/flexget/plugins/operate/formlogin.py
@@ -59,7 +59,11 @@ class FormLogin(object):
         username = config['username']
         password = config['password']
 
-        br = mechanize.Browser(factory=mechanize.RobustFactory())
+        try:
+            br = mechanize.Browser(factory=mechanize.RobustFactory())
+        except Exception:
+            br = mechanize.Browser()
+
         br.add_handler(SanitizeHandler())
         br.set_handle_robots(False)
         try:

--- a/flexget/plugins/operate/formlogin.py
+++ b/flexget/plugins/operate/formlogin.py
@@ -59,10 +59,7 @@ class FormLogin(object):
         username = config['username']
         password = config['password']
 
-        try:
-            br = mechanize.Browser(factory=mechanize.RobustFactory())
-        except Exception:
-            br = mechanize.Browser()
+        br = mechanize.Browser(factory=mechanize.RobustFactory())
 
         br.add_handler(SanitizeHandler())
         br.set_handle_robots(False)

--- a/flexget/plugins/operate/formlogin.py
+++ b/flexget/plugins/operate/formlogin.py
@@ -59,7 +59,7 @@ class FormLogin(object):
         username = config['username']
         password = config['password']
 
-        br = mechanize.Browser()
+        br = mechanize.Browser(factory=mechanize.RobustFactory())
         br.add_handler(SanitizeHandler())
         br.set_handle_robots(False)
         try:

--- a/flexget/plugins/sites/newpct.py
+++ b/flexget/plugins/sites/newpct.py
@@ -57,9 +57,7 @@ class UrlRewriteNewPCT(object):
         except requests.exceptions.RequestException as e:
             raise UrlRewritingError(e)
         try:
-            html = page.text
-            html = html.replace('\n', '').replace('\r', '')
-            soup = get_soup(html)
+            soup = get_soup(page.text)
         except Exception as e:
             raise UrlRewritingError(e)
 
@@ -67,7 +65,7 @@ class UrlRewriteNewPCT(object):
             torrent_id_prog = re.compile(r'descargar-torrent/(.+)/')
             torrent_ids = soup.findAll(href=torrent_id_prog)
         else:
-            torrent_id_prog = re.compile("(?:parametros\s*=\s*.*?)'(?:torrentID|id)'\s*:\s*'(\d+)'")
+            torrent_id_prog = re.compile("(?:parametros\s*=\s*\n?)\s*{\s*\n(?:\s*'\w+'\s*:.*\n)+\s*'(?:torrentID|id)'\s*:\s*'(\d+)'")
             torrent_ids = soup.findAll(text=torrent_id_prog)
 
         if len(torrent_ids) == 0:

--- a/flexget/plugins/sites/newpct.py
+++ b/flexget/plugins/sites/newpct.py
@@ -65,7 +65,7 @@ class UrlRewriteNewPCT(object):
             torrent_id_prog = re.compile(r'descargar-torrent/(.+)/')
             torrent_ids = soup.findAll(href=torrent_id_prog)
         else:
-            torrent_id_prog = re.compile("'(?:torrentID|id)'\s*:\s*'(\d+)'")
+            torrent_id_prog = re.compile("(?:parametros\s*=\s*.*?)'(?:torrentID|id)'\s*:\s*'(\d+)'")
             torrent_ids = soup.findAll(text=torrent_id_prog)
 
         if len(torrent_ids) == 0:

--- a/flexget/plugins/sites/newpct.py
+++ b/flexget/plugins/sites/newpct.py
@@ -57,7 +57,9 @@ class UrlRewriteNewPCT(object):
         except requests.exceptions.RequestException as e:
             raise UrlRewritingError(e)
         try:
-            soup = get_soup(page.text)
+            html = page.text
+            html = html.replace('\n', '').replace('\r', '')
+            soup = get_soup(html)
         except Exception as e:
             raise UrlRewritingError(e)
 


### PR DESCRIPTION
### Config usage if relevant (new plugin or updated schema):
```
    rss:
      url: http://feeds2.feedburner.com/newpctorrent
    form:
      url: http://www.newpct.com/entrar/
      userfield: userName
      passfield: userPass
      username: '{? newpct.user ?}'
      password: '{? newpct.pass ?}'

```
### Log and/or tests output (preferably both):
```
CRITICAL task          newpct    BUG: Unhandled error in plugin form: expected name token at '<!<31?106:(132,0x0))'
CRITICAL manager       newpct    An unexpected crash has occurred. Writing crash report to /home/rsalas/.flexget/crash_report.2017.05.29.114147849135.log. Please verify you are running the latest version of flexget by using "flexget -V" from CLI or by using version_checker plugin at http://flexget.com/wiki/Plugins/version_checker. You are currently using version 2.10.55
WARNING  task          newpct    Aborting task (plugin: form)
```

