### PR TITLE
Allow config to specify date format preferences for exists_series

### DIFF
--- a/flexget/plugins/filter/exists_series.py
+++ b/flexget/plugins/filter/exists_series.py
@@ -91,8 +91,8 @@ class FilterExistsSeries(object):
                     try:
                         disk_parser = get_plugin_by_name('parsing').instance.parse_series(data=filename.name,
                                                                                           name=series_parser.name,
-                                                                                          date_dayfirst=config['date_dayfirst'],
-                                                                                          date_yearfirst=config['date_yearfirst'])
+                                                                                          date_dayfirst=config.get('date_dayfirst'),
+                                                                                          date_yearfirst=config.get('date_yearfirst'))
                     except ParseWarning as pw:
                         disk_parser = pw.parsed
                         log_once(pw.value, logger=log)

--- a/flexget/plugins/filter/exists_series.py
+++ b/flexget/plugins/filter/exists_series.py
@@ -33,7 +33,7 @@ class FilterExistsSeries(object):
                 'type': 'object',
                 'properties': {
                     'path': one_or_more({'type': 'string', 'format': 'path'}),
-                    'allow_different_qualities': {'enum': ['better', True, False], 'default': False}
+                    'allow_different_qualities': {'enum': ['better', True, False], 'default': False},
                     'date_dayfirst': {'type': 'boolean', 'default': False},
                     'date_yearfirst': {'type': 'boolean', 'default': False}
                 },

--- a/flexget/plugins/filter/exists_series.py
+++ b/flexget/plugins/filter/exists_series.py
@@ -34,6 +34,8 @@ class FilterExistsSeries(object):
                 'properties': {
                     'path': one_or_more({'type': 'string', 'format': 'path'}),
                     'allow_different_qualities': {'enum': ['better', True, False], 'default': False}
+                    'date_dayfirst': {'type': 'boolean', 'default': False},
+                    'date_yearfirst': {'type': 'boolean', 'default': False}
                 },
                 'required': ['path'],
                 'additionalProperties': False
@@ -88,7 +90,9 @@ class FilterExistsSeries(object):
                     # run parser on filename data
                     try:
                         disk_parser = get_plugin_by_name('parsing').instance.parse_series(data=filename.name,
-                                                                                          name=series_parser.name)
+                                                                                          name=series_parser.name,
+                                                                                          date_dayfirst=config['date_dayfirst'],
+                                                                                          date_yearfirst=config['date_yearfirst'])
                     except ParseWarning as pw:
                         disk_parser = pw.parsed
                         log_once(pw.value, logger=log)


### PR DESCRIPTION
### Motivation for changes:
Series identified by date are stored using YYYY-mm-dd format but when this is processed using default datetime parameters within exists_series it reads files from disc as YYYY-dd-mm thus creating false comparisons. 

This change allows the user to tell exists_series to assume dates are in a specific format on disc. Useful if you rename your series using series_id.

NOTE: this only works on the built in parser, guessit parsing is not influenced by this change

### Detailed changes:
- Added date_dayfirst and date_yearfirst to exists_series plugin

### Addressed issues:
- Fixes exists_series parsing dates as YYYY-dd-mm instead of YYYY-mm-dd

### Config usage if relevant (new plugin or updated schema):
```
    exists_series:
      path: >
        /media/TV/{{ tvdb_series_name|default(series_name,True)|replace('/', '_')|replace(':', ' -')|replace(',', '') }}
      allow_different_qualities: better
      date_dayfirst: False
      date_yearfirst: True
```

