### PR TITLE
[add] series CLI - manually add entities to series database

### DIFF
--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -262,7 +262,6 @@ def add(manager, options):
     series_name = options.series_name
     entity_ids = options.entity_id
     quality = options.quality
-    downloaded = not options.not_downloaded
     series_name = series_name.replace(r'\!', '!')
     normalized_name = normalize_series_name(series_name)
     with Session() as session:
@@ -276,7 +275,7 @@ def add(manager, options):
             series = series[0]
         for ent_id in entity_ids:
             try:
-                add_series_entity(session, series, ent_id, quality=quality, downloaded=downloaded)
+                add_series_entity(session, series, ent_id, quality=quality)
             except ValueError as e:
                 console(e.args[0])
             else:
@@ -335,8 +334,6 @@ def register_parser_arguments():
                                 help='Episode or season entity ID(s) to add')
     addshow_parser.add_argument('--quality', default=None, metavar='<quality>',
                                 help='Quality string to be stored for all entity ID(s)')
-    addshow_parser.add_argument('--not-downloaded', action='store_true', dest='not_downloaded',
-                                help='Do not mark entity ID(s) as downloaded')
 
     forget_parser = subparsers.add_parser('forget', parents=[series_parser],
                                           help='Removes episodes or whole series from the entire database '

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -14,7 +14,7 @@ try:
     from flexget.plugins.filter.series import (Series, remove_series, remove_series_entity, set_series_begin,
                                                normalize_series_name, new_entities_after, get_latest_release,
                                                get_series_summary, shows_by_name, show_episodes, shows_by_exact_name,
-                                               get_all_entities)
+                                               get_all_entities, add_series_entity)
 except ImportError:
     raise plugin.DependencyError(issued_by='cli_series', missing='series',
                                  message='Series commandline interface not loaded')
@@ -42,6 +42,8 @@ def do_cli(manager, options):
         remove(manager, options, forget=True)
     elif options.series_action == 'begin':
         begin(manager, options)
+    elif options.series_action == 'add':
+        add(manager, options)
 
 
 def display_summary(options):
@@ -256,6 +258,33 @@ def display_details(options):
         console(footer)
 
 
+def add(manager, options):
+    series_name = options.series_name
+    entity_ids = options.entity_id
+    quality = options.quality
+    downloaded = not options.not_downloaded
+    series_name = series_name.replace(r'\!', '!')
+    normalized_name = normalize_series_name(series_name)
+    with Session() as session:
+        series = shows_by_exact_name(normalized_name, session)
+        if not series:
+            console('Series not yet in database, adding `%s`' % series_name)
+            series = Series()
+            series.name = series_name
+            session.add(series)
+        else:
+            series = series[0]
+        for ent_id in entity_ids:
+            try:
+                add_series_entity(session, series, ent_id, quality=quality, downloaded=downloaded)
+            except ValueError as e:
+                console(e.args[0])
+            else:
+                console('Added entity `%s` to series `%s`.' % (ent_id, series.name.title()))
+        session.commit()
+    manager.config_changed()
+
+
 @event('options.register')
 def register_parser_arguments():
     # Register the command
@@ -299,6 +328,16 @@ def register_parser_arguments():
     begin_parser.add_argument('episode_id', metavar='<episode ID>',
                               help='Episode ID to start getting the series from (e.g. S02E01, 2013-12-11, or 9, '
                                    'depending on how the series is numbered)')
+
+    addshow_parser = subparsers.add_parser('add', parents=[series_parser],
+                                           help='Add episode(s) and season(s) to series history')
+    addshow_parser.add_argument('entity_id', nargs='+', default=None, metavar='<entity_id>',
+                                help='Episode or season entity ID(s) to add')
+    addshow_parser.add_argument('--quality', default=None, metavar='<quality>',
+                                help='Quality string to be stored for all entity ID(s)')
+    addshow_parser.add_argument('--not-downloaded', action='store_true', dest='not_downloaded',
+                                help='Do not mark entity ID(s) as downloaded')
+
     forget_parser = subparsers.add_parser('forget', parents=[series_parser],
                                           help='Removes episodes or whole series from the entire database '
                                                '(including seen plugin)')

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -19,6 +19,8 @@ except ImportError:
     raise plugin.DependencyError(issued_by='cli_series', missing='series',
                                  message='Series commandline interface not loaded')
 
+
+ENV_ADD_QUALITY = 'FLEXGET_SERIES_ADD_QUALITY'
 SORT_COLUMN_COLOR = 'yellow'
 NEW_EP_COLOR = 'green'
 FRESH_EP_COLOR = 'yellow'
