### PR TITLE
Refactor decompress plugin to be a bit cleaner

### DIFF
--- a/flexget/plugins/output/decompress.py
+++ b/flexget/plugins/output/decompress.py
@@ -53,7 +53,7 @@ def get_output_path(to, entry):
             return render_from_entry(to, entry)
         else:
             return os.path.dirname(entry.get('location'))
-    except RenderError as error:
+    except RenderError:
         raise PluginError('Could not render path: %s', to)
 
 

--- a/flexget/plugins/output/decompress.py
+++ b/flexget/plugins/output/decompress.py
@@ -23,17 +23,17 @@ def fail_entry_with_error(entry, error):
 
 def open_archive_entry(entry):
     """
-    Convenience method for opening archives from entries. Returns an archive.Archive object
+    Convenience function for opening archives from entries. Returns an archive.Archive object
     """
     archive = None
 
     try:
         archive_path = entry.get('location', '')
 
-        if not os.path.exists(archive_path):
-            log.error('File no longer exists: %s', entry['location'])
-        elif not archive_path:
+        if not archive_path:
             log.error('Entry does not appear to represent a local file.')
+        elif not os.path.exists(archive_path):
+            log.error('File no longer exists: %s', entry['location'])
         else:
             archive = archiveutil.open_archive(archive_path)
     except archiveutil.BadArchive as error:

--- a/flexget/plugins/output/decompress.py
+++ b/flexget/plugins/output/decompress.py
@@ -30,7 +30,7 @@ def open_archive_entry(entry):
     try:
         archive_path = entry['location']
         if not archive_path:
-            raise ValueError()
+            raise ValueError('Entry does not appear to represent a local file.')
 
         archive = archiveutil.open_archive(archive_path)
     except (KeyError, ValueError):
@@ -63,11 +63,11 @@ def extract_info(info, archive, to, keep_dirs):
         info.extract(archive, destination)
     except archiveutil.FSError as error:
         log.error('OS error while creating file: %s (%s)' % (destination, error))
+    except archiveutil.FileAlreadyExists as error:
+        log.warn('File already exists: %s' % destination)
     except archiveutil.ArchiveError as error:
         log.error('Failed to extract file: %s in %s (%s)' % (info.filename,
                                                                    entry['location'], error))
-    except archiveutil.FileAlreadyExists as error:
-        log.warn('File already exists: %s' % destination)
 
 
 def get_destination_path(info, to, keep_dirs):

--- a/flexget/plugins/output/decompress.py
+++ b/flexget/plugins/output/decompress.py
@@ -85,7 +85,14 @@ def get_destination_path(info, to, keep_dirs):
 def is_match(info, pattern):
     """Returns whether an info record matches the supplied regex"""
     match = re.compile(pattern, re.IGNORECASE).match
-    return bool(match(info.filename))
+    is_match = bool(match(info.filename))
+
+    if is_match:
+        log.debug('Found matching file: %s', info.filename)
+    else:
+        log.debug('File did not match regexp: %s', info.filename)
+
+    return is_match
 
 
 class Decompress(object):
@@ -176,10 +183,7 @@ class Decompress(object):
 
         for info in archive.infolist():
             if is_match(info, config['regexp']):
-                log.debug('Found matching file: %s', info.filename)
                 extract_info(info, archive, to, config['keep_dirs'])
-            else:
-                log.debug('File did not match regexp: %s', info.filename)
 
         if config['delete_archive']:
             archive.delete()

--- a/flexget/plugins/output/decompress.py
+++ b/flexget/plugins/output/decompress.py
@@ -73,10 +73,7 @@ def extract_info(info, archive, to, keep_dirs):
 def get_destination_path(info, to, keep_dirs):
     """Generate the destination path for a given file"""
 
-    if keep_dirs:
-        path_suffix = info.path
-    else:
-        path_suffix = os.path.basename(info.path)
+    path_suffix = info.path if keep_dirs else os.path.basename(info.path)
 
     return os.path.join(to, path_suffix)
 

