### PR TITLE
Changes how root_folder_path option is setup

### DIFF
--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -33,10 +33,7 @@ class SonarrSet(MutableSet):
             'profile_id': {'type': 'integer', 'default': 1},
             'season_folder': {'type': 'boolean', 'default': False},
             'monitored': {'type': 'boolean', 'default': True},
-            # Users are passing actual RootFolderPath ID instead of starting from 0 and counting up.
-            # Passing root_folder_path as a String seems to make the script fail, so had to use int instead.
-            # Read comment on show['rootFolderPath'] for more information.
-            'root_folder_path': {'type': 'integer', 'default': 1},
+            'root_folder_path': {'type': 'string'},
             'series_type': {'type': 'string', 'enum': ['standard', 'daily', 'anime'], 'default': 'standard'},
             'tags': {'type': 'array', 'items': {'type': 'integer'}, 'default': [0]}
         },
@@ -208,10 +205,7 @@ class SonarrSet(MutableSet):
         show['monitored'] = self.config.get('monitored')
         show['seriesType'] = self.config.get('series_type')
         show['tags'] = self.config.get('tags')
-        # Requires both rootFolder and path otherwise it fails.
-        # takes root_folder_path ID from config and subtracts 1 from it due to how script is setup
-        # since users are passing actual ID it won't be confusing to users
-        show['rootFolderPath'] = rootfolder[self.config.get('root_folder_path') - 1]['path']
+        show['rootFolderPath'] = self.config.get('root_folder_path', rootfolder[0]['path'])
         show['addOptions'] = {"ignoreEpisodesWithFiles": self.config.get('ignore_episodes_with_files'),
                               "ignoreEpisodesWithoutFiles": self.config.get('ignore_episodes_without_files'),
                               "searchForMissingEpisodes": self.config.get('search_missing_episodes')}


### PR DESCRIPTION
### Motivation for changes:
None really lol
### Detailed changes:
- Changes how root_folder_path config option is setup. Now uses string value instead of an integer. Defaults to using an integer if no value is passed in config.
- Removed comments on old root_folder_path setup.

