### PR TITLE
Use name.utf-8 and path.utf-8 when present

### DIFF
--- a/flexget/utils/bittorrent.py
+++ b/flexget/utils/bittorrent.py
@@ -223,15 +223,23 @@ class Torrent(object):
         files = []
         if 'length' in self.content['info']:
             # single file torrent
-            t = {'name': self.content['info']['name'],
+            if 'name.utf-8' in self.content['info']:
+                name = self.content['info']['name.utf-8']
+            else:
+                name = self.content['info']['name']
+            t = {'name': name,
                  'size': self.content['info']['length'],
                  'path': ''}
             files.append(t)
         else:
             # multifile torrent
             for item in self.content['info']['files']:
-                t = {'path': '/'.join(item['path'][:-1]),
-                     'name': item['path'][-1],
+                if 'path.utf-8' in item:
+                    path = item['path.utf-8']
+                else:
+                    path = item['path']
+                t = {'path': '/'.join(path[:-1]),
+                     'name': path[-1],
                      'size': item['length']}
                 files.append(t)
 


### PR DESCRIPTION
### Motivation for changes:
I had some crash in bittorent.py when handling torrents that included a directory using Chinese chars. 
Looking at others torrent python code (deluge) I see that they use the dictionary keys name.utf-8/path.utf-8 instead of name/path when present. 
In the torrent that crashed those keys are present and contains proper utf-8 while path/name contains some bytes that are not UTF-8

### Detailed changes:
- ins bittorent.py get_filelist check if the name.utf-8/path.utf-8 keys are present and use them if they are.

### Addressed issues:
- Fixes #2024 and an other I can't find anymore
