### PR TITLE
[add] series CLI - use environment variables for defaults

### DIFF
--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -218,6 +218,8 @@ def display_details(options):
         table_data = [header]
         entities = get_all_entities(series, session=session, sort_by=sort_by, reverse=reverse)
         for entity in entities:
+            if not entity.releases:
+                continue
             if entity.identifier is None:
                 identifier = colorize(ERROR_COLOR, 'MISSING')
                 age = ''

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -66,7 +66,7 @@ def display_summary(options):
     porcelain = options.table_type == 'porcelain'
     configured = options.configured or os.environ.get(ENV_LIST_CONFIGURED, 'configured')
     premieres = True if (os.environ.get(ENV_LIST_PREMIERES) == 'yes' or
-                         options.premieres == 'premieres') else False
+                         options.premieres) else False
     sort_by = options.sort_by or os.environ.get(ENV_LIST_SORTBY_FIELD, 'name')
     if options.order is not None:
         descending = True if options.order == 'desc' else False
@@ -322,7 +322,7 @@ def register_parser_arguments():
                                         help='List a summary of the different series being tracked')
     list_parser.add_argument('configured', nargs='?', choices=['configured', 'unconfigured', 'all'],
                              help='Limit list to series that are currently in the config or not (default: %(default)s)')
-    list_parser.add_argument('--premieres', action='store_const', const='premieres',
+    list_parser.add_argument('--premieres', action='store_true',
                              help='limit list to series which only have episode 1 (and maybe also 2) downloaded')
     list_parser.add_argument('--new', nargs='?', type=int, metavar='DAYS', const=7,
                              help='Limit list to series with a release seen in last %(const)s days. number of days can '

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -20,6 +20,16 @@ except ImportError:
     raise plugin.DependencyError(issued_by='cli_series', missing='series',
                                  message='Series commandline interface not loaded')
 
+# Enviroment variables to set defaults for `series list` and `series show`
+ENV_SHOW_SORTBY_FIELD = 'FLEXGET_SERIES_SHOW_SORTBY_FIELD'
+ENV_SHOW_SORTBY_ORDER = 'FLEXGET_SERIES_SHOW_SORTBY_ORDER'
+ENV_LIST_CONFIGURED = 'FLEXGET_SERIES_LIST_CONFIGURED'
+ENV_LIST_PREMIERES = 'FLEXGET_SERIES_LIST_PREMIERES'
+ENV_LIST_STATUS = 'FLEXGET_SERIES_LIST_STATUS'
+ENV_LIST_NUMDAYS = 'FLEXGET_SERIES_LIST_NUMDAYS'
+ENV_LIST_SORTBY_FIELD = 'FLEXGET_SERIES_LIST_SORTBY_FIELD'
+ENV_LIST_SORTBY_ORDER = 'FLEXGET_SERIES_LIST_SORTBY_ORDER'
+# Colors for console output
 SORT_COLUMN_COLOR = 'yellow'
 NEW_EP_COLOR = 'green'
 FRESH_EP_COLOR = 'yellow'
@@ -51,26 +61,26 @@ def display_summary(options):
     :param options: argparse options from the CLI
     """
     porcelain = options.table_type == 'porcelain'
-    configured = options.configured or os.environ.get('FLEXGET_SERIES_LIST_CONFIGURED', 'configured')
-    premieres = True if (os.environ.get('FLEXGET_SERIES_LIST_PREMIERES') == 'yes' or
+    configured = options.configured or os.environ.get(ENV_LIST_CONFIGURED, 'configured')
+    premieres = True if (os.environ.get(ENV_LIST_PREMIERES) == 'yes' or
                          options.premieres == 'premieres') else False
-    sort_by = options.sort_by or os.environ.get('FLEXGET_SERIES_LIST_SORTBY_FIELD', 'name')
+    sort_by = options.sort_by or os.environ.get(ENV_LIST_SORTBY_FIELD, 'name')
     if options.order is not None:
         descending = True if options.order == 'desc' else False
     else:
-        descending = True if os.environ.get('FLEXGET_SERIES_LIST_SORTBY_ORDER') == 'desc' else False
+        descending = True if os.environ.get(ENV_LIST_SORTBY_ORDER) == 'desc' else False
     with Session() as session:
         kwargs = {'configured': configured,
                   'premieres': premieres,
                   'session': session,
                   'sort_by': sort_by,
                   'descending': descending}
-        if options.new or os.environ.get('FLEXGET_SERIES_LIST_STATUS') == 'new':
+        if options.new or os.environ.get(ENV_LIST_STATUS) == 'new':
             kwargs['status'] = 'new'
-            kwargs['days'] = options.new or int(os.environ.get('FLEXGET_SERIES_LIST_NUMDAYS', 7))
-        elif options.stale or os.environ.get('FLEXGET_SERIES_LIST_STATUS') == 'stale':
+            kwargs['days'] = options.new or int(os.environ.get(ENV_LIST_NUMDAYS, 7))
+        elif options.stale or os.environ.get(ENV_LIST_STATUS) == 'stale':
             kwargs['status'] = 'stale'
-            kwargs['days'] = options.stale or int(os.environ.get('FLEXGET_SERIES_LIST_NUMDAYS', 365))
+            kwargs['days'] = options.stale or int(os.environ.get(ENV_LIST_NUMDAYS, 365))
         if sort_by == 'name':
             kwargs['sort_by'] = 'show_name'
         else:
@@ -192,11 +202,11 @@ def get_latest_status(episode):
 def display_details(options):
     """Display detailed series information, ie. series show NAME"""
     name = options.series_name
-    sort_by = options.sort_by or os.environ.get('FLEXGET_SERIES_SORTBY_FIELD', 'age')
+    sort_by = options.sort_by or os.environ.get(ENV_SHOW_SORTBY_FIELD, 'age')
     if options.order is not None:
         reverse = True if options.order == 'desc' else False
     else:
-        reverse = True if os.environ.get('FLEXGET_SERIES_SORTBY_ORDER') == 'desc' else False
+        reverse = True if os.environ.get(ENV_SHOW_SORTBY_ORDER) == 'desc' else False
     with Session() as session:
         name = normalize_series_name(name)
         # Sort by length of name, so that partial matches always show shortest matching title


### PR DESCRIPTION
### Motivation for changes:
[Feature request](https://github.com/Flexget/Flexget/commit/dba8b0b37dc87316c67c754e98c491c2c015b920#commitcomment-22299675)

### Detailed changes:
`series show` and `series list` CLI subcommands now read environment variables to determine default parameters. These can be overridden on a per-run basis by utilizing the existing command-line arguments.

- `flexget series show`:
  - `FLEXGET_SERIES_SHOW_SORTBY_FIELD` can be set to `age` (default) or `identifier` to determine which field releases are sorted by. (`--sort-by` optional argument)
  - `FLEXGET_SERIES_SHOW_SORTBY_ORDER` can be set to `desc` to display results in descending order. (`--descending`/`--ascending` optional arguments)

- `flexget series list`:
  - `FLEXGET_SERIES_LIST_CONFIGURED` can be set to `configured` (default), `unconfigured`, or `all` to determine whether to only show series which are currently in the config. (positional argument)
  - `FLEXGET_SERIES_LIST_PREMIERES` can be set to `yes` to only show series which only have episode 1, or 1 and 2, downloaded. (`--premieres` optional argument)
  - `FLEXGET_SERIES_LIST_STATUS` can be set to `new` to only show series that have seen a release in the last 7 days, or `stale` to only show series that haven't seen a release in the last 365 days. (`--new`/`--stale` optional arguments)
  - `FLEXGET_SERIES_LIST_NUMDAYS` can be set to the number of days that `STATUS` limits to. (the `DAYS` option in `--new DAYS`/`--stale DAYS`)
  - `FLEXGET_SERIES_LIST_SORTBY_FIELD` can be set to `name` (default) or `age` to determine which field series are sorted by. (`--sort-by` optional argument)
  - `FLEXGET_SERIES_LIST_SORTBY_ORDER` can be set to `desc` to display results in descending order. (`--descending`/`--ascending` optional arguments)

Note there are presently bugs with the output of `series list --premieres` and `series list --sort-by age`, which already existed and are unrelated to these changes. Specifically, `series list --premieres` doesn't take season packs into account when determining which series to display, and `series list --sort-by age` seems to sort-of-but-not-completely sort by age. I'll be looking at these separately and submit another PR if I can resolve them.