### PR TITLE
Add option to escape unescaped ampersands

### DIFF
--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -192,7 +192,7 @@ class InputRSS(object):
 
         for idx, char in enumerate(content):
 
-            if type(char) is int:
+            if isinstance(char, int):
                 char = tobytes(chr(char))
             if not in_cdata_block and char == b'&':
                 if not content[idx:idx + 7].startswith(valid_escapes):

--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -186,22 +186,19 @@ class InputRSS(object):
         log.critical('I have saved the invalid content to %s for you to view', filepath)
 
     def escape_content(self, content):
-        valid_escapes = ['&quot;', '&apos;', '&lt;', '&gt;', '&amp;']
+        valid_escapes = ('&quot;', '&apos;', '&lt;', '&gt;', '&amp;')
         future_result = []
         in_cdata_block = False
         
         for idx, char in enumerate(content):
             char = chr(char)
             if not in_cdata_block and char == '&':
-                for escape in valid_escapes:
-                    if content[idx:idx+len(escape)] == escape:
-                        break
-                else:
+                if not str(content[idx:idx+8]).startswith(valid_escapes):
                     char = '&amp;'
             elif not in_cdata_block and char == '<' and content[idx:idx+9] == '<![CDATA[':
                 in_cdata_block = True
-            elif in_cdata_block and char == ']' and content[idx:idx+3] == ']]>':
-                should_change = False
+            elif in_cdata_block and char == ']' and content[idx-2:idx+1] == ']]>':
+                in_cdata_block = False
             future_result.append(char)
         return ''.join(future_result)
 

--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -190,23 +190,19 @@ class InputRSS(object):
         future_result = []
         in_cdata_block = False
         
-        for idx, char in enumerate(letter for letter in content):
-            if not in_cdata_block and chr(char) == '&':
+        for idx, char in enumerate(content):
+            char = chr(char)
+            if not in_cdata_block and char == '&':
                 for escape in valid_escapes:
                     if content[idx:idx+len(escape)] == escape:
                         break
                 else:
-                    future_result.append('&amp;')
-            elif not in_cdata_block and chr(char) == '<':
-                if content[idx:idx+9] == '<![CDATA[':
-                    should_change = False
-                future_result.append(chr(char))
-            elif in_cdata_block and chr(char) == ']':
-                if content[idx:idx+3] == ']]>':
-                    should_change = True
-                future_result.append(chr(char))
-            else:
-                future_result.append(chr(char))
+                    char = '&amp;'
+            elif not in_cdata_block and char == '<' and content[idx:idx+9] == '<![CDATA[':
+                in_cdata_block = True
+            elif in_cdata_block and char == ']' and content[idx:idx+3] == ']]>':
+                should_change = False
+            future_result.append(char)
         return ''.join(future_result)
 
     def add_enclosure_info(self, entry, enclosure, filename=True, multiple=False):

--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -189,7 +189,7 @@ class InputRSS(object):
         valid_escapes = ('&quot;', '&apos;', '&lt;', '&gt;', '&amp;')
         future_result = []
         in_cdata_block = False
-        
+
         for idx, char in enumerate(content):
             char = chr(char)
             if not in_cdata_block and char == '&':
@@ -197,7 +197,7 @@ class InputRSS(object):
                     char = '&amp;'
             elif not in_cdata_block and char == '<' and content[idx:idx+9] == '<![CDATA[':
                 in_cdata_block = True
-            elif in_cdata_block and char == ']' and content[idx-2:idx+1] == ']]>':
+            elif in_cdata_block and char == ']' and content[idx-1:idx+2] == ']]>':
                 in_cdata_block = False
             future_result.append(char)
         return ''.join(future_result)

--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -267,10 +267,6 @@ class InputRSS(object):
                 # convert content to ascii (cleanup), can also help with parsing problems on malformed feeds
                 content = response.text.encode('ascii', 'ignore')
 
-            if config.get('escape'):
-                log.debug("Trying to escape unescaped ampersands in RSS")
-                content = self.escape_content(content)
-
             # status checks
             status = response.status_code
             if status == 304:
@@ -306,9 +302,9 @@ class InputRSS(object):
                 # Just assuming utf-8 file in this case
                 content = content.decode('utf-8', 'ignore').encode('ascii', 'ignore')
 
