### PR TITLE
Scheduler should perhaps use a separate DB-file

### DIFF
--- a/flexget/_version.py
+++ b/flexget/_version.py
@@ -7,4 +7,4 @@ The version should always be set to the <next release version>.dev
 The jenkins release job will automatically strip the .dev for release,
 and update the version again for continued development.
 """
-__version__ = '2.14.25.dev'
+__version__ = '2.15.0.dev'


### PR DESCRIPTION
### Motivation for changes:
It appears slower devices have trouble with race conditions in the scheduler and task executions. Credit goes to #2205 (@gxfxyz).
### Detailed changes:
- Added a separate db-file for apscheduler's jobstore

### Addressed issues:
- Fixes #2205 
- Fixes #2025
- Fixes #1371