### PR TITLE
fix import and deluge 1.3 compatibility

### DIFF
--- a/flexget/plugins/clients/deluge2.py
+++ b/flexget/plugins/clients/deluge2.py
@@ -12,8 +12,8 @@ import time
 from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
-from utils.pathscrub import pathscrub
-from utils.template import RenderError
+from flexget.utils.pathscrub import pathscrub
+from flexget.utils.template import RenderError
 
 log = logging.getLogger('deluge3')
 
@@ -32,7 +32,7 @@ class DelugePlugin(object):
                                          e, log)
         config = self.prepare_config(config)
         self.client = DelugeRPCClient(config['host'], config['port'], config['username'], config['password'],
-                                      decode_utf8=True, deluge_version=2)
+                                      decode_utf8=True) #, deluge_version=2)
 
     def on_task_abort(self, task, config):
         pass


### PR DESCRIPTION
### Motivation for changes:
this plugin should work with older Deluge versions. 
### Detailed changes:
- 

### Addressed issues:
- Fixes # .

### Implemented feature requests:
- Feathub #[XX](https://feathub.com/Flexget/Flexget/+XX).

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
```
paste output here
```
#### To Do:

- [ ] Stuff..

