### PR TITLE
Update cache control in API to better handle dynamic content

### DIFF
--- a/flexget/api/app.py
+++ b/flexget/api/app.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 from collections import deque
-from functools import wraps
+from functools import wraps, partial
 
 from flask import Flask, request, jsonify, make_response
 from flask_compress import Compress
@@ -317,27 +317,34 @@ def api_key(session=None):
     return session.query(User).first().token
 
 
-def etag(f):
+def etag(method=None, cache_age=0):
     """
     A decorator that add an ETag header to the response and checks for the "If-Match" and "If-Not-Match" headers to
      return an appropriate response.
 
-    :param f: A GET or HEAD flask method to wrap
+    :param method: A GET or HEAD flask method to wrap
+    :param cache_age: max-age cache age for the content
     :return: The method's response with the ETag and Cache-Control headers, raises a 412 error or returns a 304 response
     """
 
-    @wraps(f)
+    # If called without method, we've been called with optional arguments.
+    # We return a decorator with the optional arguments filled in.
+    # Next time round we'll be decorating method.
+    if method is None:
+        return partial(etag, cache_age=cache_age)
+
+    @wraps(method)
     def wrapped(*args, **kwargs):
         # Identify if this is a GET or HEAD in order to proceed
         assert request.method in ['HEAD', 'GET'], '@etag is only supported for GET requests'
-        rv = f(*args, **kwargs)
+        rv = method(*args, **kwargs)
         rv = make_response(rv)
 
         # Some headers can change without data change for specific page
         content_headers = rv.headers.get('link', '') + rv.headers.get('count', '') + rv.headers.get('total-count', '')
         data = (rv.get_data().decode() + content_headers).encode()
         etag = generate_etag(data)
-        rv.headers['Cache-Control'] = 'max-age=86400'
+        rv.headers['Cache-Control'] = 'max-age=%s' % cache_age
         rv.headers['ETag'] = etag
         if_match = request.headers.get('If-Match')
         if_none_match = request.headers.get('If-None-Match')

--- a/flexget/api/core/plugins.py
+++ b/flexget/api/core/plugins.py
@@ -70,7 +70,7 @@ def plugin_to_dict(plugin):
 
 @plugins_api.route('/')
 class PluginsAPI(APIResource):
-    @etag
+    @etag(cache_age=3600)
     @api.response(200, model=plugin_list_reply_schema)
     @api.response(BadRequest)
     @api.response(NotFoundError)
@@ -125,7 +125,7 @@ class PluginsAPI(APIResource):
 
 @plugins_api.route('/<string:plugin_name>/')
 class PluginAPI(APIResource):
-    @etag
+    @etag(cache_age=3600)
     @api.response(BadRequest)
     @api.response(200, model=plugin_schema)
     @api.doc(parser=plugin_parser, params={'plugin_name': 'Name of the plugin to return'})

--- a/flexget/api/core/server.py
+++ b/flexget/api/core/server.py
@@ -164,7 +164,7 @@ class ServerPIDAPI(APIResource):
 
 @server_api.route('/config/')
 class ServerConfigAPI(APIResource):
-    @etag(cache_age=0)
+    @etag
     @api.response(200, description='Flexget config', model=empty_response)
     def get(self, session=None):
         """ Get Flexget Config in JSON form"""
@@ -173,7 +173,7 @@ class ServerConfigAPI(APIResource):
 
 @server_api.route('/raw_config/')
 class ServerRawConfigAPI(APIResource):
-    @etag(cache_age=0)
+    @etag
     @api.doc(description='Return config file encoded in Base64')
     @api.response(200, model=raw_config_schema, description='Flexget raw YAML config file encoded in Base64')
     def get(self, session=None):

--- a/flexget/api/core/server.py
+++ b/flexget/api/core/server.py
@@ -164,7 +164,7 @@ class ServerPIDAPI(APIResource):
 
 @server_api.route('/config/')
 class ServerConfigAPI(APIResource):
-    @etag
+    @etag(cache_age=0)
     @api.response(200, description='Flexget config', model=empty_response)
     def get(self, session=None):
         """ Get Flexget Config in JSON form"""
@@ -173,7 +173,7 @@ class ServerConfigAPI(APIResource):
 
 @server_api.route('/raw_config/')
 class ServerRawConfigAPI(APIResource):
-    @etag
+    @etag(cache_age=0)
     @api.doc(description='Return config file encoded in Base64')
     @api.response(200, model=raw_config_schema, description='Flexget raw YAML config file encoded in Base64')
     def get(self, session=None):

--- a/flexget/api/core/tasks.py
+++ b/flexget/api/core/tasks.py
@@ -343,7 +343,7 @@ inject_api = api.namespace('inject', description='Entry injection API')
 @tasks_api.route('/execute/params/')
 @api.doc(description='Available payload parameters for task execute')
 class TaskExecutionParams(APIResource):
