### PR TITLE
Support sync endpoint for watched episodes

### DIFF
--- a/flexget/plugins/list/trakt_list.py
+++ b/flexget/plugins/list/trakt_list.py
@@ -249,7 +249,7 @@ class TraktSet(MutableSet):
             # API restriction as they don't have an endpoint for collected episodes yet
             if self.config['list'] == 'collection':
                 raise plugin.PluginError('`type` cannot be `episodes` for collection list.')
-                return ('sync', 'history', 'episodes')
+            return ('sync', 'history', 'episodes')
 
         if self.config['list'] in ['collection', 'watchlist', 'watched', 'ratings']:
             if self.config.get('account'):

--- a/flexget/plugins/list/trakt_list.py
+++ b/flexget/plugins/list/trakt_list.py
@@ -247,7 +247,8 @@ class TraktSet(MutableSet):
     def get_list_endpoint(self, remove=False, submit=False):
         # Api restriction, but we could easily extract season and episode info from the 'shows' type
         if not submit and self.config['list'] in ['collection', 'watched'] and self.config['type'] == 'episodes':
-            raise plugin.PluginError('`type` cannot be `%s` for %s list.' % (self.config['type'], self.config['list']))
+            endpoint = ('sync', 'history', 'episodes')
+            return endpoint
 
         if self.config['list'] in ['collection', 'watchlist', 'watched', 'ratings']:
             if self.config.get('account'):

--- a/flexget/plugins/list/trakt_list.py
+++ b/flexget/plugins/list/trakt_list.py
@@ -249,7 +249,10 @@ class TraktSet(MutableSet):
             # API restriction as they don't have an endpoint for collected episodes yet
             if self.config['list'] == 'collection':
                 raise plugin.PluginError('`type` cannot be `episodes` for collection list.')
-            return ('sync', 'history', 'episodes')
+            if self.config.get('account'):
+                return ('sync', 'history', 'episodes')
+            else:
+                raise plugin.PluginError('A trakt `account` needs to be configured to get the episode history.')
 
         if self.config['list'] in ['collection', 'watchlist', 'watched', 'ratings']:
             if self.config.get('account'):

--- a/flexget/plugins/list/trakt_list.py
+++ b/flexget/plugins/list/trakt_list.py
@@ -248,8 +248,7 @@ class TraktSet(MutableSet):
         if not submit and self.config['list'] in ['collection', 'watched'] and self.config['type'] == 'episodes':
             # API restriction as they don't have an endpoint for collected episodes yet
             if self.config['list'] == 'collection':
-                raise plugin.PluginError('`type` cannot be `%s` for %s list.' % (self.config['type'], self.config['list']))
-            else:
+                raise plugin.PluginError('`type` cannot be `episodes` for collection list.')
                 return ('sync', 'history', 'episodes')
 
         if self.config['list'] in ['collection', 'watchlist', 'watched', 'ratings']:

--- a/flexget/plugins/list/trakt_list.py
+++ b/flexget/plugins/list/trakt_list.py
@@ -245,10 +245,12 @@ class TraktSet(MutableSet):
         self._items = None
 
     def get_list_endpoint(self, remove=False, submit=False):
-        # Api restriction, but we could easily extract season and episode info from the 'shows' type
         if not submit and self.config['list'] in ['collection', 'watched'] and self.config['type'] == 'episodes':
-            endpoint = ('sync', 'history', 'episodes')
-            return endpoint
+            # API restriction as they don't have an endpoint for collected episodes yet
+            if self.config['list'] == 'collection':
+                raise plugin.PluginError('`type` cannot be `%s` for %s list.' % (self.config['type'], self.config['list']))
+            else:
+                return ('sync', 'history', 'episodes')
 
         if self.config['list'] in ['collection', 'watchlist', 'watched', 'ratings']:
             if self.config.get('account'):


### PR DESCRIPTION
### Motivation for changes:

Support Trakt API route to get list of watched episodes (Only if an "account" is set up): https://discuss.flexget.com/t/delete-files-if-seen-on-trakt-tv/4327

### Detailed changes:
- Set correct route if it's a watched list with type episode

### Addressed issues:
- Fixes #2056 

