### PR TITLE
[add] slack: Support message attachments

### DIFF
--- a/flexget/plugins/notifiers/slack.py
+++ b/flexget/plugins/notifiers/slack.py
@@ -29,16 +29,57 @@ class SlackNotifier(object):
                 [username: <string>] (override username)
                 [icon_emoji: <string>] (override emoji icon)
                 [icon_url: <string>] (override emoji icon)
+                [attachments: <array>[<object>]] (override attachments)
 
     """
     schema = {
         'type': 'object',
         'properties': {
-            'web_hook_url': {'type': 'string'},
-            'channel': {'type': 'string'},
+            'web_hook_url': {'type': 'string', 'format': 'uri'},
             'username': {'type': 'string', 'default': 'Flexget'},
+            'icon_url': {'type': 'string', 'format': 'uri'},
             'icon_emoji': {'type': 'string'},
-            'icon_url': {'type': 'string', 'format': 'url'}
+            'channel': {'type': 'string'},
+            'unfurl_links': {'type': 'boolean'},
+            'message': {'type': 'string'},
+            'attachments': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'title': {'type': 'string'},
+                        'author_name': {'type': 'string'},
+                        'author_link': {'type': 'string'},
+                        'author_icon': {'type': 'string'},
+                        'title_link': {'type': 'string'},
+                        'image_url': {'type': 'string'},
+                        'thumb_url': {'type': 'string'},
+                        'footer': {'type': 'string'},
+                        'footer_icon': {'type': 'string'},
+                        'ts': {'type': 'number'},
+                        'fallback': {'type': 'string'},
+                        'text': {'type': 'string'},
+                        'pretext': {'type': 'string'},
+                        'color': {'type': 'string'},
+                        'fields': {
+                            'type': 'array',
+                            'minItems': 1,
+                            'items': {
+                                'type': 'object',
+                                'properties': {
+                                    'title': {'type': 'string'},
+                                    'value': {'type': 'string'},
+                                    'short': {'type': 'boolean'}
+                                },
+                                'required': ['title'],
+                                'additionalProperties': False
+                            }
+                        }
+                    },
+                    'required': ['fallback'],
+                    'additionalProperties': False
+                }
+            }
         },
         'not': {
             'required': ['icon_emoji', 'icon_url']
@@ -52,7 +93,12 @@ class SlackNotifier(object):
         """
         Send a Slack notification
         """
-        notification = {'text': message, 'channel': config.get('channel'), 'username': config.get('username')}
+        notification = {
+            'text': message,
+            'username': config.get('username'),
+            'channel': config.get('channel'),
+            'attachments': config.get('attachments')
+        }
         if config.get('icon_emoji'):
             notification['icon_emoji'] = ':%s:' % config['icon_emoji'].strip(':')
         if config.get('icon_url'):


### PR DESCRIPTION
### Motivation for changes:
Supersedes/reopens #1716.

### Detailed changes:
- Add attachments to schema and include in payload

### Config usage:
```
templates:
  slack:
    notify:
      entries:
        message: ":movie_camera: {{ imdb_name }}"
        via:
          - slack:
              web_hook_url: "{? slack.web_hook_url ?}"
              username: "{? slack.username ?}"
              attachments:
                - title: "{{ imdb_name }} ({{ imdb_year }})"
                  image_url: "{{ tmdb_posters | first }}" # better quality
                  title_link: "{{ imdb_url }}"
                  fallback: "{{ imdb_name }} ({{ imdb_year }})"
                  text: "{{ imdb_plot_outline }}"
                  color: "#e67e22"
                  footer: "{{ task }}"
                  footer_icon: "https://avatars2.githubusercontent.com/u/17483320?s=400&v=4"
                  fields:
                    - title: Runtime
                      value: "{{ tmdb_runtime }} mins"
                      short: true
                    - title: Score
                      value: "{{ imdb_score }}"
                      short: true
                    - title: Genres
                      value: "{{ imdb_genres | join(', ') | title }}"
                      short: true
                    - title: Rating
                      value: "{{ imdb_mpaa_rating }}"
                      short: true
                    - title: Cast
                      value: >
                        {% for key, value in imdb_actors.iteritems() %}
                          {{value}}
                          {% if not loop.last %}, {% endif %}
                        {% endfor %}
                      short: false
```

### Output:
![image](https://user-images.githubusercontent.com/8337331/43484779-9abe54e6-950f-11e8-8f0c-0c72c456d1c8.png)

#### To Do:
- Update wiki
