### PR TITLE
thetvdb_list: add support for new api

### DIFF
--- a/flexget/plugins/internal/api_tvdb.py
+++ b/flexget/plugins/internal/api_tvdb.py
@@ -29,9 +29,10 @@ class TVDBRequest(object):
     BASE_URL = 'https://api.thetvdb.com/'
     BANNER_URL = 'http://thetvdb.com/banners/'
 
-    def __init__(self, username=None, account_id=None):
+    def __init__(self, username=None, account_id=None, api_key=None):
         self.username = username
         self.account_id = account_id
+        self.api_key = api_key
         self.auth_key = self.username.lower() if self.username else 'default'
 
     def get_auth_token(self, refresh=False):
@@ -47,6 +48,8 @@ class TVDBRequest(object):
                     data['username'] = self.username
                 if self.account_id:
                     data['userkey'] = self.account_id
+                if self.api_key:
+                    data['apikey'] = self.api_key
 
                 log.debug('Authenticating to TheTVDB with %s', self.username if self.username else 'api_key')
 

--- a/flexget/plugins/list/thetvdb_list.py
+++ b/flexget/plugins/list/thetvdb_list.py
@@ -21,9 +21,10 @@ class TheTVDBSet(MutableSet):
         'properties': {
             'username': {'type': 'string'},
             'account_id': {'type': 'string'},
+            'api_key': {'type': 'string'},
             'strip_dates': {'type': 'boolean'}
         },
-        'required': ['username', 'account_id'],
+        'required': ['username', 'account_id', 'api_key'],
         'additionalProperties': False
     }
 
@@ -54,7 +55,7 @@ class TheTVDBSet(MutableSet):
     def items(self):
         if self._items is None:
             try:
-                req = TVDBRequest(username=self.config['username'], account_id=self.config['account_id']).get(
+                req = TVDBRequest(username=self.config['username'], account_id=self.config['account_id'], api_key=self.config['api_key']).get(
                     'user/favorites')
                 series_ids = [int(f_id) for f_id in req['favorites'] if f_id != '']
             except RequestException as e:
@@ -86,7 +87,7 @@ class TheTVDBSet(MutableSet):
             log.verbose('entry does not have `tvdb_id`, cannot add to list. Consider using a lookup plugin`')
             return
         try:
-            TVDBRequest(username=self.config['username'], account_id=self.config['account_id']).put(
+            TVDBRequest(username=self.config['username'], account_id=self.config['account_id'], api_key=self.config['api_key']).put(
                 'user/favorites/{}'.format(entry['tvdb_id']))
         except RequestException as e:
             log.error('Could not add tvdb_id {} to favourites list: {}'.format(entry['tvdb_id'], e))
@@ -97,7 +98,7 @@ class TheTVDBSet(MutableSet):
             log.verbose('entry does not have `tvdb_id`, cannot remove from list. Consider using a lookup plugin`')
             return
         try:
-            TVDBRequest(username=self.config['username'], account_id=self.config['account_id']).delete(
+            TVDBRequest(username=self.config['username'], account_id=self.config['account_id'], api_key=self.config['api_key']).delete(
                 'user/favorites/{}'.format(entry['tvdb_id']))
         except RequestException as e:
             log.error('Could not add tvdb_id {} to favourites list: {}'.format(entry['tvdb_id'], e))

--- a/flexget/tests/test_thetvdb.py
+++ b/flexget/tests/test_thetvdb.py
@@ -296,10 +296,12 @@ class TestTVDBList(object):
                 thetvdb_list:
                   username: flexget
                   account_id: 80FB8BD0720CA5EC
+                  api_key: 4D297D8CFDE0E105
           test_strip_dates:
             thetvdb_list:
               username: flexget
               account_id: 80FB8BD0720CA5EC
+              api_key: 4D297D8CFDE0E105
               strip_dates: yes
     """
 
@@ -350,10 +352,12 @@ class TestTVDBFavorites(object):
                 thetvdb_list:
                   username: flexget
                   account_id: 80FB8BD0720CA5EC
+                  api_key: 4D297D8CFDE0E105
           test_strip_dates:
             thetvdb_list:
               username: flexget
               account_id: 80FB8BD0720CA5EC
+              api_key: 4D297D8CFDE0E105
               strip_dates: yes
     """
 

--- a/flexget/tests/test_thetvdb_list.py
+++ b/flexget/tests/test_thetvdb_list.py
@@ -14,8 +14,9 @@ class TestTheTVDBList(object):
       tasks: {}
     """
 
-    tvdb_config = {'username': 'flexget2',
-                   'account_id': 'D3405F10B200C4DB'}
+    tvdb_config = {'username': 'flexget',
+                   'account_id': '80FB8BD0720CA5EC',
+                   'api_key': '4D297D8CFDE0E105'}
 
     def test_thetvdb_list_add(self):
         tvdb_set = TheTVDBSet(self.tvdb_config)


### PR DESCRIPTION
### Motivation for changes:
Fixes thetvdb_list plugin.

### Detailed changes:
- The authorization request now requires an api key, which can be generated at https://www.thetvdb.com/member/api now included at api_key in config.yml. More info here: https://api.thetvdb.com/swagger#/Authentication

### Addressed issues:
- n/a

### Implemented feature requests:
- n/a

### Config usage if relevant (new plugin or updated schema):
```
tasks:
  series:
    ...
    configure_series:
      from:
        thetvdb_list:
          username: invisiblek
          account_id: 1234567890ABCDEF
          api_key: 1234567890ABCDEF
```
### Log and/or tests output (preferably both):
```
Error during input plugin thetvdb_list: Error retrieving favorites from thetvdb: 503 Server Error: Service Unavailable for url: https://api.thetvdb.com/user/favorites
```
#### To Do:
- [x] Update test scripts. The accounts `flexget` and `flexget2` will need api keys generated and added to `flexget/tests/test_thetvdb.py` and `flexget/tests/test_thetvdb_list.py`, respectively.

