### PR TITLE
Add support for Telegram disable_web_page_preview option

### DIFF
--- a/flexget/plugins/notifiers/telegram.py
+++ b/flexget/plugins/notifiers/telegram.py
@@ -24,7 +24,7 @@ _PLUGIN_NAME = 'telegram'
 
 _PARSERS = ['markdown', 'html']
 
-_DSBL_PRE_ATTR = 'disable_previews'
+_DISABLE_PREVIEWS_ATTR = 'disable_previews'
 _TOKEN_ATTR = 'bot_token'
 _PARSE_ATTR = 'parse_mode'
 _RCPTS_ATTR = 'recipients'
@@ -130,7 +130,7 @@ class TelegramNotifier(object):
         'properties': {
             _TOKEN_ATTR: {'type': 'string'},
             _PARSE_ATTR: {'type': 'string', 'enum': _PARSERS},
-            _DSBL_PRE_ATTR: {'type': 'boolean', 'default': False},
+            _DISABLE_PREVIEWS_ATTR: {'type': 'boolean', 'default': False},
             _RCPTS_ATTR: {
                 'type': 'array',
                 'minItems': 1,
@@ -190,7 +190,7 @@ class TelegramNotifier(object):
         """
         self._token = config[_TOKEN_ATTR]
         self._parse_mode = config.get(_PARSE_ATTR)
-        self._disable_previews = config[_DSBL_PRE_ATTR]
+        self._disable_previews = config[_DISABLE_PREVIEWS_ATTR]
         self._usernames = []
         self._fullnames = []
         self._groups = []

--- a/flexget/plugins/notifiers/telegram.py
+++ b/flexget/plugins/notifiers/telegram.py
@@ -24,6 +24,7 @@ _PLUGIN_NAME = 'telegram'
 
 _PARSERS = ['markdown', 'html']
 
+_DSBL_PRE_ATTR = 'disable_previews'
 _TOKEN_ATTR = 'bot_token'
 _PARSE_ATTR = 'parse_mode'
 _RCPTS_ATTR = 'recipients'
@@ -82,6 +83,7 @@ class TelegramNotifier(object):
             telegram:
               bot_token: token
               use_markdown: no
+              disable_previews: yes
               recipients:
                 - username: my-user-name
                 - group: my-group-name
@@ -128,6 +130,7 @@ class TelegramNotifier(object):
         'properties': {
             _TOKEN_ATTR: {'type': 'string'},
             _PARSE_ATTR: {'type': 'string', 'enum': _PARSERS},
+            _DSBL_PRE_ATTR: {'type': 'boolean', 'default': False},
             _RCPTS_ATTR: {
                 'type': 'array',
                 'minItems': 1,
@@ -187,6 +190,7 @@ class TelegramNotifier(object):
         """
         self._token = config[_TOKEN_ATTR]
         self._parse_mode = config.get(_PARSE_ATTR)
+        self._disable_previews = config[_DSBL_PRE_ATTR]
         self._usernames = []
         self._fullnames = []
         self._groups = []
@@ -205,8 +209,8 @@ class TelegramNotifier(object):
     def _real_init(self, session, config):
         self._enforce_telegram_plugin_ver()
         self._parse_config(config)
-        self.log.debug('token=%s, parse_mode=%s, usernames=%s, fullnames=%s, groups=%s', self._token,
-                       self._parse_mode, self._usernames, self._fullnames, self._groups)
+        self.log.debug('token=%s, parse_mode=%s, disable_previews=%s, usernames=%s, fullnames=%s, groups=%s', self._token,
+                       self._parse_mode, self._disable_previews, self._usernames, self._fullnames, self._groups)
         self._init_bot()
         chat_ids = self._get_chat_ids_n_update_db(session)
         return chat_ids
@@ -239,6 +243,7 @@ class TelegramNotifier(object):
             kwargs['parse_mode'] = telegram.ParseMode.MARKDOWN
         elif self._parse_mode == 'html':
             kwargs['parse_mode'] = telegram.ParseMode.HTML
+        kwargs['disable_web_page_preview'] = self._disable_previews
         for chat_id in (x.id for x in chat_ids):
             try:
                 self.log.debug('sending msg to telegram servers: %s', msg)


### PR DESCRIPTION
### Motivation for changes:
A message or message template can include links, but the user may want to disable the webpage preview feature to minimize message length.

### Detailed changes:
- Adds option to disable webpage preview in config file. Default is still disable = False.

### Config usage if relevant (new plugin or updated schema):
```
            telegram:
              bot_token: token
              use_markdown: yes
              disable_previews: yes
              recipients:
                - username: my-user-name
                - group: my-group-name
                - fullname:
                    first: my-first-name
                    sur: my-sur-name
```
### Log and/or tests output (preferably both):
```
2018-10-14 11:38 DEBUG    notify        telegram-test   Sending a notification to `telegram`
2018-10-14 11:38 DEBUG    telegram      telegram-test   token=xxxxxxxxxx, parse_mode=markdown, disable_previews=True, usernames=[u'xxxxxxxxxx'], fullnames=[], groups=[]
2018-10-14 11:38 DEBUG    telegram.bot  telegram-test   Entering: get_me
2018-10-14 11:38 DEBUG    telegram.vendor.ptb_urllib3.urllib3.connectionpool telegram-test   Starting new HTTPS connection (1): api.telegram.org
2018-10-14 11:38 DEBUG    telegram.vendor.ptb_urllib3.urllib3.connectionpool telegram-test   https://api.telegram.org:443 "GET /botxxxxxxxxxx/getMe HTTP/1.1" 200 111
2018-10-14 11:38 DEBUG    telegram.bot  telegram-test   {'username': u'xxxxxxxxxx', 'first_name': u"xxxxxxxxxx", 'is_bot': True, 'id': xxxxxxxxxx}
2018-10-14 11:38 DEBUG    telegram.bot  telegram-test   Exiting: get_me
2018-10-14 11:38 DEBUG    telegram      telegram-test   loading cached chat ids
2018-10-14 11:38 DEBUG    telegram      telegram-test   found 1 cached chat_ids: [u'id=xxxxxxxxxx username=xxxxxxxxxx firstname=xxxxxxxxxx surname=xxxxxxxxxx']
2018-10-14 11:38 DEBUG    telegram      telegram-test   all chat ids found in cache
2018-10-14 11:38 DEBUG    telegram      telegram-test   chat_ids=[<flexget.plugins.notifiers.telegram.ChatIdEntry object at 0x10f462610>]
2018-10-14 11:38 DEBUG    telegram      telegram-test   sending msg to telegram servers: _Downloading:_

📽  [Skyscraper](https://www.imdb.com/title/tt5758778/) (2018)
FBI Hostage Rescue Team leader and U.S. war veteran Will Sawyer now assesses security for skyscrapers. On assignment in Hong Kong he finds the tallest, safest building in the world suddenly ablaze and he's been framed for it. A wanted man on the run, Will must find those responsible, clear his name and somehow rescue his family who are trapped inside the building - above the fire line.
(_5.9/10 - 46430 votes_)


2018-10-14 11:38 DEBUG    telegram.bot  telegram-test   Entering: send_message
2018-10-14 11:38 DEBUG    telegram.vendor.ptb_urllib3.urllib3.connectionpool telegram-test   https://api.telegram.org:443 "POST /botxxxxxxxxxx/sendMessage HTTP/1.1" 200 919
2018-10-14 11:38 DEBUG    telegram.bot  telegram-test   {'delete_chat_photo': False, 'new_chat_photo': [], 'from': {'username': u'xxxxxxxxxx', 'first_name': u"xxxxxxxxxx", 'is_bot': True, 'id': xxxxxxxxxx}, 'text': u"Downloading:\n\n\U0001f4fd  Skyscraper (2018)\nFBI Hostage Rescue Team leader and U.S. war veteran Will Sawyer now assesses security for skyscrapers. On assignment in Hong Kong he finds the tallest, safest building in the world suddenly ablaze and he's been framed for it. A wanted man on the run, Will must find those responsible, clear his name and somehow rescue his family who are trapped inside the building - above the fire line.\n(5.9/10 - 46430 votes)", 'caption_entities': [], 'entities': [{'length': 12, 'type': u'italic', 'offset': 0}, {'url': u'https://www.imdb.com/title/tt5758778/', 'length': 10, 'type': u'text_link', 'offset': 18}, {'length': 20, 'type': u'italic', 'offset': 426}], 'channel_chat_created': False, 'new_chat_members': [], 'supergroup_chat_created': False, 'chat': {'username': u'xxxxxxxxxx', 'first_name': u'xxxxxxxxxx', 'last_name': u'xxxxxxxxxx', 'type': u'private', 'id': xxxxxxxxxx}, 'photo': [], 'date': 1539509869, 'group_chat_created': False, 'message_id': xxxxxxxxxx}
2018-10-14 11:38 DEBUG    telegram.bot  telegram-test   Exiting: send_message
2018-10-14 11:38 VERBOSE  notify        telegram-test   Successfully sent a notification to `telegram`
```
#### To Do:

- [x] Test new configuration parameter
- [x] Test messages
