### PR TITLE
next_series_episodes: added `only_same_season` config option

### DIFF
--- a/flexget/plugins/input/next_series_episodes.py
+++ b/flexget/plugins/input/next_series_episodes.py
@@ -227,7 +227,7 @@ class NextSeriesEpisodes(object):
                 if latest.is_season:
                     # A season pack was picked up in the task, no need to look for more episodes
                     return
-                elif not self.config['only_same_season'] and identified_by == 'ep' and (
+                elif not self.config.get('only_same_season') and identified_by == 'ep' and (
                             entry['series_season'] == latest.season and entry['series_episode'] == latest.number + 1):
                     # We searched for next predicted episode of this season unsuccessfully, try the next season
                     self.rerun_entries.append(self.search_entry(series, latest.season + 1, 1, task))

--- a/flexget/plugins/input/next_series_episodes.py
+++ b/flexget/plugins/input/next_series_episodes.py
@@ -29,7 +29,8 @@ class NextSeriesEpisodes(object):
                 'type': 'object',
                 'properties': {
                     'from_start': {'type': 'boolean', 'default': False},
-                    'backfill': {'type': 'boolean', 'default': False}
+                    'backfill': {'type': 'boolean', 'default': False},
+                    'only_same_season': {'type': 'boolean', 'default': False}
                 },
                 'additionalProperties': False
             }
@@ -82,7 +83,7 @@ class NextSeriesEpisodes(object):
             return
         if isinstance(config, bool):
             config = {}
-
+        self.config = config
         if task.is_rerun:
             # Just return calculated next eps on reruns
             entries = self.rerun_entries
@@ -226,8 +227,8 @@ class NextSeriesEpisodes(object):
                 if latest.is_season:
                     # A season pack was picked up in the task, no need to look for more episodes
                     return
-                elif identified_by == 'ep' and \
-                        (entry['series_season'] == latest.season and entry['series_episode'] == latest.number + 1):
+                elif not self.config['only_same_season'] and identified_by == 'ep' and (
+                            entry['series_season'] == latest.season and entry['series_episode'] == latest.number + 1):
                     # We searched for next predicted episode of this season unsuccessfully, try the next season
                     self.rerun_entries.append(self.search_entry(series, latest.season + 1, 1, task))
                     log.debug('%s %s not found, rerunning to look for next season' %

--- a/flexget/tests/test_next_series_episodes.py
+++ b/flexget/tests/test_next_series_episodes.py
@@ -117,6 +117,15 @@ class TestNextSeriesEpisodes(object):
                  - Testing SerieS 8
             max_reruns: 0
             mock_output: yes
+          test_next_series_episodes_only_same_season:
+            next_series_episodes:
+              only_same_season: yes
+            series:
+            - Test Series 8:
+                identified_by: ep
+            regexp:
+              reject:
+              - .
     """
 
     @pytest.fixture(scope='class', params=['internal', 'guessit'], ids=['internal', 'guessit'])
@@ -220,6 +229,14 @@ class TestNextSeriesEpisodes(object):
         task = execute_task('test_next_series_episodes_alternate_name')
         s2 = len(task.mock_output[0].get('search_strings'))
         assert s2 > s1, 'Alternate names did not create sufficient search strings.'
+
+    def test_next_series_episodes_only_same_season(self, execute_task):
+        self.inject_series(execute_task, 'Test Series 8 S01E01')
+        task = execute_task('test_next_series_episodes_only_same_season')
+        assert task._rerun_count == 0
+        assert len(task.all_entries) == 1
+        assert not task.find_entry(title='Test Series 8 S02E01')
+
 
 class TestNextSeriesEpisodesSeasonPack(object):
     _config = """


### PR DESCRIPTION
### Motivation for changes:
To restrict reruns to same season as latest episode emitted
### Config usage if relevant (new plugin or updated schema):
```
next_series_episodes:
  only_same_season: yes
```
