### PR TITLE
New plugin: abort_exists

### DIFF
--- a/flexget/plugins/filter/abort_exists.py
+++ b/flexget/plugins/filter/abort_exists.py
@@ -29,6 +29,7 @@ class PluginAbortExists(object):
             # if pattern matches any entry
             if field not in entry:
                 log.debug('Field %s not found. Skipping.', field)
+                continue
             if abort_re.search(entry[field]):
                 task.abort('An entry contained %s in field %s. Abort!' % (config['regexp'], field))
 

--- a/flexget/plugins/filter/abort_exists.py
+++ b/flexget/plugins/filter/abort_exists.py
@@ -1,0 +1,37 @@
+from __future__ import unicode_literals, division, absolute_import
+import logging
+import re
+
+from flexget import plugin
+from flexget.event import event
+
+log = logging.getLogger('abort_exists')
+
+class PluginAbortExists(object):
+    """Aborts a task if an entry field matches the regexp"""
+
+    schema = {
+        'type': 'object',
+        'properties' : {
+            'regexp': {'type': 'string', 'format': 'regex'},
+            'field': {'type': 'string'}
+        },
+        'required': ['regexp', 'field'],
+        'additionalProperties': False
+    }
+
+    # Execute as the first thing in filter phase
+    @plugin.priority(255)
+    def on_task_filter(self, task, config):
+        abort_re = re.compile(config['regexp'], re.IGNORECASE)
+        field = config['field']
+        for entry in task.all_entries:
+            # if pattern matches any entry
+            if field not in entry:
+                log.debug('Field %s not found. Skipping.', field)
+            if abort_re.search(entry[field]):
+                task.abort('An entry contained %s in field %s. Abort!' % (config['regexp'], field))
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(PluginAbortExists, 'abort_exists', api_ver=2)

--- a/flexget/plugins/filter/abort_if_exists.py
+++ b/flexget/plugins/filter/abort_if_exists.py
@@ -5,9 +5,9 @@ import re
 from flexget import plugin
 from flexget.event import event
 
-log = logging.getLogger('abort_exists')
+log = logging.getLogger('abort_if_exists')
 
-class PluginAbortExists(object):
+class PluginAbortIfExists(object):
     """Aborts a task if an entry field matches the regexp"""
 
     schema = {
@@ -35,4 +35,4 @@ class PluginAbortExists(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginAbortExists, 'abort_exists', api_ver=2)
+    plugin.register(PluginAbortIfExists, 'abort_if_exists', api_ver=2)

--- a/flexget/tests/test_abort_if_exists.py
+++ b/flexget/tests/test_abort_if_exists.py
@@ -8,8 +8,8 @@ class TestAbortIfExists(object):
           global:
             disable: [seen]
             mock:
-              - {title: 'test', location: 'mock://some_file.lftp-get-status}
-              - {title: 'test2', location: 'mock://some_file.mkv}
+              - {title: 'test', location: 'mock://some_file.lftp-get-status'}
+              - {title: 'test2', location: 'mock://some_file.mkv'}
         tasks:
           test_abort:
             abort_if_exists:

--- a/flexget/tests/test_abort_if_exists.py
+++ b/flexget/tests/test_abort_if_exists.py
@@ -1,0 +1,30 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+
+class TestAbortIfExists(object):
+    config = """
+        templates:
+          global:
+            disable: [seen]
+            mock:
+              - {title: 'test', location: 'mock://some_file.lftp-get-status}
+              - {title: 'test2', location: 'mock://some_file.mkv}
+        tasks:
+          test_abort:
+            abort_if_exists:
+              regexp: '.*\.lftp-get-status'
+              field: 'location'
+          test_not_abort:
+            abort_if_exists:
+              regexp: '.*\.lftp-get-status'
+              field: 'title'
+    """
+
+    def test_abort(self, execute_task):
+        task = execute_task('test_abort')
+        assert task.aborted, 'Task should have aborted'
+
+    def test_not_abort(self, execute_task):
+        task = execute_task('test_not_abort')
+        assert not task.aborted, 'Task should have aborted'

--- a/flexget/tests/test_abort_if_exists.py
+++ b/flexget/tests/test_abort_if_exists.py
@@ -22,8 +22,8 @@ class TestAbortIfExists(object):
     """
 
     def test_abort(self, execute_task):
-        task = execute_task('test_abort')
-        assert task.aborted, 'Task should have aborted'
+        with pytest.raises(TaskAbort):
+            task = execute_task('test_abort')
 
     def test_not_abort(self, execute_task):
         task = execute_task('test_not_abort')

--- a/flexget/tests/test_abort_if_exists.py
+++ b/flexget/tests/test_abort_if_exists.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
+import pytest
+
+from flexget.task import TaskAbort
 
 class TestAbortIfExists(object):
     config = """


### PR DESCRIPTION
### Motivation for changes:
I wants it. When using LFTP or another program to download from a remote location, it can ruin a lot if FlexGet moves files before the transfer is completed. A lot of it can be handled by using "incomplete" filenames in LFTP, but there are situations where I want the transfer to be fully completed before moving.

### Detailed changes:
- Added new plugin