### PR TITLE
Preparation phase

### DIFF
--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -155,7 +155,7 @@ DEFAULT_PRIORITY = 128
 
 # task phases, in order of their execution; note that this can be extended by
 # registering new phases at runtime
-task_phases = ['preparation', 'start', 'input', 'metainfo', 'filter', 'download', 'modify', 'output', 'learn', 'exit']
+task_phases = ['prepare', 'start', 'input', 'metainfo', 'filter', 'download', 'modify', 'output', 'learn', 'exit']
 
 # map phase names to method names
 phase_methods = {

--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -155,7 +155,7 @@ DEFAULT_PRIORITY = 128
 
 # task phases, in order of their execution; note that this can be extended by
 # registering new phases at runtime
-task_phases = ['start', 'input', 'metainfo', 'filter', 'download', 'modify', 'output', 'learn', 'exit']
+task_phases = ['preparation', 'start', 'input', 'metainfo', 'filter', 'download', 'modify', 'output', 'learn', 'exit']
 
 # map phase names to method names
 phase_methods = {
@@ -414,7 +414,7 @@ def _load_plugins_from_dirs(dirs):
             else:
                 log.trace('Loaded module %s from %s', module_name, plugin_path)
     _check_phase_queue()
-                      
+
 
 def _load_plugins_from_packages():
     """Load plugins installed via PIP"""

--- a/flexget/plugins/filter/remember_rejected.py
+++ b/flexget/plugins/filter/remember_rejected.py
@@ -79,33 +79,27 @@ class FilterRememberRejected(object):
 
     @plugin.priority(0)
     def on_task_start(self, task, config):
-        with Session() as session:
-            remember_task = session.query(RememberTask).filter(RememberTask.name == task.name).first()
-            if not remember_task:
-                # Create this task in the db if not present
-                session.add(RememberTask(name=task.name))
-
-    @plugin.priority(-255)
-    def on_task_input(self, task, config):
         """Purge remembered entries if the config has changed."""
         with Session() as session:
             # See if the task has changed since last run
-            remember_task = session.query(RememberTask).filter(RememberTask.name == task.name).first()
-            if not task.is_rerun and remember_task and task.config_modified:
+            old_task = session.query(RememberTask).filter(RememberTask.name == task.name).first()
+            if not task.is_rerun and old_task and task.config_modified:
                 log.debug('Task config has changed since last run, purging remembered entries.')
-                session.delete(remember_task)
-                remember_task = None
-            if not remember_task:
+                session.delete(old_task)
+                old_task = None
+            if not old_task:
                 # Create this task in the db if not present
                 session.add(RememberTask(name=task.name))
             elif not task.is_rerun:
                 # Delete expired items if this is not a rerun
-                deleted = session.query(RememberEntry).filter(RememberEntry.task_id == remember_task.id). \
+                deleted = session.query(RememberEntry).filter(RememberEntry.task_id == old_task.id). \
                     filter(RememberEntry.expires < datetime.now()).delete()
                 if deleted:
                     log.debug('%s entries have expired from remember_rejected table.' % deleted)
                     task.config_changed()
 
+    @plugin.priority(-255)
+    def on_task_input(self, task, config):
         for entry in task.all_entries:
             entry.on_reject(self.on_entry_reject)
 

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -2030,6 +2030,10 @@ class SeriesDBManager(FilterSeriesBase):
 
     @plugin.priority(0)
     def on_task_start(self, task, config):
+        # Only operate if task changed
+        if not task.config_modified:
+            return
+
         # Clear all series from this task
         with Session() as session:
             session.query(SeriesTask).filter(SeriesTask.name == task.name).delete()

--- a/flexget/plugins/operate/configure_series.py
+++ b/flexget/plugins/operate/configure_series.py
@@ -49,7 +49,7 @@ class ConfigureSeries(FilterSeriesBase):
             'additionalProperties': False
         }
 
-    def on_task_preparation(self, task, config):
+    def on_task_prepare(self, task, config):
 
         series = {}
         for input_name, input_config in config.get('from', {}).items():

--- a/flexget/plugins/operate/configure_series.py
+++ b/flexget/plugins/operate/configure_series.py
@@ -49,7 +49,7 @@ class ConfigureSeries(FilterSeriesBase):
             'additionalProperties': False
         }
 
