### PR TITLE
Added fast_resume option for rtorrent

### DIFF
--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -638,12 +638,13 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
                 files = []
 
                 for f in entry['torrent'].get_filelist():
+                    file_path = os.path.join(base, os.path.join(f['path'], f['name']))
                     # TODO should it simply add the torrent anyway?
-                    if not os.path.exists(f['path']):
+                    if not os.path.exists(file_path) and not os.path.isfile(file_path):
                         entry.fail('Not a local file. Cannot add fast resume data.')
                         return
                     # cannot bencode floats, so we need to coerce to int
-                    mtime = int(os.path.getmtime(os.path.join(base, f['path'])))
+                    mtime = int(os.path.getmtime(file_path))
                     files.append({'priority': 0, 'mtime': mtime})
 
                 entry['torrent'].set_libtorrent_resume(chunks, files)

--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -339,6 +339,9 @@ class RTorrent(object):
 
         return result
 
+    def get_directory(self):
+        return self._server.get_directory()
+
     def torrent(self, info_hash, fields=None):
         """ Get the details of a torrent """
         info_hash = native_str(info_hash)
@@ -417,8 +420,7 @@ class RTorrentPluginBase(object):
     def _build_options(self, config, entry, entry_first=True):
         options = {}
 
-        for opt_key in ('path', 'message', 'priority',
-                        'custom1', 'custom2', 'custom3', 'custom4', 'custom5'):
+        for opt_key in ('path', 'message', 'priority', 'custom1', 'custom2', 'custom3', 'custom4', 'custom5'):
             # Values do not merge config with task
             # Task takes priority then config is used
             entry_value = entry.get(opt_key)
@@ -485,6 +487,7 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
             'custom3': {'type': 'string'},
             'custom4': {'type': 'string'},
             'custom5': {'type': 'string'},
+            'fast_resume': {'type': 'boolean', 'default': False}
         },
         'required': ['uri'],
         'additionalProperties': False,
@@ -528,7 +531,10 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
                     entry.fail("failed to render properties %s" % str(e))
                     continue
 
-                self.add_entry(client, entry, options, start=config['start'], mkdir=config['mkdir'])
+                # fast_resume is not really an rtorrent option so it's not in _build_options
+                fast_resume = entry.get('fast_resume', config['fast_resume'])
+                self.add_entry(client, entry, options, start=config['start'], mkdir=config['mkdir'],
+                               fast_resume=fast_resume)
 
             info_hash = entry.get('torrent_info_hash')
 
@@ -598,7 +604,7 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
             entry.fail('Failed to update: %s' % str(e))
             return
 
-    def add_entry(self, client, entry, options, start=True, mkdir=False):
+    def add_entry(self, client, entry, options, start=True, mkdir=False, fast_resume=False):
 
         if 'torrent_info_hash' not in entry:
             entry.fail('missing torrent_info_hash')
@@ -621,6 +627,29 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
                 entry.fail("Downloaded temp file '%s' is not a torrent file" % entry['file'])
                 return
 
+            # Modify the torrent with resume data if needed
+            if fast_resume:
+                base = options.get('directory')
+                if not base:
+                    base = client.get_directory()
+
+                piece_size = entry['torrent'].piece_size
+                chunks = int((entry['torrent'].size + piece_size - 1) / piece_size)
+                files = []
+
+                for f in entry['torrent'].get_filelist():
+                    # TODO should it simply add the torrent anyway?
+                    if not os.path.exists(f['path']):
+                        entry.fail('Not a local file. Cannot add fast resume data.')
+                        return
+                    # cannot bencode floats, so we need to coerce to int
+                    mtime = int(os.path.getmtime(os.path.join(base, f['path'])))
+                    files.append({'priority': 0, 'mtime': mtime})
+
+                entry['torrent'].set_libtorrent_resume(chunks, files)
+                # Since we modified the torrent, we need to write it to entry['file'] again
+                with open(entry['file'], 'wb+') as f:
+                    f.write(entry['torrent'].encode())
             try:
                 with open(entry['file'], 'rb') as f:
                     torrent_raw = f.read()

--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -644,10 +644,11 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
                     file_path = os.path.join(base, relative_file_path)
                     # TODO should it simply add the torrent anyway?
                     if not os.path.exists(file_path) and not os.path.isfile(file_path):
-                        entry.fail('Not a local file. Cannot add fast resume data.')
+                        entry.fail('%s does not exist. Cannot add fast resume data.' % file_path)
                         return
                     # cannot bencode floats, so we need to coerce to int
                     mtime = int(os.path.getmtime(file_path))
+                    # priority 0 should be "don't download"
                     files.append({'priority': 0, 'mtime': mtime})
 
                 entry['torrent'].set_libtorrent_resume(chunks, files)

--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -638,7 +638,10 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
                 files = []
 
                 for f in entry['torrent'].get_filelist():
-                    file_path = os.path.join(base, os.path.join(f['path'], f['name']))
+                    relative_file_path = os.path.join(f['path'], f['name'])
+                    if entry['torrent'].is_multi_file:
+                        relative_file_path = os.path.join(entry['torrent'].name, relative_file_path)
+                    file_path = os.path.join(base, relative_file_path)
                     # TODO should it simply add the torrent anyway?
                     if not os.path.exists(file_path) and not os.path.isfile(file_path):
                         entry.fail('Not a local file. Cannot add fast resume data.')

--- a/flexget/utils/bittorrent.py
+++ b/flexget/utils/bittorrent.py
@@ -188,7 +188,7 @@ def bencode(data):
     if isinstance(data, dict):
         return encode_dictionary(data)
 
-    raise TypeError
+    raise TypeError('Unknown type for bencode: ' + str(type(data)))
 
 
 class Torrent(object):
@@ -305,6 +305,20 @@ class Torrent(object):
     @comment.setter
     def comment(self, comment):
         self.content['comment'] = comment
+        self.modified = True
+
+    @property
+    def piece_size(self):
+        return int(self.content['info']['piece length'])
+
+    @property
+    def libtorrent_resume(self):
+        return self.content.get('libtorrent_resume', {})
+
+    def set_libtorrent_resume(self, chunks, files):
+        self.content['libtorrent_resume'] = {}
+        self.content['libtorrent_resume']['bitfield'] = chunks
+        self.content['libtorrent_resume']['files'] = files
         self.modified = True
 
     def remove_multitracker(self, tracker):


### PR DESCRIPTION
### Motivation for changes:
Fast resume saves a lot of CPU cycles

### Detailed changes:
- Added `fast_resume` option that adds resume data to a .torrent. **Note: it only works if flexget has direct access to the files**
