### PR TITLE
[fix] Make sqlalchemy 1.1 and 1.2 behave the same. fix #2058

### DIFF
--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -256,22 +256,22 @@ class AlternateNames(Base):
     _alt_name_normalized = Column('alt_name_normalized', Unicode, index=True, unique=True)
     series_id = Column(Integer, ForeignKey('series.id'), nullable=False)
 
-    def name_setter(self, value):
+    @hybrid_property
+    def alt_name(self):
+        return self._alt_name
+
+    @alt_name.setter
+    def alt_name(self, value):
         self._alt_name = value
         self._alt_name_normalized = normalize_series_name(value)
 
-    def name_getter(self):
-        return self._alt_name
-
-    def name_comparator(self):
+    @alt_name.comparator
+    def alt_name(self):
         return NormalizedComparator(self._alt_name_normalized)
 
     @property
     def name_normalized(self):
         return self._alt_name_normalized
-
-    alt_name = hybrid_property(name_getter, name_setter)
-    alt_name.comparator(name_comparator)
 
     def __init__(self, name):
         self.alt_name = name

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -304,22 +304,22 @@ class Series(Base):
     seasons = relation('Season', backref='series', cascade='all, delete, delete-orphan')
 
     # Make a special property that does indexed case insensitive lookups on name, but stores/returns specified case
-    def name_getter(self):
+    @hybrid_property
+    def name(self):
         return self._name
 
-    def name_setter(self, value):
+    @name.setter
+    def name(self, value):
         self._name = value
         self._name_normalized = normalize_series_name(value)
 
-    def name_comparator(self):
+    @name.comparator
+    def name(self):
         return NormalizedComparator(self._name_normalized)
 
     @property
     def name_normalized(self):
         return self._name_normalized
-
-    name = hybrid_property(name_getter, name_setter)
-    name.comparator(name_comparator)
 
     def __str__(self):
         return '<Series(id=%s,name=%s)>' % (self.id, self.name)

--- a/flexget/utils/database.py
+++ b/flexget/utils/database.py
@@ -198,7 +198,7 @@ def quality_property(text_attr):
         return QualComparator(getattr(self, text_attr))
 
     prop = hybrid_property(getter, setter)
-    prop.comparator(comparator)
+    prop = prop.comparator(comparator)
     return prop
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ rebulk==0.9.0
 requests==2.16.5
 rpyc==3.3.0
 six==1.10.0               # via apscheduler, cheroot, cherrypy, flask-cors, flask-restful, flask-restplus, html5lib, python-dateutil, rebulk, tempora
-sqlalchemy==1.1.10
+sqlalchemy==1.2.6
 tempora==1.8              # via portend
 terminaltables==3.1.0
 tzlocal==1.4              # via apscheduler


### PR DESCRIPTION
### Motivation for changes:
SQLAlchemy update to 1.2.0 breaks some stuff for us

### Detailed changes:
[This](http://docs.sqlalchemy.org/en/latest/changelog/migration_12.html#hybrid-attributes-support-reuse-among-subclasses-redefinition-of-getter) change in sqlalchemy 1.2 broke our custom comparators for hybrid properties we were using. Since calling 'comparator' method on hybrid properties no longer mutates the property, we have to re-assign the result back to the property name.

Replaces #2119, fixing the issue at the root.

### Addressed issues:
- Fixes #2058


