### PR TITLE
Add jinja2 templates to ftp_download and fix infinite loop bug.

### DIFF
--- a/flexget/plugins/output/ftp_download.py
+++ b/flexget/plugins/output/ftp_download.py
@@ -8,6 +8,7 @@ import ftplib
 
 from flexget import plugin
 from flexget.event import event
+from flexget.utils.pathscrub import pathscrub
 
 log = logging.getLogger('ftp')
 
@@ -88,10 +89,10 @@ class OutputFtp(object):
             except ftplib.all_errors as e:
                 entry.fail("Unable to connect to server : %s" % (e))
                 break
-
-            if not os.path.isdir(config['ftp_tmp_path']):
-                log.debug('creating base path: %s' % config['ftp_tmp_path'])
-                os.mkdir(config['ftp_tmp_path'])
+            to_path = pathscrub(entry.render(config['ftp_tmp_path']))
+            if not os.path.isdir(to_path):
+                log.debug('creating base path: %s' % to_path)
+                os.makedirs(to_path)
 
             file_name = os.path.basename(ftp_url.path)
 
@@ -99,14 +100,14 @@ class OutputFtp(object):
                 # Directory
                 ftp = self.check_connection(ftp, config, ftp_url, current_path)
                 ftp.cwd(file_name)
-                self.ftp_walk(ftp, os.path.join(config['ftp_tmp_path'], file_name), config, ftp_url, ftp_url.path)
+                self.ftp_walk(ftp, os.path.join(to_path, file_name), config, ftp_url, ftp_url.path)
                 ftp = self.check_connection(ftp, config, ftp_url, current_path)
                 ftp.cwd('..')
                 if config['delete_origin']:
                     ftp.rmd(file_name)
             except ftplib.error_perm:
                 # File
-                self.ftp_down(ftp, file_name, config['ftp_tmp_path'], config, ftp_url, current_path)
+                self.ftp_down(ftp, file_name, to_path, config, ftp_url, current_path)
 
             ftp.close()
 


### PR DESCRIPTION
### Motivation for changes:
ftp_download is really not useful without the ability to use jinja2 templates.
Also made a quick fix for cases when we run into download problems and the download loop starts to loop forever.

### Detailed changes:
- Really simple fix and feature so all is explained above.

