### PR TITLE
Fix non-critical PassThePopcorn entry field comparison error

### DIFF
--- a/flexget/plugins/sites/passthepopcorn.py
+++ b/flexget/plugins/sites/passthepopcorn.py
@@ -294,12 +294,12 @@ class SearchPassThePopcorn(object):
                     e['scene'] = torrent['Scene']
                     e['uploaded_at'] = dateutil_parse(torrent['UploadTime'])
 
-                    e['ptp_remaster_title'] = torrent.get('RemasterTitle') # tags such as remux, 4k remaster, etc.
-                    e['ptp_quality'] = torrent.get('Quality') # high, ultra high, or standard definition
-                    e['ptp_resolution'] = torrent.get('Resolution') # 1080p, 720p, etc.
-                    e['ptp_source'] = torrent.get('Source') # blu-ray, dvd, etc.
-                    e['ptp_container'] = torrent.get('Container') # mkv, vob ifo, etc.
-                    e['ptp_codec'] = torrent.get('Codec') # x264, XviD, etc.
+                    e['ptp_remaster_title'] = torrent.get('RemasterTitle', '') # tags such as remux, 4k remaster, etc.
+                    e['ptp_quality'] = torrent.get('Quality', '') # high, ultra high, or standard definition
+                    e['ptp_resolution'] = torrent.get('Resolution', '') # 1080p, 720p, etc.
+                    e['ptp_source'] = torrent.get('Source', '') # blu-ray, dvd, etc.
+                    e['ptp_container'] = torrent.get('Container', '') # mkv, vob ifo, etc.
+                    e['ptp_codec'] = torrent.get('Codec', '') # x264, XviD, etc.
 
                     e['url'] = self.base_url + 'torrents.php?action=download&id={}&authkey={}&torrent_pass={}'.format(
                         e['torrent_id'], authkey, passkey


### PR DESCRIPTION
### Motivation for changes:

Fixes a non-critical error occurring when accessing one of the entry fields that is None-type. This was occurring for me when comparing a string to type None for example. 

### Detailed changes:
- Sets the default value for entries without values to be an empty string instead of None. This will remove any errors when trying to compare a string in the entry field. 