### PR TITLE
IFTTT notifications

### DIFF
--- a/flexget/plugins/notifiers/ifttt.py
+++ b/flexget/plugins/notifiers/ifttt.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
-from future.utils import text_to_native_str
 
 import logging
 

--- a/flexget/plugins/notifiers/ifttt.py
+++ b/flexget/plugins/notifiers/ifttt.py
@@ -10,7 +10,6 @@ from flexget.utils.requests import Session
 from flexget.plugin import PluginWarning
 
 from requests.exceptions import RequestException
-from types import StringTypes
 
 plugin_name = 'ifttt'
 log = logging.getLogger(plugin_name)
@@ -83,7 +82,7 @@ class IFTTTNotifier(object):
             raise PluginWarning("Failed to send notifications")
 
     def prepare_config(self, config):
-        if isinstance(config['keys'], StringTypes):
+        if not isinstance(config['keys'], list):
             config['keys'] = [config['keys']]
         return config
 

--- a/flexget/plugins/notifiers/ifttt.py
+++ b/flexget/plugins/notifiers/ifttt.py
@@ -7,7 +7,7 @@ from flexget import plugin
 from flexget.config_schema import one_or_more
 from flexget.event import event
 from flexget.utils.requests import Session
-from requests.exceptions import HTTPError
+from requests.exceptions import RequestError
 
 plugin_name = 'ifttt'
 log = logging.getLogger(plugin_name)
@@ -65,18 +65,13 @@ class IFTTTNotifier(object):
         :param str title: message subject
         :param dict config: plugin config
         """
-        notification_body = dict()
-        notification_body['value1'] = title
-        notification_body['value2'] = message
+        notification_body = {'value1': title, 'value2': message}
         for key in config['keys']:
             url = self.url_template.format(config['event'], key)
             try:
-                res = self.session.post(url, json = notification_body)
-                if res.ok:
-                    log.info("Sent notification to key: {}".format(key))
-                else:
-                    log.error("Error sending to: {}: {} {} -- {}".format(url, res.status_code, res.reason, res.text))
-            except HTTPError as e:
+                res = self.session.post(url, json=notification_body)
+                log.info("Sent notification to key: {}".format(key))
+            except RequestError as e:
                 log.error("Error sending to {}: {}".format(url, e))
 
 

--- a/flexget/plugins/notifiers/ifttt.py
+++ b/flexget/plugins/notifiers/ifttt.py
@@ -74,10 +74,10 @@ class IFTTTNotifier(object):
             url = self.url_template.format(config['event'], key)
             try:
                 self.session.post(url, json=notification_body)
-                log.info("Sent notification to key: {}".format(key))
+                log.info("Sent notification to key: %s", key)
             except RequestException as e:
-                log.error("Error sending notification to key {}: {} ".format(key, e))
-                errors += 1
+                log.error("Error sending notification to key %s: %s", key, e)
+                errors = True
         if errors:
             raise PluginWarning("Failed to send notifications")
 


### PR DESCRIPTION
Notification plugin to send notification to ifttt.com's webhook service.
(https://ifttt.com/maker_webhooks)

### Motivation for changes:
Adds a simple notification plugin to send the notification to IFTTT webhook trigger that then can be used
in an IFTTT applet.

### Config usage if relevant (new plugin or updated schema):
```
notify:
  task:
    via:
      - ifttt:
          keys:
            - some api key
            - other api key
          event: test
```
### Log and/or tests output (preferably both):
```
2018-01-02 13:53 INFO     ifttt         notify_download Sent notification to key: some_valid_api_key
2018-01-02 13:53 ERROR    ifttt         notify_download Error sending to https://maker.ifttt.com/trigger/test/with/key/bad_key: 401 Client Error: Unauthorized for url: https://maker.ifttt.com/trigger/test/with/key/bad_key
```