-    @etag
+    @etag(cache_age=3600)
     @api.response(200, model=task_execution_params)
     def get(self, session=None):
         """ Execute payload parameters """

--- a/flexget/api/plugins/tmdb_lookup.py
+++ b/flexget/api/plugins/tmdb_lookup.py
@@ -81,7 +81,7 @@ tmdb_parser.add_argument('include_backdrops', type=inputs.boolean, default=False
 @tmdb_api.route('/movies/')
 @api.doc(description=description)
 class TMDBMoviesAPI(APIResource):
-    @etag
+    @etag(cache_age=3600)
     @api.response(200, model=return_schema)
     @api.response(NotFoundError)
     @api.response(BadRequest)

--- a/flexget/api/plugins/trakt_lookup.py
+++ b/flexget/api/plugins/trakt_lookup.py
@@ -115,7 +115,7 @@ lookup_parser.add_argument('include_translations', type=inputs.boolean, help='In
 @trakt_api.route('/series/<string:title>/')
 @api.doc(params={'title': 'Series name'})
 class TraktSeriesSearchApi(APIResource):
-    @etag
+    @etag(cache_age=3600)
     @api.response(200, 'Successfully found show', series_return_schema)
     @api.response(NotFoundError)
     @api.doc(parser=lookup_parser)
@@ -141,7 +141,7 @@ class TraktSeriesSearchApi(APIResource):
 @trakt_api.route('/movies/<string:title>/')
 @api.doc(params={'title': 'Movie name'})
 class TraktMovieSearchApi(APIResource):
-    @etag
+    @etag(cache_age=3600)
     @api.response(200, 'Successfully found show', movie_return_schema)
     @api.response(NotFoundError)
     @api.doc(parser=lookup_parser)

--- a/flexget/api/plugins/tvdb_lookup.py
+++ b/flexget/api/plugins/tvdb_lookup.py
@@ -97,7 +97,7 @@ series_parser.add_argument('include_actors', type=inputs.boolean, help='Include 
 @tvdb_api.route('/series/<string:title>/')
 @api.doc(params={'title': 'TV Show name or TVDB ID'}, parser=series_parser)
 class TVDBSeriesLookupAPI(APIResource):
-    @etag
+    @etag(cache_age=3600)
     @api.response(200, 'Successfully found show', tvdb_series_schema)
     @api.response(NotFoundError)
     def get(self, title, session=None):
@@ -139,7 +139,7 @@ episode_parser.add_argument('air_date', type=inputs.date, help='Episode airdate 
 @tvdb_api.route('/episode/<int:tvdb_id>/')
 @api.doc(params={'tvdb_id': 'TVDB ID of show'}, parser=episode_parser)
 class TVDBEpisodeSearchAPI(APIResource):
-    @etag
+    @etag(cache_age=3600)
     @api.response(200, 'Successfully found episode', tvdb_episode_schema)
     @api.response(NotFoundError)
     @api.response(BadRequest)
@@ -186,7 +186,7 @@ search_parser.add_argument('force_search', type=inputs.boolean,
 @tvdb_api.route('/search/')
 @api.doc(parser=search_parser)
 class TVDBSeriesSearchAPI(APIResource):
-    @etag
+    @etag(cache_age=3600)
     @api.response(200, 'Successfully got results', search_results_schema)
     @api.response(BadRequest)
     @api.response(NotFoundError)

--- a/flexget/api/plugins/tvmaze_lookup.py
+++ b/flexget/api/plugins/tvmaze_lookup.py
@@ -94,7 +94,7 @@ tvmaze_episode_schema = api.schema_model('tvmaze_episode_schema', ObjectsContain
 @tvmaze_api.route('/series/<string:title>/')
 @api.doc(params={'title': 'TV Show name or TVMaze ID'})
 class TVDBSeriesSearchApi(APIResource):
-    @etag
+    @etag(cache_age=3600)
     @api.response(200, 'Successfully found show', model=tvmaze_series_schema)
     @api.response(NotFoundError)
     def get(self, title, session=None):
@@ -123,7 +123,7 @@ episode_parser.add_argument('air_date', type=inputs.date_from_iso8601, help="Air
 @api.doc(params={'tvmaze_id': 'TVMaze ID of show'})
 @api.doc(parser=episode_parser)
 class TVDBEpisodeSearchAPI(APIResource):
-    @etag
+    @etag(cache_age=3600)
     @api.response(200, 'Successfully found episode', tvmaze_episode_schema)
     @api.response(NotFoundError)
     @api.response(BadRequest)


### PR DESCRIPTION
Update ETag Cache params for the WebUI.

### Motivation for changes:
The etag for content such as getting the entries within a list should have a cache max-age of 0 otherwise you may see weird behaviour within the WebUI.
