### PR TITLE
added ability to read the special content object created by feedparser

### DIFF
--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -382,6 +382,16 @@ class InputRSS(object):
                 # fields dict may be modified during this loop, so loop over a copy (fields.items())
                 for rss_field, flexget_field in list(fields.items()):
                     if rss_field in entry:
+                        if rss_field == 'content':
+                            content_str = ''
+                            for content in entry[rss_field]:
+                                try:
+                                    content_str += decode_html(content.value)
+                                except UnicodeDecodeError:
+                                    log.warning('Failed to decode entry `%s` field `%s`', ea['title'], rss_field)
+                            ea[flexget_field] = content_str
+                            log.debug('Field `%s` set to `%s` for `%s`', rss_field, ea[rss_field], ea['title'])
+                            continue
                         if not isinstance(getattr(entry, rss_field), str):
                             # Error if this field is not a string
                             log.error('Cannot grab non text field `%s` from rss.', rss_field)

--- a/flexget/tests/rss.xml
+++ b/flexget/tests/rss.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:other="http://localhost/flexget">
+<rss version="2.0" xmlns:other="http://localhost/flexget"
+xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>FlexGet RSS test</title>
     <ttl>15</ttl>
@@ -70,6 +71,23 @@
       <link>http://localhost/empty</link>
       <pubDate>Sun, 28 Dec 2008 14:00:00 -0200</pubDate>
       <description>Description, empty title</description>
+    </item>
+
+    <item>
+      <title>Content</title>
+      <link>http://localhost/content</link>
+      <pubDate>Sun, 28 Dec 2008 14:20:00 -0200</pubDate>
+      <description>Description, content</description>
+      <content:encoded><![CDATA[<p>test content:encoded</p>]]></content:encoded>
+    </item>
+
+    <item>
+      <title>Multiple content items</title>
+      <link>http://localhost/multi_content</link>
+      <pubDate>Sun, 28 Dec 2008 14:20:00 -0200</pubDate>
+      <description>Description, multi_content</description>
+      <content:encoded><![CDATA[<p>test content1</p>]]></content:encoded>
+      <content:encoded><![CDATA[<p>test content2</p>]]></content:encoded>
     </item>
 
   </channel>

--- a/flexget/tests/rss.xml
+++ b/flexget/tests/rss.xml
@@ -67,13 +67,6 @@ xmlns:content="http://purl.org/rss/1.0/modules/content/">
     </item>
 
     <item>
-      <title></title>
-      <link>http://localhost/empty</link>
-      <pubDate>Sun, 28 Dec 2008 14:00:00 -0200</pubDate>
-      <description>Description, empty title</description>
-    </item>
-
-    <item>
       <title>Content</title>
       <link>http://localhost/content</link>
       <pubDate>Sun, 28 Dec 2008 14:20:00 -0200</pubDate>
@@ -88,6 +81,13 @@ xmlns:content="http://purl.org/rss/1.0/modules/content/">
       <description>Description, multi_content</description>
       <content:encoded><![CDATA[<p>test content1</p>]]></content:encoded>
       <content:encoded><![CDATA[<p>test content2</p>]]></content:encoded>
+    </item>
+
+    <item>
+      <title></title>
+      <link>http://localhost/empty</link>
+      <pubDate>Sun, 28 Dec 2008 14:00:00 -0200</pubDate>
+      <description>Description, empty title</description>
     </item>
 
   </channel>

--- a/flexget/tests/test_rss.py
+++ b/flexget/tests/test_rss.py
@@ -47,6 +47,11 @@ class TestInputRSS(object):
               title: "other:Title"
               other_fields:
               - "Other:field"
+          test_content:
+            rss:
+              <<: *rss
+              other_fields:
+                - content
     """
 
     def test_rss(self, execute_task):
@@ -144,6 +149,13 @@ class TestInputRSS(object):
         assert entry['title'] == 'alt title'
         assert entry['url'] == 'http://localhost/altlink'
         assert entry['other:field'] == 'otherfield'
+
+    def test_content(self, execute_task):
+        task = execute_task('test_content')
+        assert task.find_entry(title='Content', content='<p>test content:encoded</p>'), \
+            'RSS entry missing: content:encoded'
+        assert task.find_entry(title='Multiple content items', content='<p>test content1</p><p>test content2</p>'), \
+            'RSS entry missing: multiple content tags'
 
 
 @pytest.mark.xfail(reason="silverorange changed some stuff")


### PR DESCRIPTION
### Motivation for changes:
The rss plugin fails to import the 'content' field of a rss feed (in my case the field was named content:encoded) and logs an error: Cannot grab non text field content from rss.

This is because feedparser stores content in an object rather than a string: https://pythonhosted.org/feedparser/reference-entry-content.html

Since 'content' can be particularly useful, it may be worthwile to write a workaround.

This pull request fixed the issue for me.

### Detailed changes:
- added 10 lines of code that properly handle the `FeedParserDict` object which feedparser delivers for content elements in rss feeds
- since there may be more than one content element in atom feeds, the code loops over all content elements delivered by feedparser

### Addressed issues:
- Fixes #656 .

### Implemented feature requests:
- Feathub #[25](http://feathub.com/Flexget/Flexget/+25).

### Log and/or tests output (preferably both):
```
WARNING  rss  Failed to decode entry `<title>` field `content`
DEBUG      rss  Field `content` set to `<content string>`  for `<title>`
```
#### To Do:
- [ ] similar routines for other rss elements for which feedparser does not return a string
