### PR TITLE
PassThePopcorn ignore movie year discrepancies if we have imdb id

### DIFF
--- a/flexget/plugins/sites/passthepopcorn.py
+++ b/flexget/plugins/sites/passthepopcorn.py
@@ -266,10 +266,14 @@ class SearchPassThePopcorn(object):
             passkey = result['PassKey']
 
             for movie in result['Movies']:
-                # skip movies that are irrelevant
-                if entry.get('movie_year') and int(movie['Year']) != int(entry['movie_year']):
-                    log.debug('Movie year %s does not match %s', movie['Year'], entry['movie_year'])
+                # skip movies with wrong year
+                # don't consider if we have imdb_id (account for year discrepancies if we know we have
+                # the right movie)
+                if (not entry.get('imdb_id') and entry.get('movie_year') and
+                        int(movie['Year']) != int(entry['movie_year'])):
+                    log.debug('Movie year %s does not match default %s', movie['Year'], entry['movie_year'])
                     continue
+
                 # imdb id in the json result is without 'tt'
                 if entry.get('imdb_id') and movie['ImdbId'] not in entry['imdb_id']:
                     log.debug('imdb id %s does not match %s', movie['ImdbId'], entry['imdb_id'])

--- a/flexget/plugins/sites/passthepopcorn.py
+++ b/flexget/plugins/sites/passthepopcorn.py
@@ -269,13 +269,13 @@ class SearchPassThePopcorn(object):
                 # skip movies with wrong year
                 # don't consider if we have imdb_id (account for year discrepancies if we know we have
                 # the right movie)
-                if (not entry.get('imdb_id') and entry.get('movie_year') and
+                if ('imdb_id' not in movie and 'movie_year' in movie and
                         int(movie['Year']) != int(entry['movie_year'])):
                     log.debug('Movie year %s does not match default %s', movie['Year'], entry['movie_year'])
                     continue
 
                 # imdb id in the json result is without 'tt'
-                if entry.get('imdb_id') and movie['ImdbId'] not in entry['imdb_id']:
+                if 'imdb_id' in movie and movie['ImdbId'] not in entry['imdb_id']:
                     log.debug('imdb id %s does not match %s', movie['ImdbId'], entry['imdb_id'])
                     continue
 
@@ -284,8 +284,7 @@ class SearchPassThePopcorn(object):
 
                     e['title'] = torrent['ReleaseName']
 
-                    if entry.get('imdb_id'):
-                        e['imdb_id'] = entry.get('imdb_id')
+                    e['imdb_id'] = entry.get('imdb_id')
 
                     e['torrent_tags'] = movie['Tags']
                     e['content_size'] = parse_filesize(torrent['Size'] + ' b')


### PR DESCRIPTION
### Motivation for changes:

Sometimes if there is a year discrepancy in a movie's release year between trakt (or other input sites that originally set movie_year), imdb, and passthepopcorn, it will reject the movie on passthepopcorn based on this discrepancy. This change will allow to ignore year discrepancies if we are dealing specifically with an imdb_id (no possibility of mismatches).

### Detailed changes:
- Ignores year matching check in PassThePopcorn plugin if using imdb_lookup and thus dealing with imdb ids i.e. there will be no mismatches so checking the year is not necessary. 

Note that if whatever plugin produces the imdb_id produces the wrong or incorrect id, PassThePopcorn will download that movie with the imdb_id without failsafe procedure.

