### PR TITLE
auto-generate a somewhat reasonable content id if there isn't one

### DIFF
--- a/flexget/components/series/metainfo_series.py
+++ b/flexget/components/series/metainfo_series.py
@@ -29,7 +29,7 @@ class MetainfoSeries:
             return
         for entry in task.entries:
             # If series plugin already parsed this, don't touch it.
-            if entry.get('id'):
+            if entry.get('series_name'):
                 continue
             self.guess_entry(entry)
 

--- a/flexget/components/series/series.py
+++ b/flexget/components/series/series.py
@@ -80,9 +80,6 @@ def populate_entry_fields(entry, parser, config):
     """
     entry['series_parser'] = copy(parser)
 
-    if parser.identifier:
-        entry['id'] = ('%s %s' % (parser.name, parser.identifier)).lower().strip()
-
     # add series, season and episode to entry
     entry['series_name'] = parser.name
     if 'quality' in entry and entry['quality'] != parser.quality:

--- a/flexget/plugins/filter/best_quality.py
+++ b/flexget/plugins/filter/best_quality.py
@@ -34,7 +34,7 @@ class FilterBestQuality:
             return
 
         identified_by = (
-            '{{ id }}' if config['identified_by'] == 'auto' else config['identified_by']
+            '{{ media_id }}' if config['identified_by'] == 'auto' else config['identified_by']
         )
 
         action_on_best = (

--- a/flexget/plugins/filter/timeframe.py
+++ b/flexget/plugins/filter/timeframe.py
@@ -62,7 +62,7 @@ class FilterTimeFrame:
             return
 
         identified_by = (
-            '{{ id }}' if config['identified_by'] == 'auto' else config['identified_by']
+            '{{ media_id }}' if config['identified_by'] == 'auto' else config['identified_by']
         )
 
         grouped_entries = group_entries(task.accepted, identified_by)
@@ -164,7 +164,7 @@ class FilterTimeFrame:
             return
 
         identified_by = (
-            '{{ id }}' if config['identified_by'] == 'auto' else config['identified_by']
+            '{{ media_id }}' if config['identified_by'] == 'auto' else config['identified_by']
         )
 
         grouped_entries = group_entries(task.accepted, identified_by)

--- a/flexget/plugins/filter/upgrade.py
+++ b/flexget/plugins/filter/upgrade.py
@@ -104,7 +104,7 @@ class FilterUpgrade:
             return
 
         identified_by = (
-            '{{ id }}' if config['identified_by'] == 'auto' else config['identified_by']
+            '{{ media_id }}' if config['identified_by'] == 'auto' else config['identified_by']
         )
 
         grouped_entries = group_entries(task.accepted + task.undecided, identified_by)
@@ -185,7 +185,7 @@ class FilterUpgrade:
             return
 
         identified_by = (
-            '{{ id }}' if config['identified_by'] == 'auto' else config['identified_by']
+            '{{ media_id }}' if config['identified_by'] == 'auto' else config['identified_by']
         )
 
         grouped_entries = group_entries(task.accepted, identified_by)

--- a/flexget/plugins/metainfo/media_id.py
+++ b/flexget/plugins/metainfo/media_id.py
@@ -35,9 +35,9 @@ class MetainfoMediaId(object):
                 media_id = f'{media_id} {entry["series_year"]}'
 
             if entry.get('series_episode'):
-                media_id = f'{media_id} S{entry.get("series_season") or 0}E{entry["series_episode"]}'
+                media_id = f'{media_id} S{(entry.get("series_season") or 0):02}E{entry["series_episode"]:02}'
             elif entry.get('series_season'):
-                media_id = f'{media_id} S{entry["series_season"]}E0'
+                media_id = f'{media_id} S{entry["series_season"]:02}E00'
             elif entry.get('series_date'):
                 media_id = f'{media_id} {entry["series_date"]}'
             else:

--- a/flexget/plugins/metainfo/media_id.py
+++ b/flexget/plugins/metainfo/media_id.py
@@ -1,0 +1,55 @@
+from loguru import logger
+
+from flexget import plugin
+from flexget.event import event
+
+logger = logger.bind(name='metainfo_media_id')
+
+
+class MetainfoMediaId(object):
+    """
+    Populate media_id field based on media type etc.
+    """
+
+    schema = {'type': 'boolean'}
+
+    @plugin.priority(0)  # run after other metainfo plugins
+    def on_task_metainfo(self, task, config):
+        # Don't run if we are disabled
+        if config is False:
+            return
+        for entry in task.entries:
+            entry.register_lazy_func(self.get_media_id, ['media_id'])
+
+    @staticmethod
+    def get_media_id(entry):
+        # Try to generate a media id based on available parser fields
+        media_id = None
+        if bool(entry.get('movie_name')):
+            media_id = entry['movie_name']
+            if entry.get('movie_year'):
+                media_id = f'{media_id} {entry["movie_year"]}'
+        elif bool(entry.get('series_name')):
+            media_id = entry['series_name']
+            if entry.get('series_year'):
+                media_id = f'{media_id} {entry["series_year"]}'
+
+            if entry.get('series_episode'):
+                media_id = f'{media_id} S{entry.get("series_season") or 0}E{entry["series_episode"]}'
+            elif entry.get('series_season'):
+                media_id = f'{media_id} S{entry["series_season"]}E0'
+            elif entry.get('series_date'):
+                media_id = f'{media_id} {entry["series_date"]}'
+            else:
+                # We do not want a media id for series
+                media_id = None
+
+        if media_id:
+            media_id = media_id.strip().lower()
+
+        entry['media_id'] = media_id
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(MetainfoMediaId, 'metainfo_media_id', api_ver=2, builtin=True)

--- a/flexget/plugins/metainfo/media_id.py
+++ b/flexget/plugins/metainfo/media_id.py
@@ -25,11 +25,11 @@ class MetainfoMediaId(object):
     def get_media_id(entry):
         # Try to generate a media id based on available parser fields
         media_id = None
-        if bool(entry.get('movie_name')):
+        if entry.get('movie_name'):
             media_id = entry['movie_name']
             if entry.get('movie_year'):
                 media_id = f'{media_id} {entry["movie_year"]}'
-        elif bool(entry.get('series_name')):
+        elif entry.get('series_name'):
             media_id = entry['series_name']
             if entry.get('series_year'):
                 media_id = f'{media_id} {entry["series_year"]}'

--- a/flexget/plugins/metainfo/metainfo_movie.py
+++ b/flexget/plugins/metainfo/metainfo_movie.py
@@ -25,7 +25,7 @@ class MetainfoMovie:
             return
         for entry in task.entries:
             # If movie parser already parsed this, don't touch it.
-            if entry.get('id'):
+            if entry.get('movie_name'):
                 continue
             self.guess_entry(entry)
 

--- a/flexget/tests/cassettes/test_metainfo.TestMetainfoSeries.test_jinja_tvdb
+++ b/flexget/tests/cassettes/test_metainfo.TestMetainfoSeries.test_jinja_tvdb
@@ -1,0 +1,171 @@
+interactions:
+  - request:
+      body: '{"apikey": "4D297D8CFDE0E105"}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '30'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - FlexGet/3.0.27.dev (www.flexget.com)
+      method: POST
+      uri: https://api.thetvdb.com/login
+    response:
+      body:
+        string: '{"token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzgyMjAxODIsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc3NjE1MzgyfQ.p0QmJkb0WWNV0yzCvoEZoHi29wlZgYSavhrR69lYDdeqSjZMxlEn1JcxHl3Cw1gLuikzzMR41o12sDtK2mKM5Fgc6ivCfZZH_Zc6shZk0mXP1LQShbNr8ADuwvUriOfb1SqgAUD16Rcky4C1zYIzp4p5LZO-HKbDzO3CWsYBlKR4j_bz_aje3y6U7yWiBAesQ7JzWmd3CkbGVSyVkQOeaxwPp_-bwN_VHEKFOU74ieXrG2UqE880wAwbH1Apf7lRvePryVXBeDCB_3ceQ04ibsvKrpmy9fM34nKiS5MYI_BTGkFB5LlaGPe1vr9SlInzvzYTgvkC6GFcR4phUp1lfQ"}'
+      headers:
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '466'
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Sun, 29 Dec 2019 10:29:42 GMT
+        Vary:
+          - Accept-Language
+        Via:
+          - 1.1 c0f81b73b25f5689e5357fd24a5fcb0d.cloudfront.net (CloudFront)
+        X-Amz-Cf-Id:
+          - GngEBj8YFm5QhkNItK03NPGE3Y-e6NXxWwRKwv7HAJCGaRkFgiQT4w==
+        X-Amz-Cf-Pop:
+          - CPH50-C1
+        X-Cache:
+          - Miss from cloudfront
+        X-Powered-By:
+          - Thundar!
+        X-Thetvdb-Api-Version:
+          - 3.0.0
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Accept-Language:
+          - en
+        Authorization:
+          - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzgyMjAxODIsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc3NjE1MzgyfQ.p0QmJkb0WWNV0yzCvoEZoHi29wlZgYSavhrR69lYDdeqSjZMxlEn1JcxHl3Cw1gLuikzzMR41o12sDtK2mKM5Fgc6ivCfZZH_Zc6shZk0mXP1LQShbNr8ADuwvUriOfb1SqgAUD16Rcky4C1zYIzp4p5LZO-HKbDzO3CWsYBlKR4j_bz_aje3y6U7yWiBAesQ7JzWmd3CkbGVSyVkQOeaxwPp_-bwN_VHEKFOU74ieXrG2UqE880wAwbH1Apf7lRvePryVXBeDCB_3ceQ04ibsvKrpmy9fM34nKiS5MYI_BTGkFB5LlaGPe1vr9SlInzvzYTgvkC6GFcR4phUp1lfQ
+        Connection:
+          - keep-alive
+        User-Agent:
+          - FlexGet/3.0.27.dev (www.flexget.com)
+      method: GET
+      uri: https://api.thetvdb.com/search/series?name=Westworld
+    response:
+      body:
+        string: '{"data":[{"aliases":[],"banner":"/banners/posters/296762-3.jpg","firstAired":"2016-10-2","id":296762,"network":"HBO","overview":"Westworld
+          is a dark odyssey about the dawn of artificial consciousness and the evolution
+          of sin. Set at the intersection of the near future and the reimagined past,
+          it explores a world in which every human appetite, no matter how noble or
+          depraved, can be indulged.","seriesName":"Westworld","slug":"westworld","status":"Continuing"},{"aliases":[],"banner":"/banners/posters/77993-2.jpg","firstAired":"1980-3-5","id":77993,"network":"CBS","overview":"Beyond
+          Westworld was a short-lived 1980 television series that carried on the stories
+          of the two feature films, Westworld and Futureworld. It featured Jim McMullan
+          as Security Chief John Moore of the Delos Corporation. The story revolved
+          around John Moore having to stop the evil scientist, Quaid, as he planned
+          to use the robots in Delos to try to take over the world. Despite being
+          nominated for two Emmys (Outstanding Achievement In Makeup, and Outstanding
+          Art Direction For A Series), only five episodes were produced, and only
+          three of them were aired before cancellation.","seriesName":"Beyond Westworld","slug":"beyond-westworld","status":"Ended"},{"aliases":[],"banner":"/banners/posters/5daa4b060618d.jpg","firstAired":"2018-7-18","id":371131,"network":"Tencent
+          Video","seriesName":"The Westward","slug":"the-westward","status":"Continuing"},{"aliases":["Discovery
+          Next World","Discovery NextWorld","Next World"],"banner":"/banners/posters/82754-1.jpg","firstAired":"2008-8-6","id":82754,"network":null,"overview":"The
+          science fiction of today will be science fact of the future. The Discovery
+          Channel series NextWorld reveals the science, the inventions and the innovations
+          that seem impossible now, but will be a reality in our lifetimes. Imagine
+          cities under the oceans, bionic suits, space tourism, superspeed trains,
+          cyborg moths, windships, hoverbikes, somatic sensors, virtual reality, people
+          living to 150 years old -- these may be just the dreams of today but they
+          will shape the NextWorld. ","seriesName":"NextWorld","slug":"nextworld","status":"Ended"}]}'
+      headers:
+        Cache-Control:
+          - private, max-age=86400
+        Connection:
+          - keep-alive
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Sun, 29 Dec 2019 10:29:43 GMT
+        Vary:
+          - Accept-Language
+        Via:
+          - 1.1 0326fbaba639f5673ce3c647a7884df0.cloudfront.net (CloudFront)
+        X-Amz-Cf-Id:
+          - VqkXSwwMZLDmxAz-hQUXl5cKKP65cMLSD1T8JJTRLLXslCVFhNX6YQ==
+        X-Amz-Cf-Pop:
+          - CPH50-C1
+        X-Cache:
+          - Miss from cloudfront
+        X-Powered-By:
+          - Thundar!
+        X-Thetvdb-Api-Version:
+          - 3.0.0
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Accept-Language:
+          - en
+        Authorization:
+          - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzgyMjAxODIsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc3NjE1MzgyfQ.p0QmJkb0WWNV0yzCvoEZoHi29wlZgYSavhrR69lYDdeqSjZMxlEn1JcxHl3Cw1gLuikzzMR41o12sDtK2mKM5Fgc6ivCfZZH_Zc6shZk0mXP1LQShbNr8ADuwvUriOfb1SqgAUD16Rcky4C1zYIzp4p5LZO-HKbDzO3CWsYBlKR4j_bz_aje3y6U7yWiBAesQ7JzWmd3CkbGVSyVkQOeaxwPp_-bwN_VHEKFOU74ieXrG2UqE880wAwbH1Apf7lRvePryVXBeDCB_3ceQ04ibsvKrpmy9fM34nKiS5MYI_BTGkFB5LlaGPe1vr9SlInzvzYTgvkC6GFcR4phUp1lfQ
+        Connection:
+          - keep-alive
+        User-Agent:
+          - FlexGet/3.0.27.dev (www.flexget.com)
+      method: GET
+      uri: https://api.thetvdb.com/series/296762
+    response:
+      body:
+        string: '{"data":{"id":296762,"seriesId":"194892","seriesName":"Westworld","aliases":[],"season":"2","poster":"posters/296762-3.jpg","banner":"graphical/296762-g3.jpg","fanart":"fanart/original/296762-7.jpg","status":"Continuing","firstAired":"2016-10-02","network":"HBO","networkId":"333","runtime":"60","language":"en","genre":["Adventure","Drama","Science
+          Fiction","Western"],"overview":"Westworld is a dark odyssey about the dawn
+          of artificial consciousness and the evolution of sin. Set at the intersection
+          of the near future and the reimagined past, it explores a world in which
+          every human appetite, no matter how noble or depraved, can be indulged.","lastUpdated":1577073800,"airsDayOfWeek":"Sunday","airsTime":"9:00
+          PM","rating":"TV-MA","imdbId":"tt0475784","zap2itId":"SH02476964","added":"2015-06-10
+          14:07:01","addedBy":67309,"siteRating":8.9,"siteRatingCount":3255,"slug":"westworld"}}'
+      headers:
+        Cache-Control:
+          - private, max-age=86400
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '888'
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Sat, 28 Dec 2019 22:09:52 GMT
+        Last-Modified:
+          - Mon, 23 Dec 2019 04:03:20 GMT
+        Vary:
+          - Accept-Language
+        Via:
+          - 1.1 4bade328d3b2aa91384925c67cd91548.cloudfront.net (CloudFront)
+        X-Amz-Cf-Id:
+          - LpXZok7IkG27pfHuLhAk9EQw94ft-HPwIXXR_qANGYMBbNyM-G5big==
+        X-Amz-Cf-Pop:
+          - CPH50-C1
+        X-Cache:
+          - Hit from cloudfront
+        X-Powered-By:
+          - Thundar!
+        X-Thetvdb-Api-Version:
+          - 3.0.0
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/flexget/tests/test_metainfo.py
+++ b/flexget/tests/test_metainfo.py
@@ -88,6 +88,13 @@ class TestMetainfoSeries:
               series: __parser__
             metainfo_series: yes
         tasks:
+          test_jinja_tvdb:
+            thetvdb_lookup: yes
+            mock:
+              - {title: 'Westworld (2016) S01E01', series_name: 'Westworld'}
+            set:
+              title: "{{tvdb_series_name}}"
+            accept_all: yes
           test:
             mock:
               - {title: 'FlexGet.S01E02.TheName.HDTV.xvid'}
@@ -179,6 +186,11 @@ class TestMetainfoSeries:
             assert 'series_name' not in entry, error
             assert 'series_guessed' not in entry, error
             assert 'series_parser' not in entry, error
+
+    @pytest.mark.online
+    def test_jinja_tvdb(self, execute_task):
+        task = execute_task('test_jinja_tvdb')
+        assert task.entries[0]['title'] == 'Westworld'
 
 
 class TestMetainfoMovie:

--- a/flexget/tests/test_metainfo.py
+++ b/flexget/tests/test_metainfo.py
@@ -130,21 +130,21 @@ class TestMetainfoSeries:
             series_season=1,
             series_episode=2,
             quality='hdtv xvid',
-            id='flexget s01e02',
+            media_id='flexget s01e02',
         ), 'Failed to parse series info'
         assert task.find_entry(
             series_name='Some Series',
             series_season=3,
             series_episode=14,
             quality='720p',
-            id='some series s03e14',
+            media_id='some series s03e14',
         ), 'Failed to parse series info'
         assert task.find_entry(
             series_name='Something',
             series_season=2,
             series_episode=1,
             quality='hdtv',
-            id='something s02e01',
+            media_id='something s02e01',
         ), 'Failed to parse series info'
         # Test unwanted prefixes get stripped from series name
         assert task.find_entry(
@@ -152,14 +152,14 @@ class TestMetainfoSeries:
             series_season=3,
             series_episode=15,
             quality='720p',
-            id='some series s03e15',
+            media_id='some series s03e15',
         ), 'Failed to parse series info'
         assert task.find_entry(
             series_name='Some Series',
             series_season=3,
             series_episode=16,
             quality='720p',
-            id='some series s03e16',
+            media_id='some series s03e16',
         ), 'Failed to parse series info'
         # Test episode title and parentheses are stripped from series name
         assert task.find_entry(
@@ -167,14 +167,14 @@ class TestMetainfoSeries:
             series_season=2,
             series_episode=9,
             quality='hdtv',
-            id='show-a us s02e09',
+            media_id='show-a us s02e09',
         ), 'Failed to parse series info'
         assert task.find_entry(
             series_name='Jack\'s Show',
             series_season=3,
             series_episode=1,
             quality='1080p',
-            id='jack\'s show s03e01',
+            media_id='jack\'s show s03e01',
         ), 'Failed to parse series info'
 
     def test_false_positives(self, execute_task):

--- a/flexget/tests/test_nfo_lookup.py
+++ b/flexget/tests/test_nfo_lookup.py
@@ -207,6 +207,7 @@ class TestNfoLookupWithMovies:
                     'title',
                     'original_title',
                     'filename',
+                    'media_id',
                     'nfo_id',
                     'task',
                     'url',

--- a/flexget/tests/test_timeframe.py
+++ b/flexget/tests/test_timeframe.py
@@ -22,31 +22,31 @@ class TestTimeFrame:
               wait: 1 day
               target: 1080p
             mock:
-              - {title: 'Movie.BRRip.x264.720p', 'id': 'Movie'}
-              - {title: 'Movie.720p WEB-DL X264 AC3', 'id': 'Movie'} 
+              - {title: 'Movie.BRRip.x264.720p', 'media_id': 'Movie'}
+              - {title: 'Movie.720p WEB-DL X264 AC3', 'media_id': 'Movie'} 
           reached_and_backlog:
             timeframe:
               wait: 1 hour
               target: 1080p
               on_reached: accept
             mock:
-              - {title: 'Movie.720p WEB-DL X264 AC3', 'id': 'Movie'} 
-              - {title: 'Movie.BRRip.x264.720p', 'id': 'Movie'}
+              - {title: 'Movie.720p WEB-DL X264 AC3', 'media_id': 'Movie'} 
+              - {title: 'Movie.BRRip.x264.720p', 'media_id': 'Movie'}
           target1:
             timeframe:
               wait: 1 hour
               target: 1080p
               on_reached: accept
             mock:
-              - {title: 'Movie.720p WEB-DL X264 AC3', 'id': 'Movie'} 
-              - {title: 'Movie.BRRip.x264.720p', 'id': 'Movie'}
+              - {title: 'Movie.720p WEB-DL X264 AC3', 'media_id': 'Movie'} 
+              - {title: 'Movie.BRRip.x264.720p', 'media_id': 'Movie'}
           target2:
             timeframe:
               wait: 1 hour
               target: 1080p
               on_reached: accept
             mock:
-              - {title: 'Movie.1080p WEB-DL X264 AC3', 'id': 'Movie'} 
+              - {title: 'Movie.1080p WEB-DL X264 AC3', 'media_id': 'Movie'} 
     """
 
     def test_wait(self, execute_task):
