### PR TITLE
Add option to allow empty links in html plugin

### DIFF
--- a/flexget/plugins/input/html.py
+++ b/flexget/plugins/input/html.py
@@ -44,6 +44,7 @@ class InputHtml(object):
         advanced.accept('text', key='password')
         advanced.accept('text', key='dump')
         advanced.accept('text', key='title_from')
+        advanced.accept('boolean', key='allow_empty_links')
         regexps = advanced.accept('list', key='links_re')
         regexps.accept('regexp')
         advanced.accept('boolean', key='increment')
@@ -180,7 +181,7 @@ class InputHtml(object):
             if not link.has_attr('href'):
                 continue
             # no content in the link
-            if not link.contents:
+            if not link.contents and not config.get('allow_empty_links', False):
                 continue
 
             url = link['href']


### PR DESCRIPTION
### Motivation for changes: 

Some links are sometimes empty but have a CSS style that make them visible (typically an icon) but html plugin ignores them

### Detailed changes:
- Add a `allow_empty_links` option in html plugin
- Update skipping code

`allow_empty_links` is False by default for backward compatibility.


