### PR TITLE
add base_path support to sonarr_list plugin

### DIFF
--- a/flexget/plugins/list/sonarr_list.py
+++ b/flexget/plugins/list/sonarr_list.py
@@ -32,6 +32,7 @@ class SonarrSet(MutableSet):
         'type': 'object',
         'properties': {
             'base_url': {'type': 'string', 'default': 'http://localhost'},
+            'base_path': {'type': 'string', 'default': ''},
             'port': {'type': 'number', 'default': 80},
             'api_key': {'type': 'string'},
             'include_ended': {'type': 'boolean', 'default': True},
@@ -54,7 +55,8 @@ class SonarrSet(MutableSet):
     def _sonarr_request(self, endpoint, term=None, method='get', data=None):
         base_url = self.config['base_url']
         port = self.config['port']
-        url = '{}:{}/api/{}'.format(base_url, port, endpoint)
+        base_path = self.config['base_path']
+        url = '{}:{}{}/api/{}'.format(base_url, port, base_path, endpoint)
         headers = {'X-Api-Key': self.config['api_key']}
         if term:
             url += '?term={}'.format(term)


### PR DESCRIPTION
If Sonarr is behind a reverse proxy with a custom `URL Base` setting, the `sonarr_list` plugin wouldn't work because it doesn't support a custom base path. This should fix that.

### Motivation for changes:
- Can't use `sonarr_list` with my Sonarr setup (custom base path with reverse proxy)

### Detailed changes:
- Added `base_path` config schema option to `sonarr_list` with default value of `''` (should be backwards compatible)

### Config usage if relevant (new plugin or updated schema):
```yml
tasks:
  task-name:
    sonarr_list:
      base_url: https://server.example.com
      port: 8443
      base_path: /sonarr
      api_key: ...
```

This example config will use `https://server.example.com:8443/sonarr/api/` as the base API path.
