### PR TITLE
[add] Allow any plugin to modify content_files

### DIFF
--- a/flexget/plugins/clients/deluge.py
+++ b/flexget/plugins/clients/deluge.py
@@ -590,7 +590,7 @@ class OutputDeluge(DelugePlugin):
                         except:
                             log.debug('Cannot find file `%s` in modified_content_files', current_file['path'])
                             continue
-                        file_priorities.append(1 if modified_file['download'] == 1 else 0)
+                        file_priorities.append(modified_file['download'] if modified_file.get('download') else 1)
                         if modified_file['new_path'] and modified_file['new_path'] != current_file['path']:
                             new_filename = unused_name(modified_file['new_path'])
                             rename(current_file, new_filename)

--- a/flexget/plugins/clients/deluge.py
+++ b/flexget/plugins/clients/deluge.py
@@ -236,8 +236,7 @@ class InputDeluge(DelugePlugin):
         'save_path': 'deluge_path',
         'label': 'deluge_label',
         'total_size': ('content_size', lambda size: size / 1024 / 1024),
-        'files': ('content_files', lambda file_dicts: [f['path'] for f in file_dicts]),
-        'file_sizes': ('content_file_sizes', lambda file_sizes: [f['size'] for f in file_sizes])}
+        'files': ('content_files', lambda file_dicts: [{'path': f['path'], 'size': f['size']} for f in file_dicts])}
 
     extra_settings_map = {
         'active_time': ('active_time', lambda time: time / 3600),
@@ -604,12 +603,16 @@ class OutputDeluge(DelugePlugin):
                                                        else modified_file['new_path'])
                             rename(current_file, new_filename)
                         else:
-                            log.verbose('Not renaming because `%s` is identical to the existing filename',
-                                        modified_file['new_path'])
+                            if modified_file.get('new_path'):
+                                log.verbose('Not renaming because `%s` is identical to the existing filename',
+                                            modified_file['new_path'])
+                            else:
+                                log.debug('No renaming requested')
 
                     if file_priorities:
                         main_file_dlist.append(
                             client.core.set_torrent_file_priorities(torrent_id, file_priorities))
