### PR TITLE
[fix] qbittorrent - Issue #2097, jinja replacement in qbittorrent path

### DIFF
--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -109,7 +109,7 @@ class OutputQBitTorrent(object):
     def add_entries(self, task, config):
         for entry in task.accepted:
             form_data = {}
-            save_path = entry.get('path', config.get('path'))
+            save_path = entry.render(config.get('path'))
             if save_path:
                 form_data['savepath'] = save_path
 


### PR DESCRIPTION
### Motivation for changes:
- Jinja replacement was not working in 'path' for qbittorrent plugin.

### Addressed issues:
- Fixes #2097  .