### PR TITLE
Force quality field to Quality instance during metainfo phase

### DIFF
--- a/flexget/plugins/metainfo/quality.py
+++ b/flexget/plugins/metainfo/quality.py
@@ -25,7 +25,12 @@ class MetainfoQuality(object):
         if config is False:
             return
         for entry in task.entries:
-            entry.register_lazy_func(self.get_quality, ['quality'])
+            if isinstance(entry.get('quality', eval_lazy=False), str):
+                log.debug('Quality is already set to %s for %s, but has not been instantiated properly.' %
+                          (entry['quality'], entry['title']))
+                entry['quality'] = qualities.Quality(entry.get('quality', eval_lazy=False))
+            else:
+                entry.register_lazy_func(self.get_quality, ['quality'])
 
     def get_quality(self, entry):
         if entry.get('quality', eval_lazy=False):

--- a/flexget/tests/test_qualities.py
+++ b/flexget/tests/test_qualities.py
@@ -161,6 +161,11 @@ class TestFilterQuality(object):
             quality: "<=cam <HR"
           min_max:
             quality: HR-720i
+          quality_str:
+            template: no_global
+            mock:
+              - {title: 'Test S01E01 HDTV 1080p', quality: 'hdtv 1080p dd+5.1'}
+            accept_all: yes
     """
 
     @pytest.fixture(scope='class', params=['internal', 'guessit'], ids=['internal', 'guessit'])
@@ -211,6 +216,12 @@ class TestFilterQuality(object):
         assert entry in task.accepted, 'HR should be accepted'
         assert len(task.rejected) == 3, 'wrong number of entries rejected'
         assert len(task.accepted) == 1, 'wrong number of entries accepted'
+
+    def test_quality_string(self, execute_task):
+        task = execute_task('quality_str')
+        entry = task.find_entry('accepted', title='Test S01E01 HDTV 1080p')
+        assert isinstance(entry['quality'], Quality), 'Wrong quality type, should be Quality not str'
+        assert str(entry['quality']) == '1080p hdtv dd+5.1'
 
 
 class TestQualityAudio(object):


### PR DESCRIPTION
### Motivation for changes:
Makes sense
### Detailed changes:
- During metainfo phase, force quality str to Quality instance instead

### Addressed issues:
- Fixes #2242