### PR TITLE
Trakt to Sonarr plugin: Add couple more options.

### DIFF
--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -33,7 +33,7 @@ class SonarrSet(MutableSet):
             'profile_id': {'type': 'integer', 'default': 1},
             'season_folder': {'type': 'boolean', 'default': False},
             'monitored': {'type': 'boolean', 'default': True},
-            'root_folder_path': {'type': 'integer', 'default': 1}, # Users are passing actual rootFolderPath ID (number (integer) starting from 1 and going up) as apposed to an number (integer) system starting from 0. Read comment on show['rootFolderPath'] for more information.
+            'root_folder_path': {'type': 'integer', 'default': 1}, # Users are passing actual rootFolderPath ID (number (integer) starting from 1 and going up) as apposed to an number (integer) system starting from 0. Passing root_folder_path as a string seems to make the script fail, so that's why it's coded as an integerinstead. Read comment on show['rootFolderPath'] for more information.
             'series_type': {'type': 'string', 'enum': ['standard', 'daily', 'anime'], 'default': 'standard'},
             'tags': {'type': 'array', 'items': {'type': 'integer'}, 'default': [0]}
         },

--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -29,7 +29,10 @@ class SonarrSet(MutableSet):
             'include_data': {'type': 'boolean', 'default': False},
             'search_missing_episodes': {'type': 'boolean', 'default': True},
             'ignore_episodes_without_files': {'type': 'boolean', 'default': False},
-            'ignore_episodes_with_files': {'type': 'boolean', 'default': False}
+            'ignore_episodes_with_files': {'type': 'boolean', 'default': False},
+            'profile_id': {'type': 'number', 'default': 1},
+            'season_folder': {'type': 'boolean', 'default': False},
+            'monitored': {'type': 'boolean', 'default': True}
         },
         'required': ['api_key', 'base_url'],
         'additionalProperties': False
@@ -193,8 +196,10 @@ class SonarrSet(MutableSet):
         rootfolder = self.get_json(rootfolder_series_url, headers=rootfolder_series_headers)
 
         # Setting defaults for Sonarr
-        show['profileId'] = 1
-        show['qualityProfileId '] = 1
+        show['profileId'] = self.config.get('profile_id')
+        show['qualityProfileId'] = self.config.get('profile_id')
+        show['seasonFolder'] = self.config.get('season_folder')
+        show['monitored'] = self.config.get('monitored')
         show['rootFolderPath'] = rootfolder[0]['path']
         show['addOptions'] = {"ignoreEpisodesWithFiles": self.config.get('ignore_episodes_with_files'),
                               "ignoreEpisodesWithoutFiles": self.config.get('ignore_episodes_without_files'),

--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -32,7 +32,8 @@ class SonarrSet(MutableSet):
             'ignore_episodes_with_files': {'type': 'boolean', 'default': False},
             'profile_id': {'type': 'number', 'default': 1},
             'season_folder': {'type': 'boolean', 'default': False},
-            'monitored': {'type': 'boolean', 'default': True}
+            'monitored': {'type': 'boolean', 'default': True},
+            'rootFolderPath': {'type': 'number', 'default': 1}
         },
         'required': ['api_key', 'base_url'],
         'additionalProperties': False
@@ -200,7 +201,7 @@ class SonarrSet(MutableSet):
         show['qualityProfileId'] = self.config.get('profile_id')
         show['seasonFolder'] = self.config.get('season_folder')
         show['monitored'] = self.config.get('monitored')
-        show['rootFolderPath'] = rootfolder[0]['path']
+        show['rootFolderPath'] = rootfolder[self.config.get('rootFolderPath') - 1]['path']
         show['addOptions'] = {"ignoreEpisodesWithFiles": self.config.get('ignore_episodes_with_files'),
                               "ignoreEpisodesWithoutFiles": self.config.get('ignore_episodes_without_files'),
                               "searchForMissingEpisodes": self.config.get('search_missing_episodes')}

--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -33,7 +33,7 @@ class SonarrSet(MutableSet):
             'profile_id': {'type': 'number', 'default': 1},
             'season_folder': {'type': 'boolean', 'default': False},
             'monitored': {'type': 'boolean', 'default': True},
