### PR TITLE
Fix caplog test issue

### DIFF
--- a/flexget/tests/conftest.py
+++ b/flexget/tests/conftest.py
@@ -68,7 +68,7 @@ def manager(request, config, caplog, monkeypatch, filecopy):  # enforce filecopy
         mockmanager = MockManager(config, request.cls.__name__)
     except Exception:
         # Since we haven't entered the test function yet, pytest won't print the logs on failure. Print them manually.
-        print(caplog.text())
+        print(caplog.text)
         raise
     yield mockmanager
     mockmanager.shutdown()


### PR DESCRIPTION
### Motivation for changes:
When a test fails before entering the test function, the exception is printed by conftest.py instead pytest.
caplog.text is of type unicode

### Detailed changes:
- print `caplog.text` instead `caplog.text()`

### Failing test example:
```python
class TestTmp:
    config = """"""
    def test_tmp(self, execute_task):
        execute_task('d')
```
### Log and/or tests output (preferably both):
```
  ( ... )
        try:
            mockmanager = MockManager(config, request.cls.__name__)
        except Exception:
            # Since we haven't entered the test function yet, pytest won't print the logs on failure. Print them manually.
>           print(caplog.text())
E           TypeError: 'unicode' object is not callable

conftest.py:71: TypeError
```
