### PR TITLE
Additional options for adding Sonarr series

### DIFF
--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -27,9 +27,9 @@ class SonarrSet(MutableSet):
             'include_ended': {'type': 'boolean', 'default': True},
             'only_monitored': {'type': 'boolean', 'default': True},
             'include_data': {'type': 'boolean', 'default': False},
-            'searchForMissingEpisodes': {'type': 'boolean', 'default': True},
-            'ignoreEpisodesWithoutFiles': {'type': 'boolean', 'default': False},
-            'ignoreEpisodesWithFiles': {'type': 'boolean', 'default': False}
+            'search_missing_episodes': {'type': 'boolean', 'default': True},
+            'ignore_episodes_without_files': {'type': 'boolean', 'default': False},
+            'ignore_episodes_with_files': {'type': 'boolean', 'default': False}
         },
         'required': ['api_key', 'base_url'],
         'additionalProperties': False
@@ -196,9 +196,9 @@ class SonarrSet(MutableSet):
         show['profileId'] = 1
         show['qualityProfileId '] = 1
         show['rootFolderPath'] = rootfolder[0]['path']
-        show['addOptions'] = {"ignoreEpisodesWithFiles": self.config.get('ignoreEpisodesWithFiles'),
-                              "ignoreEpisodesWithoutFiles": self.config.get('ignoreEpisodesWithoutFiles'),
-                              "searchForMissingEpisodes": self.config.get('searchForMissingEpisodes')}
+        show['addOptions'] = {"ignoreEpisodesWithFiles": self.config.get('ignore_episodes_with_files'),
+                              "ignoreEpisodesWithoutFiles": self.config.get('ignore_episodes_without_files'),
+                              "searchForMissingEpisodes": self.config.get('search_missing_episodes')}
 
         series_url, series_headers = self.request_builder(self.config.get('base_url'), 'series',
                                                           self.config.get('port'), self.config['api_key'])

--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -26,7 +26,10 @@ class SonarrSet(MutableSet):
             'api_key': {'type': 'string'},
             'include_ended': {'type': 'boolean', 'default': True},
             'only_monitored': {'type': 'boolean', 'default': True},
-            'include_data': {'type': 'boolean', 'default': False}
+            'include_data': {'type': 'boolean', 'default': False},
+            'searchForMissingEpisodes': {'type': 'boolean', 'default': True},
+            'ignoreEpisodesWithoutFiles': {'type': 'boolean', 'default': False},
+            'ignoreEpisodesWithFiles': {'type': 'boolean', 'default': False}
         },
         'required': ['api_key', 'base_url'],
         'additionalProperties': False
@@ -193,6 +196,9 @@ class SonarrSet(MutableSet):
         show['profileId'] = 1
         show['qualityProfileId '] = 1
         show['rootFolderPath'] = rootfolder[0]['path']
+        show['addOptions'] = {"ignoreEpisodesWithFiles": self.config.get('ignoreEpisodesWithFiles'),
+                              "ignoreEpisodesWithoutFiles": self.config.get('ignoreEpisodesWithoutFiles'),
+                              "searchForMissingEpisodes": self.config.get('searchForMissingEpisodes')}
 
         series_url, series_headers = self.request_builder(self.config.get('base_url'), 'series',
                                                           self.config.get('port'), self.config['api_key'])


### PR DESCRIPTION
### Motivation for changes:
Where are no options to add series to Sonarr in unmonitored state.
Sonarr starts searching episodes right after adding.
It's not always good especially if series consist of many seasons.     

### Detailed changes:
- Added `addOptions` to Sonarr POST data.
[Documentation link](https://github.com/Sonarr/Sonarr/wiki/Series#post)

New options have defaults and not affected users configs.


### Config usage if relevant (new plugin or updated schema):
```
    list_add:
      - sonarr_list:
          base_url: '{? sonarr.url ?}'
          port: '{? sonarr.port ?}'
          api_key: '{? sonarr.api ?}'
          ignoreEpisodesWithFiles: False
          ignoreEpisodesWithoutFiles: True
          searchForMissingEpisodes: False
```
### Log and/or tests output (preferably both):
```
2017-09-24 15:08 DEBUG    sonarr_list   Trakt2Sonar     adding show {u'certification': u'TV-MA', u'overview': u"A gritty chronicle of the war against Colombia's most notorious drug cartels.", u'airTime': u'03:00', u'firstAired': u'2015-08-27T21:00:00Z', u'tvRageId': 37241, u'year': 2015, u'images': [{u'coverType': u'fanart', u'url': u'http://thetvdb.com/banners/fanart/original/282670-21.jpg'}, {u'coverType': u'banner', u'url': u'http://thetvdb.com/banners/graphical/282670-g.jpg'}, {u'coverType': u'poster', u'url': u'http://thetvdb.com/banners/posters/282670-13.jpg'}], u'rootFolderPath': u'/data/TV_Shows/', u'ratings': {u'votes': 77, u'value': 8.9}, u'genres': [u'Crime', u'Drama'], u'monitored': True, u'network': u'Netflix', u'title': u'Narcos', u'remotePoster': u'http://thetvdb.com/banners/posters/282670-13.jpg', u'seasonCount': 3, u'seriesType': u'standard', u'status': u'continuing', u'added': u'0001-01-01T00:00:00Z', u'tvdbId': 282670, u'tags': [], u'imdbId': u'tt2707408', u'seasonFolder': False, u'cleanTitle': u'narcos', u'sortTitle': u'narcos', u'seasons': [{u'monitored': False, u'seasonNumber': 0}, {u'monitored': True, u'seasonNumber': 1}, {u'monitored': True, u'seasonNumber': 2}, {u'monitored': True, u'seasonNumber': 3}], u'qualityProfileId ': 1, u'useSceneNumbering': False, u'addOptions': {u'searchForMissingEpisodes': True, u'ignoreEpisodesWithFiles': False, u'ignoreEpisodesWithoutFiles': False}, u'titleSlug': u'narcos', u'qualityProfileId': 0, u'profileId': 1, u'runtime': 50, u'tvMazeId': 2705} to sonarr
2017-09-24 15:08 VERBOSE  sonarr_list   Trakt2Sonar     Successfully added show Narcos to Sonarr

```
#### To Do:

- Need to update [documentation](https://flexget.com/Plugins/List/sonarr_list)

