### PR TITLE
Update sonarr_list.py

### DIFF
--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -148,14 +148,15 @@ class SonarrSet(MutableSet):
                           slug=show.get('titleSlug'),
                           sonarr_id=show.get('id'),
                           configure_series_target=fg_cutoff)
-            if len(fg_qualities) > 1:
-                entry['configure_series_qualities'] = fg_qualities
-            elif len(fg_qualities) == 1:
-                entry['configure_series_quality'] = fg_qualities[0]
-            else:
-                entry['configure_series_quality'] = fg_qualities
-            if path:
-                entry['configure_series_path'] = path
+            if self.config.get('include_data'):
+                if len(fg_qualities) > 1:
+                    entry['configure_series_qualities'] = fg_qualities
+                elif len(fg_qualities) == 1:
+                    entry['configure_series_quality'] = fg_qualities[0]
+                else:
+                    entry['configure_series_quality'] = fg_qualities
+                if path:
+                    entry['configure_series_path'] = path
             if entry.isvalid():
                 log.debug('returning entry %s', entry)
                 entries.append(entry)


### PR DESCRIPTION
configure_series_qulity, configure_series_qualities, and configure_series_path should NOT be altered unless INCLUDE_DATA is TRUE.

### Motivation for changes:
When NOT using INCLUDE_DATA configure_series quality settings do not work.  This is because sonarr_list clears configure_series_quality when not using INCLUDE_DATA
### Detailed changes:
- Add an if statement.