### PR TITLE
[fix] bug in rmz.py that caused an error if the entry does not contai…

### DIFF
--- a/flexget/plugins/sites/rmz.py
+++ b/flexget/plugins/sites/rmz.py
@@ -76,7 +76,7 @@ class UrlRewriteRmz(object):
         except Exception as e:
             raise UrlRewritingError(str(e))
         link_elements = soup.find_all('pre', class_='links')
-        if entry['urls']:
+        if 'urls' in entry:
             urls = list(entry['urls'])
         else:
             urls = []


### PR DESCRIPTION
### Motivation for changes:
A bug occurred in rmz.py when an `entry` had no `urls` field.

### Addressed issues:
- Fixes a bug I just recently found.