### PR TITLE
Added ability to filter pending list entries via API

### DIFF
--- a/flexget/api/plugins/pending_list.py
+++ b/flexget/api/plugins/pending_list.py
@@ -154,6 +154,7 @@ pending_lists_entries_return_schema = api.schema_model('pending_list.entry_retur
 
 sort_choices = ('id', 'added', 'title', 'original_url', 'list_id', 'approved')
 entries_parser = api.pagination_parser(sort_choices=sort_choices, default='title')
+entries_parser.add_argument('filter', help='Filter by title name')
 
 
 @pending_list_api.route('/<int:list_id>/entries/')
@@ -177,6 +178,8 @@ class PendingListEntriesAPI(APIResource):
         sort_by = args['sort_by']
         sort_order = args['order']
 
+        filter_ = args['filter']
+
         # Handle max size limit
         if per_page > 100:
             per_page = 100
@@ -191,6 +194,7 @@ class PendingListEntriesAPI(APIResource):
             'list_id': list_id,
             'order_by': sort_by,
             'descending': descending,
+            'filter': filter_,
             'session': session
         }
 

--- a/flexget/plugins/list/pending_list.py
+++ b/flexget/plugins/list/pending_list.py
@@ -208,9 +208,11 @@ def delete_list_by_id(list_id, session=None):
 
 @with_session
 def get_entries_by_list_id(list_id, start=None, stop=None, order_by='title', descending=False, approved=False,
-                           session=None):
+                           filter=None, session=None):
     log.debug('querying entries from pending list with id %d', list_id)
     query = session.query(PendingListEntry).filter(PendingListEntry.list_id == list_id)
+    if filter:
+        query = query.filter(func.lower(PendingListEntry.title).contains(filter.lower()))
     if approved:
         query = query.filter(PendingListEntry.approved is approved)
     if descending:


### PR DESCRIPTION
### Motivation for changes:
@stevezau asked
### Detailed changes:
- Added `/pending_list/<list_id>/entries?search=<string>` endpoint

