### PR TITLE
rss plugin all_entries option broken on python 3.3+

### DIFF
--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -3,6 +3,7 @@ from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 from future.utils import tobytes
 from future.moves.urllib.parse import urlparse, urlsplit
 
+import hashlib
 import os
 import logging
 import xml.sax
@@ -210,7 +211,7 @@ class InputRSS(object):
         log.debug('Requesting task `%s` url `%s`', task.name, config['url'])
 
         # Used to identify which etag/modified to use
-        url_hash = str(hash(config['url']))
+        url_hash = hashlib.md5(config['url'].encode('utf-8')).hexdigest()
 
         # set etag and last modified headers if config has not changed since
         # last run and if caching wasn't disabled with --no-cache argument.


### PR DESCRIPTION
### Motivation for changes:
`all_entries: no` option for rss plugin did not work between runs on python 3.3+

### Detailed changes:
The builtin python `hash` function was being used to remember the url for a given run, but on python 3.3+ it was no longer the same between runs. Switched to using md5 to create the hash key.
