### PR TITLE
Update url to match current hliang url format

### DIFF
--- a/flexget/plugins/sites/hliang.py
+++ b/flexget/plugins/sites/hliang.py
@@ -16,7 +16,7 @@ class UrlRewriteHliang(object):
     # urlrewriter API
     def url_rewritable(self, task, entry):
         url = entry['url']
-        if url.startswith('http://bt.hliang.com/show.php'):
+        if url.startswith('http://bt.hliang.com/show-'):
             return True
         return False
 


### PR DESCRIPTION
### Motivation for changes:
bt.hliang.com changed their torrent page url format.  The home page used to list torrent pages as `http://bt.hliang.com/show.php?...`, but now lists it as `http://bt.hliang.com/show-...` (e.g. `http://bt.hliang.com/show-c7fb6d575a06a80820a045903face704f4a43b3c.html`)

As a result, the urlrewrite plugin no longer returns `true` when asks if the plugin supports the hliang url, and the plugin no longer works.

### Detailed changes:
- Update the url to match the latest format.