-            if config.get('escape'):
-                log.debug("Trying to escape unescaped in RSS")
-                content = self.escape_content(content)
+        if config.get('escape'):
+            log.debug("Trying to escape unescaped in RSS")
+            content = self.escape_content(content)
 
         if not content:
             log.error('No data recieved for rss feed.')

--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -193,7 +193,7 @@ class InputRSS(object):
         for idx, char in enumerate(content):
             char = chr(char)
             if not in_cdata_block and char == '&':
-                if not str(content[idx:idx+8]).startswith(valid_escapes):
+                if not str(content[idx:idx+7]).startswith(valid_escapes):
                     char = '&amp;'
             elif not in_cdata_block and char == '<' and content[idx:idx+9] == '<![CDATA[':
                 in_cdata_block = True

--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -267,6 +267,7 @@ class InputRSS(object):
                 content = response.text.encode('ascii', 'ignore')
 
             if config.get('escape'):
+                log.debug("Trying to escape unescaped ampersands in RSS")
                 content = self.escape_content(content)
 
             # status checks
@@ -303,6 +304,10 @@ class InputRSS(object):
             if config.get('ascii'):
                 # Just assuming utf-8 file in this case
                 content = content.decode('utf-8', 'ignore').encode('ascii', 'ignore')
+
+            if config.get('escape'):
+                log.debug("Trying to escape unescaped in RSS")
+                content = self.escape_content(content)
 
         if not content:
             log.error('No data recieved for rss feed.')

--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -191,7 +191,9 @@ class InputRSS(object):
         in_cdata_block = False
 
         for idx, char in enumerate(content):
-            char = chr(char)
+
+            if type(char) is int:
+                char = chr(char)
             if not in_cdata_block and char == '&':
                 if not str(content[idx:idx+7]).startswith(valid_escapes):
                     char = '&amp;'

--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -186,23 +186,23 @@ class InputRSS(object):
         log.critical('I have saved the invalid content to %s for you to view', filepath)
 
     def escape_content(self, content):
-        valid_escapes = ('&quot;', '&apos;', '&lt;', '&gt;', '&amp;')
+        valid_escapes = (b'&quot;', b'&apos;', b'&lt;', b'&gt;', b'&amp;')
         future_result = []
         in_cdata_block = False
 
         for idx, char in enumerate(content):
 
             if type(char) is int:
-                char = chr(char)
-            if not in_cdata_block and char == '&':
-                if not str(content[idx:idx+7]).startswith(valid_escapes):
-                    char = '&amp;'
-            elif not in_cdata_block and char == '<' and content[idx:idx+9] == '<![CDATA[':
+                char = tobytes(chr(char))
+            if not in_cdata_block and char == b'&':
+                if not content[idx:idx + 7].startswith(valid_escapes):
+                    char = b'&amp;'
+            elif not in_cdata_block and char == b'<' and content[idx:idx + 9] == b'<![CDATA[':
                 in_cdata_block = True
-            elif in_cdata_block and char == ']' and content[idx-1:idx+2] == ']]>':
+            elif in_cdata_block and char == b']' and content[idx - 1:idx + 2] == b']]>':
                 in_cdata_block = False
             future_result.append(char)
-        return ''.join(future_result)
+        return b''.join(future_result)
 
     def add_enclosure_info(self, entry, enclosure, filename=True, multiple=False):
         """Stores information from an rss enclosure into an Entry."""

--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -190,10 +190,9 @@ class InputRSS(object):
         future_result = []
         in_cdata_block = False
 
-        for idx, char in enumerate(content):
+        for idx, char in enumerate(bytes(content)):
 
-            if isinstance(char, int):
-                char = tobytes(chr(char))
+            char = bytes([char])
             if not in_cdata_block and char == b'&':
                 if not content[idx:idx + 7].startswith(valid_escapes):
                     char = b'&amp;'

--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -302,13 +302,12 @@ class InputRSS(object):
                 # Just assuming utf-8 file in this case
                 content = content.decode('utf-8', 'ignore').encode('ascii', 'ignore')
 
-        if config.get('escape'):
-            log.debug("Trying to escape unescaped in RSS")
-            content = self.escape_content(content)
-
         if not content:
             log.error('No data recieved for rss feed.')
             return []
+        if config.get('escape'):
+            log.debug("Trying to escape unescaped in RSS")
+            content = self.escape_content(content)
         try:
             rss = feedparser.parse(content)
         except LookupError as e:

