### PR TITLE
Force single values from guessit

### DIFF
--- a/flexget/plugins/parsers/parser_guessit.py
+++ b/flexget/plugins/parsers/parser_guessit.py
@@ -73,7 +73,12 @@ class ParserGuessit(object):
 
     @staticmethod
     def _guessit_options(options):
-        settings = {'name_only': True, 'allowed_languages': ['en', 'fr'], 'allowed_countries': ['us', 'uk', 'gb']}
+        settings = {
+            'name_only': True,
+            'allowed_languages': ['en', 'fr'],
+            'allowed_countries': ['us', 'uk', 'gb'],
+            'single_value': True
+        }
         options['episode_prefer_number'] = not options.get('identified_by') == 'ep'
         if options.get('allow_groups'):
             options['expected_group'] = options['allow_groups']

--- a/flexget/tests/test_movieparser.py
+++ b/flexget/tests/test_movieparser.py
@@ -55,3 +55,10 @@ class TestParser(object):
         assert movie.name == 'A Movie Title', 'failed to parse %s (got %s)' % (movie.data, movie.name)
         assert movie.year == 2013, 'failed to parse year from %s' % movie.data
         assert movie.quality.name == '720p h264'
+
+    def test_multiple_property_values(self, parse):
+        """ Test correct parsing for title's with multiple propertie definitions """
+        movie = parse(name='FlexGet', data='FlexGet (premiere 2018)(2016/MHD/1080P/AC3 5.1/DUAL/SUB/bluray/Webrip)')
+        assert movie.valid
+        assert movie.year == 2018
+        assert movie.quality.source == 'bluray'


### PR DESCRIPTION
### Motivation for changes:

Guessit would return a list of property values; found when parsing instead of a string.
This resulted in unexpected behaviour and errors on flexget side. Most noticable erroring out in the guessit parser mappings.

### Addressed issues:
- #2249
- https://discuss.flexget.com/t/unhandled-error-in-lazy-lookup-plugin-unhashable-type-list/4384/
- https://github.com/Flexget/Flexget/pull/2197
