### PR TITLE
Adapt to latest newpct1 changes

### DIFF
--- a/flexget/plugins/sites/newpct.py
+++ b/flexget/plugins/sites/newpct.py
@@ -23,7 +23,7 @@ requests.add_domain_limiter(TimedLimiter('newpct1.com', '2 seconds'))
 requests.add_domain_limiter(TimedLimiter('newpct.com', '2 seconds'))
 
 NEWPCT_TORRENT_FORMAT = 'http://www.newpct.com/torrents/{:0>6}.torrent'
-NEWPCT1_TORRENT_FORMAT = 'http://www.newpct1.com/torrents/{:0>6}.torrent'
+NEWPCT1_TORRENT_FORMAT = 'http://www.newpct1.com/download/{:0>6}.torrent'
 
 class UrlRewriteNewPCT(object):
     """NewPCT urlrewriter and search."""
@@ -73,7 +73,7 @@ class UrlRewriteNewPCT(object):
             if match:
                 torrent_id = match.group(1)
         if not torrent_id:
-            torrent_id_prog = re.compile('function openTorrent.*\n.*\{.*(\n.*)+window\.location\.href =\s*\".*\/(\d+).*\";')
+            torrent_id_prog = re.compile('function openTorrent.*\n.*\{.*(\n.*)+window\.location\.href =\s*\".*\/(\d+.*)\";')
             torrent_ids = soup.findAll(text=torrent_id_prog)
             log.debug('torrent ID not found, searching openTorrent script')
             if torrent_ids:


### PR DESCRIPTION
Fix URL for Newpct1 and modify regular expression to capture the new torrent ID

### Motivation for changes:

Plugin started failing when downloading torrents from newpct1 feeds

### Detailed changes:
- Changed URL rewrite prefix to adapt to newpct1 changes
- Changed regular expression capturing torrent ID to adapt to newpct/newpct1 changes

### Log and/or tests output (preferably both):
```
Tested the changes locally and the plugin is working again for newpct1
```
#### To Do:

- [ ] Ensure newpct.com is also working and if not fix it. Probably not working either before this patch as torrent id seems to have changed.