@@ -54,7 +54,7 @@ class TestTimeFrame:
         with Session() as session:
             query = session.query(EntryTimeFrame).all()
             assert len(query) == 1, 'There should be one tracked entity present.'
-            assert query[0].id == 'movie', 'Should of tracked name `Movie`.'
+            assert query[0].id == 'movie', 'Should have tracked name `Movie`.'
 
         entry = task.find_entry('rejected', title='Movie.BRRip.x264.720p')
         assert entry, 'Movie.BRRip.x264.720p should be rejected'

--- a/flexget/tests/test_upgrade.py
+++ b/flexget/tests/test_upgrade.py
@@ -10,27 +10,27 @@ class TestUpgrade:
             upgrade:
               tracking: yes
             mock:
-              - {title: 'Movie.720p.WEB-DL.X264.AC3-GRP1', 'id': 'Movie'}
+              - {title: 'Movie.720p.WEB-DL.X264.AC3-GRP1', 'media_id': 'Movie'}
           tracking_only:
             upgrade:
               tracking: yes
             mock:
-              - {title: 'Movie.1080p WEB-DL X264 AC3', 'id': 'Movie'} 
+              - {title: 'Movie.1080p WEB-DL X264 AC3', 'media_id': 'Movie'} 
           upgrade_quality:
             upgrade:
               target: 1080p
             mock:
