### PR TITLE
[add] CLI - environment variables for defaults

### DIFF
--- a/flexget/plugins/cli/history.py
+++ b/flexget/plugins/cli/history.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 from sqlalchemy import desc
+import os
 
 from flexget import options
 from flexget.event import event
@@ -9,8 +10,14 @@ from flexget.manager import Session
 from flexget.terminal import TerminalTable, TerminalTableError, table_parser, console
 from flexget.plugins.output.history import History
 
+# environment variables to set defaults
+ENV_LIST_LIMIT = 'FLEXGET_HISTORY_LIST_LIMIT'
+ENV_LIST_SHORT = 'FLEXGET_HISTORY_LIST_SHORT'
+
 
 def do_cli(manager, options):
+    limit = options.limit or int(os.environ.get(ENV_LIST_LIMIT, 50))
+    short = True if (os.environ.get(ENV_LIST_SHORT).lower() in ['yes', 'true'] or options.short) else False
     with Session() as session:
         query = session.query(History)
         if options.search:
@@ -18,12 +25,12 @@ def do_cli(manager, options):
             query = query.filter(History.title.like('%' + search_term + '%'))
         if options.task:
             query = query.filter(History.task.like('%' + options.task + '%'))
-        query = query.order_by(desc(History.time)).limit(options.limit)
+        query = query.order_by(desc(History.time)).limit(limit)
         table_data = []
-        if options.short:
+        if short:
             table_data.append(['Time', 'Title'])
         for item in reversed(query.all()):
-            if not options.short:
+            if not short:
                 table_data.append(['Task', item.task])
                 table_data.append(['Title', item.title])
                 table_data.append(['URL', item.url])
@@ -39,12 +46,12 @@ def do_cli(manager, options):
         console('No history to display')
         return
     title = 'Showing {} entries from History'.format(query.count())
-    if options.table_type != 'porcelain' and not options.short:
+    if options.table_type != 'porcelain' and not short:
         del table_data[-1]
 
     try:
         table = TerminalTable(options.table_type, table_data, title=title, wrap_columns=[1])
-        if not options.short:
+        if not short:
             table.table.inner_heading_row_border = False
         console(table.output)
     except TerminalTableError as e:
@@ -55,8 +62,8 @@ def do_cli(manager, options):
 def register_parser_arguments():
     parser = options.register_command('history', do_cli, help='View the history of entries that FlexGet has accepted',
                                       parents=[table_parser])
