### PR TITLE
Fix relative vs absolute URLs on PirateBay

### DIFF
--- a/flexget/plugins/sites/piratebay.py
+++ b/flexget/plugins/sites/piratebay.py
@@ -117,7 +117,7 @@ class UrlRewritePirateBay(object):
             torrent_url = tag_a.get('href')
             # URL is sometimes missing the schema
             if torrent_url.startswith('//'):
-                torrent_url = 'http:' + torrent_url
+                torrent_url = urlparse(url).scheme + ':' + torrent_url
             return torrent_url
         except Exception as e:
             raise UrlRewritingError(e)
@@ -157,7 +157,10 @@ class UrlRewritePirateBay(object):
                 if not entry['title']:
                     log.error('Malformed search result. No title or url found. Skipping.')
                     continue
-                entry['url'] = self.url + link.get('href')
+                href = link.get('href')
+                if href.startswith('/'):  # relative link?
+                    href = self.url + href
+                entry['url'] = href
                 tds = link.parent.parent.parent.find_all('td')
                 entry['torrent_seeds'] = int(tds[-2].contents[0])
                 entry['torrent_leeches'] = int(tds[-1].contents[0])


### PR DESCRIPTION
Fix relative vs absolute URLs on PirateBay
also small update for https scheme support in broken torrent URLs

### Motivation for changes:
Current Pirate Bay plugin is broken because the links to the torrent URLs have been changed from relative to absolute and resulted in errors like:
```
RequestException HTTPSConnectionPool(host='pirateproxy.lifehttps', port=443): Max retries exceeded with url: //pirateproxy.life/torrent/xxx/xxx (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7f37157726d0>: Failed to establish a new connection: [Errno -2] Name or service not known',)), while downloading https://pirateproxy.lifehttps://pirateproxy.life/torrent/xxx/xxx
Failed XXX (Network error during request: HTTPSConnectionPool(host='pirateproxy.lifehttps', port=443): Max retries exceeded with url: //pirateproxy.life/torrent/xxx/xxx (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7f37157726d0>: Failed to establish a new connection: [Errno -2] Name or service not known',)))
```


