### PR TITLE
Add tags to my_anime_list plugin entries

### DIFF
--- a/flexget/plugins/input/my_anime_list.py
+++ b/flexget/plugins/input/my_anime_list.py
@@ -32,6 +32,7 @@ ANIME_TYPE = [
     'unknown'
 ]
 
+
 class MyAnimeList(object):
     """" Creates entries for series and movies from MyAnimeList list
     Syntax:
@@ -90,7 +91,8 @@ class MyAnimeList(object):
                         url="https://myanimelist.net" + anime["anime_url"],
                         mal_name=anime["anime_title"],
                         mal_poster=anime["anime_image_path"],
-                        mal_type=anime["anime_media_type_string"]
+                        mal_type=anime["anime_media_type_string"],
+                        mal_tags=anime["tags"]
                     )
                 )
         return entries


### PR DESCRIPTION
### Motivation for changes:
Allow user to filter by entry tags with the `if` plugin - example in config_usage
### Detailed changes:
- Add `mal_tags` field to the entries produced by my_anime_list plugin, populated by `tags` provided by MyAnimeList API

### Config usage if relevant (new plugin or updated schema):
```
      if:
        - '"ignored" not in mal_tags.split(", ")': accept
```
