### PR TITLE
Tasks api disabled tasks

### DIFF
--- a/flexget/api/app.py
+++ b/flexget/api/app.py
@@ -21,7 +21,7 @@ from flexget.utils.database import with_session
 from flexget.webserver import User
 from . import __path__
 
-__version__ = '1.4.2'
+__version__ = '1.4.3'
 
 log = logging.getLogger('api')
 

--- a/flexget/api/core/tasks.py
+++ b/flexget/api/core/tasks.py
@@ -175,13 +175,14 @@ class TasksAPI(APIResource):
     def get(self, session=None):
         """ List all tasks """
 
+        active_tasks = {task: task_data for task, task_data in self.manager.user_config.get('tasks', {}).items()
+                        if not task.startswith('_')}
+
         args = tasks_parser.parse_args()
         if not args.get('include_config'):
-            return jsonify(list(self.manager.user_config.get('tasks', {})))
+            return jsonify(list(active_tasks))
 
-        tasks = []
-        for name, config in self.manager.user_config.get('tasks', {}).items():
-            tasks.append({'name': name, 'config': config})
+        tasks = [{'name': name, 'config': config} for name, config in active_tasks.items()]
         return jsonify(tasks)
 
     @api.validate(task_input_schema, description='New task object')

--- a/flexget/tests/api_tests/test_tasks_api.py
+++ b/flexget/tests/api_tests/test_tasks_api.py
@@ -3,10 +3,11 @@ from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 import json
 
+from mock import patch
+
 from flexget.api.app import base_message
 from flexget.api.core.tasks import ObjectsContainer as OC
 from flexget.manager import Manager
-from mock import patch
 
 
 class TestTaskAPI(object):
@@ -266,3 +267,22 @@ class TestTaskQueue(object):
         assert not errors
 
         assert data == []
+
+
+class TestDisabledTasks(object):
+    config = """
+        tasks:
+          live_task:
+            mock:
+            - title: foo
+          _disabled_task:
+            mock:
+            - title: bar
+    """
+
+    def test_only_active_tasks_return(self, api_client):
+        rsp = api_client.get('/tasks/')
+        data = json.loads(rsp.get_data(as_text=True))
+
+        assert len(data) == 1
+        assert not data[0].get('name') == '_disabled_task'


### PR DESCRIPTION
### Motivation for changes:
Hidden tasks should be returned by the API
### Detailed changes:
- Filtered out hidden tasks for `/tasks/` endpoint

### Addressed issues:
- Fixes #2084 