-    parser.add_argument('--limit', action='store', type=int, metavar='NUM', default=50,
+    parser.add_argument('--limit', action='store', type=int, metavar='NUM', default=None,
                         help='limit to %(metavar)s results')
     parser.add_argument('--search', action='store', metavar='TERM', help='Limit to results that contain %(metavar)s')
     parser.add_argument('--task', action='store', metavar='TASK', help='Limit to results in specified %(metavar)s')
-    parser.add_argument('--short', '-s', action='store_true', dest='short', default=False, help='Shorter output')
+    parser.add_argument('--short', '-s', action='store_true', dest='short', help='Shorter output')

--- a/flexget/plugins/cli/inject.py
+++ b/flexget/plugins/cli/inject.py
@@ -3,6 +3,7 @@ from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 import argparse
 import cgi
+import os
 import string
 import random
 import yaml
@@ -13,9 +14,15 @@ from flexget.event import event
 from flexget.terminal import console
 from flexget.utils import requests
 
+# environment variables to set defaults
+ENV_FORCE = 'FLEXGET_INJECT_FORCE'
+ENV_ACCEPT = 'FLEXGET_INJECT_ACCEPT'
+
 
 @event('manager.subcommand.inject')
 def do_cli(manager, options):
+    force = True if (os.environ.get(ENV_FORCE).lower() in ['yes', 'true'] or options.short) else False
+    accept = True if (os.environ.get(ENV_ACCEPT).lower() in ['yes', 'true'] or options.short) else False
     if not options.url:
         # Determine if first positional argument is a URL or a title
         if '://' in options.title:
@@ -36,9 +43,9 @@ def do_cli(manager, options):
         entry['url'] = options.url
     else:
         entry['url'] = 'http://localhost/inject/%s' % ''.join(random.sample(string.ascii_letters + string.digits, 30))
-    if options.force:
+    if force:
         entry['immortal'] = True
-    if options.accept:
+    if accept:
         entry.accept(reason='accepted by CLI inject')
     if options.fields:
         for key, value in options.fields:

--- a/flexget/plugins/cli/series.py
+++ b/flexget/plugins/cli/series.py
@@ -20,7 +20,7 @@ except ImportError:
     raise plugin.DependencyError(issued_by='cli_series', missing='series',
                                  message='Series commandline interface not loaded')
 
-# Enviroment variables to set defaults for `series list` and `series show`
+# Enviroment variables to set defaults
 ENV_SHOW_SORTBY_FIELD = 'FLEXGET_SERIES_SHOW_SORTBY_FIELD'
 ENV_SHOW_SORTBY_ORDER = 'FLEXGET_SERIES_SHOW_SORTBY_ORDER'
 ENV_LIST_CONFIGURED = 'FLEXGET_SERIES_LIST_CONFIGURED'
@@ -65,8 +65,7 @@ def display_summary(options):
     """
     porcelain = options.table_type == 'porcelain'
     configured = options.configured or os.environ.get(ENV_LIST_CONFIGURED, 'configured')
-    premieres = True if (os.environ.get(ENV_LIST_PREMIERES) == 'yes' or
-                         options.premieres) else False
+    premieres = True if (os.environ.get(ENV_LIST_PREMIERES).lower() in ['yes', 'true'] or options.premieres) else False
     sort_by = options.sort_by or os.environ.get(ENV_LIST_SORTBY_FIELD, 'name')
     if options.order is not None:
         descending = True if options.order == 'desc' else False
@@ -218,11 +217,11 @@ def get_latest_status(episode):
 def display_details(options):
     """Display detailed series information, ie. series show NAME"""
     name = options.series_name
-    sort_by = options.sort_by or os.environ.get(ENV_SHOW_SORTBY_FIELD, 'age')
+    sort_by = options.sort_by or os.environ.get(ENV_SHOW_SORTBY_FIELD, 'age').lower()
     if options.order is not None:
         reverse = True if options.order == 'desc' else False
     else:
-        reverse = True if os.environ.get(ENV_SHOW_SORTBY_ORDER) == 'desc' else False
+        reverse = True if os.environ.get(ENV_SHOW_SORTBY_ORDER).lower() == 'desc' else False
     with Session() as session:
         name = normalize_series_name(name)
         # Sort by length of name, so that partial matches always show shortest matching title

--- a/flexget/plugins/cli/status.py
+++ b/flexget/plugins/cli/status.py
@@ -3,6 +3,7 @@ from builtins import *  # noqa
 
 import datetime
 from datetime import timedelta
+import os
 
 from colorclass.toggles import disable_all_colors
 from flexget import options


### PR DESCRIPTION
### Motivation for changes:
Add the ability to set defaults via environment variables where it makes sense.

### Detailed changes:
`history`:
- `FLEXGET_HISTORY_LIST_LIMIT`: limit to `<num>` results (`--limit` argument)
- `FLEXGET_HISTORY_LIST_SHORT`: `yes` or `true` for shorter output (`--short` argument)

`inject`:
- `FLEXGET_INJECT_FORCE`: `yes` or `true` to always force entries to be accepted (`--force` argument)
- `FLEXGET_INJECT_ACCEPT`: `yes` or `true` to immediately accept entries (`--accept` argument)

`series`:
- `FLEXGET_SERIES_LIST_PREMIERES`: not new, but can now be `yes` or `true`, previously limited to `yes` (`--premieres` argument to `series list`)

`status`:
- `FLEXGET_STATUS_LIST_LIMIT`: limit to `<num>` results (`--limit` argument)