### PR TITLE
updated the nyaa plugin to use the new url.

### DIFF
--- a/flexget/plugins/sites/nyaa.py
+++ b/flexget/plugins/sites/nyaa.py
@@ -16,10 +16,10 @@ log = logging.getLogger('nyaa')
 # TODO: Other categories
 CATEGORIES = {'all': '0_0',
               'anime': '1_0',
-              'anime eng': '1_37',
-              'anime non-eng': '1_38',
-              'anime raw': '1_11'}
-FILTERS = ['all', 'filter remakes', 'trusted only', 'a+ only']
+              'anime eng': '1_2',
+              'anime non-eng': '1_3',
+              'anime raw': '1_4'}
+FILTERS = ['all', 'filter remakes', 'trusted only']
 
 
 class UrlRewriteNyaa(object):
@@ -47,8 +47,8 @@ class UrlRewriteNyaa(object):
         entries = set()
         for search_string in entry.get('search_strings', [entry['title']]):
             name = normalize_unicode(search_string)
-            url = 'http://www.nyaa.se/?page=rss&cats=%s&filter=%s&term=%s' % (
-                CATEGORIES[config['category']], FILTERS.index(config['filter']), quote(name.encode('utf-8')))
+            url = 'https://www.nyaa.si/?page=rss&q=%s&c=%s&f=%s' % (
+                quote(name.encode('utf-8')), CATEGORIES[config['category']], FILTERS.index(config['filter']))
 
             log.debug('requesting: %s' % url)
             rss = feedparser.parse(url)
@@ -79,10 +79,10 @@ class UrlRewriteNyaa(object):
         return entries
 
     def url_rewritable(self, task, entry):
-        return entry['url'].startswith('http://www.nyaa.se/?page=torrentinfo&tid=')
+        return entry['url'].startswith('https://www.nyaa.si/view/')
 
     def url_rewrite(self, task, entry):
-        entry['url'] = entry['url'].replace('torrentinfo', 'download')
+        entry['url'] = entry['url'].replace('view', 'download') + ".torrent"
 
 
 @event('plugin.register')

--- a/flexget/tests/test_urlrewriting.py
+++ b/flexget/tests/test_urlrewriting.py
@@ -53,10 +53,10 @@ class TestURLRewriters(object):
         task = execute_task('test')
         entry = task.find_entry(title='nyaa')
         urlrewriter = self.get_urlrewriter('nyaa')
-        assert entry['url'] == 'http://www.nyaa.se/?page=torrentinfo&tid=12345'
+        assert entry['url'] == 'https://www.nyaa.si/view/12345'
         assert urlrewriter.url_rewritable(task, entry)
         urlrewriter.url_rewrite(task, entry)
-        assert entry['url'] == 'http://www.nyaa.se/?page=download&tid=12345'
+        assert entry['url'] == 'https://www.nyaa.si/download/12345.torrent'
 
     def test_cinemageddon(self, execute_task):
         task = execute_task('test')

--- a/flexget/tests/test_urlrewriting.py
+++ b/flexget/tests/test_urlrewriting.py
@@ -53,10 +53,10 @@ class TestURLRewriters(object):
         task = execute_task('test')
         entry = task.find_entry(title='nyaa')
         urlrewriter = self.get_urlrewriter('nyaa')
-        assert entry['url'] == 'https://www.nyaa.si/view/12345'
+        assert entry['url'] == 'https://www.nyaa.si/view/15'
         assert urlrewriter.url_rewritable(task, entry)
         urlrewriter.url_rewrite(task, entry)
-        assert entry['url'] == 'https://www.nyaa.si/download/12345.torrent'
+        assert entry['url'] == 'https://www.nyaa.si/download/15.torrent'
 
     def test_cinemageddon(self, execute_task):
         task = execute_task('test')

--- a/flexget/tests/test_urlrewriting.py
+++ b/flexget/tests/test_urlrewriting.py
@@ -19,7 +19,7 @@ class TestURLRewriters(object):
               - {title: 'tbp torrent', url: 'http://torrents.thepiratebay.se/8492471/Test.torrent'}
               - {title: 'tbp torrent subdomain', url: 'http://torrents.thepiratebay.se/8492471/Test.avi'}
               - {title: 'tbp torrent bad subdomain', url: 'http://torrent.thepiratebay.se/8492471/Test.avi'}
-              - {title: 'nyaa', url: 'http://www.nyaa.se/?page=torrentinfo&tid=12345'}
+              - {title: 'nyaa', url: 'https://www.nyaa.si/view/15'}
               - {title: 'cinemageddon download', url: 'http://cinemageddon.net/details.php?id=1234'}
     """
 


### PR DESCRIPTION
nyaatorrents.se voluntarily took itself offline because of some rumors that the "police" were coming after them. a few alternate versions popped up shortly after, and this seems to be the de facto one. I simply took the old nyaa plugin and updated the urls and values wherever necessary.

### Motivation for changes:
The old nyaa plugin was using a url that no longer is online. 

### Detailed changes:
- I changed the category dictionary's values because they use different numbers.
- Their url is completely different, so I had to move around where the values get plugged in.
- I added a ".torrent" append to the url_rewrite function because the new site has a different url structure.