-    def on_task_start(self, task, config):
+    def on_task_preparation(self, task, config):
 
         series = {}
         for input_name, input_config in config.get('from', {}).items():

--- a/flexget/plugins/operate/include.py
+++ b/flexget/plugins/operate/include.py
@@ -30,7 +30,7 @@ class PluginInclude(object):
     schema = one_or_more({'type': 'string'})
 
     @plugin.priority(256)
-    def on_task_preparation(self, task, config):
+    def on_task_prepare(self, task, config):
         if not config:
             return
 

--- a/flexget/plugins/operate/include.py
+++ b/flexget/plugins/operate/include.py
@@ -30,7 +30,7 @@ class PluginInclude(object):
     schema = one_or_more({'type': 'string'})
 
     @plugin.priority(256)
-    def on_task_start(self, task, config):
+    def on_task_preparation(self, task, config):
         if not config:
             return
 

--- a/flexget/plugins/operate/template.py
+++ b/flexget/plugins/operate/template.py
@@ -60,7 +60,7 @@ class PluginTemplate(object):
         return config
 
     @plugin.priority(257)
-    def on_task_start(self, task, config):
+    def on_task_preparation(self, task, config):
         if config is False:  # handles 'template: no' form to turn off template on this task
             return
         # implements --template NAME

--- a/flexget/plugins/operate/template.py
+++ b/flexget/plugins/operate/template.py
@@ -60,7 +60,7 @@ class PluginTemplate(object):
         return config
 
     @plugin.priority(257)
-    def on_task_preparation(self, task, config):
+    def on_task_prepare(self, task, config):
         if config is False:  # handles 'template: no' form to turn off template on this task
             return
         # implements --template NAME

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -459,8 +459,8 @@ class Task(object):
                 finally:
                     fire_event('task.execute.after_plugin', self, plugin.name)
                 self.session = None
-        # check config hash for changes at the end of 'preparation' phase
-        if phase == 'preparation':
+        # check config hash for changes at the end of 'prepare' phase
+        if phase == 'prepare':
             self.check_config_hash()
 
     def __run_plugin(self, plugin, phase, args=None, kwargs=None):

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -459,8 +459,8 @@ class Task(object):
                 finally:
                     fire_event('task.execute.after_plugin', self, plugin.name)
                 self.session = None
-        # check config hash for changes at the end of 'start' phase
-        if phase == 'start':
+        # check config hash for changes at the end of 'preparation' phase
+        if phase == 'preparation':
             self.check_config_hash()
 
     def __run_plugin(self, plugin, phase, args=None, kwargs=None):

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -601,8 +601,8 @@ class Task(object):
                             log.info('Plugin %s is not executed because %s phase is disabled (e.g. --test)' %
                                      (plugin.name, phase))
                     continue
-                if phase == 'start' and self.is_rerun:
-                    log.debug('skipping task_start during rerun')
+                if phase in ('start', 'prepare') and self.is_rerun:
+                    log.debug('skipping phase %s during rerun', phase)
                 elif phase == 'exit' and self._rerun and self._rerun_count < self.max_reruns:
                     log.debug('not running task_exit yet because task will rerun')
                 else:


### PR DESCRIPTION
### Motivation for changes:
Plugins that have config modifying operations (include, configure_series and templates currently) trigger task.config+changed flag, but only after `start` phase is done. Other plugin that rely on this data need to either catch it on a later phase (like input) or ignore it, and both of this options suck.

By adding a new `preparation` phase to occur before `start`, the correct behavior of checking if config has changed in start phase can still be used.

### Detailed changes:
- Added `preparation` phase before `start` phase
- Moved `include`, `templates` and `configure_series` operations to occur on that phase
- Changed config check on Task to occur after `preparation` instead of `start`
- Reinstated the logic in `series` plugin and `remeber_rejected` to occur at `start` phase

### Addressed issues:
- Hopefully Fixes #1865 

