### PR TITLE
Add more entry fields to PassThePopcorn search plugin

### DIFF
--- a/flexget/plugins/sites/passthepopcorn.py
+++ b/flexget/plugins/sites/passthepopcorn.py
@@ -291,6 +291,7 @@ class SearchPassThePopcorn(object):
                     e['torrent_id'] = int(torrent['Id'])
                     e['golden_popcorn'] = torrent['GoldenPopcorn']
                     e['checked'] = torrent['Checked']
+                    e['scene'] = torrent['Scene']
                     e['uploaded_at'] = dateutil_parse(torrent['UploadTime'])
 
                     e['url'] = self.base_url + 'torrents.php?action=download&id={}&authkey={}&torrent_pass={}'.format(

--- a/flexget/plugins/sites/passthepopcorn.py
+++ b/flexget/plugins/sites/passthepopcorn.py
@@ -294,6 +294,13 @@ class SearchPassThePopcorn(object):
                     e['scene'] = torrent['Scene']
                     e['uploaded_at'] = dateutil_parse(torrent['UploadTime'])
 
+                    e['ptp_remaster_title'] = torrent['RemasterTitle'] # tags such as remux, 4k remaster, etc.
+                    e['ptp_quality'] = torrent['RemasterTitle'] # high, ultra high, or standard definition
+                    e['ptp_resolution'] = torrent['Resolution'] # 1080p, 720p, etc.
+                    e['ptp_source'] = torrent['Source'] # blu-ray, dvd, etc.
+                    e['ptp_container'] = torrent['Container'] # mkv, vob ifo, etc.
+                    e['ptp_codec'] = torrent['Codec'] # x264, XviD, etc.
+
                     e['url'] = self.base_url + 'torrents.php?action=download&id={}&authkey={}&torrent_pass={}'.format(
                         e['torrent_id'], authkey, passkey
                     )

--- a/flexget/plugins/sites/passthepopcorn.py
+++ b/flexget/plugins/sites/passthepopcorn.py
@@ -295,7 +295,7 @@ class SearchPassThePopcorn(object):
                     e['uploaded_at'] = dateutil_parse(torrent['UploadTime'])
 
                     e['ptp_remaster_title'] = torrent['RemasterTitle'] # tags such as remux, 4k remaster, etc.
-                    e['ptp_quality'] = torrent['RemasterTitle'] # high, ultra high, or standard definition
+                    e['ptp_quality'] = torrent['Quality'] # high, ultra high, or standard definition
                     e['ptp_resolution'] = torrent['Resolution'] # 1080p, 720p, etc.
                     e['ptp_source'] = torrent['Source'] # blu-ray, dvd, etc.
                     e['ptp_container'] = torrent['Container'] # mkv, vob ifo, etc.

--- a/flexget/plugins/sites/passthepopcorn.py
+++ b/flexget/plugins/sites/passthepopcorn.py
@@ -224,7 +224,7 @@ class SearchPassThePopcorn(object):
         if 'tags' in config:
             tags = config['tags'] if isinstance(config['tags'], list) else [config['tags']]
             params['taglist'] = ',+'.join(tags)
-        
+
         release_type = config.get('release_type')
         if release_type:
             params['scene'] = RELEASE_TYPES[release_type]
@@ -279,6 +279,9 @@ class SearchPassThePopcorn(object):
                     e = Entry()
 
                     e['title'] = torrent['ReleaseName']
+
+                    if entry.get('imdb_id'):
+                        e['imdb_id'] = entry.get('imdb_id')
 
                     e['torrent_tags'] = movie['Tags']
                     e['content_size'] = parse_filesize(torrent['Size'] + ' b')

--- a/flexget/plugins/sites/passthepopcorn.py
+++ b/flexget/plugins/sites/passthepopcorn.py
@@ -294,12 +294,12 @@ class SearchPassThePopcorn(object):
                     e['scene'] = torrent['Scene']
                     e['uploaded_at'] = dateutil_parse(torrent['UploadTime'])
 
-                    e['ptp_remaster_title'] = torrent['RemasterTitle'] # tags such as remux, 4k remaster, etc.
-                    e['ptp_quality'] = torrent['Quality'] # high, ultra high, or standard definition
-                    e['ptp_resolution'] = torrent['Resolution'] # 1080p, 720p, etc.
-                    e['ptp_source'] = torrent['Source'] # blu-ray, dvd, etc.
-                    e['ptp_container'] = torrent['Container'] # mkv, vob ifo, etc.
-                    e['ptp_codec'] = torrent['Codec'] # x264, XviD, etc.
+                    e['ptp_remaster_title'] = torrent.get('RemasterTitle') # tags such as remux, 4k remaster, etc.
+                    e['ptp_quality'] = torrent.get('Quality') # high, ultra high, or standard definition
+                    e['ptp_resolution'] = torrent.get('Resolution') # 1080p, 720p, etc.
+                    e['ptp_source'] = torrent.get('Source') # blu-ray, dvd, etc.
+                    e['ptp_container'] = torrent.get('Container') # mkv, vob ifo, etc.
+                    e['ptp_codec'] = torrent.get('Codec') # x264, XviD, etc.
 
                     e['url'] = self.base_url + 'torrents.php?action=download&id={}&authkey={}&torrent_pass={}'.format(
                         e['torrent_id'], authkey, passkey


### PR DESCRIPTION
### Motivation for changes:

Ability for more reliable and finer control over passthepopcorn search results.

### Detailed changes:
- Added entry fields from search results that are already present in the request, but are currently ignored and not saved. 

#### To Do:

- If possible, I could try to map passthepopcorn qualities to current flexget qualities e.g. Blu-ray:bluray. These mapped qualities would take precedence over parsed qualities from torrent title which would result in more accurate quality mapping. However, I'm not sure how viable or even possible this would be. 

