### PR TITLE
add encoding field to regexp_parse

### DIFF
--- a/flexget/plugins/input/regexp_parse.py
+++ b/flexget/plugins/input/regexp_parse.py
@@ -43,6 +43,7 @@ class RegexpParse(object):
 
     regexp_parse:
       source: http://username:password@ezrss.it/feed/
+      encoding: "utf-8"
       sections:
         - {regexp: "(?<=<item>).*?(?=</item>)", flags: "DOTALL,IGNORECASE"}
 
@@ -88,6 +89,7 @@ class RegexpParse(object):
 
         root.accept('url', key='source', required=True)
         root.accept('file', key='source', required=True)
+        root.accept('text', key='encoding')
 
         # sections to divied source into
         sections_regexp_lists = root.accept('list', key='sections')
@@ -152,13 +154,16 @@ class RegexpParse(object):
     @plugin.internet(log)
     def on_task_input(self, task, config):
         url = config['source']
+        encoding = config.get('encoding', 'utf-8')
 
         # if it's a file open it and read into content (assume utf-8 encoding)
         if os.path.isfile(os.path.expanduser(url)):
-            content = codecs.open(url, 'r', encoding='utf-8').read()
+            content = codecs.open(url, 'r', encoding=encoding).read()
         # else use requests to get the data
         else:
-            content = task.requests.get(url).text
+            resp = task.requests.get(url)
+            resp.encoding = encoding
+            content = resp.text
 
         sections = []
         seperators = config.get('sections')


### PR DESCRIPTION
### Motivation for changes:
Sometimes servers are not aware of the content encoding which they serve, thus it is necessary to give a hint to Flexget about it.

### Detailed changes:
- Field **encoding** is added as _optional_ to the schema of **regexp_parse** plugin. If the value is set, it will be given to requests.Response.encoding as a hint about content encoding.

### Addressed issues:
N/A

### Implemented feature requests:
N/A

### Config usage if relevant (new plugin or updated schema):
**regexp_parse** plugin schema is updated with an optional **encoding** field and documentation is updated.
```
    regexp_parse:
      source: http://username:password@ezrss.it/feed/
      encoding: "utf-8"
      sections:
        - {regexp: "(?<=<item>).*?(?=</item>)", flags: "DOTALL,IGNORECASE"}
```

### Log and/or tests output (preferably both):
N/A

#### To Do:

- [ ] **Optional**: make e.g. encoding == _auto_, use requests.Response.apparent_encoding