@@ -261,7 +263,7 @@ def display_details(options):
 def add(manager, options):
     series_name = options.series_name
     entity_ids = options.entity_id
-    quality = options.quality
+    quality = options.quality or os.environ.get(ENV_ADD_QUALITY, None)
     series_name = series_name.replace(r'\!', '!')
     normalized_name = normalize_series_name(series_name)
     with Session() as session:

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1001,7 +1001,7 @@ def set_series_begin(series, ep_id):
     series.begin = episode
 
 
-def add_series_entity(session, series, identifier, quality=None, downloaded=True):
+def add_series_entity(session, series, identifier, quality=None):
     """
     Adds entity identified by `identifier` to series `name` in database.
 
@@ -1010,19 +1010,16 @@ def add_series_entity(session, series, identifier, quality=None, downloaded=True
     :param quality: If supplied, this will override the quality from the series parser.
     """
     name_to_parse = '{} {}'.format(series.name, identifier)
-    if quality:
-        name_to_parse = '{} {} {}'.format(series.name, identifier, quality)
     parsed = get_plugin_by_name('parsing').instance.parse_series(name_to_parse, name=series.name)
     if not parsed.valid:
         raise ValueError('Invalid identifier for series `{}`: `{}`.'.format(series.name, identifier))
 
-    added = store_parser(session, parsed, series=series)
+    added = store_parser(session, parsed, series=series, quality=quality)
     if not added:
         raise ValueError('Unable to add `%s` to series `%s`.' % (identifier, series.name.capitalize()))
     else:
-        if downloaded:
-            for release in added:
-                release.downloaded = True
+        for release in added:
+            release.downloaded = True
         log.debug('Entity `%s` from series `%s` added to database.', identifier, series.name)
 
 

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1010,11 +1010,13 @@ def add_series_entity(session, series, identifier, quality=None):
     :param quality: If supplied, this will override the quality from the series parser.
     """
     name_to_parse = '{} {}'.format(series.name, identifier)
+    if quality:
+        name_to_parse += ' {}'.format(quality)
     parsed = get_plugin_by_name('parsing').instance.parse_series(name_to_parse, name=series.name)
     if not parsed.valid:
         raise ValueError('Invalid identifier for series `{}`: `{}`.'.format(series.name, identifier))
 
-    added = store_parser(session, parsed, series=series, quality=quality)
+    added = store_parser(session, parsed, series=series)
     if not added:
         raise ValueError('Unable to add `%s` to series `%s`.' % (identifier, series.name.capitalize()))
     else:

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1001,6 +1001,31 @@ def set_series_begin(series, ep_id):
     series.begin = episode
 
 
+def add_series_entity(session, series, identifier, quality=None, downloaded=True):
+    """
+    Adds entity identified by `identifier` to series `name` in database.
+
+    :param series: Series in database to add entity to.
+    :param identifier: Series identifier to be added.
+    :param quality: If supplied, this will override the quality from the series parser.
+    """
+    name_to_parse = '{} {}'.format(series.name, identifier)
+    if quality:
+        name_to_parse = '{} {} {}'.format(series.name, identifier, quality)
+    parsed = get_plugin_by_name('parsing').instance.parse_series(name_to_parse, name=series.name)
+    if not parsed.valid:
+        raise ValueError('Invalid identifier for series `{}`: `{}`.'.format(series.name, identifier))
+
+    added = store_parser(session, parsed, series=series)
+    if not added:
+        raise ValueError('Unable to add `%s` to series `%s`.' % (identifier, series.name.capitalize()))
+    else:
+        if downloaded:
+            for release in added:
+                release.downloaded = True
+        log.debug('Entity `%s` from series `%s` added to database.', identifier, series.name)
+
+
 def remove_series(name, forget=False):
     """
     Remove a whole series `name` from database.


### PR DESCRIPTION
### Motivation for changes:
Provide a better way to inject episodes and season packs into the series database.

### Detailed changes:
Implements a new CLI subcommand:
```
series add "<series_name>" <entity_id> [<entity_id> ...] [--quality <quality_string>]
```
- `<entity_id>`: One or more entity IDs recognized by FlexGet, either episodes or season packs.
- `--quality <quality_string>`: Set quality for all entities (otherwise will be shown as 'None' in `series show <series_name>`). Accepts any string that the series parser will recognize as a quality string.

### Implemented feature requests:
- Feathub #[16](https://feathub.com/Flexget/Flexget/+16).