### PR TITLE
change irc daemon task_re configuration structure to enable AND conditions

### DIFF
--- a/flexget/plugins/daemon/irc.py
+++ b/flexget/plugins/daemon/irc.py
@@ -55,23 +55,32 @@ schema = {
                     'task': one_or_more({
                         'type': 'string'
                     }),
-                    'task_re': one_or_more({
-                        'type': 'object',
-                        'properties': {
-                            'task': {
-                                'type': 'string'
-                            },
-                            'patterns': one_or_more({
-                                'type': 'object',
-                                'properties': {
-                                    'regexp': {'type': 'string'},
-                                    'field': {'type': 'string'}
+                    'task_re': {
+                        'type': 'array',
+                        'items': {
+                            'type': 'object',
+                            'properties': {
+                                'task': {
+                                    'type': 'string'
                                 },
-                                'required': ['regexp', 'field'],
-                                'additionalProperties': False
-                            })
-                        },
-                    }, unique_items=True),
+                                'patterns': {
+                                    'type': 'array',
+                                    'items': {
+                                        'type': 'object',
+                                        'properties': {
+                                            'regexp': {'type': 'string'},
+                                            'field': {'type': 'string'}
+                                        },
+                                        'required': ['regexp', 'field'],
+                                        'additionalProperties': False
+                                    }
+                                }
+                            },
+                            'required': ['task', 'patterns'],
+                            'additionalProperties': False
+
+                        }
+                    },
                     'queue_size': {'type': 'integer', 'default': 1},
                     'use_ssl': {'type': 'boolean', 'default': False},
                     'task_delay': {'type': 'integer'},


### PR DESCRIPTION
### Motivation for changes:
The current `task_re` functionality in the `irc_daemon` plugin allows users to define one or more regex that when matched will cause that task to execute.  When more than one regex is defined for a task, the task is executed when ANY of them are a match.  If you want to only execute a task when regex1 matches AND regex2 matches, this cannot currently be done.

This pull request restructures the format of the `task_re` config so both AND conditions and OR conditions can be achieved.

### Detailed changes:
Change format of `task_re` config to allow a task multiple times with different regexes (OR condition) and multiple regexes to be defined for a single task (AND condition).

### Config usage if relevant (new plugin or updated schema):
In this example, the tasks will only execute when both of their respective patterns are a match:
```
task_re:
  - task: get_movie_entry
    patterns:
      - regexp: (MovieHD)
        field: irc_category
      - regexp: 'true'
        field: irc_scene
  - task: get_tv_entry
    patterns:
      - regexp: (TvHD)
        field: irc_category
      - regexp: 'true'
        field: irc_scene
```
In this example, the `get_tv_entry` will execute if either regex matches (or both):
```
task_re:
  - task: get_tv_entry
    patterns:
      - regexp: (TvSD)
        field: irc_category
  - task: get_tv_entry
    patterns:
      - regexp: (TvHD)
        field: irc_category
```

#### To Do:

- [ ] Update documentation