-            'rootFolderPath': {'type': 'number', 'default': 1}
+            'root_folder_path': {'type': 'number', 'default': 1}
         },
         'required': ['api_key', 'base_url'],
         'additionalProperties': False
@@ -201,7 +201,7 @@ class SonarrSet(MutableSet):
         show['qualityProfileId'] = self.config.get('profile_id')
         show['seasonFolder'] = self.config.get('season_folder')
         show['monitored'] = self.config.get('monitored')
-        show['rootFolderPath'] = rootfolder[self.config.get('rootFolderPath') - 1]['path']
+        show['rootFolderPath'] = rootfolder[self.config.get('root_folder_path') - 1]['path']
         show['addOptions'] = {"ignoreEpisodesWithFiles": self.config.get('ignore_episodes_with_files'),
                               "ignoreEpisodesWithoutFiles": self.config.get('ignore_episodes_without_files'),
                               "searchForMissingEpisodes": self.config.get('search_missing_episodes')}

--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -30,11 +30,11 @@ class SonarrSet(MutableSet):
             'search_missing_episodes': {'type': 'boolean', 'default': True},
             'ignore_episodes_without_files': {'type': 'boolean', 'default': False},
             'ignore_episodes_with_files': {'type': 'boolean', 'default': False},
-            'profile_id': {'type': 'number', 'default': 1},
+            'profile_id': {'type': 'integer', 'default': 1},
             'season_folder': {'type': 'boolean', 'default': False},
             'monitored': {'type': 'boolean', 'default': True},
-            'root_folder_path': {'type': 'number', 'default': 1},
-            'series_type': {'type': 'string', 'default': 'standard'}
+            'root_folder_path': {'type': 'integer', 'default': 1},
+            'series_type': {'type': 'string', 'enum': ['standard', 'daily', 'anime'], 'default': 'standard'}
         },
         'required': ['api_key', 'base_url'],
         'additionalProperties': False

--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -208,7 +208,7 @@ class SonarrSet(MutableSet):
         show['monitored'] = self.config.get('monitored')
         show['seriesType'] = self.config.get('series_type')
         show['tags'] = self.config.get('tags')
-        # Requires both rootFolderPath and path otherwise it fails.
+        # Requires both rootFolder and path otherwise it fails.
         # takes root_folder_path ID from config and subtracts 1 from it due to how script is setup
         # since users are passing actual ID it won't be confusing to users
         show['rootFolderPath'] = rootfolder[self.config.get('root_folder_path') - 1]['path'] 

--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -34,7 +34,8 @@ class SonarrSet(MutableSet):
             'season_folder': {'type': 'boolean', 'default': False},
             'monitored': {'type': 'boolean', 'default': True},
             'root_folder_path': {'type': 'integer', 'default': 1},
-            'series_type': {'type': 'string', 'enum': ['standard', 'daily', 'anime'], 'default': 'standard'}
+            'series_type': {'type': 'string', 'enum': ['standard', 'daily', 'anime'], 'default': 'standard'},
+            'tags': {'type': 'array', 'items': {'type': 'integer'}, 'default': [0]}
         },
         'required': ['api_key', 'base_url'],
         'additionalProperties': False
@@ -203,6 +204,7 @@ class SonarrSet(MutableSet):
         show['seasonFolder'] = self.config.get('season_folder')
         show['monitored'] = self.config.get('monitored')
         show['seriesType'] = self.config.get('series_type')
+        show['tags'] = self.config.get('tags')
         show['rootFolderPath'] = rootfolder[self.config.get('root_folder_path') - 1]['path']
         show['addOptions'] = {"ignoreEpisodesWithFiles": self.config.get('ignore_episodes_with_files'),
                               "ignoreEpisodesWithoutFiles": self.config.get('ignore_episodes_without_files'),

--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -33,7 +33,7 @@ class SonarrSet(MutableSet):
             'profile_id': {'type': 'integer', 'default': 1},
             'season_folder': {'type': 'boolean', 'default': False},
             'monitored': {'type': 'boolean', 'default': True},
-            'root_folder_path': {'type': 'integer', 'default': 1},
+            'root_folder_path': {'type': 'integer', 'default': 1}, # Users are passing actual rootFolderPath ID as apposed to an number (integer) system starting from 0. Read comment on show['rootFolderPath'] for more information.
             'series_type': {'type': 'string', 'enum': ['standard', 'daily', 'anime'], 'default': 'standard'},
             'tags': {'type': 'array', 'items': {'type': 'integer'}, 'default': [0]}
         },
