### PR TITLE
[add] new notifier/Discord plugin

### DIFF
--- a/flexget/plugins/notifiers/discord.py
+++ b/flexget/plugins/notifiers/discord.py
@@ -1,0 +1,138 @@
+from __future__ import unicode_literals, division, absolute_import
+
+import logging
+
+from flexget import plugin
+from flexget.event import event
+from flexget.plugin import PluginWarning
+from requests.exceptions import RequestException
+
+from flexget.utils import requests
+
+# requests = (max_retires=3)
+
+plugin_name = 'discord'
+
+log = logging.getLogger(plugin_name)
+
+
+class DiscordNotifier(object):
+    """
+    Example
+
+      notify:
+        entries:
+          via:
+            - discord:
+                web_hook_url: <string>
+                [username: <string>] (override the default username of the webhook)
+                [avatar_url: <string>] (override the default avatar of the webhook)
+                [embeds: <arrays>[<object>]] (override embeds)
+    """
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'web_hook_url': {'type': 'string', 'format': 'uri'},
+            'username': {'type': 'string', 'default': 'Flexget'},
+            'avatar_url': {'type': 'string', 'format': 'uri'},
+            'embeds': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'title': {'type': 'string'},
+                        'description': {'type': 'string'},
+                        'url': {'type': 'string', 'format': 'uri'},
+                        'color': {'type': 'integer'},
+                        'footer': {
+                            'type': 'object',
+                            'properties': {
+                                'text': {'type': 'string'},
+                                'icon_url': {'type': 'string', 'format': 'uri'},
+                                'proxy_icon_url': {'type': 'string', 'format': 'uri'},
+                            },
+                            'required': ['text'],
+                            'additionalProperties': False
+                        },
+                        'image': {
+                            'type': 'object',
+                            'properties': {
+                                'url': {'type': 'string', 'format': 'uri'},
+                                'proxy_url': {'type': 'string', 'format': 'uri'},
+                            },
+                            'additionalProperties': False
+                        },
+                        'thumbnail': {
+                            'type': 'object',
+                            'properties': {
+                                'url': {'type': 'string', 'format': 'uri'},
+                                'proxy_url': {'type': 'string', 'format': 'uri'},
+                            },
+                            'additionalProperties': False
+                        },
+                        'provider': {
+                            'type': 'object',
+                            'properties': {
+                                'name': {'type': 'string'},
+                                'url': {'type': 'string', 'format': 'uri'},
+                            },
+                            'additionalProperties': False
+                        },
+                        'author': {
+                            'type': 'object',
+                            'properties': {
+                                'name': {'type': 'string'},
+                                'url': {'type': 'string', 'format': 'uri'},
+                                'icon_url': {'type': 'string', 'format': 'uri'},
+                                'proxy_icon_url': {'type': 'string', 'format': 'uri'},
+                            },
+                            'additionalProperties': False
+                        },
+                        'fields': {
+                            'type': 'array',
+                            'minItems': 1,
+                            'items': {
+                                'type': 'object',
+                                'properties': {
+                                    'name': {'type': 'string'},
+                                    'value': {'type': 'string'},
+                                    'inline': {'type': 'boolean'}
+                                },
+                                'required': ['name', 'value'],
+                                'additionalProperties': False
+                            }
+                        }
+                    },
+                    'additionalProperties': False
+                }
+            },
+        },
+        'required': ['web_hook_url'],
+        'additionalProperties': False
+    }
+
+    def notify(self, title, message, config):
+        """
+        Send discord notification
+
+        :param str message: message body
+        :param dict config: discord plugin config
+        """
+
+        web_hook = {
+            'content': message,
+            'username': config.get('username'),
+            'avatar_url': config.get('avatar_url'),
+            'embeds': config.get('embeds')
+        }
+
+        try:
+            r = requests.post(config['web_hook_url'], json=web_hook)
+        except RequestException as e:
+            raise PluginWarning(e.args[0])
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(DiscordNotifier, plugin_name, api_ver=2, interfaces=['notifiers'])

--- a/flexget/plugins/notifiers/discord.py
+++ b/flexget/plugins/notifiers/discord.py
@@ -128,7 +128,7 @@ class DiscordNotifier(object):
         }
 
         try:
-            r = requests.post(config['web_hook_url'], json=web_hook)
+            requests.post(config['web_hook_url'], json=web_hook)
         except RequestException as e:
             raise PluginWarning(e.args[0])
 

--- a/flexget/plugins/notifiers/discord.py
+++ b/flexget/plugins/notifiers/discord.py
@@ -9,7 +9,6 @@ from requests.exceptions import RequestException
 
 from flexget.utils import requests
 
-# requests = (max_retires=3)
 
 plugin_name = 'discord'
 


### PR DESCRIPTION
### Implemented feature requests:
- Support Discord webhook for notify plugin 
- Feathub #[53](https://feathub.com/Flexget/Flexget/+53).

### Implementation:
- I based the plugin on the already existing slack plugin
- I adapted the schema of the config to correspond to discord webhook format: https://discordapp.com/developers/docs/resources/webhook#execute-webhook

### Config usage:
```
    notify:
      entries:
        message: "{{series_name}} - {{series_id }}"
        via:
          - discord:
              web_hook_url: "{? web_hook_url ?}
              avatar_url: "{? avatar_url ?}
              username: "Flexget"
              embeds:
                - title: "{{series_name}}"
                  description: "{{tvmaze_series_summary|default('Unknown')}}"
                  url: "{{tvmaze_series_url}}"
                  color: 0xe67e22
                  author:
                    name: "Flexget"
                    url: "https://flexget.com"
                    icon_url: "https://i.imgur.com/R66g1Pe.jpg"
                  fields:
                    - name: "Episode Name:"
                      value: "{{tvmaze_episode_name|default('Unknown')}}"
                      inline: True
                    - name: "Score"
                      value: "{{tvmaze_series_rating|default('Unknown')}}"
                      inline: True
                    - name: "Made in"
                      value: ":flag_jp:"
                  thumbnail:
                    url: "{{tvdb_ep_image|default('https://i.imgflip.com/j69nf.jpg')}}"
                  image:
                    url: "{{tvmaze_series_original_image}}"
                  footer:
                    text: "Such amaze, Much wow !"
                    icon_url: "{? icon_url ?}"

```
### Discord output:
![discord_hook](https://user-images.githubusercontent.com/18049222/49756761-06533380-fcbb-11e8-98f6-ce754618e259.PNG)
#### To Do:

- Wiki


