### PR TITLE
Add metacritic score parsing

### DIFF
--- a/flexget/utils/imdb.py
+++ b/flexget/utils/imdb.py
@@ -251,6 +251,7 @@ class ImdbParser(object):
         self.writers = {}
         self.score = 0.0
         self.votes = 0
+        self.meta_score = 0
         self.year = 0
         self.plot_outline = None
         self.name = None
@@ -320,6 +321,12 @@ class ImdbParser(object):
             self.score = float(score_elem.text)
         else:
             log.debug('No score found for %s' % self.imdb_id)
+            
+        meta_score_elem = title_overview.find(class='metacriticScore')
+        if meta_score_elem:
+            self.meta_score = str_to_int(meta_score_elem.text)
+        else:
+            log.debug('No Metacritic score found for %s' % self.imdb_id)
 
         # get director(s)
         for director in title_overview.select('[itemprop="director"] > a'):

--- a/flexget/utils/imdb.py
+++ b/flexget/utils/imdb.py
@@ -322,7 +322,7 @@ class ImdbParser(object):
         else:
             log.debug('No score found for %s' % self.imdb_id)
             
-        meta_score_elem = title_overview.find(class='metacriticScore')
+        meta_score_elem = title_overview.find(attrs={'class': 'metacriticScore'})
         if meta_score_elem:
             self.meta_score = str_to_int(meta_score_elem.text)
         else:

--- a/flexget/utils/imdb.py
+++ b/flexget/utils/imdb.py
@@ -321,7 +321,7 @@ class ImdbParser(object):
             self.score = float(score_elem.text)
         else:
             log.debug('No score found for %s' % self.imdb_id)
-            
+
         meta_score_elem = title_overview.find(attrs={'class': 'metacriticScore'})
         if meta_score_elem:
             self.meta_score = str_to_int(meta_score_elem.text)


### PR DESCRIPTION
Add metacritic score parsing from IMDB movie pages. 

Note: I was not able to test this. I think this should work, but the HTML class is defined as follows in IMDB:
<div class="metacriticScore score_favorable titleReviewBarSubItem">

I'm not sure if the class statement on line 325 needs to include all three classes to make the match.

### Motivation for changes:

### Detailed changes:
- 

### Addressed issues:
- Fixes # .

### Implemented feature requests:
- Feathub #[XX](https://feathub.com/Flexget/Flexget/+XX).

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
```
paste output here
```
#### To Do:

- [ ] Stuff..

