### PR TITLE
[fix] sabnzbd: Handle local nzb files correctly

### DIFF
--- a/flexget/plugins/output/sabnzbd.py
+++ b/flexget/plugins/output/sabnzbd.py
@@ -62,7 +62,6 @@ class OutputSabnzbd(object):
             params['ma_username'] = config['username']
         if 'password' in config:
             params['ma_password'] = config['password']
-        params['mode'] = 'addurl'
         return params
 
     def on_task_output(self, task, config):
@@ -81,6 +80,13 @@ class OutputSabnzbd(object):
             params['name'] = ''.join([x for x in entry['url'] if ord(x) < 128])
             # add cleaner nzb name (undocumented api feature)
             params['nzbname'] = ''.join([x for x in entry['title'] if ord(x) < 128])
+
+            # check whether file is local or remote
+            if entry['url'].startswith('file://'):
+                params['mode'] = 'addlocalfile'
+                params['name'] = entry['location']
+            else:
+                params['mode'] = 'addurl'
 
             request_url = config['url'] + urlencode(params)
             log.debug('request_url: %s' % request_url)


### PR DESCRIPTION
### Motivation for changes:
SABnzbd is mishandling local nzb files while logging them as successful.

### Detailed changes:
- Add a check for the URI scheme
- Uses `addlocalfile` endpoint if dealing with a file, or `addurl` otherwise

### Addressed issues:
- Fixes #2186