@@ -205,7 +205,7 @@ class SonarrSet(MutableSet):
         show['monitored'] = self.config.get('monitored')
         show['seriesType'] = self.config.get('series_type')
         show['tags'] = self.config.get('tags')
-        show['rootFolderPath'] = rootfolder[self.config.get('root_folder_path') - 1]['path']
+        show['rootFolderPath'] = rootfolder[self.config.get('root_folder_path') - 1]['path'] # Requires both rootFolderPath and path otherwise it fails, takes root_folder_path ID from config and subtracts 1 from it to due to how script is setup (users are passing actual ID so it won't be confusing to users), code may/will only seem confusing to people who look at it from behind the scenes.
         show['addOptions'] = {"ignoreEpisodesWithFiles": self.config.get('ignore_episodes_with_files'),
                               "ignoreEpisodesWithoutFiles": self.config.get('ignore_episodes_without_files'),
                               "searchForMissingEpisodes": self.config.get('search_missing_episodes')}

--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -33,7 +33,7 @@ class SonarrSet(MutableSet):
             'profile_id': {'type': 'integer', 'default': 1},
             'season_folder': {'type': 'boolean', 'default': False},
             'monitored': {'type': 'boolean', 'default': True},
-            # Users are passing actual RootFolderPath ID instead of starting from 0 and counting up. 
+            # Users are passing actual RootFolderPath ID instead of starting from 0 and counting up.
             # Passing root_folder_path as a String seems to make the script fail, so had to use int instead.
             # Read comment on show['rootFolderPath'] for more information.
             'root_folder_path': {'type': 'integer', 'default': 1},
@@ -211,7 +211,7 @@ class SonarrSet(MutableSet):
         # Requires both rootFolder and path otherwise it fails.
         # takes root_folder_path ID from config and subtracts 1 from it due to how script is setup
         # since users are passing actual ID it won't be confusing to users
-        show['rootFolderPath'] = rootfolder[self.config.get('root_folder_path') - 1]['path'] 
+        show['rootFolderPath'] = rootfolder[self.config.get('root_folder_path') - 1]['path']
         show['addOptions'] = {"ignoreEpisodesWithFiles": self.config.get('ignore_episodes_with_files'),
                               "ignoreEpisodesWithoutFiles": self.config.get('ignore_episodes_without_files'),
                               "searchForMissingEpisodes": self.config.get('search_missing_episodes')}

--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -33,7 +33,7 @@ class SonarrSet(MutableSet):
             'profile_id': {'type': 'integer', 'default': 1},
             'season_folder': {'type': 'boolean', 'default': False},
             'monitored': {'type': 'boolean', 'default': True},
-            'root_folder_path': {'type': 'integer', 'default': 1}, # Users are passing actual rootFolderPath ID as apposed to an number (integer) system starting from 0. Read comment on show['rootFolderPath'] for more information.
+            'root_folder_path': {'type': 'integer', 'default': 1}, # Users are passing actual rootFolderPath ID (number (integer) starting from 1 and going up) as apposed to an number (integer) system starting from 0. Read comment on show['rootFolderPath'] for more information.
             'series_type': {'type': 'string', 'enum': ['standard', 'daily', 'anime'], 'default': 'standard'},
             'tags': {'type': 'array', 'items': {'type': 'integer'}, 'default': [0]}
         },

--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -33,7 +33,8 @@ class SonarrSet(MutableSet):
             'profile_id': {'type': 'number', 'default': 1},
             'season_folder': {'type': 'boolean', 'default': False},
             'monitored': {'type': 'boolean', 'default': True},
-            'root_folder_path': {'type': 'number', 'default': 1}
+            'root_folder_path': {'type': 'number', 'default': 1},
+            'series_type': {'type': 'string', 'default': 'standard'}
         },
         'required': ['api_key', 'base_url'],
         'additionalProperties': False
