### PR TITLE
Use 'pycodestyle' in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 license-file = LICENSE
 
-[pep8]
+[pycodestyle]
 ignore = E711,E712,W291,W293,E261,E128
 max-line-length = 120
 


### PR DESCRIPTION
### Motivation for changes:

The latest version of pycodestyle/linter gives continually warnings because `[pep8]` is still used in setup.cfg:
```
/usr/lib/python3/dist-packages/pycodestyle.py:2190: UserWarning: [pep8] section is deprecated. Use [pycodestyle].
  warnings.warn('[pep8] section is deprecated. Use [pycodestyle].')
```

### Detailed changes:
- Changed the appropiate header in setup.cfg

