### PR TITLE
[add] bittorrent - expose torrent name in Torrent class

### DIFF
--- a/flexget/utils/bittorrent.py
+++ b/flexget/utils/bittorrent.py
@@ -252,6 +252,11 @@ class Torrent(object):
         return files
 
     @property
+    def name(self):
+        """Return name of the torrent"""
+        return self.content['info'].get('name', False)
+
+    @property
     def size(self):
         """Return total size of the torrent"""
         size = 0

--- a/flexget/utils/bittorrent.py
+++ b/flexget/utils/bittorrent.py
@@ -254,7 +254,7 @@ class Torrent(object):
     @property
     def name(self):
         """Return name of the torrent"""
-        return self.content['info'].get('name', False)
+        return self.content['info'].get('name', '')
 
     @property
     def size(self):


### PR DESCRIPTION
### Motivation for changes:
The `name` attribute of the `info` dictionary in the torrent file is often used as the container folder name in various torrent programs. However, this is not exposed in FlexGet.

### Detailed changes:
- `name` is now a property of the `Torrent` class and returns the `name` attribute of the `info` dictionary from the torrent file.