### PR TITLE
[tvdb] Commit early

### DIFF
--- a/flexget/api/plugins/tvdb_lookup.py
+++ b/flexget/api/plugins/tvdb_lookup.py
@@ -153,7 +153,7 @@ class TVDBEpisodeSearchAPI(APIResource):
         ep_number = args.get('ep_number')
         air_date = args.get('air_date')
 
-        if not ((season_number and ep_number) or absolute_number or air_date):
+        if not (season_number and ep_number or absolute_number or air_date):
             raise BadRequest('not enough parameters for lookup. Either season and episode number or absolute number '
                              'are required.')
         kwargs = {'tvdb_id': tvdb_id,

--- a/flexget/plugins/internal/api_tvdb.py
+++ b/flexget/plugins/internal/api_tvdb.py
@@ -637,7 +637,6 @@ def lookup_episode(name=None, season_number=None, episode_number=None, absolute_
                 if not episode or (episode and episode.expired is not False):
                     updated_episode = TVDBEpisode(series.id, results[0]['id'], language=language)
                     episode = session.merge(updated_episode)
-                    session.commit()
         except requests.RequestException as e:
             raise LookupError('Error looking up episode from TVDb (%s)' % e)
     if episode:

--- a/flexget/plugins/metainfo/thetvdb_lookup.py
+++ b/flexget/plugins/metainfo/thetvdb_lookup.py
@@ -1,9 +1,8 @@
 from __future__ import unicode_literals, division, absolute_import
-
-from functools import partial
-
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
+
+from functools import partial
 import logging
 
 from flexget import plugin
@@ -118,7 +117,7 @@ class PluginThetvdbLookup(object):
             )
             entry.update_using_map(field_map, series)
         except LookupError as e:
-            log.debug('Error looking up tvdb series information for %s: %s', entry['title'], e.args[0])
+            log.debug('Error looking up tvdb series information for %s: %s', entry['title'], e)
         return entry
 
     def lazy_series_lookup(self, entry, language):


### PR DESCRIPTION
### Motivation for changes:
Db locks
### Detailed changes:
- Commit after any DML to avoid a long running transaction, which locks the db needlessly.