### PR TITLE
Sometimes the NPO-page does not return valid content

### DIFF
--- a/flexget/plugins/input/npo_watchlist.py
+++ b/flexget/plugins/input/npo_watchlist.py
@@ -176,13 +176,14 @@ class NPOWatchlist(object):
             log.debug('Series info found at: %s', response.url)
             page = get_soup(response.content)
             series = page.find('section', class_='npo-header-episode-meta')
-            # create a stub to store the common values for all episodes of this series
-            series_info = {'npo_url': response.url,  # we were redirected to the true URL
-                           'npo_name': series.find('h1').text,
-                           'npo_description': series.find('div', id='metaContent').find('p').text,
-                           'npo_language': 'nl',  # hard-code the language as if in NL, for lookup plugins
-                           'npo_version': page.find('meta', attrs={'name': 'generator'})['content']}  # include NPO website version
-            log.debug('Parsed series info for: %s (%s)', series_info['npo_name'], mediaId)
+            if series:  # sometimes the NPO page does not return valid content
+                # create a stub to store the common values for all episodes of this series
+                series_info = {'npo_url': response.url,  # we were redirected to the true URL
+                               'npo_name': series.find('h1').text,
+                               'npo_description': series.find('div', id='metaContent').find('p').text,
+                               'npo_language': 'nl',  # hard-code the language as if in NL, for lookup plugins
+                               'npo_version': page.find('meta', attrs={'name': 'generator'})['content']}  # include NPO website version
+                log.debug('Parsed series info for: %s (%s)', series_info['npo_name'], mediaId)
         except RequestException as e:
             log.error('Request error: %s' % str(e))
         return series_info


### PR DESCRIPTION
and then _get_series_info() does fail, with a critical error.
This fix avoids the critical error, and will just make it skip only this serie.

Original error that would sometimes occur:
``BUG: Unhandled error in plugin npo_watchlist: 'NoneType' object has no attribute 'find'
flexget/plugins/input/npo_watchlist.py", line 181, in _get_series_info
    'npo_name': series.find('h1').text,
AttributeError: 'NoneType' object has no attribute 'find'``