@@ -201,6 +202,7 @@ class SonarrSet(MutableSet):
         show['qualityProfileId'] = self.config.get('profile_id')
         show['seasonFolder'] = self.config.get('season_folder')
         show['monitored'] = self.config.get('monitored')
+        show['seriesType'] = self.config.get('series_type')
         show['rootFolderPath'] = rootfolder[self.config.get('root_folder_path') - 1]['path']
         show['addOptions'] = {"ignoreEpisodesWithFiles": self.config.get('ignore_episodes_with_files'),
                               "ignoreEpisodesWithoutFiles": self.config.get('ignore_episodes_without_files'),

--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -33,7 +33,10 @@ class SonarrSet(MutableSet):
             'profile_id': {'type': 'integer', 'default': 1},
             'season_folder': {'type': 'boolean', 'default': False},
             'monitored': {'type': 'boolean', 'default': True},
-            'root_folder_path': {'type': 'integer', 'default': 1}, # Users are passing actual rootFolderPath ID (number (integer) starting from 1 and going up) as apposed to an number (integer) system starting from 0. Passing root_folder_path as a string seems to make the script fail, so that's why it's coded as an integerinstead. Read comment on show['rootFolderPath'] for more information.
+            # Users are passing actual RootFolderPath ID instead of starting from 0 and counting up. 
+            # Passing root_folder_path as a String seems to make the script fail, so had to use int instead.
+            # Read comment on show['rootFolderPath'] for more information.
+            'root_folder_path': {'type': 'integer', 'default': 1},
             'series_type': {'type': 'string', 'enum': ['standard', 'daily', 'anime'], 'default': 'standard'},
             'tags': {'type': 'array', 'items': {'type': 'integer'}, 'default': [0]}
         },
@@ -205,7 +208,10 @@ class SonarrSet(MutableSet):
         show['monitored'] = self.config.get('monitored')
         show['seriesType'] = self.config.get('series_type')
         show['tags'] = self.config.get('tags')
-        show['rootFolderPath'] = rootfolder[self.config.get('root_folder_path') - 1]['path'] # Requires both rootFolderPath and path otherwise it fails, takes root_folder_path ID from config and subtracts 1 from it to due to how script is setup (users are passing actual ID so it won't be confusing to users), code may/will only seem confusing to people who look at it from behind the scenes.
+        # Requires both rootFolderPath and path otherwise it fails.
+        # takes root_folder_path ID from config and subtracts 1 from it due to how script is setup
+        # since users are passing actual ID it won't be confusing to users
+        show['rootFolderPath'] = rootfolder[self.config.get('root_folder_path') - 1]['path'] 
         show['addOptions'] = {"ignoreEpisodesWithFiles": self.config.get('ignore_episodes_with_files'),
                               "ignoreEpisodesWithoutFiles": self.config.get('ignore_episodes_without_files'),
                               "searchForMissingEpisodes": self.config.get('search_missing_episodes')}


### PR DESCRIPTION
### Motivation for changes:

Adding more options to the sonarr plugin for Trakt to sonarr

### Detailed changes:
- Added option to set quality profile ID (defaults to 1/any) -- You can find quality profile/profile ID at http://localhost:8989/api/profile?apikey=APIKEY
- Added option to set season folder -- True/False (Default is False)
- Added option to set monitored status of whole series -- True/False (Default is True)

*** NOTE
One thing I don't understand is the why there is a profileId and a qualityProfileId as it seems only the profileId actually does anything, but I'm leaving it in as it seems it's part of the API call anyways versus profileId not being any part of the Sonarr API..

EDIT:

- Added option to set rootfolderpath -- The way I had to set this up was that it uses the ID instead of a string path (as I couldn't get string paths to work for some reason) and it would take the number from "rootFolderPath" config and subtract it by 1 due to how things are currently programs in the sonarr.py script, so 1 = 0, 2 = 1, so on and so forth. (Defaults to 1) You can find the rootFolder ID here http://localhost:8989/api/rootfolder?apikey=APIKEY

Sadly the way I had to setup rootFolderPath means you have to already have 1 or more rootFolderPaths already created in sonarr for this option to work.

EDIT2:

- Added Option for seriesType, string value of standard, daily, or anime. (default value is standard)