### PR TITLE
Microsoft team notifier added

### DIFF
--- a/flexget/plugins/notifiers/microsoftteams.py
+++ b/flexget/plugins/notifiers/microsoftteams.py
@@ -10,49 +10,47 @@ from flexget.utils.requests import Session as RequestSession
 
 requests = RequestSession(max_retries=3)
 
-__name__ = 'microsoftteams'
+plugin_name = 'ms_teams'
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(plugin_name)
 
-class TeamsNotifier(object):
+
+class MsTeamsNotifier(object):
     """
     Example:
 
-      teams:
-        web_hook_url: <string>
-        [message: <string>]
-        [title: <string>]
-        [themecolor: <string>]
+      notify:
+        entries:
+          via:
+            ms_teams:
+              web_hook_url: <string>
+              [message: <string>]
+              [title: <string>]
+              [theme_color: <string>]
     """
     schema = {
         'type': 'object',
         'properties': {
             'web_hook_url': {'type': 'string'},
-            'message': {'type': 'string'},
             'title': {'type': 'string'},
-            'themecolor': {'type': 'string'},
+            'theme_color': {'type': 'string'},
         },
-        'required': ['web_hook_url', 'message'],
+        'required': ['web_hook_url'],
         'additionalProperties': False
     }
 
     def notify(self, web_hook_url, message, config, title=None, themecolor=None):
         """
         Send notification to Microsoft Teams
-
-        :param str web_hook_url: WebHook Url
-        :param str message: Notification message
-        :param str title: Message title
-        :return:
         """
-
-        notification = {'text': message, 'title': title, 'themecolor': themecolor}
+        notification = {'text': message, 'title': title, 'theme_color': themecolor}
 
         try:
             requests.post(config['web_hook_url'], json=notification)
         except RequestException as e:
             raise PluginWarning(e.args[0])
 
+
 @event('plugin.register')
 def register_plugin():
-    plugin.register(TeamsNotifier, __name__, api_ver=2, groups=['notifiers'])
+    plugin.register(MsTeamsNotifier, plugin_name, api_ver=2, interfaces=['notifiers'])

--- a/flexget/plugins/notifiers/microsoftteams.py
+++ b/flexget/plugins/notifiers/microsoftteams.py
@@ -1,0 +1,58 @@
+from builtins import *
+
+import logging
+
+from flexget import plugin
+from flexget.event import event
+from flexget.plugin import PluginWarning
+from requests.exceptions import RequestException
+from flexget.utils.requests import Session as RequestSession
+
+requests = RequestSession(max_retries=3)
+
+__name__ = 'microsoftteams'
+
+log = logging.getLogger(__name__)
+
+class TeamsNotifier(object):
+    """
+    Example:
+
+      teams:
+        web_hook_url: <string>
+        [message: <string>]
+        [title: <string>]
+        [themecolor: <string>]
+    """
+    schema = {
+        'type': 'object',
+        'properties': {
+            'web_hook_url': {'type': 'string'},
+            'message': {'type': 'string'},
+            'title': {'type': 'string'},
+            'themecolor': {'type': 'string'},
+        },
+        'required': ['web_hook_url', 'message'],
+        'additionalProperties': False
+    }
+
+    def notify(self, web_hook_url, message, config, title=None, themecolor=None):
+        """
+        Send notification to Microsoft Teams
+
+        :param str web_hook_url: WebHook Url
+        :param str message: Notification message
+        :param str title: Message title
+        :return:
+        """
+
+        notification = {'text': message, 'title': title, 'themecolor': themecolor}
+
+        try:
+            requests.post(config['web_hook_url'], json=notification)
+        except RequestException as e:
+            raise PluginWarning(e.args[0])
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(TeamsNotifier, __name__, api_ver=2, groups=['notifiers'])


### PR DESCRIPTION
### Motivation for changes:
Added support for sending notifications to Microsoft Teams
### Detailed changes:
- 

### Addressed issues:
- Fixes # .

### Implemented feature requests:
- Feathub #[XX](https://feathub.com/Flexget/Flexget/+XX).

### Config usage if relevant (new plugin or updated schema):
```
    notify:
      entries:
        via:
          - microsoftteams:
              web_hook_url: http://example.com
              title: 'Flexget'
```
### Log and/or tests output (preferably both):
```
paste output here
```
#### To Do:

- [ ] Stuff..

