### PR TITLE
Fix for rTorrent v0.9.7+

### DIFF
--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -302,7 +302,13 @@ class RTorrent(object):
         params = ['d.%s=' % field for field in fields]
         params.insert(0, view)
 
-        resp = self._server.d.multicall(params)
+        try:
+            resp = self._server.d.multicall(params)
+        except xmlrpc_client.Fault as err:
+            if err.faultCode == -506:
+                resp = self._server.d.multicall2('', params)
+            else:
+                raise err
 
         # Response is formatted as a list of lists, with just the values
         return [dict(list(zip(self._clean_fields(fields, reverse=True), val))) for val in resp]

--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -302,13 +302,7 @@ class RTorrent(object):
         params = ['d.%s=' % field for field in fields]
         params.insert(0, view)
 
-        try:
-            resp = self._server.d.multicall(params)
-        except xmlrpc_client.Fault as err:
-            if err.faultCode == -506:
-                resp = self._server.d.multicall2('', params)
-            else:
-                raise err
+        resp = self._server.d.multicall2('', params)
 
         # Response is formatted as a list of lists, with just the values
         return [dict(list(zip(self._clean_fields(fields, reverse=True), val))) for val in resp]


### PR DESCRIPTION
### Motivation for changes:
As described in #2239, starting with rTorrent v0.9.7. I was mistaken as to when these were taken out. They were depreciated as of v0.9.0, and then finally removed in v0.9.7.

### Detailed changes:
- Wrap the `d.multicall` in a try/except catching a fault
- If the fault code is [-506](https://github.com/mirror/xmlrpc-c/blob/master/stable/include/xmlrpc-c/base.hpp#L468), call `d.multicall2` which has a slightly different definition
- Otherwise, raise the error

### Addressed issues:
- Fixes #2239 

### Log and/or tests output (preferably both):
Line 4 here in this log. For reference, I am on rTorrent v0.9.7.
```
...
2018-11-12 13:55 DEBUG    task          test_rtorrent   executing test_rtorrent
2018-11-12 13:55 DEBUG    status        test_rtorrent   Adding new task test_rtorrent
2018-11-12 13:55 WARNING  task          test_rtorrent   Aborting task (plugin: from_rtorrent)
2018-11-12 13:55 DEBUG    task_queue                    task test_rtorrent aborted: TaskAbort(reason=Could not get torrents (main): <Fault -506: "Method 'd.multicall' not defined">, silent=False)
2018-11-12 13:55 DEBUG    task_queue                    task queue shut down
2018-11-12 13:55 INFO     ipc.rpyc                      server has terminated
2018-11-12 13:55 INFO     ipc.rpyc                      listener closed
2018-11-12 13:55 DEBUG    util.simple_persistence                 Flushing simple persistence for task None to db.
2018-11-12 13:55 DEBUG    manager                       Shutting down
2018-11-12 13:55 INFO     manager                       Removed test database
2018-11-12 13:55 DEBUG    manager                       Removed /home/xvicarious/repos/Flexget/.test-config-lock
```

