### PR TITLE
Add a threshold setting for number of episodes already downloaded to …

### DIFF
--- a/flexget/plugins/input/next_series_seasons.py
+++ b/flexget/plugins/input/next_series_seasons.py
@@ -31,7 +31,8 @@ class NextSeriesSeasons(object):
                 'type': 'object',
                 'properties': {
                     'from_start': {'type': 'boolean', 'default': False},
-                    'backfill': {'type': 'boolean', 'default': False}
+                    'backfill': {'type': 'boolean', 'default': False},
+                    'threshold': {'type': 'integer', 'minimum': 0}
                 },
                 'additionalProperties': False
             }
@@ -80,6 +81,8 @@ class NextSeriesSeasons(object):
             return entries
         else:
             self.rerun_entries = []
+
+        threshold = config.get('threshold', None)
 
         entries = []
         impossible = {}
@@ -134,6 +137,9 @@ class NextSeriesSeasons(object):
                 for season in range(latest_season, low_season, -1):
                     if season in series.completed_seasons:
                         log.debug('season %s is marked as completed, skipping', season)
+                        continue
+                    if threshold is not None and series.episodes_for_season(season) > threshold:
+                        log.debug('season %s has met threshold of threshold of %s, skipping', season, threshold)
                         continue
                     log.trace('Evaluating season %s for series `%s`', season, series.name)
                     latest = get_latest_release(series, season=season, downloaded=check_downloaded)

--- a/flexget/plugins/input/next_series_seasons.py
+++ b/flexget/plugins/input/next_series_seasons.py
@@ -82,7 +82,7 @@ class NextSeriesSeasons(object):
         else:
             self.rerun_entries = []
 
-        threshold = config.get('threshold', None)
+        threshold = config.get('threshold')
 
         entries = []
         impossible = {}
@@ -124,7 +124,7 @@ class NextSeriesSeasons(object):
                     latest_season - series.begin.season > MAX_SEASON_DIFF_WITH_BEGIN):
                     if series.begin:
                         log.error('Series `%s` has a begin episode set (`%s`), but the season currently being processed '
-                                  '(%s) is %s seasons later than it. To prevent emitting incorrect seasons, this ' 
+                                  '(%s) is %s seasons later than it. To prevent emitting incorrect seasons, this '
                                   'series will not emit unless the begin episode is adjusted to a season that is less '
                                   'than %s seasons from season %s.', series.name, series.begin.identifier, latest_season,
                                   (latest_season - series.begin.season), MAX_SEASON_DIFF_WITH_BEGIN, latest_season)


### PR DESCRIPTION
Adds a threshold to `next_series_seasons` to specify how many episodes may be downloaded for a particular season before emitting a season pack.

### Motivation for changes:

If several episodes of a season are already downloaded, I don't usually want to download the entire season pack.

### Detailed changes:
- Added `threshold` property to `next_series_seasons`
- If `series.episodes_for_season()` is greater than the threshold, skip the season

### Config usage if relevant (new plugin or updated schema):
```
tasks:
  discover-tv:
    discover:
      release_estimations:
        optimistic: 30 days
      what:
        - next_series_seasons:
            backfill: yes
            from_start: yes
            threshold: 4
      from:
        - piratebay:
            category: "highres tv"
            sort_by: seeds
      interval: 1 day
```
