### PR TITLE
[symlink] Support Jinja2 templating for "to" field

### DIFF
--- a/flexget/plugins/output/symlink.py
+++ b/flexget/plugins/output/symlink.py
@@ -6,6 +6,7 @@ import os
 
 from flexget import plugin
 from flexget.event import event
+from flexget.utils.template import render_from_entry, RenderError
 
 log = logging.getLogger('symlink')
 
@@ -51,6 +52,12 @@ class Symlink(object):
             lnkfrom = entry['location']
             name = os.path.basename(lnkfrom)
             lnkto = os.path.join(config['to'], name)
+            try:
+                lnkto = render_from_entry(lnkto, entry)
+            except RenderError as error:
+                log.error('Could not render path: %s', lnkto)
+                entry.fail(str(error))
+                return
             # Hardlinks for dirs will not be failed here
             if os.path.exists(lnkto) and (config['link_type'] == 'soft' or os.path.isfile(lnkfrom)):
                 msg = 'Symlink destination %s already exists' % lnkto


### PR DESCRIPTION
This is on par with "decompress" plugin.

### Motivation for changes:
I would like to inject data into path while making hard links.

### Config usage if relevant (new plugin or updated schema):
```
symlink:
      to: '/home/user/{{ variable }}'
```

Tested ✅ 