--- a/flexget/tests/api_tests/test_server_api.py
+++ b/flexget/tests/api_tests/test_server_api.py
@@ -71,6 +71,7 @@ class TestServerAPI(object):
                         'url': u'http://test/rss',
                         'group_links': False,
                         'ascii': False,
+                        'escape': False,
                         'silent': False,
                         'all_entries': True
                     }

--- a/flexget/tests/api_tests/test_tasks_api.py
+++ b/flexget/tests/api_tests/test_tasks_api.py
@@ -36,6 +36,7 @@ class TestTaskAPI(object):
                         'url': u'http://test/rss',
                         'group_links': False,
                         'ascii': False,
+                        'escape': False,
                         'silent': False,
                         'all_entries': True
                     }

--- a/flexget/tests/api_tests/test_tasks_api.py
+++ b/flexget/tests/api_tests/test_tasks_api.py
@@ -61,6 +61,7 @@ class TestTaskAPI(object):
                     'url': u'http://test/rss',
                     'group_links': False,
                     'ascii': False,
+                    'escape': False,
                     'silent': False,
                     'all_entries': True
                 }
@@ -110,7 +111,7 @@ class TestTaskAPI(object):
                     'url': u'http://test/rss',
                     'group_links': False,
                     'ascii': False,
-                    'escape': False
+                    'escape': False,
                     'silent': False,
                     'all_entries': True
                 }

--- a/flexget/tests/api_tests/test_tasks_api.py
+++ b/flexget/tests/api_tests/test_tasks_api.py
@@ -110,6 +110,7 @@ class TestTaskAPI(object):
                     'url': u'http://test/rss',
                     'group_links': False,
                     'ascii': False,
+                    'escape': False
                     'silent': False,
                     'all_entries': True
                 }

--- a/flexget/tests/rss_escape.xml
+++ b/flexget/tests/rss_escape.xml
@@ -39,5 +39,13 @@
             <description>Snatch s02e07</description>
             <enclosure url="http://correct&amp;url4" length="0" type="application/x-bittorrent" />
         </item>
+        <item>
+            <title><![CDATA[Cyrillic &тест]]></title>
+            <guid isPermaLink="true">http://newstudio.tv/viewtopic.php?t=5</guid>
+            <pubDate>Sun, 07 Oct 2018 22:10:55 +0300</pubDate>
+            <link>http://newstudio.tv/viewtopic.php?t=4</link>
+            <description>Snatch s02e07</description>
+            <enclosure url="http://correct&amp;url5" length="0" type="application/x-bittorrent" />
+        </item>
     </channel>
 </rss>

--- a/flexget/tests/rss_escape.xml
+++ b/flexget/tests/rss_escape.xml
@@ -1,0 +1,43 @@
+<?xml version = "1.0" encoding = "utf-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>NewStudio</title>
+        <link>http://newstudio.tv/</link>
+        <description>NewStudio Tracker</description>
+        <language>en-us</language>
+        <atom:link href="http://newstudio.tv/rss.php" rel="self" type="application/rss+xml"/>
+
+        <item>
+            <title>Snatch</title>
+            <guid isPermaLink="true">http://newstudio.tv/viewtopic.php?t=1</guid>
+            <pubDate>Sun, 07 Oct 2018 22:10:55 +0300</pubDate>
+            <link>http://newstudio.tv/viewtopic.php?t=1</link>
+            <description>Snatch s02e07</description>
+            <enclosure url="http://wrong&url2" length="0" type="application/x-bittorrent" />
+        </item>
+        <item>
+            <title>Snatch &2</title>
+            <guid isPermaLink="true">http://newstudio.tv/viewtopic.php?t=2</guid>
+            <pubDate>Sun, 07 Oct 2018 22:10:55 +0300</pubDate>
+            <link>http://newstudio.tv/viewtopic.php?t=2</link>
+            <description>Snatch s02e07</description>
+            <enclosure url="http://some/url" length="0" type="application/x-bittorrent" />
+        </item>
+        <item>
+            <title>Snatch &amp;4</title>
+            <guid isPermaLink="true">http://newstudio.tv/viewtopic.php?t=3</guid>
+            <pubDate>Sun, 07 Oct 2018 22:10:55 +0300</pubDate>
+            <link>http://newstudio.tv/viewtopic.php?t=3</link>
+            <description>Snatch s02e07</description>
+            <enclosure url="http://correct&amp;url3" length="0" type="application/x-bittorrent" />
+        </item>
+        <item>
+            <title><![CDATA[Snatch &5]]></title>
+            <guid isPermaLink="true">http://newstudio.tv/viewtopic.php?t=4</guid>
+            <pubDate>Sun, 07 Oct 2018 22:10:55 +0300</pubDate>
+            <link>http://newstudio.tv/viewtopic.php?t=4</link>
+            <description>Snatch s02e07</description>
+            <enclosure url="http://correct&amp;url4" length="0" type="application/x-bittorrent" />
+        </item>
+    </channel>
+</rss>

