### PR TITLE
Recognise "p60"

### DIFF
--- a/flexget/tests/test_qualities.py
+++ b/flexget/tests/test_qualities.py
@@ -70,6 +70,7 @@ class TestQualityParser(object):
         ('Test.File.br-rip', 'bluray'),
         ('Test.File.720px', '720p'),
         ('Test.File.720p50', '720p'),
+        ('Test.File.720p60', '720p'),
 
         ('Test.File.dvd.rip', 'dvdrip'),
         ('Test.File.dvd.rip.r5', 'r5'),

--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -124,10 +124,10 @@ _resolutions = [
     QualityComponent('resolution', 40, '576p', '576p?'),
     QualityComponent('resolution', 45, 'hr'),
     QualityComponent('resolution', 50, '720i'),
-    QualityComponent('resolution', 60, '720p', '(1280x)?720(p|hd)?x?(50)?'),
+    QualityComponent('resolution', 60, '720p', '(1280x)?720(p|hd)?x?([56]0)?'),
     QualityComponent('resolution', 70, '1080i'),
-    QualityComponent('resolution', 80, '1080p', '(1920x)?1080p?x?(50)?'),
-    QualityComponent('resolution', 90, '2160p', '((3840x)?2160p?x?(50)?)|4k')
+    QualityComponent('resolution', 80, '1080p', '(1920x)?1080p?x?([56]0)?'),
+    QualityComponent('resolution', 90, '2160p', '((3840x)?2160p?x?([56]0)?)|4k')
 ]
 _sources = [
     QualityComponent('source', 10, 'workprint', modifier=-8),


### PR DESCRIPTION
Resolutions can contain p60, like p50.

### Motivation for changes:
Qualities aren't matching.

### Detailed changes:
- Recognise p60 rates