--- a/flexget/plugins/output/decompress.py
+++ b/flexget/plugins/output/decompress.py
@@ -28,7 +28,7 @@ def open_archive_entry(entry):
     archive = None
 
     try:
-        archive_path = entry.get('location')
+        archive_path = entry.get('location', '')
 
         if not os.path.exists(archive_path):
             log.error('File no longer exists: %s', entry['location'])

--- a/flexget/tests/test_decompress.py
+++ b/flexget/tests/test_decompress.py
@@ -10,7 +10,7 @@ except ImportError:
     rarfile = None
 
 
-@pytest.mark.usefixtures('tmpdir', 'caplog')
+@pytest.mark.usefixtures('tmpdir')
 class TestExtract(object):
     config = """
         templates:

--- a/flexget/tests/test_decompress.py
+++ b/flexget/tests/test_decompress.py
@@ -10,7 +10,7 @@ except ImportError:
     rarfile = None
 
 
-@pytest.mark.usefixtures('tmpdir')
+@pytest.mark.usefixtures('tmpdir', 'caplog')
 class TestExtract(object):
     config = """
         templates:
@@ -22,6 +22,15 @@ class TestExtract(object):
             zip_file:
                 mock:
                     - {title: 'test', location: '__tmp__/test_zip.zip'}
+            empty_path:
+                mock:
+                    - {title: 'test', location: ''}
+            file_not_exists:
+                mock:
+                    - {title: 'test', location: '__tmp__/nothing_here.zip'}
+            no_path:
+                mock:
+                    - {title: 'test'}
         tasks:
             test_rar:
                 template: rar_file
@@ -50,7 +59,23 @@ class TestExtract(object):
                     to: '__tmp__'
                     keep_dirs: no
                     delete_archive: yes
-                    
+            test_empty_path:
+                template: empty_path
+                decompress:
+                    to: '__tmp__'
+                    keep_dirs: no
+            test_no_path:
+                template: no_path
+                decompress:
+                    to: '__tmp__'
+                    keep_dirs: no
+                    delete_archive: yes
+            test_file_not_exists:
+                template: file_not_exists
+                decompress:
+                    to: '__tmp__'
+                    keep_dirs: no
+                    delete_archive: yes
         """
 
     # Files
@@ -65,6 +90,10 @@ class TestExtract(object):
     # Paths
     rar_path = os.path.join(source_dir, rar_name)
     zip_path = os.path.join(source_dir, zip_name)
+
+    # Error messages
+    error_not_local = 'Entry does not appear to represent a local file.'
+    error_not_exists = 'File no longer exists:'
 
     @pytest.mark.skipif(rarfile is None, reason='rarfile module required')
     @pytest.mark.filecopy(rar_path, '__tmp__')
@@ -100,3 +129,18 @@ class TestExtract(object):
         """Test Zip deletion after extraction"""
         execute_task('test_delete_zip')
         assert not tmpdir.join(self.zip_name).exists(), 'Zip archive was not deleted.'
+
+    def test_empty_path(self, execute_task, caplog):
+        """Test when an empty location is provided"""
+        execute_task('test_empty_path')
+        assert self.error_not_local in caplog.text, 'Plugin logs an error when entry has an empty path.'
+
+    def test_no_path(self, execute_task, caplog):
+        """Test when no location is provided"""
+        execute_task('test_no_path')
+        assert self.error_not_local in caplog.text, 'Plugin logs an error when entry has no path.'
+
+    def test_not_a_file(self, execute_task, caplog):
+        """Test when a non-existent path is provided"""
+        execute_task('test_file_not_exists')
+        assert self.error_not_exists in caplog.text, 'Plugin logs an error when file does not exist.'

--- a/flexget/utils/archive.py
+++ b/flexget/utils/archive.py
@@ -50,6 +50,11 @@ class FSError(ArchiveError):
     pass
 
 
+class FileAlreadyExists(ArchiveError):
+    """Exception to be raised when destination file already exists"""
+    pass
+
+
 def rarfile_set_tool_path(config):
     """
     Manually set the path of unrar executable if it can't be resolved from the
