### PR TITLE
Fixes plugin from exiting entry loop upon first found NFO file

### DIFF
--- a/flexget/plugins/metainfo/nfo_lookup.py
+++ b/flexget/plugins/metainfo/nfo_lookup.py
@@ -53,13 +53,13 @@ class NfoLookup(object):
             # If there is no 'filename' field there is also no nfo file
             if filename is None or location is None:
                 log.warning("Entry %s didn't come from the filesystem plugin", entry.get('title'))
-                return
+                continue
             else:
                 # This will be None if there is no nfo file
                 nfo_filename = self.get_nfo_filename(entry)
                 if nfo_filename is None:
                     log.warning("Entry %s has no corresponding %s file", entry.get('title'), self.nfo_file_extension)
-                    return
+                    continue
 
             # Populate the fields from the information in the .nfo file Note that at this point `nfo_filename` has the
             # name of an existing '.nfo' file


### PR DESCRIPTION
### Motivation for changes:
NFO file lookup plugin would exit after it finding the first NFO file.

### Detailed changes:
- Changed appropriate "return" to "continue" to exit the entry loop, not function.
