### PR TITLE
Parser cache

### DIFF
--- a/flexget/plugins/parsers/parser_internal.py
+++ b/flexget/plugins/parsers/parser_internal.py
@@ -19,18 +19,25 @@ from .parser_common import ParseWarning
 log = logging.getLogger('parser_internal')
 
 series_parser_cache = lru_cache()(SeriesParser)
+movie_parser_cache = lru_cache()(MovieParser)
 
 
 def series_parser_factory(**kwargs):
     """Returns a series parser from the cache, or creates one."""
-    if not kwargs.get('name'):
-        # Don't cache parsing calls that aren't for a specific series (e.g. from metainfo_series or series_premiere)
-        return SeriesParser(**kwargs)
     # Turn our list arguments to tuples so that they are hashable by lru_cache
     for key, val in kwargs.items():
         if isinstance(val, list):
             kwargs[key] = tuple(val)
     return series_parser_cache(**kwargs)
+
+
+def movie_parser_factory(**kwargs):
+    """Returns a series parser from the cache, or creates one."""
+    # Turn our list arguments to tuples so that they are hashable by lru_cache
+    for key, val in kwargs.items():
+        if isinstance(val, list):
+            kwargs[key] = tuple(val)
+    return movie_parser_cache(**kwargs)
 
 
 class ParserInternal(object):
@@ -40,7 +47,7 @@ class ParserInternal(object):
     def parse_movie(self, data, **kwargs):
         log.debug('Parsing movie: `%s` kwargs: %s', data, kwargs)
         start = time.clock()
-        parser = MovieParser()
+        parser = movie_parser_factory(**kwargs)
         try:
             parser.parse(data)
         except ParseWarning as pw:

--- a/flexget/plugins/parsers/parser_internal.py
+++ b/flexget/plugins/parsers/parser_internal.py
@@ -18,8 +18,8 @@ from .parser_common import ParseWarning
 
 log = logging.getLogger('parser_internal')
 
-series_parser_cache = lru_cache()(SeriesParser)
-movie_parser_cache = lru_cache()(MovieParser)
+series_parser_cache = lru_cache(maxsize=256)(SeriesParser)
+movie_parser_cache = lru_cache(maxsize=256)(MovieParser)
 
 
 def series_parser_factory(**kwargs):

--- a/flexget/utils/titles/series.py
+++ b/flexget/utils/titles/series.py
@@ -107,7 +107,7 @@ class SeriesParser(TitleParser):
         """
 
         self.name = name
-        self.alternate_names = alternate_names or []
+        self.alternate_names = list(alternate_names or ())
         self.data = ''
         self.identified_by = identified_by
         # Stores the type of identifier found, 'ep', 'date', 'sequence' or 'special'
@@ -118,7 +118,9 @@ class SeriesParser(TitleParser):
         for mode in ID_TYPES:
             listname = mode + '_regexps'
             if locals()[listname]:
-                setattr(self, listname, ReList(locals()[listname] + getattr(SeriesParser, listname)))
+                newrelist = ReList(locals()[listname])
+                newrelist.extend(getattr(SeriesParser, listname))
+                setattr(self, listname, newrelist)
         self.specials = self.specials + [i.lower() for i in (special_ids or [])]
         self.prefer_specials = prefer_specials
         self.assume_special = assume_special

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,4 @@ urllib3==1.22           # via requests
 webencodings==0.5.1       # via html5lib
 werkzeug==0.12.2          # via flask
 zxcvbn-python==4.4.15
+backports.functools_lru_cache==1.4; python_version <= '2.7'


### PR DESCRIPTION
### Motivation for changes:
Reduce compute by caching internal parser using lru cache

Tests on 100 entries show a speedup of 3x with multiple tasks.
