### PR TITLE
Fix unicode handling for urlopen in Python 2

### DIFF
--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 from future.moves.urllib.request import urlopen
 from future.moves.urllib.parse import urlparse
+from future.utils import PY2
 
 import time
 import logging
@@ -139,7 +140,11 @@ def _wrap_urlopen(url, timeout=None):
 
     """
     try:
-        raw = urlopen(url, timeout=timeout)
+        if PY2:
+            encoded_url = url.encode('utf-8')
+        else:
+            encoded_url = url
+        raw = urlopen(encoded_url, timeout=timeout)
     except IOError as e:
         msg = 'Error getting %s: %s' % (url, e)
         log.error(msg)

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -140,7 +140,7 @@ def _wrap_urlopen(url, timeout=None):
 
     """
     try:
-        raw = urlopen(text_to_native_str(url), timeout=timeout)
+        raw = urlopen(text_to_native_str(url, encoding='utf-8'), timeout=timeout)
     except IOError as e:
         msg = 'Error getting %s: %s' % (url, e)
         log.error(msg)

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 from future.moves.urllib.request import urlopen
 from future.moves.urllib.parse import urlparse
-from future.utils import PY2
+from future.utils import text_to_native_str
 
 import time
 import logging
@@ -140,11 +140,7 @@ def _wrap_urlopen(url, timeout=None):
 
     """
     try:
-        if PY2:
-            encoded_url = url.encode('utf-8')
-        else:
-            encoded_url = url
-        raw = urlopen(encoded_url, timeout=timeout)
+        raw = urlopen(text_to_native_str(url), timeout=timeout)
     except IOError as e:
         msg = 'Error getting %s: %s' % (url, e)
         log.error(msg)


### PR DESCRIPTION
### Motivation for changes:

### Detailed changes:
- Encoding to utf-8 in Py2

### Addressed issues:
- Fixes #1965