### PR TITLE
Erichlf torrentday

### DIFF
--- a/flexget/plugins/sites/torrentday.py
+++ b/flexget/plugins/sites/torrentday.py
@@ -136,9 +136,15 @@ class UrlRewriteTorrentday(object):
             except RequestException as e:
                 raise PluginError('Could not connect to torrentday: {}'.format(e))
 
-            soup = get_soup(page)
+            # the following should avoid table being None due to a malformed
+            # html in td search results
+            soup = get_soup(page).contents[1].contents[1].next.next.nextSibling
+            table = soup.find('table', {'id': 'torrentTable'})
+            if (table is None):
+                raise PluginError('Search returned by torrentday appears to be empty or malformed.')
+
             # the first row is the header so skip it
-            for tr in soup.find_all('tr')[1:]:
+            for tr in table.find_all('tr')[1:]:
                 entry = Entry()
                 # find the torrent names
                 td = tr.find('td', { 'class': 'torrentNameInfo' })

--- a/flexget/plugins/sites/torrentday.py
+++ b/flexget/plugins/sites/torrentday.py
@@ -165,8 +165,8 @@ class UrlRewriteTorrentday(object):
                 entry['url'] = torrent_url
 
                 # us tr object for seeders/leechers
-                seeders = tr.find_all('td', { 'class': 'ac seedersInfo'})
-                leechers = tr.find_all('td', { 'class': 'ac leechersInfo'})
+                seeders = tr.find('td', { 'class': 'ac seedersInfo'})
+                leechers = tr.find('td', { 'class': 'ac leechersInfo'})
                 entry['torrent_seeds'] = int(seeders.contents[0].replace(',', ''))
                 entry['torrent_leeches'] = int(leechers.contents[0].replace(',', ''))
                 entry['search_sort'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])

--- a/flexget/plugins/sites/torrentday.py
+++ b/flexget/plugins/sites/torrentday.py
@@ -144,12 +144,18 @@ class UrlRewriteTorrentday(object):
                 entry = Entry()
                 # find the torrent names
                 td = tr.find('td', { 'class': 'torrentNameInfo' })
+                if not td:
+                    raise PluginError('Could not find entry torrentNameInfo for {}.'.format(search_string))
                 title = td.find('a')
+                if not title:
+                    raise PluginError('Could not determine title for {}.'.format(search_string))
                 entry['title'] = title.contents[0]
                 log.debug('title: %s', title.contents[0])
 
                 # find download link
                 torrent_url = tr.find_all('td', { 'class': 'ac' })[0]
+                if not torrent_url:
+                    raise PluginError('Could not determine download link for {}.'.format(search_string))
                 torrent_url = torrent_url.find('a').get('href')
 
                 # construct download URL

--- a/flexget/plugins/sites/torrentday.py
+++ b/flexget/plugins/sites/torrentday.py
@@ -137,10 +137,8 @@ class UrlRewriteTorrentday(object):
                 raise PluginError('Could not connect to torrentday: {}'.format(e))
 
             soup = get_soup(page)
-            form = soup.find('form', id='torrents')
-            table = form.find('table', { 'id': 'torrentTable' })
             # the first row is the header so skip it
-            for tr in table.find_all('tr')[1:]:
+            for tr in soup.find_all('tr')[1:]:
                 entry = Entry()
                 # find the torrent names
                 td = tr.find('td', { 'class': 'torrentNameInfo' })
@@ -167,7 +165,8 @@ class UrlRewriteTorrentday(object):
                 entry['url'] = torrent_url
 
                 # us tr object for seeders/leechers
-                seeders, leechers = tr.find_all('td', { 'class': ['ac seedersInfo', 'ac leechersInfo']})
+                seeders = tr.find_all('td', { 'class': 'ac seedersInfo'})
+                leechers = tr.find_all('td', { 'class': 'ac leechersInfo'})
                 entry['torrent_seeds'] = int(seeders.contents[0].replace(',', ''))
                 entry['torrent_leeches'] = int(leechers.contents[0].replace(',', ''))
                 entry['search_sort'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])


### PR DESCRIPTION
### Motivation for changes:
torrentday webpages seemed to be malformed. To address this issue one can skip over that portion of the webpage.

Additionally, the seeders and leechers portion of td plugin results in an error, since it is using find_all when it should use find.

### Detailed changes:
- add  hack to bypass malformed portion of html
- switch from find_all to find for seeders and leechers

### Addressed issues:
- Fixes #2272
- Fixes #2273

