### PR TITLE
Python 3.7 support

### DIFF
--- a/flexget/ipc.py
+++ b/flexget/ipc.py
@@ -61,6 +61,10 @@ class DaemonService(rpyc.Service):
     # This will be populated when the server is started
     manager = None
 
+    def on_connect(self, conn):
+        self._conn = conn
+        super(DaemonService, self).on_connect(conn)
+
     def exposed_version(self):
         return IPC_VERSION
 
@@ -98,12 +102,14 @@ class DaemonService(rpyc.Service):
 
 
 class ClientService(rpyc.Service):
-    def on_connect(self):
+    def on_connect(self, conn):
+        self._conn = conn
         """Make sure the client version matches our own."""
         daemon_version = self._conn.root.version()
         if IPC_VERSION != daemon_version:
             self._conn.close()
             raise ValueError('Daemon is different version than client.')
+        super(ClientService, self).on_connect(conn)
 
     def exposed_version(self):
         return IPC_VERSION

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ pyparsing==2.2.0
 pyrss2gen==1.1
 python-dateutil==2.6.1
 pytz==2017.2              # via apscheduler, flask-restful, flask-restplus, tempora, tzlocal
-pyyaml==3.12
+pyyaml==3.13
 rebulk==0.9.0
 requests==2.20.1
 rpyc==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ pytz==2017.2              # via apscheduler, flask-restful, flask-restplus, temp
 pyyaml==3.12
 rebulk==0.9.0
 requests==2.20.1
-rpyc==3.3.0
+rpyc==4.0.1
 six==1.10.0               # via apscheduler, cheroot, cherrypy, flask-cors, flask-restful, flask-restplus, html5lib, python-dateutil, rebulk, tempora
 sqlalchemy==1.2.6
 tempora==1.8              # via portend


### PR DESCRIPTION
### Motivation for changes:
Python3.7 compatibility

### Detailed changes:
- updated rpyc to 4.0.2
- updated pyyaml to 3.12
- updated Daemon/ClientService to use the new rpyc Service.on_connect() signature

### Addressed issues:
- Fixes #2189

### Log and/or tests output (preferably both):
```
I'm not sure what to put here
```

### Todo
- add python 3.7 tests to circleci, i have no idea how to do this