--- a/flexget/tests/test_rss.py
+++ b/flexget/tests/test_rss.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
@@ -167,20 +168,35 @@ class TestEscapeInputRSS(object):
               escape: yes
     """
 
-    def test_rss(self, execute_task):
+    def test_rss_broken_url(self, execute_task):
         task = execute_task('test')
 
         assert task.find_entry(title='Snatch', url='http://wrong&url2'), \
             'RSS entry: broken url'
 
+    def test_rss_broken_title(self, execute_task):
+        task = execute_task('test')
+
         assert task.find_entry(title='Snatch &2', url='http://some/url'), \
             'RSS entry: broken name'
+
+    def test_rss_normal_after_escaping(self, execute_task):
+        task = execute_task('test')
 
         assert task.find_entry(title='Snatch &4', url='http://correct&url3'), \
             'RSS entry: normal'
 
+    def test_rss_with_cdata(self, execute_task):
+        task = execute_task('test')
+
         assert task.find_entry(title='Snatch &5', url='http://correct&url4'), \
             'RSS entry: CDATA in title'
+
+    def test_rss_with_cyrillic(self, execute_task):
+        task = execute_task('test')
+
+        assert task.find_entry(title='Cyrillic &тест', url='http://correct&url5'), \
+            'RSS entry: Cyrillic'
 
 
 @pytest.mark.xfail(reason="silverorange changed some stuff")

--- a/flexget/tests/test_rss.py
+++ b/flexget/tests/test_rss.py
@@ -176,10 +176,10 @@ class TestEscapeInputRSS(object):
         assert task.find_entry(title='Snatch &2', url='http://some/url'), \
             'RSS entry: broken name'
 
-        assert task.find_entry(title='Snatch &amp;4', url='http://correct&url3'), \
+        assert task.find_entry(title='Snatch &4', url='http://correct&url3'), \
             'RSS entry: normal'
 
-        assert task.find_entry(title='Snatch &amp;5', url='http://correct&url4'), \
+        assert task.find_entry(title='Snatch &5', url='http://correct&url4'), \
             'RSS entry: CDATA in title'
 
 

--- a/flexget/tests/test_rss.py
+++ b/flexget/tests/test_rss.py
@@ -158,6 +158,31 @@ class TestInputRSS(object):
             'RSS entry missing: multiple content tags'
 
 
+class TestEscapeInputRSS(object):
+    config = """
+        tasks:
+          test:
+            rss:
+              url: rss_escape.xml
+              escape: yes
+    """
+
+    def test_rss(self, execute_task):
+        task = execute_task('test')
+
+        assert task.find_entry(title='Snatch', url='http://wrong&url2'), \
+            'RSS entry: broken url'
+
+        assert task.find_entry(title='Snatch &2', url='http://some/url'), \
+            'RSS entry: broken name'
+
+        assert task.find_entry(title='Snatch &amp;4', url='http://correct&url3'), \
+            'RSS entry: normal'
+
+        assert task.find_entry(title='Snatch &amp;5', url='http://correct&url4'), \
+            'RSS entry: CDATA in title'
+
+
 @pytest.mark.xfail(reason="silverorange changed some stuff")
 @pytest.mark.online
 class TestRssOnline(object):


### PR DESCRIPTION


### Motivation for changes:

Right now some trackers (e.g. newstudio) do not eascape ampersands with `&amp;`

### Detailed changes:

This commits adds logics to fix that. Option is disabled by default because it adds some processing overhead and needs to go thru whole XML content and then rebuild new XML.

### Config usage if relevant (new plugin or updated schema):
```
tasks:
  Newstudio:
    rss:
      url: '{? newstudio.address ?}'
      escape: yes
```
