### PR TITLE
add check for libtorrent version 1.1.3 or higher

### DIFF
--- a/flexget/plugins/modify/convert_magnet.py
+++ b/flexget/plugins/modify/convert_magnet.py
@@ -35,7 +35,7 @@ class ConvertMagnet(object):
         params = libtorrent.parse_magnet_uri(magnet_uri)
         session = libtorrent.session()
         lt_version = [int(v) for v in libtorrent.version.split('.')]
-        if lt_version > [0,16,13,0] and lt_version < [1,1,4,0]:
+        if lt_version > [0,16,13,0] and lt_version < [1,1,3,0]:
             # for some reason the info_hash needs to be bytes but it's a struct called sha1_hash
             params['info_hash'] = params['info_hash'].to_bytes()
         handle = libtorrent.add_magnet_uri(session, magnet_uri, params)

--- a/flexget/plugins/modify/convert_magnet.py
+++ b/flexget/plugins/modify/convert_magnet.py
@@ -35,7 +35,7 @@ class ConvertMagnet(object):
         params = libtorrent.parse_magnet_uri(magnet_uri)
         session = libtorrent.session()
         lt_version = [int(v) for v in libtorrent.version.split('.')]
-        if lt_version > [0,16,13,0]:
+        if lt_version > [0,16,13,0] and lt_version < [1,1,4,0]:
             # for some reason the info_hash needs to be bytes but it's a struct called sha1_hash
             params['info_hash'] = params['info_hash'].to_bytes()
         handle = libtorrent.add_magnet_uri(session, magnet_uri, params)


### PR DESCRIPTION
### Motivation for changes:
data type of info_hash has changed in libtorrent 1.1.3

### Detailed changes:
- add check if libtorrent version is less than 1.1.3 and only convert to bytes if the version is between 0.16.13 and 1.1.3

### Addressed issues:
- Fixes #1983 .

### Config usage if relevant (new plugin or updated schema):
```
tasks:
  stage:
    convert_magnet: yes
    rss: http://xxx.xxx/rss
    accept_all: yes
    download:
      path: /home/flexget/test/
```

### Log and/or tests output (preferably both):
```
2017-10-09 16:08 VERBOSE  manager                       Creating new database /home/flexget/test/db-config.sqlite - DO NOT I
NTERUPT ...
2017-10-09 16:08 VERBOSE  task_queue                    There are 1 tasks to execute. Shutdown will commence when they h$
ve completed.                                                                                                            2017-10-09 16:08 VERBOSE  details       stage           Produced 74 entries.
2017-10-09 16:08 INFO     series        stage           identified_by has locked in to type `ep` for Lucifer             2017-10-09 16:08 VERBOSE  task          stage           ACCEPTED: `Lucifer S03E02 1080p HDTV X264 DIMENSION` by series p$
ugin because choosing best available quality                                                                             2017-10-09 16:08 VERBOSE  task          stage           ACCEPTED: `Lucifer S03E01 1080p HDTV X264 DIMENSION` by series p$
ugin because choosing best available quality
2017-10-09 16:08 INFO     convert_magnet stage           Converting entry Lucifer S03E02 1080p HDTV X264 DIMENSION magne$ URI to a torrent file
2017-10-09 16:08 INFO     convert_magnet stage           Converting entry Lucifer S03E01 1080p HDTV X264 DIMENSION magne$
 URI to a torrent file
2017-10-09 16:08 INFO     download      stage           Downloading: Lucifer S03E02 1080p HDTV X264 DIMENSION
2017-10-09 16:08 INFO     download      stage           Downloading: Lucifer S03E01 1080p HDTV X264 DIMENSION
2017-10-09 16:08 VERBOSE  details       stage           Summary - Accepted: 2 (Rejected: 0 Undecided: 72 Failed: 0)
```


### References: 
https://github.com/arvidn/libtorrent/releases/tag/libtorrent-1_1_3
https://github.com/arvidn/libtorrent/commit/2e367ea53b1ce36d42eec73d12056ca4cd8029a4