### PR TITLE
[fix] Show reasonable error if login to to torrentleech.org fails

### DIFF
--- a/flexget/plugins/sites/torrentleech.py
+++ b/flexget/plugins/sites/torrentleech.py
@@ -115,7 +115,7 @@ class UrlRewriteTorrentleech(object):
         except RequestException as e:
             raise PluginError('Could not connect to torrentleech: %s' % str(e))
 
-        if login.url.endswith(u'/user/account/login/'):
+        if login.url.endswith('/user/account/login/'):
             raise PluginError('Could not login to torrentleech, faulty credentials?')
 
         if not isinstance(config, dict):

--- a/flexget/plugins/sites/torrentleech.py
+++ b/flexget/plugins/sites/torrentleech.py
@@ -115,6 +115,9 @@ class UrlRewriteTorrentleech(object):
         except RequestException as e:
             raise PluginError('Could not connect to torrentleech: %s' % str(e))
 
+        if login.url.endswith(u'/user/account/login/'):
+            raise PluginError('Could not login to torrentleech, faulty credentials?')
+
         if not isinstance(config, dict):
             config = {}
             # sort = SORT.get(config.get('sort_by', 'seeds'))


### PR DESCRIPTION
## Motivation for changes
The torrentleech plugin didn't detect if tbe login to the torrentleech site failed. Instead it failed on every attempt to search for a series or movie with a JSON Decode error.

## Detailed changes
Check if the url of the response still has the login part in it and raise an exception in this case.