-              - {title: 'Movie.1080p WEB-DL X264 AC3', 'id': 'Movie'}
-              - {title: 'Movie.720p.WEB-DL.X264.AC3', 'id': 'Movie'}
-              - {title: 'Movie.BRRip.x264.720p', 'id': 'Movie'}
+              - {title: 'Movie.1080p WEB-DL X264 AC3', 'media_id': 'Movie'}
+              - {title: 'Movie.720p.WEB-DL.X264.AC3', 'media_id': 'Movie'}
+              - {title: 'Movie.BRRip.x264.720p', 'media_id': 'Movie'}
           reject_lower:
             upgrade:
               target: 1080p
               on_lower: reject
             mock:
-              - {title: 'Movie.1080p.BRRip.X264.AC3', 'id': 'Movie'}
-              - {title: 'Movie.1080p WEB-DL X264', 'id': 'Movie'}
-              - {title: 'Movie.BRRip.x264.720p', 'id': 'Movie'}
+              - {title: 'Movie.1080p.BRRip.X264.AC3', 'media_id': 'Movie'}
+              - {title: 'Movie.1080p WEB-DL X264', 'media_id': 'Movie'}
+              - {title: 'Movie.BRRip.x264.720p', 'media_id': 'Movie'}
     """
 
     def test_learn(self, execute_task):
@@ -38,7 +38,7 @@ class TestUpgrade:
         with Session() as session:
             query = session.query(EntryUpgrade).all()
             assert len(query) == 1, 'There should be one tracked entity present.'
-            assert query[0].id == 'movie', 'Should of tracked name `Movie`.'
+            assert query[0].id == 'movie', 'Should have tracked name `Movie`.'
 
     def test_tracking(self, execute_task):
         execute_task('first_download')


### PR DESCRIPTION
### Motivation for changes:
None
### Detailed changes:
- Automatically generate a content id based on entry type if the entry hasn't been parsed by internal or guessit

### Addressed issues:
- Fixes #2071 

#### To Do:

- [x] Test

