### PR TITLE
Fix several issues with new deluge-client implementation

### DIFF
--- a/flexget/plugins/clients/deluge.py
+++ b/flexget/plugins/clients/deluge.py
@@ -540,7 +540,7 @@ class OutputDeluge(DelugePlugin):
 
             def unused_name(name):
                 # If on local computer, tries appending a (#) suffix until a unique filename is found
-                if self.client.call('is_localhost'):
+                if self.client.host in ['127.0.0.1', 'localhost']:
                     counter = 2
                     while file_exists(name):
                         name = ''.join([os.path.splitext(name)[0],

--- a/flexget/plugins/clients/deluge.py
+++ b/flexget/plugins/clients/deluge.py
@@ -77,6 +77,8 @@ class DelugePlugin(object):
             auth_file = os.path.join(os.getenv('APPDATA'), 'deluge', 'auth')
         else:
             auth_file = os.path.expanduser('~/.config/deluge/auth')
+        if not os.path.isfile(auth_file):
+            return None
 
         with open(auth_file) as auth:
             for line in auth:

--- a/flexget/plugins/clients/deluge.py
+++ b/flexget/plugins/clients/deluge.py
@@ -464,7 +464,10 @@ class OutputDeluge(DelugePlugin):
                     except Exception as e:
                         log.info('%s was not added to deluge! %s', entry['title'], e)
                         entry.fail('Could not be added to deluge')
-                self._set_torrent_options(added_torrent, entry, modify_opts)
+                if not added_torrent:
+                    log.error('There was an error adding %s to deluge.' % entry['title'])
+                else:
+                    self._set_torrent_options(added_torrent, entry, modify_opts)
 
     def on_task_learn(self, task, config):
         """ Make sure all temp files are cleaned up when entries are learned """


### PR DESCRIPTION
### Motivation for changes:
Multiple crashes with new deluge-client implementation fixed

### Detailed changes:
- Fix a crash when no username/password was provided and the deluge auth file can't be found
- Fix a crash when trying to use content_filename option. #2233
- Prevent making calls to modify torrent options when we haven't received a torrent_id back after adding it to deluge. (I think this may have been a bug with deluge. After restarting the deluge daemon once I could not reproduce.)

### Addressed issues:
- Fixes #2233


