### PR TITLE
Added filtering based on metacritic score

### DIFF
--- a/flexget/plugins/filter/imdb.py
+++ b/flexget/plugins/filter/imdb.py
@@ -23,7 +23,7 @@ class FilterImdb(object):
       min_meta_score: <num>
       min_year: <num>
       max_year: <num>
-      
+
       # accept movies with any of these genres
       accept_genres:
         - genre1

--- a/flexget/plugins/filter/imdb.py
+++ b/flexget/plugins/filter/imdb.py
@@ -20,9 +20,10 @@ class FilterImdb(object):
 
       min_score: <num>
       min_votes: <num>
+      min_meta_score: <num>
       min_year: <num>
       max_year: <num>
-
+      
       # accept movies with any of these genres
       accept_genres:
         - genre1
@@ -87,6 +88,7 @@ class FilterImdb(object):
             'max_year': {'type': 'integer'},
             'min_votes': {'type': 'integer'},
             'min_score': {'type': 'number'},
+            'min_meta_score': {'type': 'integer'},
             'accept_genres': {'type': 'array', 'items': {'type': 'string'}},
             'reject_genres': {'type': 'array', 'items': {'type': 'string'}},
             'reject_languages': {'type': 'array', 'items': {'type': 'string'}},
@@ -134,6 +136,9 @@ class FilterImdb(object):
             if 'min_votes' in config:
                 if entry.get('imdb_votes', 0) < config['min_votes']:
                     reasons.append('min_votes (%s < %s)' % (entry.get('imdb_votes'), config['min_votes']))
+            if 'min_meta_score' in config:
+                if entry.get('imdb_meta_score', 0) < config['min_meta_score']:
+                    reasons.append('min_meta_score (%s < %s)' % (entry.get('imdb_meta_score'), config['min_meta_score']))
             if 'min_year' in config:
                 if entry.get('imdb_year', 0) < config['min_year']:
                     reasons.append('min_year (%s < %s)' % (entry.get('imdb_year'), config['min_year']))


### PR DESCRIPTION
Added filtering based on Metacritic score parsed from IMDB page.

### Motivation for changes:
I want to be able to filter movies based on metacritic score as well as IMDB score

### Detailed changes:
- added/defined "min_meta_score" as a parameter for filtering and added filtering of results based on this parameter (done int he same method as for min_score)

### Addressed issues:
- Fixes # .

### Implemented feature requests:
- Feathub #[XX](https://feathub.com/Flexget/Flexget/+XX).

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
```
paste output here
```
#### To Do:

- [ ] Stuff..

