### PR TITLE
 Fully qualify plugin.PluginError

### DIFF
--- a/flexget/plugins/output/decompress.py
+++ b/flexget/plugins/output/decompress.py
@@ -54,7 +54,7 @@ def get_output_path(to, entry):
         else:
             return os.path.dirname(entry.get('location'))
     except RenderError:
-        raise PluginError('Could not render path: %s', to)
+        raise plugin.PluginError('Could not render path: %s', to)
 
 
 def extract_info(info, archive, to, keep_dirs):

--- a/flexget/plugins/output/decompress.py
+++ b/flexget/plugins/output/decompress.py
@@ -54,7 +54,7 @@ def get_output_path(to, entry):
         else:
             return os.path.dirname(entry.get('location'))
     except RenderError:
-        raise plugin.PluginError('Could not render path: %s', to)
+        raise plugin.PluginError('Could not render path: %s' % to)
 
 
 def extract_info(info, archive, to, keep_dirs):


### PR DESCRIPTION
### Motivation for changes:
Decompress plugin was failing to throw `PluginError`.
### Detailed changes:
- Fully qualified `plugin.PluginError` in Decompress plugin


### Log and/or tests output (preferably both):
```
2018-07-19 12:34 CRITICAL task          Movies-Decompress BUG: Unhandled error in plugin decompress: global name 'PluginError' is not defined
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/flexget/task.py", line 486, in __run_plugin
    return method(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/flexget/event.py", line 23, in __call__
    return self.func(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/flexget/plugins/output/decompress.py", line 205, in on_task_output
    self.handle_entry(entry, config)
  File "/usr/lib/python2.7/site-packages/flexget/plugins/output/decompress.py", line 182, in handle_entry
    to = get_output_path(config['to'], entry)
  File "/usr/lib/python2.7/site-packages/flexget/plugins/output/decompress.py", line 57, in get_output_path
    raise PluginError('Could not render path: %s', to)
NameError: global name 'PluginError' is not defined
```