+                        log.debug('Setting file priorities for `%s`', entry['title'])
                 return defer.DeferredList(main_file_dlist)
 
             status_keys = ['files', 'total_size', 'save_path', 'move_on_completed_path',

--- a/flexget/plugins/filter/content_filter.py
+++ b/flexget/plugins/filter/content_filter.py
@@ -52,8 +52,8 @@ class FilterContentFilter(object):
         :param entry: Entry to process
         :return: True, if entry was rejected.
         """
-        if 'content_files' in entry:
-            files = entry['content_files']
+        if entry.get('content_files'):
+            files = [f['path'] for f in entry['content_files']]
             log.debug('%s files: %s' % (entry['title'], files))
 
             def matching_mask(files, masks):

--- a/flexget/plugins/metainfo/torrent_files.py
+++ b/flexget/plugins/metainfo/torrent_files.py
@@ -17,9 +17,12 @@ class TorrentFiles(object):
     def on_task_modify(self, task, config):
         for entry in task.entries:
             if 'torrent' in entry:
-                files = [posixpath.join(item['path'], item['name']) for item in entry['torrent'].get_filelist()]
+                files = []
+                for item in entry['torrent'].get_filelist():
+                    files.append({'path': posixpath.join(entry['torrent'].name if item['path'] else '', item['path'],
+                                                         item['name']), 'size': item['size']})
                 if files:
-                    log.debug('%s files: %s' % (entry['title'], files))
+                    log.debug('`%s` files: %s', entry['title'], files)
                     entry['content_files'] = files
 
 

--- a/flexget/plugins/modify/deluge_rename.py
+++ b/flexget/plugins/modify/deluge_rename.py
@@ -1,0 +1,146 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+from future.utils import native
+
+import logging
+import os
+import re
+
+from flexget import plugin
+from flexget.event import event
+from flexget.utils.template import RenderError
+from flexget.utils.pathscrub import pathscrub
+
+log = logging.getLogger('deluge_rename')
+
+
+class DelugeRename(object):
+    schema = {
+        'type': 'object',
+        'properties': {
+            'content_filename': {'type': 'string'},
+            'main_file_only': {'type': 'boolean'},
+            'main_file_ratio': {'type': 'number'},
+            'container_directory': {'type': 'string'},
+            'hide_sparse_files': {'type': 'boolean'},
+            'keep_subs': {'type': 'boolean'},
+        },
+        'additionalProperties': False
+    }
+
+    def prepare_config(self, config):
+        config.setdefault('main_file_ratio', 0.90)
+        config.setdefault('keep_subs', True) # does nothing without 'content_filename' or 'main_file_only' enabled
+        config.setdefault('hide_sparse_files', False) # does nothing without 'main_file_only' enabled
+        return config
+
+    def on_task_modify(self, task, config):
+        config = self.prepare_config(config)
+        keep_subs = config.get('keep_subs')
+        log.debug('keep_subs: %s', keep_subs)
+        for entry in task.accepted:
+            modified_content_files = []
+            if entry.get('modified_content_files'):
+                modified_content_files = entry['modified_content_files']
+                content_files = [f['new_path'] for f in modified_content_files]
+            elif entry.get('content_files'):
+                content_files = [os.path.join(entry['torrent'].name, f) if entry.get('torrent') else f
+                                 for f in entry['content_files']]
+                modified_content_files = [{'new_path': f, 'download': 0 if config.get('main_file_only') else 1}
+                                          for f in content_files]
+                #for count, f in enumerate(content_files):
+                #    modified_content_files.append({'new_path': f,
+                #                                   'download': 0 if config.get('main_file_only') else 1})
+            else:
+                entry.fail('`content_files` not present in entry')
+            if entry.get('torrent'):
+                total_size = entry['torrent'].size
+                content_file_sizes = entry['torrent'].get_filelist()
+            elif entry.get('content_size') and entry.get('content_file_sizes'):
+                total_size = entry['content_size'] * 1024 * 1024
+                content_file_sizes = entry['content_file_sizes']
+            else:
+                entry.fail('Unable to determine torrent or individual file sizes')
+            big_file_name = ''
+            if config.get('content_filename') or config.get('main_file_only'):
+                # find a file that makes up more than main_file_ratio (default: 90%) of the total size
+                main_file = sub_file = main_file_key = sub_file_key = None
+                sub_exts = [".srt", ".sub"]
+                for count, filename in enumerate(content_files):
+                    if content_file_sizes[count] > (total_size * config.get('main_file_ratio')) and not main_file:
+                        main_file_key = count
+                        main_file = filename
+                    ext = os.path.splitext(filename)[1]
+                    if keep_subs and ext in sub_exts and not sub_file:
+                        sub_file_key = count
+                        sub_file = filename
+
+                if main_file is not None:
+                    # proceed with renaming only if such a big file is found
+                    content_filename = ''
+                    try:
+                        content_filename = entry.get('content_filename', config.get('content_filename', ''))
+                        content_filename = pathscrub(entry.render(content_filename))
+                    except RenderError as e:
+                        log.error('Error rendering content_filename for `%s`: %s', entry['title'], e)
+                    container_directory = ''
+                    try:
+                        container_directory = pathscrub(entry.render(entry.get('container_directory',
+                                                                               config.get('container_directory', ''))))
+                    except RenderError as e:
+                        log.error('Error rendering container_directory for `%s`: %s', entry['title'], e)
+                    # check for single file torrents so we dont add unnecessary folders
+                    if len(content_files) > 1:
+                        # check for top folder in user config
+                        if container_directory:
+                            top_files_dir = container_directory + '/'
+                        elif config.get('content_filename') and os.path.dirname(config['content_filename']) is not '':
+                            top_files_dir = os.path.dirname(config['content_filename']) + '/'
+                        else:
+                            top_files_dir = os.path.dirname(main_file) + '/'
+                    else:
+                        top_files_dir = '/'
+
+                    if content_filename:
+                        # rename the main file
+                        big_file_name = '{}{}{}'.format(top_files_dir,
+                                                        os.path.basename(content_filename),
+                                                        os.path.splitext(main_file)[1])
+                        file_info = {'new_path': big_file_name, 'download': 1}
+                        modified_content_files[main_file_key].update(file_info)
+                        log.verbose('Main file `%s` will be renamed to `%s`', main_file, big_file_name)
+
+                        # rename subs along with the main file
+                        if sub_file is not None and keep_subs:
+                            sub_file_name = '{}{}'.format(os.path.splitext(big_file_name)[0],
+                                                          os.path.splitext(sub_file)[1])
+                            file_info = {'new_path': sub_file_name, 'download': 1}
+                            modified_content_files[sub_file_key].update(file_info)
+                            log.verbose('Subs file `%s` will be renamed to `%s`', main_file, big_file_name)
+
+                    hide_sparse_files = (config.get('main_file_only') and config.get('hide_sparse_files'))
+                    if len(content_files) > 1:
+                        for count, f in enumerate(content_files):
+                            filepath = ''
+                            # hide the other sparse files that are not supposed to download but are created anyway
+                            # http://dev.deluge-torrent.org/ticket/1827
+                            # Made sparse files behave better with deluge http://flexget.com/ticket/2881
+                            if hide_sparse_files and count != main_file_key and (count != sub_file_key
+                                                                                 or not keep_subs):
+                                file_path = '{}{}{}'.format(top_files_dir, '.sparse_files/', os.path.basename(f))
+                                modified_content_files[count].update(file_info)
+                            elif container_directory:
+                                file_path = '{}{}'.format(top_files_dir, os.path.basename(f))
+                            if filepath:
+                                file_info = {'new_path': file_path}
+                                modified_content_files[count].update(file_info)
+
+                    # update the entry with the results
+                    entry['modified_content_files'] = modified_content_files
+                else:
+                    log.warning('No files in `%s` are > %d%% of content size, no files renamed.',
+                                entry['title'], config.get('main_file_ratio') * 100)
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(DelugeRename, 'deluge_rename', api_ver=2)

--- a/flexget/plugins/modify/modify_content_files.py
+++ b/flexget/plugins/modify/modify_content_files.py
@@ -169,7 +169,9 @@ class ModifyContentFiles(object):
                                      else config['unlisted_filetype_default'])
                     if isinstance(this_filetype, dict):
                         log.trace('Settings or default settings present for this filetype.')
-                        file_settings.update({'rename': True if this_filetype.get('rename') else False,
+                        file_settings.update({'rename': True if this_filetype.get('rename',
+                                                                                  this_filetype.get('content_filename'))
+                                                                                  else False,
                                               'download': True if this_filetype.get('download') else False,
                                               'priority': this_filetype['priority'] if
                                               this_filetype.get('priority') else 0})

--- a/flexget/plugins/modify/torrent_rename_files.py
+++ b/flexget/plugins/modify/torrent_rename_files.py
@@ -121,7 +121,7 @@ class TorrentRenameFiles(object):
                             break
 
             top_level = False
-            if len(set(top_levels)) == 1 and len(content_files) > 1:
+            if len(set(top_levels)) == 1:
                 top_level = True
                 log.trace('Common top level folder detected.')
             if main_fileid < 0:
@@ -140,15 +140,15 @@ class TorrentRenameFiles(object):
                 # for each file
                 if not entry.get('season_pack') and not entry.get('season_pack_lookup'):
                     if entry.get('series_parser'):
-                        log.trace('Copying entry parser')
+                        log.debug('Copying entry parser')
                         tokens_title_parser = copy(entry['series_parser'])
                     elif entry.get('series_name'):
-                        log.trace('Creating parser with series name')
+                        log.debug('Creating parser with series name')
                         tokens_title_parser = \
                             get_plugin_by_name('parsing').instance.parse_series(data=search_title,
                                                                                 name=entry['series_name'])
                     else:
-                        log.trace('Creating parser without series name')
+                        log.debug('Creating parser without series name')
                         tokens_title_parser = get_plugin_by_name('parsing').instance.parse_series(data=search_title)
 
             new_filenames = []
@@ -206,7 +206,7 @@ class TorrentRenameFiles(object):
                         # season pack - must run new parser for each file
                         parser = get_plugin_by_name('parsing').instance.parse_series(data=cur_filename,
                                                                                      name=entry_copy['series_name'])
-                    elif not entry_copy['series_parser'] or not entry_copy['series_parser'].valid:
+                    elif not entry_copy.get('series_parser') or not entry_copy['series_parser'].valid:
                         log.trace('Using new parser')
                         if 'series_name' in entry_copy:
                             parser = get_plugin_by_name('parsing').instance.parse_series(data=cur_filename,

--- a/flexget/plugins/modify/torrent_rename_files.py
+++ b/flexget/plugins/modify/torrent_rename_files.py
@@ -16,8 +16,8 @@ from flexget.plugin import get_plugin_by_name
 from flexget.utils.pathscrub import pathscrub
 from flexget.plugins.filter.series import populate_entry_fields
 
-
 log = logging.getLogger('torrent_rename_files')
+
 
 class TorrentRenameFiles(object):
     """
@@ -59,7 +59,7 @@ class TorrentRenameFiles(object):
         config.setdefault('main_file_ratio', 0.90)
         config.setdefault('keep_container', True)
         config.setdefault('container_directory', '')
-        config.setdefault('container_only_for_multi', '')
+        config.setdefault('container_only_for_multi', True)
         config.setdefault('fix_year', False)
         config.setdefault('rename_main_file_only', False)
         config.setdefault('unlisted_filetype_default', True)

--- a/flexget/plugins/modify/torrent_rename_files.py
+++ b/flexget/plugins/modify/torrent_rename_files.py
@@ -1,0 +1,287 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+from future.utils import native
+
+import logging
+import posixpath
+import os
+import re
+from copy import copy
+
+from flexget import plugin
+from flexget.event import event
+
+from flexget.utils.template import RenderError
+from flexget.plugin import get_plugin_by_name
+from flexget.utils.pathscrub import pathscrub
+from flexget.plugins.filter.series import populate_entry_fields
+
+
+log = logging.getLogger('torrent_rename_files')
+
+class TorrentRenameFiles(object):
+    """
+    Performs renaming operations on `content_files`, or `modified_content_files` if it exists in entry.
+
+
+    Hierarchy:
+      keep_subs overrides rename_main_file_only
+      rename_main_file_only overrides filetypes
+      filetypes overrides unlisted_filetype_default
+    """
+    schema = {
+        'type': 'object',
+        'properties': {
+            'main_file_only': {'type': 'boolean'},
+            'main_file_ratio': {'type': 'number'},
+            'keep_subs': {'type': 'boolean'},
+            'keep_container': {'type': 'boolean'},
+            'container_directory': {'type': 'string'},
+            'container_only_for_multi': {'type': 'boolean'},
+            'content_filename': {'type': 'string'},
+            'rename_main_file_only': {'type': 'boolean'},
+            'fix_year': {'type': 'boolean'},
+            'unlisted_filetype_default': {'type': 'boolean'},
+            'filetypes': {
+                'type': 'object',
+                'additionalProperties': {
+                    'oneOf': [
+                        {'type': 'string'},
+                        {'type': 'boolean'},
+                    ]
+                }
+            }
+        },
+        'additionalProperties': False
+    }
+
+    def prepare_config(self, config):
+        config.setdefault('main_file_only', False)
+        config.setdefault('main_file_ratio', 0.90)
+        config.setdefault('keep_container', True)
+        config.setdefault('container_directory', '')
+        config.setdefault('container_only_for_multi', '')
+        config.setdefault('fix_year', False)
+        config.setdefault('rename_main_file_only', False)
+        config.setdefault('unlisted_filetype_default', True)
+        config.setdefault('filetypes', {})
+        return config
+
+    def on_task_modify(self, task, config):
+        config = self.prepare_config(config)
+        for entry in task.accepted:
+            if entry.get('modified_content_files'):
+                content_keys = [k for k in entry['modified_content_files'].keys()]
+                content_files = [f['new_path'] for f in entry['modified_content_files']]
+            else:
+                content_keys = content_files = entry['content_files']
+            # get total torrent size
+            if entry.get('torrent'):
+                total_size = entry['torrent'].size
+            elif entry.get('content_size'):
+                total_size = entry['content_size'] * 1024 * 1024
+            else:
+                entry.fail('Unable to determine torrent size')
+            file_ratio = total_size * config['main_file_ratio']
+            log.debug('Torrent size: %s, main file size minimum: %s', total_size, file_ratio)
+
+            main_fileid = -1
+            subs_fileid = -1
+            top_levels = []
+            # loop through to determine main_fileid and if there is a top-level folder
+            for count, t_file in enumerate(entry['torrent'].get_filelist()):
+                # split path into directory structure
+                structure = t_file['path'][:-1] if t_file['path'] else t_file['name'].split(os.sep)
+                # if there is more than 1 directory, there is a top-level; if so, add it to the list
+                if len(structure) > 1:
+                    top_levels.extend([structure[0]])
+                # if this file is greater than main_file_ratio% of the total torrent size, it is the "main" file
+                log.trace('File size is %s for file: %s', t_file['size'], t_file['path'])
+                if t_file['size'] > file_ratio:
+                    log.trace('Greater than main_file_ratio: %s', count)
+                    main_fileid = count
+                    if config.get('keep_subs'):
+                        sub_file = None
+                        sub_exts = [".srt", ".sub"]
+                        for count, sub_file in enumerate(entry['content_files']):
+                            if os.path.splitext(sub_file['path'])[1] in sub_exts:
+                                subs_fileid = count
+                                break
+            top_level = False
+            if len(set(top_levels)) == 1:
+                top_level = True
+                log.trace('Common top level folder detected.')
+            if main_fileid < 0:
+                if config.get('rename_main_file_only'):
+                    log.verbose('No files in `%s` are > %s%% of content size. No files will be renamed.',
+                                entry['title'], config.get('main_file_ratio')*100)
+            else:
+                log.trace('main_fileid: %s', main_fileid)
+
+            series_tokens = False
+            if config.get('content_filename') and 'series_' in config['content_filename']:
+                series_tokens = True
+                log.trace('Series token(s) present, obtaining parser')
+                search_title = entry['title']
+                # no point in generating a parser now if it's a season pack, since in that case it has to be run
+                # for each file
+                if not entry.get('season_pack') and not entry.get('season_pack_lookup'):
+                    if entry.get('series_parser'):
+                        log.trace('Copying entry parser')
+                        tokens_title_parser = copy(entry['series_parser'])
+                    elif entry.get('series_name'):
+                        log.trace('Creating parser with series name')
+                        tokens_title_parser = \
+                            get_plugin_by_name('parsing').instance.parse_series(data=search_title,
+                                                                                name=entry['series_name'])
+                    else:
+                        log.trace('Creating parser without series name')
+                        tokens_title_parser = get_plugin_by_name('parsing').instance.parse_series(data=search_title)
+
+            new_filenames = []
+            files = {}
+            os_sep = os.sep
+            do_container = False
+            if ((config.get('container_only_for_multi') and len(content_files) > 1)
+                 or not config.get('container_only_for_multi')):
+                do_container = True
+            for count, t_file in enumerate(content_files):
+                torrent_filename = (os.path.join(entry['torrent'].name, content_keys[count])
+                                    if len(content_files) > 1 else content_keys[count])
+                entry_copy = copy(entry)
+                original_pathfile = t_file
+                log.debug('Current file: %s', original_pathfile)
+
+                original_path = cur_path = os.path.split(t_file)[0]
+                original_filename = cur_filename = os.path.split(t_file)[1]
+                original_ext = os.path.splitext(original_filename)[1][1:]
+
+                to_download = subs_file = main_file = rename_file = False
+                content_filename = ''
+                if config.get('keep_subs') and count == subs_fileid:
+                    log.debug('This is subs file, renaming it.')
+                    subs_file = True
+                    rename_file = True
+                    to_download = True
+                if config.get('rename_main_file_only') and count == main_fileid:
+                    log.debug('This is main file, renaming it.')
+                    main_file = True
+                    rename_file = True
+                    to_download = True
+                if original_ext in config.get('filetypes'):
+                    if isinstance(config.get('filetypes')[original_ext], basestring):
+                        log.trace('Custom template present for this filetype.')
+                        content_filename = config.get('filetypes')[original_ext]
+                        rename_file = True
+                        to_download = True
+                    elif config.get('filetypes')[original_ext]:
+                        log.trace('Using content_filename to rename this filetype.')
+                        rename_file = True
+                        to_download = True
+                elif config.get('unlisted_filetype_default'):
+                    log.trace('Filetype is unlisted, but default is to rename all files.')
+                    rename_file = True
+                    to_download = True
+                if rename_file and not content_filename:
+                    if config.get('content_filename'):
+                        log.debug('Using content_filename for renaming template.')
+                        content_filename = config.get('content_filename')
+                    else:
+                        rename_file = False
+                        log.error('Settings indicate to rename file, but content_filename template was not provided.')
+
+                removed_container = ''
+                if series_tokens and (config.get('container_directory') or content_filename):
+                    if entry_copy.get('season_pack') or entry_copy.get('season_pack_lookup'):
+                        # season pack - must run new parser for each file
+                        parser = get_plugin_by_name('parsing').instance.parse_series(data=cur_filename,
+                                                                                     name=entry_copy['series_name'])
+                    elif not entry_copy['series_parser'] or not entry_copy['series_parser'].valid:
+                        log.trace('Using new parser')
+                        if 'series_name' in entry_copy:
+                            parser = get_plugin_by_name('parsing').instance.parse_series(data=cur_filename,
+                                                                                         name=entry_copy['series_name'])
+                        else:
+                            parser = get_plugin_by_name('parsing').instance.parse_series(data=cur_filename)
+                    else:
+                        parser = entry_copy['series_parser']
+
+                    if parser and parser.valid:
+                        populate_entry_fields(entry_copy, parser, False)
+                        if entry.get('season_pack'):
+                            entry_copy['season_pack'] = True
+                        if re.search(r'\d{4}', entry_copy['series_name'][-4:]) and config.get('fix_year'):
+                            entry_copy['series_name'] = ''.join([entry_copy['series_name'][0:-4], '(',
+                                                           entry_copy['series_name'][-4:], ')'])
+
+                if not config.get('keep_container') and top_level:
+                    log.debug('Existing path: %s', cur_path)
+                    removed_container_path = cur_path.split(os.sep)[0]
+                    log.debug('Removed container: %s', removed_container)
+                    cur_path = os_sep.join(cur_path.split(os.sep)[1:])
+                    log.debug('New path: %s', cur_path)
+                    removed_container = True
+
+                if config.get('container_directory') and do_container:
+                    try:
+                        container_directory = pathscrub(entry_copy.render(config.get('container_directory')))
+                        cur_path = os.path.join(container_directory, cur_path)
+                        log.debug('Added container directory. New path: %s', cur_path)
+                    except RenderError as e:
+                        log.error('Error rendering container_directory for %s: %s', cur_filename, e)
+                        if removed_container:
+                            # this seems silly but it's reversing the change by putting the value
+                            #   of container_directory back to what it was
+                            container_directory = removed_container_path
+                            cur_path = os.path.join(container_directory, cur_path)
+                            log.debug('Due to failure to add container, readding removed container to path.'
+                                      ' New path: %s', cur_path)
+
+                if content_filename and rename_file:
+                    try:
+                        cur_filename = pathscrub(entry_copy.render(content_filename))
+                        log.debug('Rendered filename: %s', cur_filename)
+                    except RenderError as e:
+                        log.error('Error rendering content_filename for %s: %s', original_filename, e)
+                    cur_withext = cur_filename + os.path.splitext(original_filename)[1]
+                    log.trace('Filename with extension: %s', cur_withext)
+
+                    if new_filenames.count(os.path.join(cur_path, cur_withext)) > 0:
+                        entry.fail('Duplicate filenames would result from renaming')
+                    if cur_filename[-len(original_ext):] != original_ext:
+                        cur_filename = cur_withext
+                        log.trace('Appended extension to filename: %s', cur_filename)
+                    if cur_filename != original_filename:
+                        #cur_withext = cur_filename + original_ext
+                        new_filenames.append(os.path.join(cur_path, cur_withext))
+                        log.verbose('Added file to rename group: %s', os.path.join(cur_path, cur_withext))
+                    #else:
+                        #log.debug('New and old filenames matched, no action taken')
+
+                # hide sparse files
+                if config.get('main_file_only') and not main_file and config.get('hide_sparse_files'):
+                    if not config.get('keep_subs') or not subs_file:
+                        add_path = ''
+                        if container_directory:
+                            add_path = container_directory
+                        elif cur_filename:
+                            add_path = cur_filename
+                        cur_path = os.path.join(['._' + add_path, cur_path])
+                        log.trace('Changed cur_path: %s', cur_path)
+
+                file_info = {'new_path': os.path.join(cur_path, cur_filename),
+                             'download': 1 if to_download else 0}
+                # if modified_content_files exists, we'll update it as we go. otherwise, files will put into
+                # modified_content_files after all entries are processed
+                if entry.get('modified_content_files'):
+                    entry['modified_content_files'][torrent_filename].update(file_info)
+                else:
+                    files.update({torrent_filename: file_info})
+
+            if not entry.get('modified_content_files'):
+                entry['modified_content_files'] = files
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(TorrentRenameFiles, 'torrent_rename_files', api_ver=2)


### PR DESCRIPTION
### Motivation for changes:
`entry['content_files']` is currently generated only for torrents and is only actually used by the `deluge` plugin.
Additionally, the `transmission` and `deluge` plugins each do very similar renaming routines within the respective plugins, though `transmission` doesn't use `content_files`.
To allow wider use of the `content_files` key, even beyond just torrents, and to reduce redundant code in the above-listed torrent client plugins, the bulk of the renaming logic is being removed from those plugins. New modification plugins have been created which iterate over `content_files` and generate renamed files, download priorities, and other details (depending on the plugin).
To the extent that other plugins use lists of files, they can be converted to use this system as well. The source (i.e. torrent or `from_deluge` plugin) and output (i.e. `transmission` or `deluge` plugins) will be the content-specific parts of the process. The modify plugins in the middle are intended to be content-agnostic and generic.

Also, this (along with my release of [`app_deluge_find`](https://github.com/tubedogg/flexget-plugins/blob/master/app_deluge_find.py) as a separate plugin) is the final step in me not needing a custom Deluge plugin anymore. :D No, this isn't a huge part of the motivation, it's just a happy benefit.

### Detailed changes:
- Renaming logic removed from `deluge` and `transmission` plugins. If `content_files` exists in the entry, renaming operations and download priorities are run against the torrent once it's added to Deluge/Transmission.
- `content_files` is a list of dicts, currently generated by the `torrent_files` metainfo plugin:
  - The structure of each dict at creation is: `{'path': 'torrent-name/path/filename.mkv', 'size': 123456789}`.
  - Additional keys currently recognized by the torrent client plugins are:
    - `new_path`, which is what the file is to be renamed to
    - `download`, which determines whether the file is downloaded (1 or 0, default 1)
    - `priority` ([2,5,7] with 2 meaning low, 5 meaning normal, and 7 meaning high; default 5 if `download` is 1 but `priority` is not present)
    - further keys may be specified with no adverse effects, but the intended output plugin would need to be modified to take advantage of them
- New plugin `modify_content_files`. This is a cleaned-up version of my personal renaming plugin that I've been using for the past couple of years that works for movies, single-file TV episodes and multi-file TV season packs. See documentation below.
- The new plugin `deluge_rename` has been created and functions (though is not coded) identically to the old built-in logic. Simply moving the `deluge` plugin keys `content_filename`, `main_file_only`, `main_file_ratio`, `container_directory`, `hide_sparse_files`, and `keep_subs` under the `deluge_rename` plugin key should result in a seamless transition. _This is something that needs to be thoroughly tested by those who used the old renaming logic. I tested to the best of my ability but I haven't used it in my config in years, so I'm bound to have missed something._

### Config usage if relevant (new plugin or updated schema):
```yaml
modify_content_files:
  content_filename: '{{series_id}}'
  fix_year: yes
  keep_container: no
  container_directory: '{% if season_pack %}{{series_name}} Season {{series_season}}{% else %}{{series_name}}{{" - " ~ series_id|lower}}{% endif %}'
  container_only_for_multi: yes
```
```yaml
deluge_rename:
  content_filename: '{%- if tvdb_series_name is defined -%}{{tvdb_series_name}}{%- else -%}{{series_name}}{%- endif -%}{{" - " ~ series_id|lower}}{%- if proper -%}{{" P" if proper == True else ""}}{%- endif -%}'
  main_file_only: yes
```


#### To Do:

- [x] Put old renaming logic from `deluge` plugin into its own plugin for people who want to continue using it
- [x] Change `torrent_rename_files` to not use `Torrent.get_filelist()` or `Torrent.name` if the input was `from_deluge` and not an actual torrent file.
- [x] Document `modified_content_files` key and structure that other plugins must use for `deluge` plugin to recognize that file renaming/priority setting needs to occur.
- [x] Document `torrent_rename_files` plugin
- [x] Document `deluge_rename` plugin
- [ ] Remove renaming logic from `transmission` plugin and convert it to use new `content_files` format

#### `torrent_rename_files` Documentation

| Option | Default value | Required | Value Type | Description |
| --- | --- | --- | --- | --- |
| main_file_only | `no` | no | boolean (yes/no) | If yes, all files but the main file inside the torrent (>90% of total torrent size) will be set to 'do not download'. |
| main_file_ratio | `0.9` | no | decimal | Sets the threshold value for *main_file_only*. Expects a number between 0 and 1 (i.e. `0.85` to change to 85%). |
| keep_subs | `no` | no | boolean (yes/no) | If yes, download the first subtitle file that is found inside the torrent. |
| keep_container | `yes` | no | boolean (yes/no) | If no, the directory structure inside the torrent (if there is one) will be removed.|
| container_directory | n/a | no | Jinja template | This is a template used to rename the main container directory within the torrent. Note that `keep_container` does not affect this, as that option is only concerned with removing any existing directory structure. Therefore `keep_container: no` and `container_directory: yes` would cause the existing structure to be removed and replaced with the structure from this option.
| container_only_for_multi | `yes` | no | boolean (yes/no) | If yes, only adds `container_directory` went the torrent contains more than one file. If no, always adds `container_directory` (if it's set).
| content_filename | n/a | no | Jinja template | This can be used to rename files within the torrent. |
| rename_main_file_only | `no` | no | boolean (yes/no) | If yes, rename only the main file inside the torrent (>90% of total torrent size) using the `content_filename` setting. |
| fix_year | `no` | no | boolean (yes/no) | If yes, if the last four characters of a series' name are numbers, add parentheses around them. e.g. The Show 2017 becomes The Show (2017). |
| unlisted_filetype_default | `yes` | no | boolean (yes/no) or dictionary | Boolean: If yes, renames all files (that are not explicitly specified under the `filetypes` setting below) using `content_filename`, unless `rename_main_file_only` is set to `yes`. Dictionary: can contain `download`, `priority`, `rename`, and `content_filename` keys. `download` can be 1 (download) or 0. `priority` can be 2, 5, 7 meaning low, regular, high priority. `rename` can be yes/no. `content_filename` can be a custom Jinja template for unlisted filetypes. |
| filetypes | n/a | no | boolean (yes/no) or dictionary | Specify rename settings by file type (file extension). Each type can be set to `yes` or `no` to determine whether or not to always rename them, or can be set to a dict (same structure as allowed for `unlisted_filetype_default`). |

```yaml
# filetypes example
torrent_rename_files:
  content_filename: '{{title}}'
  filetypes:
    # uses custom Jinja template for mp3 files
    mp3:
      content_filename: "{{title}}.mp3"
    # renames mkv files with `content_filename` in entry or general configuration
    mkv: yes
```

#### `deluge_rename` Documentation
See the following keys in the [`deluge`](https://flexget.com/Plugins/deluge) plugin: `content_filename`, `main_file_only`, `main_file_ratio`, `container_directory`, `hide_sparse_files`, `keep_subs`