### PR TITLE
fix time.clock DeprecationWarning under python3.7

### DIFF
--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -41,6 +41,12 @@ log = logging.getLogger('series')
 Base = db_schema.versioned_base('series', SCHEMA_VER)
 
 
+try:
+    preferred_clock = time.process_time
+except AttributeError:
+    preferred_clock = time.clock
+
+
 @db_schema.upgrade('series')
 def upgrade(ver, session):
     if ver is None:
@@ -1606,7 +1612,7 @@ class FilterSeries(FilterSeriesBase):
 
         parser = get_plugin_by_name('parsing').instance
 
-        start_time = time.clock()
+        start_time = preferred_clock()
 
         # Sort Entries into data model similar to https://en.wikipedia.org/wiki/Trie
         # Only process series if both the entry title and series title first letter match
@@ -1648,7 +1654,7 @@ class FilterSeries(FilterSeriesBase):
                 if entries:
                     self.parse_series(entries, series_name, series_config, db_identified_by)
 
-        log.debug('series on_task_metainfo took %s to parse', time.clock() - start_time)
+        log.debug('series on_task_metainfo took %s to parse', preferred_clock() - start_time)
 
     def on_task_filter(self, task, config):
         """Filter series"""
@@ -1673,7 +1679,7 @@ class FilterSeries(FilterSeriesBase):
             # Expunge so we can work on de-attached while processing the series to minimize db locks
             session.expunge_all()
 
-        start_time = time.clock()
+        start_time = time.process_time()
         for series_item in config:
             with Session() as session:
                 series_name, series_config = list(series_item.items())[0]
@@ -1734,7 +1740,7 @@ class FilterSeries(FilterSeriesBase):
 
                 self.process_series(task, series_entries, series_config)
 
-        log.debug('processing series took %s', time.clock() - start_time)
+        log.debug('processing series took %s', time.process_time() - start_time)
 
     def parse_series(self, entries, series_name, config, db_identified_by=None):
         """

--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1679,7 +1679,7 @@ class FilterSeries(FilterSeriesBase):
             # Expunge so we can work on de-attached while processing the series to minimize db locks
             session.expunge_all()
 
-        start_time = time.process_time()
+        start_time = preferred_clock()
         for series_item in config:
             with Session() as session:
                 series_name, series_config = list(series_item.items())[0]
@@ -1740,7 +1740,7 @@ class FilterSeries(FilterSeriesBase):
 
                 self.process_series(task, series_entries, series_config)
 
-        log.debug('processing series took %s', time.process_time() - start_time)
+        log.debug('processing series took %s', preferred_clock() - start_time)
 
     def parse_series(self, entries, series_name, config, db_identified_by=None):
         """

--- a/flexget/plugins/parsers/parser_guessit.py
+++ b/flexget/plugins/parsers/parser_guessit.py
@@ -57,6 +57,12 @@ def normalize_component(data):
     return [data.lower().replace('-', '')]
 
 
+try:
+    preferred_clock = time.process_time
+except AttributeError:
+    preferred_clock = time.clock
+
+
 class ParserGuessit(object):
     SOURCE_MAP = {
         'Camera': 'cam',
@@ -168,7 +174,7 @@ class ParserGuessit(object):
     # movie_parser API
     def parse_movie(self, data, **kwargs):
         log.debug('Parsing movie: `%s` [options: %s]', data, kwargs)
-        start = time.clock()
+        start = preferred_clock()
         guessit_options = self._guessit_options(kwargs)
         guessit_options['type'] = 'movie'
         guess_result = guessit_api.guessit(data, options=guessit_options)
@@ -182,8 +188,7 @@ class ParserGuessit(object):
             release_group=guess_result.get('release_group'),
             valid=bool(guess_result.get('title'))  # It's not valid if it didn't find a name, which sometimes happens
         )
-        end = time.clock()
-        log.debug('Parsing result: %s (in %s ms)', parsed, (end - start) * 1000)
+        log.debug('Parsing result: %s (in %s ms)', parsed, (preferred_clock() - start) * 1000)
         return parsed
 
     # series_parser API
@@ -200,7 +205,7 @@ class ParserGuessit(object):
             guessit_options['expected_title'] = ['re:' + title for title in expected_titles]
         if kwargs.get('id_regexps'):
             guessit_options['id_regexps'] = kwargs.get('id_regexps')
-        start = time.clock()
+        start = preferred_clock()
         # If no series name is provided, we don't tell guessit what kind of match we are looking for
         # This prevents guessit from determining that too general of matches are series
         parse_type = 'episode' if kwargs.get('name') else None
@@ -339,8 +344,7 @@ class ParserGuessit(object):
             valid=valid
         )
 
-        end = time.clock()
-        log.debug('Parsing result: %s (in %s ms)', parsed, (end - start) * 1000)
+        log.debug('Parsing result: %s (in %s ms)', parsed, (preferred_clock() - start) * 1000)
         return parsed
 
     # TODO: The following functions are sort of legacy. No idea if they should be changed.

--- a/flexget/plugins/parsers/parser_internal.py
+++ b/flexget/plugins/parsers/parser_internal.py
@@ -14,13 +14,20 @@ from .parser_common import ParseWarning, MovieParseResult, SeriesParseResult
 log = logging.getLogger('parser_internal')
 
 
+try:
+    preferred_clock = time.process_time
+except AttributeError:
+    preferred_clock = time.clock
+
+
 class ParserInternal(object):
+
     # movie_parser API
 
     @plugin.priority(1)
     def parse_movie(self, data, **kwargs):
         log.debug('Parsing movie: `%s` kwargs: %s', data, kwargs)
-        start = time.clock()
+        start = preferred_clock()
         parser = MovieParser()
         try:
             parser.parse(data)
@@ -34,15 +41,14 @@ class ParserInternal(object):
             proper_count=parser.proper_count,
             valid=bool(parser.name)
         )
-        end = time.clock()
-        log.debug('Parsing result: %s (in %s ms)', parser, (end - start) * 1000)
+        log.debug('Parsing result: %s (in %s ms)', parser, (preferred_clock() - start) * 1000)
         return result
 
     # series_parser API
     @plugin.priority(1)
     def parse_series(self, data, **kwargs):
         log.debug('Parsing series: `%s` kwargs: %s', data, kwargs)
-        start = time.clock()
+        start = preferred_clock()
         parser = SeriesParser(**kwargs)
         try:
             parser.parse(data)
@@ -65,8 +71,7 @@ class ParserInternal(object):
             strict_name=parser.strict_name,
             identified_by=parser.identified_by
         )
-        end = time.clock()
-        log.debug('Parsing result: %s (in %s ms)', parser, (end - start) * 1000)
+        log.debug('Parsing result: %s (in %s ms)', parser, (preferred_clock() - start) * 1000)
         return result
 
 


### PR DESCRIPTION
### Motivation for changes:
Arch isnt too great at running on older python versions :smile: 

### Detailed changes:
- replace all instances of time.clock with preferred_time which is either time.process_time if supported otherwise remains time.clock. This is detected by attempting to access time.process_time on module import and setting the module level variable preferred_clock accordingly

### Addressed issues:
- Fixes #2265

### Log and/or tests output (preferably both):
```
i have log output in the linked issue of the behaviour before this patch, the DeprecationWarnings are no longer present after this patch is applied
```