### PR TITLE
sonarr list refactor

### DIFF
--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -187,11 +187,11 @@ class SonarrSet(MutableSet):
         return self._shows
 
     def _find_entry(self, entry, filters=True):
-        for sb_entry in self.shows(filters=filters):
-            if any(entry.get(id) is not None and entry[id] == sb_entry[id] for id in self.supported_ids):
-                return sb_entry
-            if entry.get('title').lower() == sb_entry.get('title').lower():
-                return sb_entry
+        for show in self.shows(filters=filters):
+            if any(entry.get(id) is not None and entry[id] == show[id] for id in self.supported_ids):
+                return show
+            if entry.get('title').lower() == show.get('title').lower():
+                return show
 
     def _from_iterable(self, it):
         # TODO: is this the right answer? the returned object won't have our custom __contains__ logic


### PR DESCRIPTION
### Motivation for changes:
sonarr_list code was old and sucky. Also a bugfix
### Detailed changes:
- Added ability to bypass filters when listing all entries. It was needed when adding or removing a show in order to get the unfiltered list of shows
- Made `base_url` default to `'http://localhost` and made it not required
- Refactor and tweaks

### Addressed issues:
- Fixes #2041 

