### PR TITLE
[fix] Made sure ignores actually work

### DIFF
--- a/flexget/plugins/daemon/irc.py
+++ b/flexget/plugins/daemon/irc.py
@@ -674,10 +674,13 @@ class IRCConnection(IRCBot):
         entries = []
         for line in lines:
             # If it's listed in ignore lines, skip it
+            ignore = False
             for rx, expected in self.ignore_lines:
                 if rx.match(line) and expected:
                     log.debug('Ignoring message: matched ignore line')
-                    continue
+                    ignore = True
+            if ignore:
+                continue
 
             entry = Entry(irc_raw_message=line)
 

--- a/flexget/plugins/daemon/irc.py
+++ b/flexget/plugins/daemon/irc.py
@@ -679,6 +679,7 @@ class IRCConnection(IRCBot):
                 if rx.match(line) and expected:
                     log.debug('Ignoring message: matched ignore line')
                     ignore = True
+                    break
             if ignore:
                 continue
 


### PR DESCRIPTION
### Motivation for changes:
Ignoring lines in IRC currently does not work. A `continue` only skips the innermost loop ;)
### Detailed changes:
- Changed from a `continue` to a boolean and moved the skip to after the iteration over all ignored patterns

### Addressed issues:
N/A

### Implemented feature requests:
N/A

### Config usage if relevant (new plugin or updated schema):
None

### Log and/or tests output (preferably both):
There doesn't seem to be any tests for the IRC plugin. I'm by no means a Python developer so I'm probably not the best person to create them. If I've missed them (Or if there's some other good place for me to add a test case for this) then feel free to point it out!

#### To Do:
None
