### PR TITLE
add imdb id field to entries returned by passthepopcorn search

### DIFF
--- a/flexget/plugins/sites/passthepopcorn.py
+++ b/flexget/plugins/sites/passthepopcorn.py
@@ -224,7 +224,7 @@ class SearchPassThePopcorn(object):
         if 'tags' in config:
             tags = config['tags'] if isinstance(config['tags'], list) else [config['tags']]
             params['taglist'] = ',+'.join(tags)
-        
+
         release_type = config.get('release_type')
         if release_type:
             params['scene'] = RELEASE_TYPES[release_type]
@@ -279,6 +279,9 @@ class SearchPassThePopcorn(object):
                     e = Entry()
 
                     e['title'] = torrent['ReleaseName']
+
+                    if entry.get('imdb_id'):
+                        e['imdb_id'] = entry.get('imdb_id')
 
                     e['torrent_tags'] = movie['Tags']
                     e['content_size'] = parse_filesize(torrent['Size'] + ' b')


### PR DESCRIPTION
### Motivation for changes:

Allows for more accurate list matching and imdb lookups for results returned from passthepopcorn site plugin. 

### Detailed changes:
- Adds imdb_id field (used by imdb_lookup if present) to passthepopcorn entries. We can do this because the passthepopcorn plugin searches by imdb_id, therefore we know all returned entries will have the same id. 

