### PR TITLE
series: save entry state before metainfo phase to avoid lazy lookups during backlog (timeframe)

### DIFF
--- a/flexget/plugins/input/backlog.py
+++ b/flexget/plugins/input/backlog.py
@@ -122,6 +122,16 @@ class InputBacklog(object):
         # Return the entries from backlog that are not already in the task
         return injections
 
+    @plugin.priority(255)
+    def on_task_metainfo(self, task, config):
+        # Take a snapshot of any new entries' states before metainfo event in case we have to store them to backlog
+        # This is really a hack to avoid unnecessary lazy lookups causing db locks
+        for entry in task.entries:
+            snapshot = entry.snapshots.get('after_input')
+            if snapshot:
+                continue
+            entry.take_snapshot('after_input')
+
     def on_task_abort(self, task, config):
         """Remember all entries until next execution when task gets aborted."""
         if task.entries:

--- a/flexget/plugins/input/backlog.py
+++ b/flexget/plugins/input/backlog.py
@@ -125,7 +125,10 @@ class InputBacklog(object):
     @plugin.priority(255)
     def on_task_metainfo(self, task, config):
         # Take a snapshot of any new entries' states before metainfo event in case we have to store them to backlog
-        # This is really a hack to avoid unnecessary lazy lookups causing db locks
+        # This is really a hack to avoid unnecessary lazy lookups causing db locks. Ideally, saving a snapshot
+        # should not cause lazy lookups, but we currently have no other way of saving a lazy field than performing its
+        # action.
+        # https://github.com/Flexget/Flexget/issues/1000
         for entry in task.entries:
             snapshot = entry.snapshots.get('after_input')
             if snapshot:


### PR DESCRIPTION
### Motivation for changes:
Old issue
### Detailed changes:
- Take an entry snapshot just before metainfo phase

### Addressed issues:
- Fixes #1000 

### Details
It's a hack, but the only reason lazy lookups are causing db locks is that some of the entries were generated after input phase or injected. Any regular entry will actually have a snapshot taken during input phase and not cause any issues, hence the changes in this PR.