### PR TITLE
Switch TPB TLD to .org

### DIFF
--- a/flexget/plugins/sites/piratebay.py
+++ b/flexget/plugins/sites/piratebay.py
@@ -15,7 +15,7 @@ from flexget.utils.tools import parse_filesize
 
 log = logging.getLogger('piratebay')
 
-CUR_TLD = 'se'
+CUR_TLD = 'org'
 TLDS = 'com|org|sx|ac|pe|gy|to|se|gd|vg|%s' % CUR_TLD
 
 URL_MATCH = re.compile('^http://(?:torrents\.)?thepiratebay\.(?:%s)/.*$' % TLDS)


### PR DESCRIPTION
### Motivation for changes:
The Pirate Bay TLD is now .org
### Detailed changes:
- Replace .se with .org tld
