### PR TITLE
fix rpyc calls timing out after 30 seconds

### DIFF
--- a/flexget/ipc.py
+++ b/flexget/ipc.py
@@ -160,14 +160,15 @@ class IPCServer(threading.Thread):
 
 
 class IPCClient(object):
-    def __init__(self, port, password):
+    def __init__(self, port, password, sync_request_timeout=3600):
         channel = rpyc.Channel(rpyc.SocketStream.connect('127.0.0.1', port))
         channel.send(password.encode('utf-8'))
         response = channel.recv()
         if response == AUTH_ERROR:
             # TODO: What to raise here. I guess we create a custom error
             raise ValueError('Invalid password for daemon')
-        self.conn = rpyc.utils.factory.connect_channel(channel, service=ClientService)
+        self.conn = rpyc.utils.factory.connect_channel(
+            channel, service=ClientService, config={'sync_request_timeout': sync_request_timeout})
 
     def close(self):
         self.conn.close()

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -336,7 +336,7 @@ class Manager(object):
             console('There is a FlexGet process already running for this config, sending execution there.')
             log.debug('Sending command to running FlexGet process: %s' % self.args)
             try:
-                client = IPCClient(ipc_info['port'], ipc_info['password'])
+                client = IPCClient(ipc_info['port'], ipc_info['password'], sync_request_timeout=self.options.timeout)
             except ValueError as e:
                 log.error(e)
             else:

--- a/flexget/options.py
+++ b/flexget/options.py
@@ -406,6 +406,7 @@ manager_parser.add_argument('--ipc-port', type=int, help=SUPPRESS)
 manager_parser.add_argument('--cron', action=CronAction, default=False, nargs=0,
                             help='use when executing FlexGet non-interactively: allows background '
                                  'maintenance to run, disables stdout and stderr output, reduces logging level')
+manager_parser.add_argument('--timeout', default=3600, help='number of seconds to run before timing out', type=int)
 
 
 class CoreArgumentParser(ArgumentParser):


### PR DESCRIPTION
### Motivation for changes:
rpyc started actually timing out sync requests in 4.0.0 https://github.com/tomerfiliba/rpyc/issues/264

### Detailed changes:
- add `--timeout` argument to Manager
- add `sync_request_timeout` to signature of `IPCClient.__init__()`
- pass `timeout` through to `IPCClient` in `Manager.start()`

### Addressed issues:
- Fixes #2267

### Log and/or tests output (preferably both):

```
paste output here
```

#### To Do:

- [ ] Merge :+1: 

