### PR TITLE
Fix #1971

### DIFF
--- a/flexget/plugins/internal/api_tvdb.py
+++ b/flexget/plugins/internal/api_tvdb.py
@@ -473,7 +473,7 @@ def find_series_id(name, language=None):
 def _update_search_strings(series, session, search=None):
     search_strings = series.search_strings
     add = [series.name.lower()] + ([a.lower() for a in series.aliases] if series.aliases else []) + [
-        search.lower()] if search else []
+        search.lower()] if search and hasattr(search, 'lower') else []
     for name in set(add):
         if name not in search_strings:
             search_result = session.query(TVDBSearchResult).filter(TVDBSearchResult.search == name).first()


### PR DESCRIPTION
### Motivation for changes:
I have had this local fix for a few weeks now, but without it I hit the exception detailed in #1971 
It looks safe, but I have been curious what the value of `search` could be when truthy and not a string. I'm not a python expert, nor am I familiar with the internals of this project enough to guess.

### Detailed changes:
- I added an extra check

### Addressed issues:
- Fixes #1971 
