### PR TITLE
[FIX] MyAnimeList - Use JSON instead of XML

### DIFF
--- a/flexget/plugins/input/my_anime_list.py
+++ b/flexget/plugins/input/my_anime_list.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 import logging
-import xml.etree.ElementTree as ET
+import json
 
 from flexget import plugin
 from flexget.config_schema import one_or_more
@@ -12,24 +12,26 @@ from flexget.utils.cached_input import cached
 from flexget.utils.requests import RequestException
 
 log = logging.getLogger('my_anime_list')
+
 STATUS = {
-    '1': 'watching',
-    '2': 'completed',
-    '3': 'on_hold',
-    '4': 'dropped',
-    '6': 'plan_to_watch',
+    'watching' : 1,
+    'completed' : 2,
+    'on_hold' : 3,
+    'dropped' : 4,
+    'plan_to_watch' : 6,
+    'all' : 7
 }
 
-ANIME_TYPE = {
-    '0': 'unknown',
-    '1': 'series',
-    '2': 'ova',
-    '3': 'movie',
-    '4': 'special',
-    '5': 'ona',
-    '6': 'music'
-}
-
+ANIME_TYPE = [
+    'all',
+    'tv',
+    'ova',
+    'movie',
+    'special',
+    'ona',
+    'music',
+    'unknown'
+]
 
 class MyAnimeList(object):
     """" Creates entries for series and movies from MyAnimeList list
@@ -48,8 +50,8 @@ class MyAnimeList(object):
         'type': 'object',
         'properties': {
             'username': {'type': 'string'},
-            'status': one_or_more({'type': 'string', 'enum': list(STATUS.values())}, unique_items=True),
-            'type': one_or_more({'type': 'string', 'enum': list(ANIME_TYPE.values())}, unique_items=True)
+            'status': one_or_more({'type': 'string', 'enum': list(STATUS.keys()), 'default': 'all'}, unique_items=True),
+            'type': one_or_more({'type': 'string', 'enum': list(ANIME_TYPE), 'default': 'all'}, unique_items=True)
         },
         'required': ['username'],
         'additionalProperties': False
@@ -58,9 +60,8 @@ class MyAnimeList(object):
     @cached('my_anime_list', persist='2 hours')
     def on_task_input(self, task, config):
         entries = []
-        parameters = {'u': config['username'], 'status': 'all', 'type': 'anime'}
-        selected_status = config.get('status', list(STATUS.values()))
-        selected_types = config.get('type', list(ANIME_TYPE.values()))
+        selected_status = config.get('status', list(STATUS.keys()))
+        selected_types = config.get('type', list(ANIME_TYPE))
 
         if not isinstance(selected_status, list):
             selected_status = [selected_status]
@@ -68,57 +69,34 @@ class MyAnimeList(object):
         if not isinstance(selected_types, list):
             selected_types = [selected_types]
 
+        for i in range(len(selected_status)):
+            selected_status[i] = STATUS[selected_status[i]]
+
         try:
-            list_response = task.requests.get('https://myanimelist.net/malappinfo.php', params=parameters)
+            list.response = task.requests.get('https://myanimelist.net/animelist/' + config['username'] + '/load.json')
         except RequestException as e:
             raise plugin.PluginError('Error finding list on url: {url}'.format(url=e.request.url))
 
         try:
-            tree = ET.fromstring(list_response.text.encode('utf-8'))
-            list_items = tree.findall('anime')
-        except ET.ParseError:
-            raise plugin.PluginError('Bad XML')
+            js = json.loads(list.response.text.encode('utf-8'))
+        except:
+            raise plugin.PluginError('Error reading JSON')
 
-        for item in list_items:
-            my_anime_list_id = item.findtext('series_animedb_id')
-            title = item.findtext('series_title').strip()
-            anime_type = ANIME_TYPE[item.findtext('series_type', 1)]
-            my_status = STATUS[item.findtext('my_status')]
-
-            my_tags = []
-            alternate_names = []
-            is_exact = False
-
-            for name in item.findtext('series_synonyms', '').split('; '):
-                stripped = name.strip()
-                if stripped and stripped is not title:
-                    alternate_names.append(name)
-
-            for tag in item.findtext('my_tags', '').split(','):
-                stripped = tag.strip()
-                if stripped:
-                    my_tags.append(stripped)
-                    if stripped is 'exact':
-                        is_exact = True
-
-            # if user has chosen a status or a type, match strictly, otherwise let it all through
-            wanted_status = not selected_status or my_status in selected_status
-            wanted_type = not selected_types or anime_type in selected_types
-
-            if wanted_status and wanted_type:
-                entry = Entry(title=title,
-                              url='https://myanimelist.net/anime/{}'.format(my_anime_list_id),
-                              configure_series_alternate_name=alternate_names,
-                              my_anime_list_type=anime_type,
-                              my_anime_list_status=my_status,
-                              my_anime_list_tags=my_tags)
-
-                if is_exact:
-                    entry['configure_series_exact'] = True
-
-                if entry.isvalid():
-                    entries.append(entry)
-
+        for anime in js:
+            if (anime["status"] in selected_status
+                or config['status'] == 'all'
+                ) and (
+                anime["anime_media_type_string"].lower() in selected_types
+                or config['type'] == 'all'
+            ):
+                entry = Entry(
+                    title = anime["anime_title"],
+                    url = "https://myanimelist.net" + anime["anime_url"],
+                    mal_name = anime["anime_title"],
+                    mal_poster = anime["anime_image_path"],
+                    mal_type = anime["anime_media_type_string"]
+                )
+                entries.append(entry)
         return entries
 
 


### PR DESCRIPTION
Fixed MyAnimeList input plugin by switching from PHP\XML to JSON parsing.
ANIME_TYPE item 'series' updated to 'tv' in order to better reflect how the site refers to these.

### Motivation for changes: Plugin stopped working after site maintenance and backend changes

### Detailed changes:
- Rewrote most of the segment responsible for fetching the data to use the JSON address and handle its data for Plex entries.

### Addressed issues:
- Fixes #2152  .

### Implemented feature requests:
- None

### Config usage if relevant (new plugin or updated schema):
- `type: series` should be updated to `type: tv`

#### To Do:

- [ ] Review
- [ ] Pull

