### PR TITLE
check if not name, if so mark not valid

### DIFF
--- a/flexget/plugins/parsers/parser_guessit.py
+++ b/flexget/plugins/parsers/parser_guessit.py
@@ -226,7 +226,9 @@ class ParserGuessit(object):
         country = guess_result.get('country')
         if not name:
             name = guess_result.get('title')
-            if country and hasattr(country, 'alpha2'):
+            if not name:
+                valid = False
+            elif country and hasattr(country, 'alpha2'):
                 name += ' (%s)' % country.alpha2
         elif guess_result.matches['title']:
             # Make sure the name match is up to FlexGet standards


### PR DESCRIPTION
### Motivation for changes:
The guessit plugin doesn't check if the name is valid after trying to get it from the `guessit_results`

### Detailed changes:
- Check if not name, if so mark it not valid. The following if was changed to elif.

### Addressed issues:
- Fixes #2276.