### PR TITLE
 Fixed Newpct, new changes in the web format

### DIFF
--- a/flexget/plugins/sites/newpct.py
+++ b/flexget/plugins/sites/newpct.py
@@ -78,6 +78,14 @@ class UrlRewriteNewPCT(object):
                 match = torrent_id_prog.search(torrent_ids[0])
                 if match:
                     torrent_id = match.group(1)
+            if not torrent_id:
+                torrent_id_prog = re.compile('function openTorrent.*\n.*\{.*(\n.*)+window\.location\.href =\s*\".*\/(\d+).*\";')
+                torrent_ids = soup.findAll(text=torrent_id_prog)
+                log.debug('torrent ID not found, searching openTorrent script')
+                if len(torrent_ids):
+                    match = torrent_id_prog.search(torrent_ids[0])
+                    if match:
+                        torrent_id = match.group(2)
 
         if not torrent_id:
             raise UrlRewritingError('Unable to locate torrent ID from url %s' % url)

--- a/flexget/plugins/sites/newpct.py
+++ b/flexget/plugins/sites/newpct.py
@@ -82,7 +82,7 @@ class UrlRewriteNewPCT(object):
                 torrent_id_prog = re.compile('function openTorrent.*\n.*\{.*(\n.*)+window\.location\.href =\s*\".*\/(\d+).*\";')
                 torrent_ids = soup.findAll(text=torrent_id_prog)
                 log.debug('torrent ID not found, searching openTorrent script')
-                if len(torrent_ids):
+                if torrent_ids:
                     match = torrent_id_prog.search(torrent_ids[0])
                     if match:
                         torrent_id = match.group(2)


### PR DESCRIPTION
### Motivation for changes:
Changes in Newpct web: Errors downloading from Newpct, can't find torrentID

### Detailed changes:
- If we can't find torrentID (old way) search into the script openTorrent for the id

