### PR TITLE
[rtorrent] Adding a torrent can sometimes take a while, so verification fails

### DIFF
--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -676,7 +676,7 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
             self._verify_load(client, entry['torrent_info_hash'])
             log.info('%s added to rtorrent' % entry['title'])
         except xmlrpc_client.Error as e:
-            entry.fail('Failed to verify torrent loaded: %s' % str(e))
+            log.warning('Failed to verify torrent %s loaded: %s', entry['title'], str(e))
 
     def on_task_learn(self, task, config):
         """ Make sure all temp files are cleaned up when entries are learned """


### PR DESCRIPTION

### Motivation for changes:
Loading torrents into rtorrent can take a while for me, so when adding multiple torrents it cannot verify the subsequent additions, but it's _never_ happened for me that it wasn't added.
### Detailed changes:
- Changed entry.fail to log.warning