@@ -72,6 +77,12 @@ def rarfile_set_path_sep(separator):
     if rarfile:
         rarfile.PATH_SEP = separator
 
+
+def makepath(path):
+    """Make directories as needed"""
+    if not os.path.exists(path):
+        log.debug('Creating path: %s', path)
+        os.makedirs(path)
 
 class Archive(object):
     """
@@ -106,7 +117,16 @@ class Archive(object):
 
     def infolist(self):
         """Returns a list of info objects describing the contents of this archive"""
-        return self.archive.infolist()
+        infolist = []
+
+        for info in self.archive.infolist():
+            try:
+                archive_info =  ArchiveInfo(info)
+                infolist.append(archive_info)
+            except ValueError as e:
+                log.debug(e)
+
+        return infolist
 
     def open(self, member):
         """Returns file-like object from where the data of a member file can be read."""
@@ -171,6 +191,44 @@ class ZipArchive(Archive):
             return super(ZipArchive, self).open(member)
         except zipfile.BadZipfile as error:
             raise ArchiveError(error)
+
+class ArchiveInfo(object):
+    """Wrapper class for  archive info objects"""
+
+    def __init__(self, info):
+        self.info = info
+        self.path = info.filename
+        self.filename = os.path.basename(self.path)
+
+        if self._is_dir():
+            raise ValueError('Appears to be a directory: %s' % self.path)
+
+    def _is_dir(self):
+        """Indicates if info object looks to be a directory"""
+
+        if hasattr(self.info, 'isdir'):
+            return self.info.isdir()
+        else:
+            return not self.filename
+
+    def extract(self, archive, destination):
+        """Extract ArchiveInfo object to the specified destination"""
+        dest_dir = os.path.dirname(destination)
+
+        if os.path.exists(destination):
+            raise FileAlreadyExists('File already exists: %s' % destination)
+
+        log.debug('Creating path: %s', dest_dir)
+        makepath(dest_dir)
+
+        try:
+            archive.extract_file(self.info, destination)
+        except Exception as error:
+            if os.path.exists(destination):
+                log.debug('Cleaning up partially extracted file: %s', destination)
+                os.remove(destination)
+            
+            raise error
 
 
 def open_archive(archive_path):

--- a/flexget/utils/archive.py
+++ b/flexget/utils/archive.py
@@ -227,7 +227,7 @@ class ArchiveInfo(object):
             if os.path.exists(destination):
                 log.debug('Cleaning up partially extracted file: %s', destination)
                 os.remove(destination)
-            
+
             raise error
 
 


### PR DESCRIPTION
### Motivation for changes:
Clean up logic in the decompress plugin to make it cleaner and easier to follow. I've also been mulling over possibly making `decompress` an entry list plugin in the future, this should make that a bit easier.

### Detailed changes:
- Added ArchiveInfo class to `utils/archive.py`, which now does most of the heavy listing for decompressing files
- Moved additional logic into standalone functions

### Addressed issues:
- Fixes # .

### Implemented feature requests:
- Feathub #[XX](https://feathub.com/Flexget/Flexget/+XX).

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
```
flexget/tests/test_decompress.py .....                                                                                                                                                               [100%]

============================================================================================= warnings summary =============================================================================================
flexget/tests/test_decompress.py::TestExtract::()::test_rar
  /Users/ieaston/Flexget/flexget/tests/conftest.py:212: DeprecationWarning: use of getfuncargvalue is deprecated, use getfixturevalue
    dst = dst.replace('__tmp__', request.getfuncargvalue('tmpdir').strpath)
  /Users/ieaston/Flexget/flexget/tests/conftest.py:66: DeprecationWarning: use of getfuncargvalue is deprecated, use getfixturevalue
    config = config.replace('__tmp__', request.getfuncargvalue('tmpdir').strpath)

-- Docs: http://doc.pytest.org/en/latest/warnings.html
=================================================================================== 5 passed, 2 warnings in 2.54 seconds ===================================================================================
```

