### PR TITLE
Trakt list: Add pagination handling

### DIFF
--- a/flexget/plugins/list/trakt_list.py
+++ b/flexget/plugins/list/trakt_list.py
@@ -3,6 +3,7 @@ from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 import logging
 from collections import MutableSet
+import math
 
 from flexget import plugin
 from flexget.entry import Entry
@@ -173,6 +174,27 @@ class TraktSet(MutableSet):
                 except ValueError:
                     log.debug('Could not decode json from response: %s', result.text)
                     raise plugin.PluginError('Error getting list from trakt.')
+
+                limit = 1000
+                pagination_item_count = int(result.headers.get('X-Pagination-Item-Count', 0))
+                number_of_pages = math.ceil(pagination_item_count / limit)
+                pagination_limit = int(result.headers.get('X-Pagination-Limit', 0))
+                if pagination_limit < pagination_item_count:
+                    # Pagination, gotta get it all, but we'll limit it to 1000 per page
+                    # but we'll have to start over from 0
+                    log.debug('Number of items: %s, number of pages: %s', pagination_item_count, number_of_pages)
+                    page = int(result.headers.get('X-Pagination-Page'))
+                    data = []  # easier to start from scratch
+                    while page <= number_of_pages:
+                        paginated_result = self.session.get(get_api_url(endpoint),
+                                                            params={'limit': limit, 'page': page})
+                        page += 1
+                        try:
+                            data.extend(paginated_result.json())
+                        except ValueError:
+                            log.debug('Could not decode json from response: %s', paginated_result.text)
+                            raise plugin.PluginError('Error getting list from trakt.')
+
             except RequestException as e:
                 raise plugin.PluginError('Could not retrieve list from trakt (%s)' % e)
 

--- a/flexget/plugins/list/trakt_list.py
+++ b/flexget/plugins/list/trakt_list.py
@@ -175,16 +175,19 @@ class TraktSet(MutableSet):
                     log.debug('Could not decode json from response: %s', result.text)
                     raise plugin.PluginError('Error getting list from trakt.')
 
-                limit = 1000
-                pagination_item_count = int(result.headers.get('X-Pagination-Item-Count', 0))
-                number_of_pages = math.ceil(pagination_item_count / limit)
-                pagination_limit = int(result.headers.get('X-Pagination-Limit', 0))
-                if pagination_limit < pagination_item_count:
+                current_page = int(result.headers.get('X-Pagination-Page', 1))
+                current_page_count = int(result.headers.get('X-Pagination-Page-Count', 1))
+                if current_page < current_page_count:
                     # Pagination, gotta get it all, but we'll limit it to 1000 per page
                     # but we'll have to start over from 0
-                    log.debug('Number of items: %s, number of pages: %s', pagination_item_count, number_of_pages)
+                    data = []
+
+                    limit = 1000
+                    pagination_item_count = int(result.headers.get('X-Pagination-Item-Count', 0))
+                    number_of_pages = math.ceil(pagination_item_count / limit)
+                    log.debug('Response is paginated. Number of items: %s, number of pages: %s',
+                              pagination_item_count, number_of_pages)
                     page = int(result.headers.get('X-Pagination-Page'))
-                    data = []  # easier to start from scratch
                     while page <= number_of_pages:
                         paginated_result = self.session.get(get_api_url(endpoint),
                                                             params={'limit': limit, 'page': page})

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_get_list
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_get_list
@@ -13,17 +13,17 @@ interactions:
           Walking Dead","year":2010,"ids":{"trakt":1393,"slug":"the-walking-dead","tvdb":153021,"imdb":"tt1520211","tmdb":1402,"tvrage":25056}}},{"rank":2,"id":90056392,"listed_at":"2016-04-06T01:08:56.000Z","type":"movie","movie":{"title":"Deadpool","year":2016,"ids":{"trakt":190430,"slug":"deadpool-2016","imdb":"tt1431045","tmdb":293660}}},{"rank":3,"id":90056410,"listed_at":"2016-04-06T01:09:11.000Z","type":"episode","episode":{"season":8,"number":15,"title":"Fidelis
           Ad Mortem","ids":{"trakt":2125119,"tvdb":5483434,"imdb":"tt5318930","tmdb":1165957,"tvrage":1065902569}},"show":{"title":"Castle","year":2009,"ids":{"trakt":1410,"slug":"castle","tvdb":83462,"imdb":"tt1219024","tmdb":1419,"tvrage":19267}}}]'}
       headers:
-        CF-RAY: [490a28be4c393d3d-CPH]
+        CF-RAY: [490a5466fa4f3cfb-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [d49a1c54bd stream 0.000000 0200 57da]
+        Cf-Railgun: [7bb3e0cc43 2.79 0.052561 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:20:09 GMT']
+        Date: ['Sat, 29 Dec 2018 06:49:57 GMT']
         Etag: [W/"7b6e0d2f1f65bce494c5691609a18856"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
         Server: [cloudflare]
-        Set-Cookie: ['__cfduid=d3312db96cb46acd7e76aa3568bab1d811546064409; expires=Sun,
-            29-Dec-19 06:20:09 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Set-Cookie: ['__cfduid=da6034fd3a53229a5d069dcfc27f738251546066197; expires=Sun,
+            29-Dec-19 06:49:57 GMT; path=/; domain=.trakt.tv; HttpOnly']
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
@@ -31,46 +31,8 @@ interactions:
         X-Pagination-Page: ['1']
         X-Pagination-Page-Count: ['1']
         X-Private-User: ['false']
-        X-Request-Id: [4885d9a2-2469-4c36-94cd-7dbbaf63d7a7]
-        X-Runtime: ['0.055175']
-        X-Sort-By: [rank]
-        X-Sort-How: [asc]
-        X-Xss-Protection: [1; mode=block]
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
-        Content-Type: [application/json]
-        Cookie: [__cfduid=d3312db96cb46acd7e76aa3568bab1d811546064409]
-        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
-        trakt-api-version: ['2']
-      method: GET
-      uri: https://api.trakt.tv/users/me/lists/testlist/items?page=1&limit=1000
-    response:
-      body: {string: '[{"rank":1,"id":90056369,"listed_at":"2016-04-06T01:08:39.000Z","type":"show","show":{"title":"The
-          Walking Dead","year":2010,"ids":{"trakt":1393,"slug":"the-walking-dead","tvdb":153021,"imdb":"tt1520211","tmdb":1402,"tvrage":25056}}},{"rank":2,"id":90056392,"listed_at":"2016-04-06T01:08:56.000Z","type":"movie","movie":{"title":"Deadpool","year":2016,"ids":{"trakt":190430,"slug":"deadpool-2016","imdb":"tt1431045","tmdb":293660}}},{"rank":3,"id":90056410,"listed_at":"2016-04-06T01:09:11.000Z","type":"episode","episode":{"season":8,"number":15,"title":"Fidelis
-          Ad Mortem","ids":{"trakt":2125119,"tvdb":5483434,"imdb":"tt5318930","tmdb":1165957,"tvrage":1065902569}},"show":{"title":"Castle","year":2009,"ids":{"trakt":1410,"slug":"castle","tvdb":83462,"imdb":"tt1219024","tmdb":1419,"tvrage":19267}}}]'}
-      headers:
-        CF-RAY: [490a28ca6fc13d3d-CPH]
-        Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [97a4f2225d 2.54 0.032193 0030 57da]
-        Connection: [keep-alive]
-        Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:20:11 GMT']
-        Etag: [W/"7b6e0d2f1f65bce494c5691609a18856"]
-        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Server: [cloudflare]
-        Vary: [Accept-Encoding]
-        X-Content-Type-Options: [nosniff]
-        X-Frame-Options: [SAMEORIGIN]
-        X-Pagination-Item-Count: ['3']
-        X-Pagination-Limit: ['1000']
-        X-Pagination-Page: ['1']
-        X-Pagination-Page-Count: ['1']
-        X-Private-User: ['false']
-        X-Request-Id: [f1351820-2502-4f1a-8303-4a836995fea7]
-        X-Runtime: ['0.026249']
+        X-Request-Id: [155ea630-434f-4011-9fba-0d6ebd80a92f]
+        X-Runtime: ['0.014572']
         X-Sort-By: [rank]
         X-Sort-How: [asc]
         X-Xss-Protection: [1; mode=block]

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_get_list
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_get_list
@@ -1,40 +1,78 @@
 interactions:
-- request:
-    body: null
-    headers:
-      Authorization: [Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a]
-      Content-Type: [application/json]
-      trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
-      trakt-api-version: ['2']
-    method: GET
-    uri: https://api.trakt.tv/users/me/lists/testlist/items
-  response:
-    body: {string: '[{"rank":1,"listed_at":"2016-04-06T01:08:39.000Z","type":"show","show":{"title":"The
-        Walking Dead","year":2010,"ids":{"trakt":1393,"slug":"the-walking-dead","tvdb":153021,"imdb":"tt1520211","tmdb":1402,"tvrage":25056}}},{"rank":2,"listed_at":"2016-04-06T01:08:56.000Z","type":"movie","movie":{"title":"Deadpool","year":2016,"ids":{"trakt":190430,"slug":"deadpool-2016","imdb":"tt1431045","tmdb":293660}}},{"rank":3,"listed_at":"2016-04-06T01:09:11.000Z","type":"episode","episode":{"season":8,"number":15,"title":"Fidelis
-        Ad Mortem","ids":{"trakt":2125119,"tvdb":5483434,"imdb":"tt5318930","tmdb":1165957,"tvrage":1065902569}},"show":{"title":"Castle","year":2009,"ids":{"trakt":1410,"slug":"castle","tvdb":83462,"imdb":"tt1219024","tmdb":1419,"tvrage":19267}}}]'}
-    headers:
-      CF-RAY: [41e72ae1dd3f3cf5-CPH]
-      Cache-Control: ['max-age=0, private, must-revalidate']
-      Cf-Railgun: [9d1890bb0c 2.91 0.022321 0030 57da]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 21 May 2018 12:50:13 GMT']
-      Etag: [W/"7b6e0d2f1f65bce494c5691609a18856"]
-      Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-      Server: [cloudflare]
-      Set-Cookie: ['__cfduid=d611c9d51eb0a60eeaf1d232d8d37dbf61526907013; expires=Tue,
-          21-May-19 12:50:13 GMT; path=/; domain=.trakt.tv; HttpOnly']
-      Vary: [Accept-Encoding]
-      X-Content-Type-Options: [nosniff]
-      X-Frame-Options: [SAMEORIGIN]
-      X-Pagination-Item-Count: ['3']
-      X-Pagination-Page: ['1']
-      X-Pagination-Page-Count: ['1']
-      X-Private-User: ['false']
-      X-Request-Id: [e319ddac-b939-421a-bca1-f05229444883]
-      X-Runtime: ['0.017527']
-      X-Sort-By: [rank]
-      X-Sort-How: [asc]
-      X-Xss-Protection: [1; mode=block]
-    status: {code: 200, message: OK}
+  - request:
+      body: null
+      headers:
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
+      method: GET
+      uri: https://api.trakt.tv/users/me/lists/testlist/items
+    response:
+      body: {string: '[{"rank":1,"id":90056369,"listed_at":"2016-04-06T01:08:39.000Z","type":"show","show":{"title":"The
+          Walking Dead","year":2010,"ids":{"trakt":1393,"slug":"the-walking-dead","tvdb":153021,"imdb":"tt1520211","tmdb":1402,"tvrage":25056}}},{"rank":2,"id":90056392,"listed_at":"2016-04-06T01:08:56.000Z","type":"movie","movie":{"title":"Deadpool","year":2016,"ids":{"trakt":190430,"slug":"deadpool-2016","imdb":"tt1431045","tmdb":293660}}},{"rank":3,"id":90056410,"listed_at":"2016-04-06T01:09:11.000Z","type":"episode","episode":{"season":8,"number":15,"title":"Fidelis
+          Ad Mortem","ids":{"trakt":2125119,"tvdb":5483434,"imdb":"tt5318930","tmdb":1165957,"tvrage":1065902569}},"show":{"title":"Castle","year":2009,"ids":{"trakt":1410,"slug":"castle","tvdb":83462,"imdb":"tt1219024","tmdb":1419,"tvrage":19267}}}]'}
+      headers:
+        CF-RAY: [490a28be4c393d3d-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [d49a1c54bd stream 0.000000 0200 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:20:09 GMT']
+        Etag: [W/"7b6e0d2f1f65bce494c5691609a18856"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Server: [cloudflare]
+        Set-Cookie: ['__cfduid=d3312db96cb46acd7e76aa3568bab1d811546064409; expires=Sun,
+            29-Dec-19 06:20:09 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Pagination-Item-Count: ['3']
+        X-Pagination-Page: ['1']
+        X-Pagination-Page-Count: ['1']
+        X-Private-User: ['false']
+        X-Request-Id: [4885d9a2-2469-4c36-94cd-7dbbaf63d7a7]
+        X-Runtime: ['0.055175']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
+      status: {code: 200, message: OK}
+  - request:
+      body: null
+      headers:
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d3312db96cb46acd7e76aa3568bab1d811546064409]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
+      method: GET
+      uri: https://api.trakt.tv/users/me/lists/testlist/items?page=1&limit=1000
+    response:
+      body: {string: '[{"rank":1,"id":90056369,"listed_at":"2016-04-06T01:08:39.000Z","type":"show","show":{"title":"The
+          Walking Dead","year":2010,"ids":{"trakt":1393,"slug":"the-walking-dead","tvdb":153021,"imdb":"tt1520211","tmdb":1402,"tvrage":25056}}},{"rank":2,"id":90056392,"listed_at":"2016-04-06T01:08:56.000Z","type":"movie","movie":{"title":"Deadpool","year":2016,"ids":{"trakt":190430,"slug":"deadpool-2016","imdb":"tt1431045","tmdb":293660}}},{"rank":3,"id":90056410,"listed_at":"2016-04-06T01:09:11.000Z","type":"episode","episode":{"season":8,"number":15,"title":"Fidelis
+          Ad Mortem","ids":{"trakt":2125119,"tvdb":5483434,"imdb":"tt5318930","tmdb":1165957,"tvrage":1065902569}},"show":{"title":"Castle","year":2009,"ids":{"trakt":1410,"slug":"castle","tvdb":83462,"imdb":"tt1219024","tmdb":1419,"tvrage":19267}}}]'}
+      headers:
+        CF-RAY: [490a28ca6fc13d3d-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [97a4f2225d 2.54 0.032193 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:20:11 GMT']
+        Etag: [W/"7b6e0d2f1f65bce494c5691609a18856"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Pagination-Item-Count: ['3']
+        X-Pagination-Limit: ['1000']
+        X-Pagination-Page: ['1']
+        X-Pagination-Page-Count: ['1']
+        X-Private-User: ['false']
+        X-Request-Id: [f1351820-2502-4f1a-8303-4a836995fea7]
+        X-Runtime: ['0.026249']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
+      status: {code: 200, message: OK}
 version: 1

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_strip_dates
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_strip_dates
@@ -13,17 +13,17 @@ interactions:
           Walking Dead","year":2010,"ids":{"trakt":1393,"slug":"the-walking-dead","tvdb":153021,"imdb":"tt1520211","tmdb":1402,"tvrage":25056}}},{"rank":2,"id":90056392,"listed_at":"2016-04-06T01:08:56.000Z","type":"movie","movie":{"title":"Deadpool","year":2016,"ids":{"trakt":190430,"slug":"deadpool-2016","imdb":"tt1431045","tmdb":293660}}},{"rank":3,"id":90056410,"listed_at":"2016-04-06T01:09:11.000Z","type":"episode","episode":{"season":8,"number":15,"title":"Fidelis
           Ad Mortem","ids":{"trakt":2125119,"tvdb":5483434,"imdb":"tt5318930","tmdb":1165957,"tvrage":1065902569}},"show":{"title":"Castle","year":2009,"ids":{"trakt":1410,"slug":"castle","tvdb":83462,"imdb":"tt1219024","tmdb":1419,"tvrage":19267}}}]'}
       headers:
-        CF-RAY: [490a29028c153d31-CPH]
+        CF-RAY: [490a548f68123d31-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [1f6ff3ee7d 2.54 0.027703 0030 57da]
+        Cf-Railgun: [c96916ede7 2.79 0.062515 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:20:20 GMT']
+        Date: ['Sat, 29 Dec 2018 06:50:04 GMT']
         Etag: [W/"7b6e0d2f1f65bce494c5691609a18856"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
         Server: [cloudflare]
-        Set-Cookie: ['__cfduid=d937eddbc2b866610f11ffd560aeed6691546064420; expires=Sun,
-            29-Dec-19 06:20:20 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Set-Cookie: ['__cfduid=d5aed07ae50a16612e07df026e0986aca1546066204; expires=Sun,
+            29-Dec-19 06:50:04 GMT; path=/; domain=.trakt.tv; HttpOnly']
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
@@ -31,46 +31,8 @@ interactions:
         X-Pagination-Page: ['1']
         X-Pagination-Page-Count: ['1']
         X-Private-User: ['false']
-        X-Request-Id: [f55db95e-1a79-46f9-9df1-6b9db751de09]
-        X-Runtime: ['0.016737']
-        X-Sort-By: [rank]
-        X-Sort-How: [asc]
-        X-Xss-Protection: [1; mode=block]
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
-        Content-Type: [application/json]
-        Cookie: [__cfduid=d937eddbc2b866610f11ffd560aeed6691546064420]
-        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
-        trakt-api-version: ['2']
-      method: GET
-      uri: https://api.trakt.tv/users/me/lists/testlist/items?limit=1000&page=1
-    response:
-      body: {string: '[{"rank":1,"id":90056369,"listed_at":"2016-04-06T01:08:39.000Z","type":"show","show":{"title":"The
-          Walking Dead","year":2010,"ids":{"trakt":1393,"slug":"the-walking-dead","tvdb":153021,"imdb":"tt1520211","tmdb":1402,"tvrage":25056}}},{"rank":2,"id":90056392,"listed_at":"2016-04-06T01:08:56.000Z","type":"movie","movie":{"title":"Deadpool","year":2016,"ids":{"trakt":190430,"slug":"deadpool-2016","imdb":"tt1431045","tmdb":293660}}},{"rank":3,"id":90056410,"listed_at":"2016-04-06T01:09:11.000Z","type":"episode","episode":{"season":8,"number":15,"title":"Fidelis
-          Ad Mortem","ids":{"trakt":2125119,"tvdb":5483434,"imdb":"tt5318930","tmdb":1165957,"tvrage":1065902569}},"show":{"title":"Castle","year":2009,"ids":{"trakt":1410,"slug":"castle","tvdb":83462,"imdb":"tt1219024","tmdb":1419,"tvrage":19267}}}]'}
-      headers:
-        CF-RAY: [490a290de8aa3d31-CPH]
-        Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [c0d070112e 2.54 0.032761 0030 57da]
-        Connection: [keep-alive]
-        Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:20:22 GMT']
-        Etag: [W/"7b6e0d2f1f65bce494c5691609a18856"]
-        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Server: [cloudflare]
-        Vary: [Accept-Encoding]
-        X-Content-Type-Options: [nosniff]
-        X-Frame-Options: [SAMEORIGIN]
-        X-Pagination-Item-Count: ['3']
-        X-Pagination-Limit: ['1000']
-        X-Pagination-Page: ['1']
-        X-Pagination-Page-Count: ['1']
-        X-Private-User: ['false']
-        X-Request-Id: [b0939172-82f7-443c-978a-3c9d492d1968]
-        X-Runtime: ['0.023391']
+        X-Request-Id: [d00f048c-91ee-42b4-99eb-832df1c97b94]
+        X-Runtime: ['0.019358']
         X-Sort-By: [rank]
         X-Sort-How: [asc]
         X-Xss-Protection: [1; mode=block]

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_strip_dates
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_strip_dates
@@ -1,40 +1,78 @@
 interactions:
-- request:
-    body: null
-    headers:
-      Authorization: [Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a]
-      Content-Type: [application/json]
-      trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
-      trakt-api-version: ['2']
-    method: GET
-    uri: https://api.trakt.tv/users/me/lists/testlist/items
-  response:
-    body: {string: '[{"rank":1,"listed_at":"2016-04-06T01:08:39.000Z","type":"show","show":{"title":"The
-        Walking Dead","year":2010,"ids":{"trakt":1393,"slug":"the-walking-dead","tvdb":153021,"imdb":"tt1520211","tmdb":1402,"tvrage":25056}}},{"rank":2,"listed_at":"2016-04-06T01:08:56.000Z","type":"movie","movie":{"title":"Deadpool","year":2016,"ids":{"trakt":190430,"slug":"deadpool-2016","imdb":"tt1431045","tmdb":293660}}},{"rank":3,"listed_at":"2016-04-06T01:09:11.000Z","type":"episode","episode":{"season":8,"number":15,"title":"Fidelis
-        Ad Mortem","ids":{"trakt":2125119,"tvdb":5483434,"imdb":"tt5318930","tmdb":1165957,"tvrage":1065902569}},"show":{"title":"Castle","year":2009,"ids":{"trakt":1410,"slug":"castle","tvdb":83462,"imdb":"tt1219024","tmdb":1419,"tvrage":19267}}}]'}
-    headers:
-      CF-RAY: [41e72aee5da93d37-CPH]
-      Cache-Control: ['max-age=0, private, must-revalidate']
-      Cf-Railgun: [a37363ac48 2.91 0.028770 0030 57da]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 21 May 2018 12:50:15 GMT']
-      Etag: [W/"7b6e0d2f1f65bce494c5691609a18856"]
-      Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-      Server: [cloudflare]
-      Set-Cookie: ['__cfduid=d9b14b10a1ade733435468acb72ecd61d1526907015; expires=Tue,
-          21-May-19 12:50:15 GMT; path=/; domain=.trakt.tv; HttpOnly']
-      Vary: [Accept-Encoding]
-      X-Content-Type-Options: [nosniff]
-      X-Frame-Options: [SAMEORIGIN]
-      X-Pagination-Item-Count: ['3']
-      X-Pagination-Page: ['1']
-      X-Pagination-Page-Count: ['1']
-      X-Private-User: ['false']
-      X-Request-Id: [b929fe39-c31a-4737-8e42-cdf5201f3141]
-      X-Runtime: ['0.024282']
-      X-Sort-By: [rank]
-      X-Sort-How: [asc]
-      X-Xss-Protection: [1; mode=block]
-    status: {code: 200, message: OK}
+  - request:
+      body: null
+      headers:
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
+      method: GET
+      uri: https://api.trakt.tv/users/me/lists/testlist/items
+    response:
+      body: {string: '[{"rank":1,"id":90056369,"listed_at":"2016-04-06T01:08:39.000Z","type":"show","show":{"title":"The
+          Walking Dead","year":2010,"ids":{"trakt":1393,"slug":"the-walking-dead","tvdb":153021,"imdb":"tt1520211","tmdb":1402,"tvrage":25056}}},{"rank":2,"id":90056392,"listed_at":"2016-04-06T01:08:56.000Z","type":"movie","movie":{"title":"Deadpool","year":2016,"ids":{"trakt":190430,"slug":"deadpool-2016","imdb":"tt1431045","tmdb":293660}}},{"rank":3,"id":90056410,"listed_at":"2016-04-06T01:09:11.000Z","type":"episode","episode":{"season":8,"number":15,"title":"Fidelis
+          Ad Mortem","ids":{"trakt":2125119,"tvdb":5483434,"imdb":"tt5318930","tmdb":1165957,"tvrage":1065902569}},"show":{"title":"Castle","year":2009,"ids":{"trakt":1410,"slug":"castle","tvdb":83462,"imdb":"tt1219024","tmdb":1419,"tvrage":19267}}}]'}
+      headers:
+        CF-RAY: [490a29028c153d31-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [1f6ff3ee7d 2.54 0.027703 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:20:20 GMT']
+        Etag: [W/"7b6e0d2f1f65bce494c5691609a18856"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Server: [cloudflare]
+        Set-Cookie: ['__cfduid=d937eddbc2b866610f11ffd560aeed6691546064420; expires=Sun,
+            29-Dec-19 06:20:20 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Pagination-Item-Count: ['3']
+        X-Pagination-Page: ['1']
+        X-Pagination-Page-Count: ['1']
+        X-Private-User: ['false']
+        X-Request-Id: [f55db95e-1a79-46f9-9df1-6b9db751de09]
+        X-Runtime: ['0.016737']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
+      status: {code: 200, message: OK}
+  - request:
+      body: null
+      headers:
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d937eddbc2b866610f11ffd560aeed6691546064420]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
+      method: GET
+      uri: https://api.trakt.tv/users/me/lists/testlist/items?limit=1000&page=1
+    response:
+      body: {string: '[{"rank":1,"id":90056369,"listed_at":"2016-04-06T01:08:39.000Z","type":"show","show":{"title":"The
+          Walking Dead","year":2010,"ids":{"trakt":1393,"slug":"the-walking-dead","tvdb":153021,"imdb":"tt1520211","tmdb":1402,"tvrage":25056}}},{"rank":2,"id":90056392,"listed_at":"2016-04-06T01:08:56.000Z","type":"movie","movie":{"title":"Deadpool","year":2016,"ids":{"trakt":190430,"slug":"deadpool-2016","imdb":"tt1431045","tmdb":293660}}},{"rank":3,"id":90056410,"listed_at":"2016-04-06T01:09:11.000Z","type":"episode","episode":{"season":8,"number":15,"title":"Fidelis
+          Ad Mortem","ids":{"trakt":2125119,"tvdb":5483434,"imdb":"tt5318930","tmdb":1165957,"tvrage":1065902569}},"show":{"title":"Castle","year":2009,"ids":{"trakt":1410,"slug":"castle","tvdb":83462,"imdb":"tt1219024","tmdb":1419,"tvrage":19267}}}]'}
+      headers:
+        CF-RAY: [490a290de8aa3d31-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [c0d070112e 2.54 0.032761 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:20:22 GMT']
+        Etag: [W/"7b6e0d2f1f65bce494c5691609a18856"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Pagination-Item-Count: ['3']
+        X-Pagination-Limit: ['1000']
+        X-Pagination-Page: ['1']
+        X-Pagination-Page-Count: ['1']
+        X-Private-User: ['false']
+        X-Request-Id: [b0939172-82f7-443c-978a-3c9d492d1968]
+        X-Runtime: ['0.023391']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
+      status: {code: 200, message: OK}
 version: 1

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add
@@ -9,59 +9,27 @@ interactions:
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/shows
     response:
-      body: {string: '[{"rank":1,"id":349979913,"listed_at":"2018-07-13T08:28:16.000Z","type":"show","show":{"title":"White
-          Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}}]'}
+      body: {string: '[]'}
       headers:
-        CF-RAY: [490a29758ae03ce3-CPH]
+        CF-RAY: [490a54b99b263d3d-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [2ed6b18cb9 99.99 0.021993 0030 57da]
+        Cf-Railgun: [8adeccbc16 99.99 0.029608 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:20:38 GMT']
-        Etag: [W/"0557d4b6f4f50f0058e5eebe13d045a5"]
+        Date: ['Sat, 29 Dec 2018 06:50:10 GMT']
+        Etag: [W/"4424072e99830138d0df9ea8ea2b71ec"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Fri, 13 Jul 2018 08:28:16 GMT']
+        Last-Modified: ['Sat, 29 Dec 2018 06:22:36 GMT']
         Server: [cloudflare]
-        Set-Cookie: ['__cfduid=db6cf24c7e65637fa8193dcc98e3902b01546064438; expires=Sun,
-            29-Dec-19 06:20:38 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Set-Cookie: ['__cfduid=df6cfde95df30cc35afff5871be2b4b1d1546066210; expires=Sun,
+            29-Dec-19 06:50:10 GMT; path=/; domain=.trakt.tv; HttpOnly']
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [6563f0a3-37ed-4d07-8768-d2512822618d]
-        X-Runtime: ['0.018988']
+        X-Request-Id: [fb04717c-c817-4527-9803-37403d853041]
+        X-Runtime: ['0.018469']
         X-Sort-By: [rank]
         X-Sort-How: [asc]
-        X-Xss-Protection: [1; mode=block]
-      status: {code: 200, message: OK}
-  - request:
-      body: '{"shows": [{"ids": {"tvrage": 20720, "tmdb": 21510, "imdb": "tt1358522",
-        "trakt": 21410, "tvdb": 108611}, "title": "White Collar", "year": 2009}]}'
-      headers:
-        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
-        Content-Length: ['146']
-        Content-Type: [application/json]
-        Cookie: [__cfduid=db6cf24c7e65637fa8193dcc98e3902b01546064438]
-        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
-        trakt-api-version: ['2']
-      method: POST
-      uri: https://api.trakt.tv/sync/watchlist/remove
-    response:
-      body: {string: '{"deleted":{"movies":0,"shows":1,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
-      headers:
-        CF-RAY: [490a297f3d9f3ce3-CPH]
-        Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [59f3816556 99.99 0.038925 0030 57da]
-        Connection: [keep-alive]
-        Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:20:40 GMT']
-        Etag: [W/"4fb81fc16aea93ef368d29b2af0e13e3"]
-        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Server: [cloudflare]
-        Vary: [Accept-Encoding]
-        X-Content-Type-Options: [nosniff]
-        X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [68317ef3-98d5-4ece-b70b-74706d1bfdd2]
-        X-Runtime: ['0.036434']
         X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
@@ -69,7 +37,7 @@ interactions:
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Type: [application/json]
-        Cookie: [__cfduid=db6cf24c7e65637fa8193dcc98e3902b01546064438]
+        Cookie: [__cfduid=df6cfde95df30cc35afff5871be2b4b1d1546066210]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
@@ -77,32 +45,32 @@ interactions:
     response:
       body: {string: '[]'}
       headers:
-        CF-RAY: [490a298ba93e3ce3-CPH]
+        CF-RAY: [490a54c5cf623d3d-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [dbdb131ff2 99.99 0.027712 0030 57da]
+        Cf-Railgun: [24cdcc5813 99.99 0.022602 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:20:42 GMT']
-        Etag: [W/"319a7b45cba95d2392df19ae463fea69"]
+        Date: ['Sat, 29 Dec 2018 06:50:12 GMT']
+        Etag: [W/"4424072e99830138d0df9ea8ea2b71ec"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:21:22 GMT']
+        Last-Modified: ['Sat, 29 Dec 2018 06:22:36 GMT']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [a386e523-365d-4642-b31f-6ec01928623d]
-        X-Runtime: ['0.018474']
+        X-Request-Id: [dbf12c7d-55bb-4f7e-9c56-49592f4d7f0a]
+        X-Runtime: ['0.020604']
         X-Sort-By: [rank]
         X-Sort-How: [asc]
         X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: '{"shows": [{"ids": {}, "title": "White Collar", "year": 2009}]}'
+      body: '{"shows": [{"title": "White Collar", "year": 2009, "ids": {}}]}'
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Length: ['63']
         Content-Type: [application/json]
-        Cookie: [__cfduid=db6cf24c7e65637fa8193dcc98e3902b01546064438]
+        Cookie: [__cfduid=df6cfde95df30cc35afff5871be2b4b1d1546066210]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: POST
@@ -110,20 +78,20 @@ interactions:
     response:
       body: {string: '{"added":{"movies":0,"shows":1,"seasons":0,"episodes":0},"existing":{"movies":0,"shows":0,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        CF-RAY: [490a29983d7a3ce3-CPH]
+        CF-RAY: [490a54d24c173d3d-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [b7f1724fe9 99.99 0.028937 0030 57da]
+        Cf-Railgun: [f417e01851 99.99 0.050139 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:20:44 GMT']
-        Etag: [W/"a6ed80a3354df97da525f8a323358fee"]
+        Date: ['Sat, 29 Dec 2018 06:50:14 GMT']
+        Etag: [W/"8d02f602e31d7d84872e75de358d300d"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [eeaff771-c1b3-49ac-bfcb-24a47cda10f8]
-        X-Runtime: ['0.027243']
+        X-Request-Id: [7f59133a-e651-4870-ac2d-d14dd85c2348]
+        X-Runtime: ['0.046500']
         X-Xss-Protection: [1; mode=block]
       status: {code: 201, message: Created}
   - request:
@@ -131,30 +99,30 @@ interactions:
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Type: [application/json]
-        Cookie: [__cfduid=db6cf24c7e65637fa8193dcc98e3902b01546064438]
+        Cookie: [__cfduid=df6cfde95df30cc35afff5871be2b4b1d1546066210]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/shows
     response:
-      body: {string: '[{"rank":1,"id":371585967,"listed_at":"2018-12-29T06:20:38.000Z","type":"show","show":{"title":"White
+      body: {string: '[{"rank":1,"id":371589379,"listed_at":"2018-12-29T06:50:57.000Z","type":"show","show":{"title":"White
           Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}}]'}
       headers:
-        CF-RAY: [490a29b87e103ce3-CPH]
+        CF-RAY: [490a54f2b9f73d3d-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [89d9960966 99.99 0.029041 0030 57da]
+        Cf-Railgun: [19dc455a45 99.99 0.174230 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:20:49 GMT']
-        Etag: [W/"7e4b57b61049dff9c5862abb44f02304"]
+        Date: ['Sat, 29 Dec 2018 06:50:20 GMT']
+        Etag: [W/"f43e8c8c125db97c38bf93c228dfea27"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:20:38 GMT']
+        Last-Modified: ['Sat, 29 Dec 2018 06:50:57 GMT']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [af31086c-ecb9-4421-8d30-8af157790c58]
-        X-Runtime: ['0.022620']
+        X-Request-Id: [5096f728-5741-4d86-99db-4bfe41211eb8]
+        X-Runtime: ['0.110217']
         X-Sort-By: [rank]
         X-Sort-How: [asc]
         X-Xss-Protection: [1; mode=block]

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add
@@ -2,134 +2,161 @@ interactions:
   - request:
       body: null
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Type: [!!python/unicode 'application/json']
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/shows
     response:
-      body: {string: !!python/unicode '[]'}
+      body: {string: '[{"rank":1,"id":349979913,"listed_at":"2018-07-13T08:28:16.000Z","type":"show","show":{"title":"White
+          Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}}]'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5fc06c7a3d25-CPH]
-        connection: [keep-alive]
-        content-length: ['2']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:28:05 GMT']
-        etag: [W/"96c03990b70f3bd751465b2e643d2bb4"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        last-modified: ['Fri, 13 Jul 2018 08:27:20 GMT']
-        server: [cloudflare]
-        set-cookie: ['__cfduid=d14081071f9f7400f47024d4d009cd86e1531470484; expires=Sat,
-            13-Jul-19 08:28:04 GMT; path=/; domain=.trakt.tv; HttpOnly']
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [f514bfb8-a697-4a55-9291-bfbd0a4d9646]
-        x-runtime: ['0.042495']
-        x-sort-by: [rank]
-        x-sort-how: [asc]
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a29758ae03ce3-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [2ed6b18cb9 99.99 0.021993 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:20:38 GMT']
+        Etag: [W/"0557d4b6f4f50f0058e5eebe13d045a5"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Last-Modified: ['Fri, 13 Jul 2018 08:28:16 GMT']
+        Server: [cloudflare]
+        Set-Cookie: ['__cfduid=db6cf24c7e65637fa8193dcc98e3902b01546064438; expires=Sun,
+            29-Dec-19 06:20:38 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [6563f0a3-37ed-4d07-8768-d2512822618d]
+        X-Runtime: ['0.018988']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
+      status: {code: 200, message: OK}
+  - request:
+      body: '{"shows": [{"ids": {"tvrage": 20720, "tmdb": 21510, "imdb": "tt1358522",
+        "trakt": 21410, "tvdb": 108611}, "title": "White Collar", "year": 2009}]}'
+      headers:
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Length: ['146']
+        Content-Type: [application/json]
+        Cookie: [__cfduid=db6cf24c7e65637fa8193dcc98e3902b01546064438]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
+      method: POST
+      uri: https://api.trakt.tv/sync/watchlist/remove
+    response:
+      body: {string: '{"deleted":{"movies":0,"shows":1,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
+      headers:
+        CF-RAY: [490a297f3d9f3ce3-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [59f3816556 99.99 0.038925 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:20:40 GMT']
+        Etag: [W/"4fb81fc16aea93ef368d29b2af0e13e3"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [68317ef3-98d5-4ece-b70b-74706d1bfdd2]
+        X-Runtime: ['0.036434']
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
       body: null
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=d14081071f9f7400f47024d4d009cd86e1531470484]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        Cookie: [__cfduid=db6cf24c7e65637fa8193dcc98e3902b01546064438]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/shows
     response:
-      body: {string: !!python/unicode '[]'}
+      body: {string: '[]'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5fc948a53d25-CPH]
-        connection: [keep-alive]
-        content-length: ['2']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:28:06 GMT']
-        etag: [W/"96c03990b70f3bd751465b2e643d2bb4"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        last-modified: ['Fri, 13 Jul 2018 08:27:20 GMT']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [c369653d-2efc-4499-ad2f-43a2e8c07fbc]
-        x-runtime: ['0.112148']
-        x-sort-by: [rank]
-        x-sort-how: [asc]
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a298ba93e3ce3-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [dbdb131ff2 99.99 0.027712 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:20:42 GMT']
+        Etag: [W/"319a7b45cba95d2392df19ae463fea69"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Last-Modified: ['Sat, 29 Dec 2018 06:21:22 GMT']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [a386e523-365d-4642-b31f-6ec01928623d]
+        X-Runtime: ['0.018474']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: !!python/unicode '{"shows": [{"year": 2009, "ids": {}, "title": "White
-        Collar"}]}'
+      body: '{"shows": [{"ids": {}, "title": "White Collar", "year": 2009}]}'
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Length: ['63']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=d14081071f9f7400f47024d4d009cd86e1531470484]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Content-Type: [application/json]
+        Cookie: [__cfduid=db6cf24c7e65637fa8193dcc98e3902b01546064438]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: POST
       uri: https://api.trakt.tv/sync/watchlist
     response:
-      body: {string: !!python/unicode '{"added":{"movies":0,"shows":1,"seasons":0,"episodes":0},"existing":{"movies":0,"shows":0,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
+      body: {string: '{"added":{"movies":0,"shows":1,"seasons":0,"episodes":0},"existing":{"movies":0,"shows":0,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5fd5ce133d25-CPH]
-        connection: [keep-alive]
-        content-length: ['192']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:28:08 GMT']
-        etag: [W/"a985f9b80abdce02453ffa525df76638"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [94a77360-2be5-401d-949f-416fa33a3048]
-        x-runtime: ['0.027188']
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a29983d7a3ce3-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [b7f1724fe9 99.99 0.028937 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:20:44 GMT']
+        Etag: [W/"a6ed80a3354df97da525f8a323358fee"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [eeaff771-c1b3-49ac-bfcb-24a47cda10f8]
+        X-Runtime: ['0.027243']
+        X-Xss-Protection: [1; mode=block]
       status: {code: 201, message: Created}
   - request:
       body: null
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=d14081071f9f7400f47024d4d009cd86e1531470484]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        Cookie: [__cfduid=db6cf24c7e65637fa8193dcc98e3902b01546064438]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/shows
     response:
-      body: {string: !!python/unicode '[{"rank":1,"listed_at":"2018-07-13T08:28:16.000Z","type":"show","show":{"title":"White
+      body: {string: '[{"rank":1,"id":371585967,"listed_at":"2018-12-29T06:20:38.000Z","type":"show","show":{"title":"White
           Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}}]'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5ffa484e3d25-CPH]
-        connection: [keep-alive]
-        content-length: ['214']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:28:14 GMT']
-        etag: [W/"0557d4b6f4f50f0058e5eebe13d045a5"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        last-modified: ['Fri, 13 Jul 2018 08:28:16 GMT']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [3484b60f-af35-4d56-83ab-fda530160824]
-        x-runtime: ['0.304691']
-        x-sort-by: [rank]
-        x-sort-how: [asc]
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a29b87e103ce3-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [89d9960966 99.99 0.029041 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:20:49 GMT']
+        Etag: [W/"7e4b57b61049dff9c5862abb44f02304"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Last-Modified: ['Sat, 29 Dec 2018 06:20:38 GMT']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [af31086c-ecb9-4421-8d30-8af157790c58]
+        X-Runtime: ['0.022620']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
 version: 1

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode
@@ -2,206 +2,166 @@ interactions:
   - request:
       body: null
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Type: [!!python/unicode 'application/json']
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/episodes
     response:
-      body: {string: !!python/unicode '[{"rank":1,"listed_at":"2018-07-13T08:25:40.000Z","type":"episode","episode":{"season":1,"number":5,"title":"Chapter
-          Five: The Flea and the Acrobat","ids":{"trakt":2124182,"tvdb":5621929,"imdb":"tt4593128","tmdb":1205904,"tvrage":1065933149}},"show":{"title":"Stranger
-          Things","year":2016,"ids":{"trakt":104439,"slug":"stranger-things","tvdb":305288,"imdb":"tt4574334","tmdb":66732,"tvrage":48493}}},{"rank":2,"listed_at":"2018-07-13T08:25:40.000Z","type":"episode","episode":{"season":1,"number":6,"title":"Chapter
-          Six: The Monster","ids":{"trakt":2124184,"tvdb":5621930,"imdb":"tt4593132","tmdb":1205905,"tvrage":1065933150}},"show":{"title":"Stranger
-          Things","year":2016,"ids":{"trakt":104439,"slug":"stranger-things","tvdb":305288,"imdb":"tt4574334","tmdb":66732,"tvrage":48493}}}]'}
+      body: {string: '[{"rank":1,"id":349979848,"listed_at":"2018-07-13T08:26:38.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
+          of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
+          of Thrones","year":2011,"ids":{"trakt":1390,"slug":"game-of-thrones","tvdb":121361,"imdb":"tt0944947","tmdb":1399,"tvrage":24493}}}]'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5d27fd963d31-CPH]
-        connection: [keep-alive]
-        content-length: ['785']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:26:18 GMT']
-        etag: [W/"a1f4aff5ae0c8b117eff871f77ad3e71"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        last-modified: ['Fri, 13 Jul 2018 08:25:40 GMT']
-        server: [cloudflare]
-        set-cookie: ['__cfduid=d5b9f0fb86cd215cf8240c5447a64d4601531470378; expires=Sat,
-            13-Jul-19 08:26:18 GMT; path=/; domain=.trakt.tv; HttpOnly']
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [7c049338-3391-40b1-b8ef-91c477258476]
-        x-runtime: ['0.026179']
-        x-sort-by: [rank]
-        x-sort-how: [asc]
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2a2b8a633d49-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [380cd92200 99.99 0.034977 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:21:07 GMT']
+        Etag: [W/"c54f8030868b5194e160669312ff949f"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Last-Modified: ['Fri, 13 Jul 2018 08:26:38 GMT']
+        Server: [cloudflare]
+        Set-Cookie: ['__cfduid=d503f757c7b65e4765b78d9a7b26b56e21546064467; expires=Sun,
+            29-Dec-19 06:21:07 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [1da7de0d-636e-4901-8f57-56b6490a061c]
+        X-Runtime: ['0.031906']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: !!python/unicode '{"shows": [{"seasons": [{"episodes": [{"number": 5}],
-        "number": 1}], "year": 2016, "ids": {"tvdb": 305288, "tvrage": 48493, "imdb":
-        "tt4574334", "trakt": 104439}, "title": "Stranger Things"}]}'
+      body: '{"shows": [{"year": 2011, "seasons": [{"number": 4, "episodes": [{"number":
+        5}]}], "title": "Game of Thrones", "ids": {"imdb": "tt0944947", "trakt": 1390,
+        "tvrage": 24493, "tvdb": 121361}}]}'
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Length: ['192']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=d5b9f0fb86cd215cf8240c5447a64d4601531470378]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Length: ['190']
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d503f757c7b65e4765b78d9a7b26b56e21546064467]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: POST
       uri: https://api.trakt.tv/sync/watchlist/remove
     response:
-      body: {string: !!python/unicode '{"deleted":{"movies":0,"shows":0,"seasons":0,"episodes":1},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
+      body: {string: '{"deleted":{"movies":0,"shows":0,"seasons":0,"episodes":1},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5d30fafd3d31-CPH]
-        connection: [keep-alive]
-        content-length: ['135']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:26:20 GMT']
-        etag: [W/"c324135b4c76b8166ce5389c6b3182ef"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [5dd29096-6970-4e35-9e81-8b6a3f2ea997]
-        x-runtime: ['0.034924']
-        x-xss-protection: [1; mode=block]
-      status: {code: 200, message: OK}
-  - request:
-      body: !!python/unicode '{"shows": [{"seasons": [{"episodes": [{"number": 6}],
-        "number": 1}], "year": 2016, "ids": {"tvdb": 305288, "tvrage": 48493, "imdb":
-        "tt4574334", "trakt": 104439}, "title": "Stranger Things"}]}'
-      headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Length: ['192']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=d5b9f0fb86cd215cf8240c5447a64d4601531470378]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
-      method: POST
-      uri: https://api.trakt.tv/sync/watchlist/remove
-    response:
-      body: {string: !!python/unicode '{"deleted":{"movies":0,"shows":0,"seasons":0,"episodes":1},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
-      headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5d3d78653d31-CPH]
-        connection: [keep-alive]
-        content-length: ['135']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:26:22 GMT']
-        etag: [W/"d6929d0c2070a2ac0b87600f298e6811"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [c519a0d8-a66f-40dd-bbb1-c36873d704e8]
-        x-runtime: ['0.030010']
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2a37adf93d49-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [ff6e0fe6ff 99.99 0.106228 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:21:09 GMT']
+        Etag: [W/"bc73677e57685ff27d449bf6310a3eb1"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [b0660ec3-932b-43ac-830c-cdefc439b4d8]
+        X-Runtime: ['0.103751']
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
       body: null
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=d5b9f0fb86cd215cf8240c5447a64d4601531470378]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d503f757c7b65e4765b78d9a7b26b56e21546064467]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/episodes
     response:
-      body: {string: !!python/unicode '[]'}
+      body: {string: '[]'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5d49e8443d31-CPH]
-        connection: [keep-alive]
-        content-length: ['2']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:26:24 GMT']
-        etag: [W/"a7717b8e09902418879055d4015c9599"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        last-modified: ['Fri, 13 Jul 2018 08:26:30 GMT']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [7c790b3e-f609-4177-a0c4-cbee0b51a2f1]
-        x-runtime: ['0.031549']
-        x-sort-by: [rank]
-        x-sort-how: [asc]
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2a4429ad3d49-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [d72b878fcb 99.99 0.021931 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:21:11 GMT']
+        Etag: [W/"f467cffde29648f4d219402632d3ead8"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Last-Modified: ['Sat, 29 Dec 2018 06:21:31 GMT']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [fa852f87-9578-4c6f-b077-7cfd5e8d4c84]
+        X-Runtime: ['0.020059']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: !!python/unicode '{"shows": [{"seasons": [{"episodes": [{"number": 5}],
-        "number": 4}], "year": 2011, "ids": {"tvdb": 121361, "tvrage": 24493, "imdb":
-        "tt0944947", "trakt": 1390}, "title": "Game of Thrones"}]}'
+      body: '{"shows": [{"year": 2011, "seasons": [{"number": 4, "episodes": [{"number":
+        5}]}], "title": "Game of Thrones", "ids": {"imdb": "tt0944947", "trakt": 1390,
+        "tvrage": 24493, "tvdb": 121361}}]}'
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Length: ['190']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=d5b9f0fb86cd215cf8240c5447a64d4601531470378]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d503f757c7b65e4765b78d9a7b26b56e21546064467]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: POST
       uri: https://api.trakt.tv/sync/watchlist
     response:
-      body: {string: !!python/unicode '{"added":{"movies":0,"shows":0,"seasons":0,"episodes":1},"existing":{"movies":0,"shows":0,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
+      body: {string: '{"added":{"movies":0,"shows":0,"seasons":0,"episodes":1},"existing":{"movies":0,"shows":0,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5d594a523d31-CPH]
-        connection: [keep-alive]
-        content-length: ['192']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:26:26 GMT']
-        etag: [W/"2a1282f460521674ff573a4f17eb4874"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [12464001-9bda-4ec4-bebd-8c1cbe35b1c1]
-        x-runtime: ['0.046238']
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2a50bcf83d49-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [def673fcca 99.99 0.045002 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:21:13 GMT']
+        Etag: [W/"0f76792d1c1abe338d7ee0d486a14e8e"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [1260ea64-1f77-4a00-8110-7efae37bfd5a]
+        X-Runtime: ['0.043040']
+        X-Xss-Protection: [1; mode=block]
       status: {code: 201, message: Created}
   - request:
       body: null
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=d5b9f0fb86cd215cf8240c5447a64d4601531470378]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d503f757c7b65e4765b78d9a7b26b56e21546064467]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/episodes
     response:
-      body: {string: !!python/unicode '[{"rank":1,"listed_at":"2018-07-13T08:26:38.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
+      body: {string: '[{"rank":1,"id":371585988,"listed_at":"2018-12-29T06:21:10.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
           of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
           of Thrones","year":2011,"ids":{"trakt":1390,"slug":"game-of-thrones","tvdb":121361,"imdb":"tt0944947","tmdb":1399,"tvrage":24493}}}]'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5d6599fb3d31-CPH]
-        connection: [keep-alive]
-        content-length: ['372']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:26:28 GMT']
-        etag: [W/"c54f8030868b5194e160669312ff949f"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        last-modified: ['Fri, 13 Jul 2018 08:26:38 GMT']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [6afcd0d6-b94d-4de9-8151-fdf2a00bf32c]
-        x-runtime: ['0.039676']
-        x-sort-by: [rank]
-        x-sort-how: [asc]
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2a5d3aa53d49-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [b6416118e6 99.99 0.025443 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:21:15 GMT']
+        Etag: [W/"20bc71bf0415376f8f365db4c764861b"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Last-Modified: ['Sat, 29 Dec 2018 06:21:10 GMT']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [756906e4-73d6-4aa4-9670-f91ff7fd365f]
+        X-Runtime: ['0.023324']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
 version: 1

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode
@@ -9,40 +9,42 @@ interactions:
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/episodes
     response:
-      body: {string: '[{"rank":1,"id":349979848,"listed_at":"2018-07-13T08:26:38.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
-          of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
-          of Thrones","year":2011,"ids":{"trakt":1390,"slug":"game-of-thrones","tvdb":121361,"imdb":"tt0944947","tmdb":1399,"tvrage":24493}}}]'}
+      body: {string: '[{"rank":1,"id":371586023,"listed_at":"2018-12-29T06:22:33.000Z","type":"episode","episode":{"season":1,"number":5,"title":"Chapter
+          Five: The Flea and the Acrobat","ids":{"trakt":2124182,"tvdb":5621929,"imdb":"tt4593128","tmdb":1205904,"tvrage":1065933149}},"show":{"title":"Stranger
+          Things","year":2016,"ids":{"trakt":104439,"slug":"stranger-things","tvdb":305288,"imdb":"tt4574334","tmdb":66732,"tvrage":48493}}},{"rank":2,"id":371586024,"listed_at":"2018-12-29T06:22:33.000Z","type":"episode","episode":{"season":1,"number":6,"title":"Chapter
+          Six: The Monster","ids":{"trakt":2124184,"tvdb":5621930,"imdb":"tt4593132","tmdb":1205905,"tvrage":1065933150}},"show":{"title":"Stranger
+          Things","year":2016,"ids":{"trakt":104439,"slug":"stranger-things","tvdb":305288,"imdb":"tt4574334","tmdb":66732,"tvrage":48493}}}]'}
       headers:
-        CF-RAY: [490a2a2b8a633d49-CPH]
+        CF-RAY: [490a55161be23d49-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [380cd92200 99.99 0.034977 0030 57da]
+        Cf-Railgun: [f66211c825 99.99 0.031221 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:21:07 GMT']
-        Etag: [W/"c54f8030868b5194e160669312ff949f"]
+        Date: ['Sat, 29 Dec 2018 06:50:25 GMT']
+        Etag: [W/"3a636032b8adb3487e7a4e1977f5436f"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Fri, 13 Jul 2018 08:26:38 GMT']
+        Last-Modified: ['Sat, 29 Dec 2018 06:22:33 GMT']
         Server: [cloudflare]
-        Set-Cookie: ['__cfduid=d503f757c7b65e4765b78d9a7b26b56e21546064467; expires=Sun,
-            29-Dec-19 06:21:07 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Set-Cookie: ['__cfduid=d71718ada61310dc70242aaac8e6013361546066225; expires=Sun,
+            29-Dec-19 06:50:25 GMT; path=/; domain=.trakt.tv; HttpOnly']
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [1da7de0d-636e-4901-8f57-56b6490a061c]
-        X-Runtime: ['0.031906']
+        X-Request-Id: [941bcf82-58db-4ad0-a4ac-e693a2c84da8]
+        X-Runtime: ['0.020077']
         X-Sort-By: [rank]
         X-Sort-How: [asc]
         X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: '{"shows": [{"year": 2011, "seasons": [{"number": 4, "episodes": [{"number":
-        5}]}], "title": "Game of Thrones", "ids": {"imdb": "tt0944947", "trakt": 1390,
-        "tvrage": 24493, "tvdb": 121361}}]}'
+      body: '{"shows": [{"seasons": [{"number": 1, "episodes": [{"number": 5}]}],
+        "title": "Stranger Things", "ids": {"trakt": 104439, "tvrage": 48493, "imdb":
+        "tt4574334", "tvdb": 305288}, "year": 2016}]}'
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
-        Content-Length: ['190']
+        Content-Length: ['192']
         Content-Type: [application/json]
-        Cookie: [__cfduid=d503f757c7b65e4765b78d9a7b26b56e21546064467]
+        Cookie: [__cfduid=d71718ada61310dc70242aaac8e6013361546066225]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: POST
@@ -50,20 +52,52 @@ interactions:
     response:
       body: {string: '{"deleted":{"movies":0,"shows":0,"seasons":0,"episodes":1},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        CF-RAY: [490a2a37adf93d49-CPH]
+        CF-RAY: [490a55224f6e3d49-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [ff6e0fe6ff 99.99 0.106228 0030 57da]
+        Cf-Railgun: [d9c0a00141 99.99 0.047977 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:21:09 GMT']
-        Etag: [W/"bc73677e57685ff27d449bf6310a3eb1"]
+        Date: ['Sat, 29 Dec 2018 06:50:27 GMT']
+        Etag: [W/"6726b262f6a644cd349f56ee5f22b603"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [b0660ec3-932b-43ac-830c-cdefc439b4d8]
-        X-Runtime: ['0.103751']
+        X-Request-Id: [c8d2590f-f995-42a2-aba4-120b8a72360e]
+        X-Runtime: ['0.045299']
+        X-Xss-Protection: [1; mode=block]
+      status: {code: 200, message: OK}
+  - request:
+      body: '{"shows": [{"seasons": [{"number": 1, "episodes": [{"number": 6}]}],
+        "title": "Stranger Things", "ids": {"trakt": 104439, "tvrage": 48493, "imdb":
+        "tt4574334", "tvdb": 305288}, "year": 2016}]}'
+      headers:
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Length: ['192']
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d71718ada61310dc70242aaac8e6013361546066225]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
+      method: POST
+      uri: https://api.trakt.tv/sync/watchlist/remove
+    response:
+      body: {string: '{"deleted":{"movies":0,"shows":0,"seasons":0,"episodes":1},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
+      headers:
+        CF-RAY: [490a552eba953d49-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [a5a9829985 99.99 0.042012 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:50:29 GMT']
+        Etag: [W/"2c04da0810a0b0b9d580502dd5547885"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [4c8c1d3b-2d75-4373-ab9f-d72db32dfadb]
+        X-Runtime: ['0.040517']
         X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
@@ -71,7 +105,7 @@ interactions:
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Type: [application/json]
-        Cookie: [__cfduid=d503f757c7b65e4765b78d9a7b26b56e21546064467]
+        Cookie: [__cfduid=d71718ada61310dc70242aaac8e6013361546066225]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
@@ -79,34 +113,34 @@ interactions:
     response:
       body: {string: '[]'}
       headers:
-        CF-RAY: [490a2a4429ad3d49-CPH]
+        CF-RAY: [490a553b4e763d49-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [d72b878fcb 99.99 0.021931 0030 57da]
+        Cf-Railgun: [a8ae4d2f26 99.99 0.021298 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:21:11 GMT']
-        Etag: [W/"f467cffde29648f4d219402632d3ead8"]
+        Date: ['Sat, 29 Dec 2018 06:50:31 GMT']
+        Etag: [W/"51b466cd90df7197513a3daa4b1a2450"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:21:31 GMT']
+        Last-Modified: ['Sat, 29 Dec 2018 06:50:23 GMT']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [fa852f87-9578-4c6f-b077-7cfd5e8d4c84]
-        X-Runtime: ['0.020059']
+        X-Request-Id: [ed99dae9-b2cb-498d-89fc-2b5e48ff2a0a]
+        X-Runtime: ['0.017572']
         X-Sort-By: [rank]
         X-Sort-How: [asc]
         X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: '{"shows": [{"year": 2011, "seasons": [{"number": 4, "episodes": [{"number":
-        5}]}], "title": "Game of Thrones", "ids": {"imdb": "tt0944947", "trakt": 1390,
-        "tvrage": 24493, "tvdb": 121361}}]}'
+      body: '{"shows": [{"seasons": [{"number": 4, "episodes": [{"number": 5}]}],
+        "title": "Game of Thrones", "ids": {"trakt": 1390, "tvrage": 24493, "imdb":
+        "tt0944947", "tvdb": 121361}, "year": 2011}]}'
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Length: ['190']
         Content-Type: [application/json]
-        Cookie: [__cfduid=d503f757c7b65e4765b78d9a7b26b56e21546064467]
+        Cookie: [__cfduid=d71718ada61310dc70242aaac8e6013361546066225]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: POST
@@ -114,20 +148,20 @@ interactions:
     response:
       body: {string: '{"added":{"movies":0,"shows":0,"seasons":0,"episodes":1},"existing":{"movies":0,"shows":0,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        CF-RAY: [490a2a50bcf83d49-CPH]
+        CF-RAY: [490a5547baa53d49-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [def673fcca 99.99 0.045002 0030 57da]
+        Cf-Railgun: [ecc19e41bb 99.99 0.045333 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:21:13 GMT']
-        Etag: [W/"0f76792d1c1abe338d7ee0d486a14e8e"]
+        Date: ['Sat, 29 Dec 2018 06:50:33 GMT']
+        Etag: [W/"256d6d48cc64c05a4847a930457d6cbc"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [1260ea64-1f77-4a00-8110-7efae37bfd5a]
-        X-Runtime: ['0.043040']
+        X-Request-Id: [dd4a0c4f-7eae-44e1-9b28-50bffb101270]
+        X-Runtime: ['0.040809']
         X-Xss-Protection: [1; mode=block]
       status: {code: 201, message: Created}
   - request:
@@ -135,31 +169,31 @@ interactions:
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Type: [application/json]
-        Cookie: [__cfduid=d503f757c7b65e4765b78d9a7b26b56e21546064467]
+        Cookie: [__cfduid=d71718ada61310dc70242aaac8e6013361546066225]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/episodes
     response:
-      body: {string: '[{"rank":1,"id":371585988,"listed_at":"2018-12-29T06:21:10.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
+      body: {string: '[{"rank":1,"id":371589391,"listed_at":"2018-12-29T06:50:37.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
           of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
           of Thrones","year":2011,"ids":{"trakt":1390,"slug":"game-of-thrones","tvdb":121361,"imdb":"tt0944947","tmdb":1399,"tvrage":24493}}}]'}
       headers:
-        CF-RAY: [490a2a5d3aa53d49-CPH]
+        CF-RAY: [490a55544f663d49-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [b6416118e6 99.99 0.025443 0030 57da]
+        Cf-Railgun: [05088313ac 99.99 0.031933 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:21:15 GMT']
-        Etag: [W/"20bc71bf0415376f8f365db4c764861b"]
+        Date: ['Sat, 29 Dec 2018 06:50:35 GMT']
+        Etag: [W/"9da3e90234f93b5f7cd3fde8ccd0a042"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:21:10 GMT']
+        Last-Modified: ['Sat, 29 Dec 2018 06:50:37 GMT']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [756906e4-73d6-4aa4-9670-f91ff7fd365f]
-        X-Runtime: ['0.023324']
+        X-Request-Id: [ebac1f90-3011-48f0-a204-b8e94c672c12]
+        X-Runtime: ['0.025751']
         X-Sort-By: [rank]
         X-Sort-How: [asc]
         X-Xss-Protection: [1; mode=block]

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_simple
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_simple
@@ -2,205 +2,165 @@ interactions:
   - request:
       body: null
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Type: [!!python/unicode 'application/json']
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/episodes
     response:
-      body: {string: !!python/unicode '[{"rank":1,"listed_at":"2018-05-21T14:25:44.000Z","type":"episode","episode":{"season":1,"number":5,"title":"Chapter
-          Five: The Flea and the Acrobat","ids":{"trakt":2124182,"tvdb":5621929,"imdb":"tt4593128","tmdb":1205904,"tvrage":1065933149}},"show":{"title":"Stranger
-          Things","year":2016,"ids":{"trakt":104439,"slug":"stranger-things","tvdb":305288,"imdb":"tt4574334","tmdb":66732,"tvrage":48493}}},{"rank":2,"listed_at":"2018-05-21T14:25:44.000Z","type":"episode","episode":{"season":1,"number":6,"title":"Chapter
-          Six: The Monster","ids":{"trakt":2124184,"tvdb":5621930,"imdb":"tt4593132","tmdb":1205905,"tvrage":1065933150}},"show":{"title":"Stranger
-          Things","year":2016,"ids":{"trakt":104439,"slug":"stranger-things","tvdb":305288,"imdb":"tt4574334","tmdb":66732,"tvrage":48493}}}]'}
+      body: {string: '[{"rank":1,"id":371585988,"listed_at":"2018-12-29T06:21:10.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
+          of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
+          of Thrones","year":2011,"ids":{"trakt":1390,"slug":"game-of-thrones","tvdb":121361,"imdb":"tt0944947","tmdb":1399,"tvrage":24493}}}]'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5b062c053d1f-CPH]
-        connection: [keep-alive]
-        content-length: ['785']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:24:51 GMT']
-        etag: [W/"a32798ff6cf76c37a365f02e0b0b9c0f"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        last-modified: ['Mon, 21 May 2018 14:25:44 GMT']
-        server: [cloudflare]
-        set-cookie: ['__cfduid=dd9d3100b3a347811ba0e4e579bc90de01531470290; expires=Sat,
-            13-Jul-19 08:24:50 GMT; path=/; domain=.trakt.tv; HttpOnly']
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [2ead986b-c8d8-4542-b478-20c556d71522]
-        x-runtime: ['0.041704']
-        x-sort-by: [rank]
-        x-sort-how: [asc]
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2ac6dfa03d43-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [6d2163708b 1.44 0.027939 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:21:32 GMT']
+        Etag: [W/"20bc71bf0415376f8f365db4c764861b"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Last-Modified: ['Sat, 29 Dec 2018 06:21:10 GMT']
+        Server: [cloudflare]
+        Set-Cookie: ['__cfduid=d8fe51d56f641511d7d02dcfa9001d35a1546064492; expires=Sun,
+            29-Dec-19 06:21:32 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [812bd057-ae4f-4dcc-b926-b3257fd55a67]
+        X-Runtime: ['0.020184']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: !!python/unicode '{"shows": [{"seasons": [{"episodes": [{"number": 5}],
-        "number": 1}], "year": 2016, "ids": {"tvdb": 305288, "tvrage": 48493, "imdb":
-        "tt4574334", "trakt": 104439}, "title": "Stranger Things"}]}'
+      body: '{"shows": [{"ids": {"imdb": "tt0944947", "trakt": 1390, "tvdb": 121361,
+        "tvrage": 24493}, "year": 2011, "title": "Game of Thrones", "seasons": [{"episodes":
+        [{"number": 5}], "number": 4}]}]}'
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Length: ['192']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=dd9d3100b3a347811ba0e4e579bc90de01531470290]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Length: ['190']
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d8fe51d56f641511d7d02dcfa9001d35a1546064492]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: POST
       uri: https://api.trakt.tv/sync/watchlist/remove
     response:
-      body: {string: !!python/unicode '{"deleted":{"movies":0,"shows":0,"seasons":0,"episodes":1},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
+      body: {string: '{"deleted":{"movies":0,"shows":0,"seasons":0,"episodes":1},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5b096d463d1f-CPH]
-        connection: [keep-alive]
-        content-length: ['135']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:24:51 GMT']
-        etag: [W/"6b89f346fcb5e30b58d3fc39a3b8ae1f"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [b8dbcccb-06b5-4470-b5a9-577645611c0b]
-        x-runtime: ['0.056152']
-        x-xss-protection: [1; mode=block]
-      status: {code: 200, message: OK}
-  - request:
-      body: !!python/unicode '{"shows": [{"seasons": [{"episodes": [{"number": 6}],
-        "number": 1}], "year": 2016, "ids": {"tvdb": 305288, "tvrage": 48493, "imdb":
-        "tt4574334", "trakt": 104439}, "title": "Stranger Things"}]}'
-      headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Length: ['192']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=dd9d3100b3a347811ba0e4e579bc90de01531470290]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
-      method: POST
-      uri: https://api.trakt.tv/sync/watchlist/remove
-    response:
-      body: {string: !!python/unicode '{"deleted":{"movies":0,"shows":0,"seasons":0,"episodes":1},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
-      headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5b15e9e93d1f-CPH]
-        connection: [keep-alive]
-        content-length: ['135']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:24:53 GMT']
-        etag: [W/"daa8b67e4fac9034fe459d4b1c80b7de"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [40f02d2e-cdeb-474e-9e00-9d122aa788be]
-        x-runtime: ['0.041997']
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2ad30a8d3d43-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [e419975429 99.99 0.045691 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:21:34 GMT']
+        Etag: [W/"c4a23d64110bd2cc6ccc44cec0a754a6"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [b55b00d6-2cc8-4e6f-9ea2-0db32d492a74]
+        X-Runtime: ['0.044016']
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
       body: null
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=dd9d3100b3a347811ba0e4e579bc90de01531470290]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d8fe51d56f641511d7d02dcfa9001d35a1546064492]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/episodes
     response:
-      body: {string: !!python/unicode '[]'}
+      body: {string: '[]'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5b22684f3d1f-CPH]
-        connection: [keep-alive]
-        content-length: ['2']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:24:55 GMT']
-        etag: [W/"a1c6999365f9f9548c0cae4d0acce10a"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        last-modified: ['Fri, 13 Jul 2018 08:25:05 GMT']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [88c8939b-550b-4a7d-8005-7307feef31b3]
-        x-runtime: ['0.028937']
-        x-sort-by: [rank]
-        x-sort-how: [asc]
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2adf8e563d43-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [41dac73f51 99.99 0.037094 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:21:36 GMT']
+        Etag: [W/"b9b8bb43cf5447bc54f50730079f90a8"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Last-Modified: ['Sat, 29 Dec 2018 06:22:08 GMT']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [b6880d05-b1fc-4a2a-815c-0ec29c8b4420]
+        X-Runtime: ['0.033134']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: !!python/unicode '{"shows": [{"seasons": [{"episodes": [{"number": 5}],
-        "number": 4}], "year": 2011, "ids": {}, "title": "Game of Thrones"}]}'
+      body: '{"shows": [{"ids": {}, "year": 2011, "title": "Game of Thrones", "seasons":
+        [{"episodes": [{"number": 5}], "number": 4}]}]}'
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Length: ['123']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=dd9d3100b3a347811ba0e4e579bc90de01531470290]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d8fe51d56f641511d7d02dcfa9001d35a1546064492]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: POST
       uri: https://api.trakt.tv/sync/watchlist
     response:
-      body: {string: !!python/unicode '{"added":{"movies":0,"shows":0,"seasons":0,"episodes":1},"existing":{"movies":0,"shows":0,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
+      body: {string: '{"added":{"movies":0,"shows":0,"seasons":0,"episodes":1},"existing":{"movies":0,"shows":0,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5b2eef0c3d1f-CPH]
-        connection: [keep-alive]
-        content-length: ['192']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:24:57 GMT']
-        etag: [W/"7c541257a74b157b3e0e7a7f1e0aab81"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [93415ab2-0654-4480-8688-4bedca2b40c7]
-        x-runtime: ['0.045182']
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2aec9b603d43-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [630c3ed6ba 99.99 0.037523 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:21:38 GMT']
+        Etag: [W/"0ef263ed47ef6e7cd57d5605c7e2185f"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [e4029991-f507-4f9e-8a0e-1cdb87ebeafe]
+        X-Runtime: ['0.035594']
+        X-Xss-Protection: [1; mode=block]
       status: {code: 201, message: Created}
   - request:
       body: null
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=dd9d3100b3a347811ba0e4e579bc90de01531470290]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d8fe51d56f641511d7d02dcfa9001d35a1546064492]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/episodes
     response:
-      body: {string: !!python/unicode '[{"rank":1,"listed_at":"2018-07-13T08:24:45.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
+      body: {string: '[{"rank":1,"id":371586009,"listed_at":"2018-12-29T06:21:42.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
           of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
           of Thrones","year":2011,"ids":{"trakt":1390,"slug":"game-of-thrones","tvdb":121361,"imdb":"tt0944947","tmdb":1399,"tvrage":24493}}}]'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5b3b6e663d1f-CPH]
-        connection: [keep-alive]
-        content-length: ['372']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:24:59 GMT']
-        etag: [W/"2314e5337618fdd1d4f610cd0ec00e68"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        last-modified: ['Fri, 13 Jul 2018 08:24:45 GMT']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [08084c52-87a2-4706-b56e-c3c3ee14ad53]
-        x-runtime: ['0.030677']
-        x-sort-by: [rank]
-        x-sort-how: [asc]
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2af88e303d43-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [a74cf27aba 99.99 0.039627 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:21:40 GMT']
+        Etag: [W/"d235aeb5d6010be0d29a4d8a25ba5af5"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Last-Modified: ['Sat, 29 Dec 2018 06:21:42 GMT']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [607c70a1-0a1b-4aff-9759-0c5846adcf7e]
+        X-Runtime: ['0.026348']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
 version: 1

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_simple
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_simple
@@ -9,40 +9,40 @@ interactions:
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/episodes
     response:
-      body: {string: '[{"rank":1,"id":371585988,"listed_at":"2018-12-29T06:21:10.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
+      body: {string: '[{"rank":1,"id":371589391,"listed_at":"2018-12-29T06:50:37.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
           of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
           of Thrones","year":2011,"ids":{"trakt":1390,"slug":"game-of-thrones","tvdb":121361,"imdb":"tt0944947","tmdb":1399,"tvrage":24493}}}]'}
       headers:
-        CF-RAY: [490a2ac6dfa03d43-CPH]
+        CF-RAY: [490a557888433d01-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [6d2163708b 1.44 0.027939 0030 57da]
+        Cf-Railgun: [1af5c26562 1.45 0.028909 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:21:32 GMT']
-        Etag: [W/"20bc71bf0415376f8f365db4c764861b"]
+        Date: ['Sat, 29 Dec 2018 06:50:41 GMT']
+        Etag: [W/"9da3e90234f93b5f7cd3fde8ccd0a042"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:21:10 GMT']
+        Last-Modified: ['Sat, 29 Dec 2018 06:50:37 GMT']
         Server: [cloudflare]
-        Set-Cookie: ['__cfduid=d8fe51d56f641511d7d02dcfa9001d35a1546064492; expires=Sun,
-            29-Dec-19 06:21:32 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Set-Cookie: ['__cfduid=dc8d32cf3445894e466e5bcbb98b00e591546066241; expires=Sun,
+            29-Dec-19 06:50:41 GMT; path=/; domain=.trakt.tv; HttpOnly']
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [812bd057-ae4f-4dcc-b926-b3257fd55a67]
-        X-Runtime: ['0.020184']
+        X-Request-Id: [02673565-39dd-44b7-9fd3-a6a0f46b36d2]
+        X-Runtime: ['0.024268']
         X-Sort-By: [rank]
         X-Sort-How: [asc]
         X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: '{"shows": [{"ids": {"imdb": "tt0944947", "trakt": 1390, "tvdb": 121361,
-        "tvrage": 24493}, "year": 2011, "title": "Game of Thrones", "seasons": [{"episodes":
-        [{"number": 5}], "number": 4}]}]}'
+      body: '{"shows": [{"year": 2011, "seasons": [{"number": 4, "episodes": [{"number":
+        5}]}], "ids": {"imdb": "tt0944947", "tvdb": 121361, "trakt": 1390, "tvrage":
+        24493}, "title": "Game of Thrones"}]}'
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Length: ['190']
         Content-Type: [application/json]
-        Cookie: [__cfduid=d8fe51d56f641511d7d02dcfa9001d35a1546064492]
+        Cookie: [__cfduid=dc8d32cf3445894e466e5bcbb98b00e591546066241]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: POST
@@ -50,20 +50,20 @@ interactions:
     response:
       body: {string: '{"deleted":{"movies":0,"shows":0,"seasons":0,"episodes":1},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        CF-RAY: [490a2ad30a8d3d43-CPH]
+        CF-RAY: [490a5584cd303d01-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [e419975429 99.99 0.045691 0030 57da]
+        Cf-Railgun: [1d4456ff61 99.99 0.055212 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:21:34 GMT']
-        Etag: [W/"c4a23d64110bd2cc6ccc44cec0a754a6"]
+        Date: ['Sat, 29 Dec 2018 06:50:43 GMT']
+        Etag: [W/"0f7f63620db9aa5e105e61f0dc596dd3"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [b55b00d6-2cc8-4e6f-9ea2-0db32d492a74]
-        X-Runtime: ['0.044016']
+        X-Request-Id: [d940968c-0cef-4ae4-9858-1df00cfc4c79]
+        X-Runtime: ['0.048661']
         X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
@@ -71,7 +71,7 @@ interactions:
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Type: [application/json]
-        Cookie: [__cfduid=d8fe51d56f641511d7d02dcfa9001d35a1546064492]
+        Cookie: [__cfduid=dc8d32cf3445894e466e5bcbb98b00e591546066241]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
@@ -79,33 +79,33 @@ interactions:
     response:
       body: {string: '[]'}
       headers:
-        CF-RAY: [490a2adf8e563d43-CPH]
+        CF-RAY: [490a559139ac3d01-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [41dac73f51 99.99 0.037094 0030 57da]
+        Cf-Railgun: [3118b38de0 99.99 0.030003 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:21:36 GMT']
-        Etag: [W/"b9b8bb43cf5447bc54f50730079f90a8"]
+        Date: ['Sat, 29 Dec 2018 06:50:45 GMT']
+        Etag: [W/"a55e6f9a0cf19d5f540044128e809434"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:22:08 GMT']
+        Last-Modified: ['Sat, 29 Dec 2018 06:50:39 GMT']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [b6880d05-b1fc-4a2a-815c-0ec29c8b4420]
-        X-Runtime: ['0.033134']
+        X-Request-Id: [bec035d6-773d-4133-aa46-6a342797a695]
+        X-Runtime: ['0.023485']
         X-Sort-By: [rank]
         X-Sort-How: [asc]
         X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: '{"shows": [{"ids": {}, "year": 2011, "title": "Game of Thrones", "seasons":
-        [{"episodes": [{"number": 5}], "number": 4}]}]}'
+      body: '{"shows": [{"year": 2011, "seasons": [{"number": 4, "episodes": [{"number":
+        5}]}], "ids": {}, "title": "Game of Thrones"}]}'
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Length: ['123']
         Content-Type: [application/json]
-        Cookie: [__cfduid=d8fe51d56f641511d7d02dcfa9001d35a1546064492]
+        Cookie: [__cfduid=dc8d32cf3445894e466e5bcbb98b00e591546066241]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: POST
@@ -113,20 +113,20 @@ interactions:
     response:
       body: {string: '{"added":{"movies":0,"shows":0,"seasons":0,"episodes":1},"existing":{"movies":0,"shows":0,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        CF-RAY: [490a2aec9b603d43-CPH]
+        CF-RAY: [490a559dbdab3d01-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [630c3ed6ba 99.99 0.037523 0030 57da]
+        Cf-Railgun: [d1c7d723f0 99.99 0.049316 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:21:38 GMT']
-        Etag: [W/"0ef263ed47ef6e7cd57d5605c7e2185f"]
+        Date: ['Sat, 29 Dec 2018 06:50:47 GMT']
+        Etag: [W/"73a1231765543ab248b05fc799421a3a"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [e4029991-f507-4f9e-8a0e-1cdb87ebeafe]
-        X-Runtime: ['0.035594']
+        X-Request-Id: [77745a41-780c-424d-b360-30d7ebdd9894]
+        X-Runtime: ['0.042071']
         X-Xss-Protection: [1; mode=block]
       status: {code: 201, message: Created}
   - request:
@@ -134,31 +134,31 @@ interactions:
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Type: [application/json]
-        Cookie: [__cfduid=d8fe51d56f641511d7d02dcfa9001d35a1546064492]
+        Cookie: [__cfduid=dc8d32cf3445894e466e5bcbb98b00e591546066241]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/episodes
     response:
-      body: {string: '[{"rank":1,"id":371586009,"listed_at":"2018-12-29T06:21:42.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
+      body: {string: '[{"rank":1,"id":371589397,"listed_at":"2018-12-29T06:51:09.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
           of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
           of Thrones","year":2011,"ids":{"trakt":1390,"slug":"game-of-thrones","tvdb":121361,"imdb":"tt0944947","tmdb":1399,"tvrage":24493}}}]'}
       headers:
-        CF-RAY: [490a2af88e303d43-CPH]
+        CF-RAY: [490a55aa38c83d01-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [a74cf27aba 99.99 0.039627 0030 57da]
+        Cf-Railgun: [7429473ea6 99.99 0.096474 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:21:40 GMT']
-        Etag: [W/"d235aeb5d6010be0d29a4d8a25ba5af5"]
+        Date: ['Sat, 29 Dec 2018 06:50:49 GMT']
+        Etag: [W/"6b2bfcc4d121ea7fd3c3476977803c6b"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:21:42 GMT']
+        Last-Modified: ['Sat, 29 Dec 2018 06:51:09 GMT']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [607c70a1-0a1b-4aff-9759-0c5846adcf7e]
-        X-Runtime: ['0.026348']
+        X-Request-Id: [97c60758-08f4-4ef4-a830-187440260d9b]
+        X-Runtime: ['0.065919']
         X-Sort-By: [rank]
         X-Sort-How: [asc]
         X-Xss-Protection: [1; mode=block]

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_task
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_task
@@ -2,142 +2,138 @@ interactions:
   - request:
       body: null
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Type: [!!python/unicode 'application/json']
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/episodes
     response:
-      body: {string: !!python/unicode '[{"rank":1,"listed_at":"2018-07-13T08:24:45.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
+      body: {string: '[{"rank":1,"id":371586009,"listed_at":"2018-12-29T06:21:42.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
           of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
           of Thrones","year":2011,"ids":{"trakt":1390,"slug":"game-of-thrones","tvdb":121361,"imdb":"tt0944947","tmdb":1399,"tvrage":24493}}}]'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5c32ad123cad-CPH]
-        connection: [keep-alive]
-        content-length: ['372']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:25:39 GMT']
-        etag: [W/"2314e5337618fdd1d4f610cd0ec00e68"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        last-modified: ['Fri, 13 Jul 2018 08:24:45 GMT']
-        server: [cloudflare]
-        set-cookie: ['__cfduid=d38463f9f136ffe566408b09ed9ff38891531470338; expires=Sat,
-            13-Jul-19 08:25:38 GMT; path=/; domain=.trakt.tv; HttpOnly']
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [c1f752af-cc3b-4502-88e7-c84fe7c23b0b]
-        x-runtime: ['0.028295']
-        x-sort-by: [rank]
-        x-sort-how: [asc]
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2b2229d03d43-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [a817e565ac 1.44 0.025278 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:21:47 GMT']
+        Etag: [W/"d235aeb5d6010be0d29a4d8a25ba5af5"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Last-Modified: ['Sat, 29 Dec 2018 06:21:42 GMT']
+        Server: [cloudflare]
+        Set-Cookie: ['__cfduid=d86b11349ac6ed0430bdc3221c3bf50a21546064507; expires=Sun,
+            29-Dec-19 06:21:47 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [6b29ca50-323b-4093-963f-1d2817db5729]
+        X-Runtime: ['0.020844']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: !!python/unicode '{"shows": [{"seasons": [{"episodes": [{"number": 5}],
-        "number": 4}], "year": 2011, "ids": {"tvdb": 121361, "tvrage": 24493, "imdb":
-        "tt0944947", "trakt": 1390}, "title": "Game of Thrones"}]}'
+      body: '{"shows": [{"year": 2011, "ids": {"trakt": 1390, "imdb": "tt0944947",
+        "tvdb": 121361, "tvrage": 24493}, "seasons": [{"episodes": [{"number": 5}],
+        "number": 4}], "title": "Game of Thrones"}]}'
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Length: ['190']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=d38463f9f136ffe566408b09ed9ff38891531470338]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d86b11349ac6ed0430bdc3221c3bf50a21546064507]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: POST
       uri: https://api.trakt.tv/sync/watchlist/remove
     response:
-      body: {string: !!python/unicode '{"deleted":{"movies":0,"shows":0,"seasons":0,"episodes":1},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
+      body: {string: '{"deleted":{"movies":0,"shows":0,"seasons":0,"episodes":1},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5c363e983cad-CPH]
-        connection: [keep-alive]
-        content-length: ['135']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:25:39 GMT']
-        etag: [W/"5692e03c7b93d5dbd40a1cb73180c72c"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [680f326d-996a-43a4-acfc-79c07d18995e]
-        x-runtime: ['0.043757']
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2b2e5c5c3d43-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [22026db34d 99.99 0.104430 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:21:49 GMT']
+        Etag: [W/"ad0a5222afe9eaeeeac730f83c2da0e2"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [df401783-2de3-4222-baea-244bbde45a19]
+        X-Runtime: ['0.056779']
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: !!python/unicode '{"shows": [{"seasons": [{"episodes": [{"number": 5}],
-        "number": 1}], "ids": {}, "title": "Stranger Things"}, {"seasons": [{"episodes":
-        [{"number": 6}], "number": 1}], "ids": {}, "title": "Stranger Things"}]}'
+      body: '{"shows": [{"ids": {}, "seasons": [{"episodes": [{"number": 5}], "number":
+        1}], "title": "Stranger Things"}, {"ids": {}, "seasons": [{"episodes": [{"number":
+        6}], "number": 1}], "title": "Stranger Things"}]}'
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Length: ['207']
-        Content-Type: [!!python/unicode 'application/json']
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Content-Type: [application/json]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: POST
       uri: https://api.trakt.tv/sync/watchlist
     response:
-      body: {string: !!python/unicode '{"added":{"movies":0,"shows":0,"seasons":0,"episodes":2},"existing":{"movies":0,"shows":0,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
+      body: {string: '{"added":{"movies":0,"shows":0,"seasons":0,"episodes":2},"existing":{"movies":0,"shows":0,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5c4378823d3d-CPH]
-        connection: [keep-alive]
-        content-length: ['192']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:25:42 GMT']
-        etag: [W/"984d25b67ab351720c0f3eb730f608e6"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        server: [cloudflare]
-        set-cookie: ['__cfduid=d8a5afa7c3fc65f592ab35b0d4e8830311531470341; expires=Sat,
-            13-Jul-19 08:25:41 GMT; path=/; domain=.trakt.tv; HttpOnly']
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [1fb8f16c-1227-484b-94ac-d25578bee0e3]
-        x-runtime: ['0.036457']
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2b3b6be93d2b-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [783faf5ae9 99.99 0.092981 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:21:51 GMT']
+        Etag: [W/"46f5442eef3bc407f7aba67b313a5ffe"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Server: [cloudflare]
+        Set-Cookie: ['__cfduid=d31d1ecbf8d1720eeda81c0d2d44a1b591546064511; expires=Sun,
+            29-Dec-19 06:21:51 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [1b95e1f3-22ee-4621-81fc-7925bea44520]
+        X-Runtime: ['0.089643']
+        X-Xss-Protection: [1; mode=block]
       status: {code: 201, message: Created}
   - request:
       body: null
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Type: [!!python/unicode 'application/json']
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/episodes
     response:
-      body: {string: !!python/unicode '[{"rank":1,"listed_at":"2018-07-13T08:25:40.000Z","type":"episode","episode":{"season":1,"number":5,"title":"Chapter
+      body: {string: '[{"rank":1,"id":371586023,"listed_at":"2018-12-29T06:22:33.000Z","type":"episode","episode":{"season":1,"number":5,"title":"Chapter
           Five: The Flea and the Acrobat","ids":{"trakt":2124182,"tvdb":5621929,"imdb":"tt4593128","tmdb":1205904,"tvrage":1065933149}},"show":{"title":"Stranger
-          Things","year":2016,"ids":{"trakt":104439,"slug":"stranger-things","tvdb":305288,"imdb":"tt4574334","tmdb":66732,"tvrage":48493}}},{"rank":2,"listed_at":"2018-07-13T08:25:40.000Z","type":"episode","episode":{"season":1,"number":6,"title":"Chapter
+          Things","year":2016,"ids":{"trakt":104439,"slug":"stranger-things","tvdb":305288,"imdb":"tt4574334","tmdb":66732,"tvrage":48493}}},{"rank":2,"id":371586024,"listed_at":"2018-12-29T06:22:33.000Z","type":"episode","episode":{"season":1,"number":6,"title":"Chapter
           Six: The Monster","ids":{"trakt":2124184,"tvdb":5621930,"imdb":"tt4593132","tmdb":1205905,"tvrage":1065933150}},"show":{"title":"Stranger
           Things","year":2016,"ids":{"trakt":104439,"slug":"stranger-things","tvdb":305288,"imdb":"tt4574334","tmdb":66732,"tvrage":48493}}}]'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5c4fedc33d13-CPH]
-        connection: [keep-alive]
-        content-length: ['785']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:25:44 GMT']
-        etag: [W/"a1f4aff5ae0c8b117eff871f77ad3e71"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        last-modified: ['Fri, 13 Jul 2018 08:25:40 GMT']
-        server: [cloudflare]
-        set-cookie: ['__cfduid=df610a3a1b78393ec6ea11789c0da05e71531470343; expires=Sat,
-            13-Jul-19 08:25:43 GMT; path=/; domain=.trakt.tv; HttpOnly']
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [502557c2-11bf-412d-89e2-92be53ada4fb]
-        x-runtime: ['0.026848']
-        x-sort-by: [rank]
-        x-sort-how: [asc]
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2b47ac493d43-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [bfce218547 99.99 0.037578 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:21:53 GMT']
+        Etag: [W/"3a636032b8adb3487e7a4e1977f5436f"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Last-Modified: ['Sat, 29 Dec 2018 06:22:33 GMT']
+        Server: [cloudflare]
+        Set-Cookie: ['__cfduid=d63689f25b558035ec0f4f9c16d60e5a71546064513; expires=Sun,
+            29-Dec-19 06:21:53 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [8e5a3fda-1a1f-4cd9-8261-c84061d8a28b]
+        X-Runtime: ['0.035118']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
 version: 1

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_task
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_task
@@ -9,40 +9,40 @@ interactions:
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/episodes
     response:
-      body: {string: '[{"rank":1,"id":371586009,"listed_at":"2018-12-29T06:21:42.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
+      body: {string: '[{"rank":1,"id":371589397,"listed_at":"2018-12-29T06:51:09.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
           of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
           of Thrones","year":2011,"ids":{"trakt":1390,"slug":"game-of-thrones","tvdb":121361,"imdb":"tt0944947","tmdb":1399,"tvrage":24493}}}]'}
       headers:
-        CF-RAY: [490a2b2229d03d43-CPH]
+        CF-RAY: [490a55d8ae9f3d07-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [a817e565ac 1.44 0.025278 0030 57da]
+        Cf-Railgun: [544b1da8d3 1.44 0.033414 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:21:47 GMT']
-        Etag: [W/"d235aeb5d6010be0d29a4d8a25ba5af5"]
+        Date: ['Sat, 29 Dec 2018 06:50:56 GMT']
+        Etag: [W/"6b2bfcc4d121ea7fd3c3476977803c6b"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:21:42 GMT']
+        Last-Modified: ['Sat, 29 Dec 2018 06:51:09 GMT']
         Server: [cloudflare]
-        Set-Cookie: ['__cfduid=d86b11349ac6ed0430bdc3221c3bf50a21546064507; expires=Sun,
-            29-Dec-19 06:21:47 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Set-Cookie: ['__cfduid=d31b2ebe16023a27f5b4cf2a89ddef78a1546066256; expires=Sun,
+            29-Dec-19 06:50:56 GMT; path=/; domain=.trakt.tv; HttpOnly']
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [6b29ca50-323b-4093-963f-1d2817db5729]
-        X-Runtime: ['0.020844']
+        X-Request-Id: [19b98b59-2ccc-4b7d-b834-179f1c485de9]
+        X-Runtime: ['0.030775']
         X-Sort-By: [rank]
         X-Sort-How: [asc]
         X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: '{"shows": [{"year": 2011, "ids": {"trakt": 1390, "imdb": "tt0944947",
-        "tvdb": 121361, "tvrage": 24493}, "seasons": [{"episodes": [{"number": 5}],
-        "number": 4}], "title": "Game of Thrones"}]}'
+      body: '{"shows": [{"year": 2011, "seasons": [{"episodes": [{"number": 5}], "number":
+        4}], "title": "Game of Thrones", "ids": {"imdb": "tt0944947", "trakt": 1390,
+        "tvdb": 121361, "tvrage": 24493}}]}'
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Length: ['190']
         Content-Type: [application/json]
-        Cookie: [__cfduid=d86b11349ac6ed0430bdc3221c3bf50a21546064507]
+        Cookie: [__cfduid=d31b2ebe16023a27f5b4cf2a89ddef78a1546066256]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: POST
@@ -50,26 +50,26 @@ interactions:
     response:
       body: {string: '{"deleted":{"movies":0,"shows":0,"seasons":0,"episodes":1},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        CF-RAY: [490a2b2e5c5c3d43-CPH]
+        CF-RAY: [490a55e45a583d07-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [22026db34d 99.99 0.104430 0030 57da]
+        Cf-Railgun: [fddb2bc305 99.99 0.041686 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:21:49 GMT']
-        Etag: [W/"ad0a5222afe9eaeeeac730f83c2da0e2"]
+        Date: ['Sat, 29 Dec 2018 06:50:58 GMT']
+        Etag: [W/"4cd7f7b8258ff3a36ca7faaae33dfdd0"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [df401783-2de3-4222-baea-244bbde45a19]
-        X-Runtime: ['0.056779']
+        X-Request-Id: [e3cf7af4-3b0f-4f5a-a13e-173926dded71]
+        X-Runtime: ['0.039311']
         X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: '{"shows": [{"ids": {}, "seasons": [{"episodes": [{"number": 5}], "number":
-        1}], "title": "Stranger Things"}, {"ids": {}, "seasons": [{"episodes": [{"number":
-        6}], "number": 1}], "title": "Stranger Things"}]}'
+      body: '{"shows": [{"seasons": [{"episodes": [{"number": 5}], "number": 1}],
+        "title": "Stranger Things", "ids": {}}, {"seasons": [{"episodes": [{"number":
+        6}], "number": 1}], "title": "Stranger Things", "ids": {}}]}'
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Length: ['207']
@@ -81,22 +81,22 @@ interactions:
     response:
       body: {string: '{"added":{"movies":0,"shows":0,"seasons":0,"episodes":2},"existing":{"movies":0,"shows":0,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        CF-RAY: [490a2b3b6be93d2b-CPH]
+        CF-RAY: [490a55f0ba143d0d-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [783faf5ae9 99.99 0.092981 0030 57da]
+        Cf-Railgun: [6019b41f82 99.99 0.049252 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:21:51 GMT']
-        Etag: [W/"46f5442eef3bc407f7aba67b313a5ffe"]
+        Date: ['Sat, 29 Dec 2018 06:51:00 GMT']
+        Etag: [W/"a521ce58227919ace1c43ab1fb389170"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
         Server: [cloudflare]
-        Set-Cookie: ['__cfduid=d31d1ecbf8d1720eeda81c0d2d44a1b591546064511; expires=Sun,
-            29-Dec-19 06:21:51 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Set-Cookie: ['__cfduid=dccc81e1c2a346b8ed45417275b1634c11546066260; expires=Sun,
+            29-Dec-19 06:51:00 GMT; path=/; domain=.trakt.tv; HttpOnly']
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [1b95e1f3-22ee-4621-81fc-7925bea44520]
-        X-Runtime: ['0.089643']
+        X-Request-Id: [c199c345-21a2-41f6-8eba-2d72b1842112]
+        X-Runtime: ['0.046315']
         X-Xss-Protection: [1; mode=block]
       status: {code: 201, message: Created}
   - request:
@@ -109,29 +109,29 @@ interactions:
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/episodes
     response:
-      body: {string: '[{"rank":1,"id":371586023,"listed_at":"2018-12-29T06:22:33.000Z","type":"episode","episode":{"season":1,"number":5,"title":"Chapter
+      body: {string: '[{"rank":1,"id":371589401,"listed_at":"2018-12-29T06:51:03.000Z","type":"episode","episode":{"season":1,"number":5,"title":"Chapter
           Five: The Flea and the Acrobat","ids":{"trakt":2124182,"tvdb":5621929,"imdb":"tt4593128","tmdb":1205904,"tvrage":1065933149}},"show":{"title":"Stranger
-          Things","year":2016,"ids":{"trakt":104439,"slug":"stranger-things","tvdb":305288,"imdb":"tt4574334","tmdb":66732,"tvrage":48493}}},{"rank":2,"id":371586024,"listed_at":"2018-12-29T06:22:33.000Z","type":"episode","episode":{"season":1,"number":6,"title":"Chapter
+          Things","year":2016,"ids":{"trakt":104439,"slug":"stranger-things","tvdb":305288,"imdb":"tt4574334","tmdb":66732,"tvrage":48493}}},{"rank":2,"id":371589402,"listed_at":"2018-12-29T06:51:03.000Z","type":"episode","episode":{"season":1,"number":6,"title":"Chapter
           Six: The Monster","ids":{"trakt":2124184,"tvdb":5621930,"imdb":"tt4593132","tmdb":1205905,"tvrage":1065933150}},"show":{"title":"Stranger
           Things","year":2016,"ids":{"trakt":104439,"slug":"stranger-things","tvdb":305288,"imdb":"tt4574334","tmdb":66732,"tvrage":48493}}}]'}
       headers:
-        CF-RAY: [490a2b47ac493d43-CPH]
+        CF-RAY: [490a55fd5a193d31-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [bfce218547 99.99 0.037578 0030 57da]
+        Cf-Railgun: [1c65c611aa 99.99 0.040913 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:21:53 GMT']
-        Etag: [W/"3a636032b8adb3487e7a4e1977f5436f"]
+        Date: ['Sat, 29 Dec 2018 06:51:02 GMT']
+        Etag: [W/"275bfc4aa5ea29a6da493e584acad540"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:22:33 GMT']
+        Last-Modified: ['Sat, 29 Dec 2018 06:51:03 GMT']
         Server: [cloudflare]
-        Set-Cookie: ['__cfduid=d63689f25b558035ec0f4f9c16d60e5a71546064513; expires=Sun,
-            29-Dec-19 06:21:53 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Set-Cookie: ['__cfduid=dae0b801cb2a68f7c75ac8ef7d6f521f81546066262; expires=Sun,
+            29-Dec-19 06:51:02 GMT; path=/; domain=.trakt.tv; HttpOnly']
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [8e5a3fda-1a1f-4cd9-8261-c84061d8a28b]
-        X-Runtime: ['0.035118']
+        X-Request-Id: [a431b0ac-99e8-40f8-85bc-79496d167ec0]
+        X-Runtime: ['0.037213']
         X-Sort-By: [rank]
         X-Sort-How: [asc]
         X-Xss-Protection: [1; mode=block]

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_pagination
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_pagination
@@ -1,0 +1,96 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
+      method: GET
+      uri: https://api.trakt.tv/sync/history/movies
+    response:
+      body: {string: '[{"id":4115573597,"watched_at":"2018-12-29T07:12:39.000Z","action":"watch","type":"movie","movie":{"title":"Mortal
+          Engines","year":2018,"ids":{"trakt":285120,"slug":"mortal-engines-2018","imdb":"tt1571234","tmdb":428078}}},{"id":4115573377,"watched_at":"2018-12-29T07:12:38.000Z","action":"watch","type":"movie","movie":{"title":"The
+          Mule","year":2018,"ids":{"trakt":351319,"slug":"the-mule-2018","imdb":"tt7959026","tmdb":504172}}},{"id":4115573567,"watched_at":"2018-12-29T07:12:34.000Z","action":"watch","type":"movie","movie":{"title":"Justice
+          League","year":2017,"ids":{"trakt":94232,"slug":"justice-league-2017","imdb":"tt0974015","tmdb":141052}}},{"id":4115573305,"watched_at":"2018-12-29T07:12:31.000Z","action":"watch","type":"movie","movie":{"title":"Deadpool
+          2","year":2018,"ids":{"trakt":226108,"slug":"deadpool-2-2018","imdb":"tt5463162","tmdb":383498}}},{"id":4115573353,"watched_at":"2018-12-29T07:12:28.000Z","action":"watch","type":"movie","movie":{"title":"Spider-Man:
+          Into the Spider-Verse","year":2018,"ids":{"trakt":205404,"slug":"spider-man-into-the-spider-verse-2018","imdb":"tt4633694","tmdb":324857}}},{"id":4115573278,"watched_at":"2018-12-29T07:12:25.000Z","action":"watch","type":"movie","movie":{"title":"Replicas","year":2018,"ids":{"trakt":237986,"slug":"replicas-2018","imdb":"tt4154916","tmdb":300681}}},{"id":4115573322,"watched_at":"2018-12-29T07:12:24.000Z","action":"watch","type":"movie","movie":{"title":"Peppermint","year":2018,"ids":{"trakt":305444,"slug":"peppermint-2018","imdb":"tt6850820","tmdb":458594}}},{"id":4115573258,"watched_at":"2018-12-29T07:12:23.000Z","action":"watch","type":"movie","movie":{"title":"The
+          Meg","year":2018,"ids":{"trakt":224015,"slug":"the-meg-2018","imdb":"tt4779682","tmdb":345940}}},{"id":4115573615,"watched_at":"2018-12-29T07:12:18.000Z","action":"watch","type":"movie","movie":{"title":"Halloween","year":2018,"ids":{"trakt":269236,"slug":"halloween-2018","imdb":"tt1502407","tmdb":424139}}},{"id":4115573084,"watched_at":"2018-12-29T07:12:18.000Z","action":"watch","type":"movie","movie":{"title":"The
+          House with a Clock in Its Walls","year":2018,"ids":{"trakt":311024,"slug":"the-house-with-a-clock-in-its-walls-2018","imdb":"tt2119543","tmdb":463821}}}]'}
+      headers:
+        CF-RAY: [490a76956aee3d2b-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [direct (starting new WAN connection)]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 07:13:18 GMT']
+        Etag: [W/"90766a37b74e3fb93b4196acbf80a3f4"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Last-Modified: ['Sat, 29 Dec 2018 07:12:18 GMT']
+        Server: [cloudflare]
+        Set-Cookie: ['__cfduid=dc2a1f0e4fb8937cdf37e68b866cb7c211546067597; expires=Sun,
+            29-Dec-19 07:13:17 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Pagination-Item-Count: ['25']
+        X-Pagination-Limit: ['10']
+        X-Pagination-Page: ['1']
+        X-Pagination-Page-Count: ['3']
+        X-Request-Id: [215b19ce-5537-4e67-baf8-eed4621107a4]
+        X-Runtime: ['0.036239']
+        X-Xss-Protection: [1; mode=block]
+      status: {code: 200, message: OK}
+  - request:
+      body: null
+      headers:
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        Cookie: [__cfduid=dc2a1f0e4fb8937cdf37e68b866cb7c211546067597]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
+      method: GET
+      uri: https://api.trakt.tv/sync/history/movies?page=1&limit=1000
+    response:
+      body: {string: '[{"id":4115573597,"watched_at":"2018-12-29T07:12:39.000Z","action":"watch","type":"movie","movie":{"title":"Mortal
+          Engines","year":2018,"ids":{"trakt":285120,"slug":"mortal-engines-2018","imdb":"tt1571234","tmdb":428078}}},{"id":4115573377,"watched_at":"2018-12-29T07:12:38.000Z","action":"watch","type":"movie","movie":{"title":"The
+          Mule","year":2018,"ids":{"trakt":351319,"slug":"the-mule-2018","imdb":"tt7959026","tmdb":504172}}},{"id":4115573567,"watched_at":"2018-12-29T07:12:34.000Z","action":"watch","type":"movie","movie":{"title":"Justice
+          League","year":2017,"ids":{"trakt":94232,"slug":"justice-league-2017","imdb":"tt0974015","tmdb":141052}}},{"id":4115573305,"watched_at":"2018-12-29T07:12:31.000Z","action":"watch","type":"movie","movie":{"title":"Deadpool
+          2","year":2018,"ids":{"trakt":226108,"slug":"deadpool-2-2018","imdb":"tt5463162","tmdb":383498}}},{"id":4115573353,"watched_at":"2018-12-29T07:12:28.000Z","action":"watch","type":"movie","movie":{"title":"Spider-Man:
+          Into the Spider-Verse","year":2018,"ids":{"trakt":205404,"slug":"spider-man-into-the-spider-verse-2018","imdb":"tt4633694","tmdb":324857}}},{"id":4115573278,"watched_at":"2018-12-29T07:12:25.000Z","action":"watch","type":"movie","movie":{"title":"Replicas","year":2018,"ids":{"trakt":237986,"slug":"replicas-2018","imdb":"tt4154916","tmdb":300681}}},{"id":4115573322,"watched_at":"2018-12-29T07:12:24.000Z","action":"watch","type":"movie","movie":{"title":"Peppermint","year":2018,"ids":{"trakt":305444,"slug":"peppermint-2018","imdb":"tt6850820","tmdb":458594}}},{"id":4115573258,"watched_at":"2018-12-29T07:12:23.000Z","action":"watch","type":"movie","movie":{"title":"The
+          Meg","year":2018,"ids":{"trakt":224015,"slug":"the-meg-2018","imdb":"tt4779682","tmdb":345940}}},{"id":4115573615,"watched_at":"2018-12-29T07:12:18.000Z","action":"watch","type":"movie","movie":{"title":"Halloween","year":2018,"ids":{"trakt":269236,"slug":"halloween-2018","imdb":"tt1502407","tmdb":424139}}},{"id":4115573084,"watched_at":"2018-12-29T07:12:18.000Z","action":"watch","type":"movie","movie":{"title":"The
+          House with a Clock in Its Walls","year":2018,"ids":{"trakt":311024,"slug":"the-house-with-a-clock-in-its-walls-2018","imdb":"tt2119543","tmdb":463821}}},{"id":4115573116,"watched_at":"2018-12-29T07:12:14.000Z","action":"watch","type":"movie","movie":{"title":"Hunter
+          Killer","year":2018,"ids":{"trakt":292679,"slug":"hunter-killer-2018","imdb":"tt1846589","tmdb":399402}}},{"id":4115573029,"watched_at":"2018-12-29T07:12:13.000Z","action":"watch","type":"movie","movie":{"title":"BlacKkKlansman","year":2018,"ids":{"trakt":334724,"slug":"blackkklansman-2018","imdb":"tt7349662","tmdb":487558}}},{"id":4115573103,"watched_at":"2018-12-29T07:12:11.000Z","action":"watch","type":"movie","movie":{"title":"Crazy
+          Rich Asians","year":2018,"ids":{"trakt":301543,"slug":"crazy-rich-asians-2018","imdb":"tt3104988","tmdb":455207}}},{"id":4115572820,"watched_at":"2018-12-29T07:12:11.000Z","action":"watch","type":"movie","movie":{"title":"Incredibles
+          2","year":2018,"ids":{"trakt":159626,"slug":"incredibles-2-2018","imdb":"tt3606756","tmdb":260513}}},{"id":4115572866,"watched_at":"2018-12-29T07:12:04.000Z","action":"watch","type":"movie","movie":{"title":"Bumblebee","year":2018,"ids":{"trakt":269568,"slug":"bumblebee-2018","imdb":"tt4701182","tmdb":424783}}},{"id":4115572781,"watched_at":"2018-12-29T07:12:02.000Z","action":"watch","type":"movie","movie":{"title":"Night
+          School","year":2018,"ids":{"trakt":300756,"slug":"night-school-2018","imdb":"tt6781982","tmdb":454293}}},{"id":4115572795,"watched_at":"2018-12-29T07:11:57.000Z","action":"watch","type":"movie","movie":{"title":"Avengers:
+          Infinity War","year":2018,"ids":{"trakt":191797,"slug":"avengers-infinity-war-2018","imdb":"tt4154756","tmdb":299536}}},{"id":4115572517,"watched_at":"2018-12-29T07:11:57.000Z","action":"watch","type":"movie","movie":{"title":"Bad
+          Times at the El Royale","year":2018,"ids":{"trakt":292712,"slug":"bad-times-at-the-el-royale-2018","imdb":"tt6628394","tmdb":446021}}},{"id":4115572262,"watched_at":"2018-12-29T07:11:55.000Z","action":"watch","type":"movie","movie":{"title":"A
+          Simple Favor","year":2018,"ids":{"trakt":331407,"slug":"a-simple-favor-2018","imdb":"tt7040874","tmdb":484247}}},{"id":4115572765,"watched_at":"2018-12-29T07:11:53.000Z","action":"watch","type":"movie","movie":{"title":"Mission:
+          Impossible - Fallout","year":2018,"ids":{"trakt":222160,"slug":"mission-impossible-fallout-2018","imdb":"tt4912910","tmdb":353081}}},{"id":4115572227,"watched_at":"2018-12-29T07:11:46.000Z","action":"watch","type":"movie","movie":{"title":"Fantastic
+          Beasts: The Crimes of Grindelwald","year":2018,"ids":{"trakt":219417,"slug":"fantastic-beasts-the-crimes-of-grindelwald-2018","imdb":"tt4123430","tmdb":338952}}},{"id":4115572215,"watched_at":"2018-12-29T07:11:44.000Z","action":"watch","type":"movie","movie":{"title":"Venom","year":2018,"ids":{"trakt":216715,"slug":"venom-2018","imdb":"tt1270797","tmdb":335983}}},{"id":4115572162,"watched_at":"2018-12-29T07:11:42.000Z","action":"watch","type":"movie","movie":{"title":"Aquaman","year":2018,"ids":{"trakt":193968,"slug":"aquaman-2018","imdb":"tt1477834","tmdb":297802}}},{"id":4115572139,"watched_at":"2018-12-29T07:11:39.000Z","action":"watch","type":"movie","movie":{"title":"Bird
+          Box","year":2018,"ids":{"trakt":250049,"slug":"bird-box-2018","imdb":"tt2737304","tmdb":405774}}},{"id":4115572803,"watched_at":"2018-12-29T07:11:37.000Z","action":"watch","type":"movie","movie":{"title":"White
+          Boy Rick","year":2018,"ids":{"trakt":284950,"slug":"white-boy-rick-2018","imdb":"tt4537896","tmdb":438808}}}]'}
+      headers:
+        CF-RAY: [490a769ecfc33d2b-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [4f8eb99602 99.99 0.182912 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 07:13:19 GMT']
+        Etag: [W/"9efac828568a8403d33fda6a176347c3"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Last-Modified: ['Sat, 29 Dec 2018 07:12:18 GMT']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Pagination-Item-Count: ['25']
+        X-Pagination-Limit: ['1000']
+        X-Pagination-Page: ['1']
+        X-Pagination-Page-Count: ['1']
+        X-Request-Id: [cd490960-464c-458c-852b-c007379978be]
+        X-Runtime: ['0.060364']
+        X-Xss-Protection: [1; mode=block]
+      status: {code: 200, message: OK}
+version: 1

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_remove
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_remove
@@ -9,38 +9,38 @@ interactions:
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/shows
     response:
-      body: {string: '[{"rank":1,"id":371585967,"listed_at":"2018-12-29T06:20:38.000Z","type":"show","show":{"title":"White
+      body: {string: '[{"rank":1,"id":371589379,"listed_at":"2018-12-29T06:50:57.000Z","type":"show","show":{"title":"White
           Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}}]'}
       headers:
-        CF-RAY: [490a2b732de73d55-CPH]
+        CF-RAY: [490a561dab7c3d49-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [4a78111d34 2.06 0.026758 0030 57da]
+        Cf-Railgun: [3d8e294756 2.05 0.020890 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:22:00 GMT']
-        Etag: [W/"7e4b57b61049dff9c5862abb44f02304"]
+        Date: ['Sat, 29 Dec 2018 06:51:07 GMT']
+        Etag: [W/"f43e8c8c125db97c38bf93c228dfea27"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:20:38 GMT']
+        Last-Modified: ['Sat, 29 Dec 2018 06:50:57 GMT']
         Server: [cloudflare]
-        Set-Cookie: ['__cfduid=d804810a0b0c6b461a756559dad47e2fe1546064520; expires=Sun,
-            29-Dec-19 06:22:00 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Set-Cookie: ['__cfduid=d4ec0b278e20fe58622a0ac7cd1e2dd4a1546066267; expires=Sun,
+            29-Dec-19 06:51:07 GMT; path=/; domain=.trakt.tv; HttpOnly']
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [e8cf7ad7-85cc-4ff2-9489-d2f4d7ebc493]
-        X-Runtime: ['0.020063']
+        X-Request-Id: [40fcb3ee-4afa-4722-b829-9aac0b9f1ce9]
+        X-Runtime: ['0.017451']
         X-Sort-By: [rank]
         X-Sort-How: [asc]
         X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: '{"shows": [{"title": "White Collar", "ids": {"tmdb": 21510, "trakt":
-        21410, "tvdb": 108611, "imdb": "tt1358522", "tvrage": 20720}, "year": 2009}]}'
+      body: '{"shows": [{"ids": {"tvrage": 20720, "imdb": "tt1358522", "trakt": 21410,
+        "tmdb": 21510, "tvdb": 108611}, "year": 2009, "title": "White Collar"}]}'
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Length: ['146']
         Content-Type: [application/json]
-        Cookie: [__cfduid=d804810a0b0c6b461a756559dad47e2fe1546064520]
+        Cookie: [__cfduid=d4ec0b278e20fe58622a0ac7cd1e2dd4a1546066267]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: POST
@@ -48,20 +48,20 @@ interactions:
     response:
       body: {string: '{"deleted":{"movies":0,"shows":1,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        CF-RAY: [490a2b7f58813d55-CPH]
+        CF-RAY: [490a5629fed83d49-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [e406137d7a 99.99 0.227601 0030 57da]
+        Cf-Railgun: [8a776a60b3 99.99 0.048807 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:22:02 GMT']
-        Etag: [W/"21d7c950abb6e8e6d13278dd9011142e"]
+        Date: ['Sat, 29 Dec 2018 06:51:09 GMT']
+        Etag: [W/"0e740e49de52e3dbe254f48d0876a57c"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [99681d8e-86e4-4938-937f-2845d28125e1]
-        X-Runtime: ['0.198144']
+        X-Request-Id: [ab0f1a24-b694-4d94-8795-e3ce57cc203e]
+        X-Runtime: ['0.042223']
         X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
@@ -69,7 +69,7 @@ interactions:
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Type: [application/json]
-        Cookie: [__cfduid=d804810a0b0c6b461a756559dad47e2fe1546064520]
+        Cookie: [__cfduid=d4ec0b278e20fe58622a0ac7cd1e2dd4a1546066267]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
@@ -77,32 +77,32 @@ interactions:
     response:
       body: {string: '[]'}
       headers:
-        CF-RAY: [490a2b8edc4d3d55-CPH]
+        CF-RAY: [490a5636baca3d49-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [0a03541e19 99.99 0.022208 0030 57da]
+        Cf-Railgun: [f77131e17f 99.99 0.072404 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:22:04 GMT']
-        Etag: [W/"7e85eafe4e4c6e13a6fa543d4bc408ef"]
+        Date: ['Sat, 29 Dec 2018 06:51:12 GMT']
+        Etag: [W/"6d19be131e3652edb78d06cc822ce7dd"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:22:44 GMT']
+        Last-Modified: ['Sat, 29 Dec 2018 06:51:23 GMT']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [0f269046-7ff9-4f37-9479-21e19c838704]
-        X-Runtime: ['0.020492']
+        X-Request-Id: [ff2e8cb4-feeb-42b3-9858-2b785e0992c3]
+        X-Runtime: ['0.066145']
         X-Sort-By: [rank]
         X-Sort-How: [asc]
         X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: '{"shows": [{"title": "White Collar", "ids": {}, "year": 2009}]}'
+      body: '{"shows": [{"ids": {}, "year": 2009, "title": "White Collar"}]}'
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Length: ['63']
         Content-Type: [application/json]
-        Cookie: [__cfduid=d804810a0b0c6b461a756559dad47e2fe1546064520]
+        Cookie: [__cfduid=d4ec0b278e20fe58622a0ac7cd1e2dd4a1546066267]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: POST
@@ -110,20 +110,20 @@ interactions:
     response:
       body: {string: '{"added":{"movies":0,"shows":1,"seasons":0,"episodes":0},"existing":{"movies":0,"shows":0,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        CF-RAY: [490a2b9ad8583d55-CPH]
+        CF-RAY: [490a5642be873d49-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [bc3276285d 99.99 0.034967 0030 57da]
+        Cf-Railgun: [7071c73887 99.99 0.043799 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:22:06 GMT']
-        Etag: [W/"7afbe97deb7ba37ff8486a10c0967842"]
+        Date: ['Sat, 29 Dec 2018 06:51:13 GMT']
+        Etag: [W/"8cc6dbc4103196ad6bd4bcc6a9889921"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [238081f6-40b5-4902-98cd-f5fbbdc9b370]
-        X-Runtime: ['0.027556']
+        X-Request-Id: [db3b1370-af24-48d4-8a92-1ffc846c2287]
+        X-Runtime: ['0.040194']
         X-Xss-Protection: [1; mode=block]
       status: {code: 201, message: Created}
   - request:
@@ -131,41 +131,41 @@ interactions:
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Type: [application/json]
-        Cookie: [__cfduid=d804810a0b0c6b461a756559dad47e2fe1546064520]
+        Cookie: [__cfduid=d4ec0b278e20fe58622a0ac7cd1e2dd4a1546066267]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/shows
     response:
-      body: {string: '[{"rank":1,"id":371586034,"listed_at":"2018-12-29T06:22:00.000Z","type":"show","show":{"title":"White
+      body: {string: '[{"rank":1,"id":371589410,"listed_at":"2018-12-29T06:51:12.000Z","type":"show","show":{"title":"White
           Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}}]'}
       headers:
-        CF-RAY: [490a2bbd8a493d55-CPH]
+        CF-RAY: [490a56632a4c3d49-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [5e4829cfa3 99.99 0.028423 0030 57da]
+        Cf-Railgun: [909afdfff9 99.99 0.024537 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:22:12 GMT']
-        Etag: [W/"ded9cee8b2279968fafede97d17d0571"]
+        Date: ['Sat, 29 Dec 2018 06:51:19 GMT']
+        Etag: [W/"1decfb8c80e9ea27f0fbfad247aaa5b8"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:22:00 GMT']
+        Last-Modified: ['Sat, 29 Dec 2018 06:51:12 GMT']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [a1739a58-d7c1-4e7d-b926-1249c24d7a08]
-        X-Runtime: ['0.026604']
+        X-Request-Id: [f1b38a46-47b1-477d-bd3a-214024b8e9c8]
+        X-Runtime: ['0.021714']
         X-Sort-By: [rank]
         X-Sort-How: [asc]
         X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: '{"shows": [{"title": "White Collar", "ids": {}, "year": 2009}]}'
+      body: '{"shows": [{"ids": {}, "year": 2009, "title": "White Collar"}]}'
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Length: ['63']
         Content-Type: [application/json]
-        Cookie: [__cfduid=d804810a0b0c6b461a756559dad47e2fe1546064520]
+        Cookie: [__cfduid=d4ec0b278e20fe58622a0ac7cd1e2dd4a1546066267]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: POST
@@ -173,20 +173,20 @@ interactions:
     response:
       body: {string: '{"deleted":{"movies":0,"shows":1,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        CF-RAY: [490a2bc9fd573d55-CPH]
+        CF-RAY: [490a566fadbb3d49-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [bb41c74e54 99.99 0.162969 0030 57da]
+        Cf-Railgun: [17e9dd9c0e 99.99 0.034665 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:22:14 GMT']
-        Etag: [W/"af972ca788698cd42ff802048cf71324"]
+        Date: ['Sat, 29 Dec 2018 06:51:21 GMT']
+        Etag: [W/"354a870a0022581fe64d680f81cb24c2"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [d9b5b4db-b362-48d8-b31d-272929be897f]
-        X-Runtime: ['0.161104']
+        X-Request-Id: [ddc99a0c-38d6-4041-bc98-07d41bd324f5]
+        X-Runtime: ['0.027887']
         X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
@@ -194,7 +194,7 @@ interactions:
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Type: [application/json]
-        Cookie: [__cfduid=d804810a0b0c6b461a756559dad47e2fe1546064520]
+        Cookie: [__cfduid=d4ec0b278e20fe58622a0ac7cd1e2dd4a1546066267]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
@@ -202,21 +202,21 @@ interactions:
     response:
       body: {string: '[]'}
       headers:
-        CF-RAY: [490a2bee5f6b3d55-CPH]
+        CF-RAY: [490a568fef1c3d49-CPH]
         Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [30ab68d4af 99.99 0.326693 0030 57da]
+        Cf-Railgun: [f4803d31eb 99.99 0.020284 0030 57da]
         Connection: [keep-alive]
         Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:22:20 GMT']
-        Etag: [W/"4424072e99830138d0df9ea8ea2b71ec"]
+        Date: ['Sat, 29 Dec 2018 06:51:26 GMT']
+        Etag: [W/"c12f799cda24d661c3dac0ee106c5e5b"]
         Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:22:36 GMT']
+        Last-Modified: ['Sat, 29 Dec 2018 06:51:47 GMT']
         Server: [cloudflare]
         Vary: [Accept-Encoding]
         X-Content-Type-Options: [nosniff]
         X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [8dfd3c65-ccb0-45cd-b1fd-8c0fbfe390fa]
-        X-Runtime: ['0.322863']
+        X-Request-Id: [453fda32-485e-4d99-a3d4-c2b07cd61dab]
+        X-Runtime: ['0.018289']
         X-Sort-By: [rank]
         X-Sort-How: [asc]
         X-Xss-Protection: [1; mode=block]

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_remove
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_remove
@@ -2,199 +2,223 @@ interactions:
   - request:
       body: null
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Type: [!!python/unicode 'application/json']
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/shows
     response:
-      body: {string: !!python/unicode '[]'}
+      body: {string: '[{"rank":1,"id":371585967,"listed_at":"2018-12-29T06:20:38.000Z","type":"show","show":{"title":"White
+          Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}}]'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5ed76e913ca1-CPH]
-        connection: [keep-alive]
-        content-length: ['2']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:27:27 GMT']
-        etag: [W/"bb539c434d4b7157384f75c2729ddbec"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        last-modified: ['Mon, 21 May 2018 12:51:30 GMT']
-        server: [cloudflare]
-        set-cookie: ['__cfduid=dcdf72ad49b775786948868357105f7151531470447; expires=Sat,
-            13-Jul-19 08:27:27 GMT; path=/; domain=.trakt.tv; HttpOnly']
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [62e736b0-0584-4cb0-8ea7-ed32247ef0d2]
-        x-runtime: ['0.028595']
-        x-sort-by: [rank]
-        x-sort-how: [asc]
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2b732de73d55-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [4a78111d34 2.06 0.026758 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:22:00 GMT']
+        Etag: [W/"7e4b57b61049dff9c5862abb44f02304"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Last-Modified: ['Sat, 29 Dec 2018 06:20:38 GMT']
+        Server: [cloudflare]
+        Set-Cookie: ['__cfduid=d804810a0b0c6b461a756559dad47e2fe1546064520; expires=Sun,
+            29-Dec-19 06:22:00 GMT; path=/; domain=.trakt.tv; HttpOnly']
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [e8cf7ad7-85cc-4ff2-9489-d2f4d7ebc493]
+        X-Runtime: ['0.020063']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
+      status: {code: 200, message: OK}
+  - request:
+      body: '{"shows": [{"title": "White Collar", "ids": {"tmdb": 21510, "trakt":
+        21410, "tvdb": 108611, "imdb": "tt1358522", "tvrage": 20720}, "year": 2009}]}'
+      headers:
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Length: ['146']
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d804810a0b0c6b461a756559dad47e2fe1546064520]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
+      method: POST
+      uri: https://api.trakt.tv/sync/watchlist/remove
+    response:
+      body: {string: '{"deleted":{"movies":0,"shows":1,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
+      headers:
+        CF-RAY: [490a2b7f58813d55-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [e406137d7a 99.99 0.227601 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:22:02 GMT']
+        Etag: [W/"21d7c950abb6e8e6d13278dd9011142e"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [99681d8e-86e4-4938-937f-2845d28125e1]
+        X-Runtime: ['0.198144']
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
       body: null
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=dcdf72ad49b775786948868357105f7151531470447]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d804810a0b0c6b461a756559dad47e2fe1546064520]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/shows
     response:
-      body: {string: !!python/unicode '[]'}
+      body: {string: '[]'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5edaa8233ca1-CPH]
-        connection: [keep-alive]
-        content-length: ['2']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:27:28 GMT']
-        etag: [W/"bb539c434d4b7157384f75c2729ddbec"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        last-modified: ['Mon, 21 May 2018 12:51:30 GMT']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [501b4a28-cefc-403b-8cba-1597c4fc4025]
-        x-runtime: ['0.034266']
-        x-sort-by: [rank]
-        x-sort-how: [asc]
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2b8edc4d3d55-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [0a03541e19 99.99 0.022208 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:22:04 GMT']
+        Etag: [W/"7e85eafe4e4c6e13a6fa543d4bc408ef"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Last-Modified: ['Sat, 29 Dec 2018 06:22:44 GMT']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [0f269046-7ff9-4f37-9479-21e19c838704]
+        X-Runtime: ['0.020492']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: !!python/unicode '{"shows": [{"year": 2009, "ids": {}, "title": "White
-        Collar"}]}'
+      body: '{"shows": [{"title": "White Collar", "ids": {}, "year": 2009}]}'
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Length: ['63']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=dcdf72ad49b775786948868357105f7151531470447]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d804810a0b0c6b461a756559dad47e2fe1546064520]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: POST
       uri: https://api.trakt.tv/sync/watchlist
     response:
-      body: {string: !!python/unicode '{"added":{"movies":0,"shows":1,"seasons":0,"episodes":0},"existing":{"movies":0,"shows":0,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
+      body: {string: '{"added":{"movies":0,"shows":1,"seasons":0,"episodes":0},"existing":{"movies":0,"shows":0,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5ee73e123ca1-CPH]
-        connection: [keep-alive]
-        content-length: ['192']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:27:30 GMT']
-        etag: [W/"06522e32812c41c5dd32336b0c55357f"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [22e6808b-a26b-4b69-a363-5952055dd2bb]
-        x-runtime: ['0.031757']
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2b9ad8583d55-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [bc3276285d 99.99 0.034967 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:22:06 GMT']
+        Etag: [W/"7afbe97deb7ba37ff8486a10c0967842"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [238081f6-40b5-4902-98cd-f5fbbdc9b370]
+        X-Runtime: ['0.027556']
+        X-Xss-Protection: [1; mode=block]
       status: {code: 201, message: Created}
   - request:
       body: null
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=dcdf72ad49b775786948868357105f7151531470447]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d804810a0b0c6b461a756559dad47e2fe1546064520]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/shows
     response:
-      body: {string: !!python/unicode '[{"rank":1,"listed_at":"2018-07-13T08:27:38.000Z","type":"show","show":{"title":"White
+      body: {string: '[{"rank":1,"id":371586034,"listed_at":"2018-12-29T06:22:00.000Z","type":"show","show":{"title":"White
           Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}}]'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5f0a2f433ca1-CPH]
-        connection: [keep-alive]
-        content-length: ['214']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:27:35 GMT']
-        etag: [W/"3e1b64b879bee45733645be565a98f7e"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        last-modified: ['Fri, 13 Jul 2018 08:27:38 GMT']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [504393a8-e2c2-4421-a3a1-b42cff831e7f]
-        x-runtime: ['0.030488']
-        x-sort-by: [rank]
-        x-sort-how: [asc]
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2bbd8a493d55-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [5e4829cfa3 99.99 0.028423 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:22:12 GMT']
+        Etag: [W/"ded9cee8b2279968fafede97d17d0571"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Last-Modified: ['Sat, 29 Dec 2018 06:22:00 GMT']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [a1739a58-d7c1-4e7d-b926-1249c24d7a08]
+        X-Runtime: ['0.026604']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
-      body: !!python/unicode '{"shows": [{"year": 2009, "ids": {}, "title": "White
-        Collar"}]}'
+      body: '{"shows": [{"title": "White Collar", "ids": {}, "year": 2009}]}'
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Length: ['63']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=dcdf72ad49b775786948868357105f7151531470447]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d804810a0b0c6b461a756559dad47e2fe1546064520]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: POST
       uri: https://api.trakt.tv/sync/watchlist/remove
     response:
-      body: {string: !!python/unicode '{"deleted":{"movies":0,"shows":1,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
+      body: {string: '{"deleted":{"movies":0,"shows":1,"seasons":0,"episodes":0},"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[],"people":[]}}'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5f18ef8d3ca1-CPH]
-        connection: [keep-alive]
-        content-length: ['135']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:27:38 GMT']
-        etag: [W/"7d241d250cf876ce931f6eaced9fd5ef"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [09b53ced-2af0-4cee-baae-e4e1775db9f4]
-        x-runtime: ['0.253561']
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2bc9fd573d55-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [bb41c74e54 99.99 0.162969 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:22:14 GMT']
+        Etag: [W/"af972ca788698cd42ff802048cf71324"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [d9b5b4db-b362-48d8-b31d-272929be897f]
+        X-Runtime: ['0.161104']
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
   - request:
       body: null
       headers:
-        Authorization: [!!python/unicode 'Bearer 7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a']
-        Content-Type: [!!python/unicode 'application/json']
-        Cookie: [__cfduid=dcdf72ad49b775786948868357105f7151531470447]
-        trakt-api-key: [!!python/unicode '57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af']
-        trakt-api-version: [!!python/unicode '2']
+        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
+        Content-Type: [application/json]
+        Cookie: [__cfduid=d804810a0b0c6b461a756559dad47e2fe1546064520]
+        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
+        trakt-api-version: ['2']
       method: GET
       uri: https://api.trakt.tv/sync/watchlist/shows
     response:
-      body: {string: !!python/unicode '[]'}
+      body: {string: '[]'}
       headers:
-        cache-control: ['max-age=0, private, must-revalidate']
-        cf-railgun: [direct (starting new WAN connection)]
-        cf-ray: [439a5f3d19e53ca1-CPH]
-        connection: [keep-alive]
-        content-length: ['2']
-        content-type: [application/json; charset=utf-8]
-        date: ['Fri, 13 Jul 2018 08:27:43 GMT']
-        etag: [W/"96c03990b70f3bd751465b2e643d2bb4"]
-        expect-ct: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        last-modified: ['Fri, 13 Jul 2018 08:27:20 GMT']
-        server: [cloudflare]
-        vary: [Accept-Encoding]
-        x-content-type-options: [nosniff]
-        x-frame-options: [SAMEORIGIN]
-        x-request-id: [4cab90d1-b96e-40c7-a190-45ec7e34fcc5]
-        x-runtime: ['0.034793']
-        x-sort-by: [rank]
-        x-sort-how: [asc]
-        x-xss-protection: [1; mode=block]
+        CF-RAY: [490a2bee5f6b3d55-CPH]
+        Cache-Control: ['max-age=0, private, must-revalidate']
+        Cf-Railgun: [30ab68d4af 99.99 0.326693 0030 57da]
+        Connection: [keep-alive]
+        Content-Type: [application/json; charset=utf-8]
+        Date: ['Sat, 29 Dec 2018 06:22:20 GMT']
+        Etag: [W/"4424072e99830138d0df9ea8ea2b71ec"]
+        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+        Last-Modified: ['Sat, 29 Dec 2018 06:22:36 GMT']
+        Server: [cloudflare]
+        Vary: [Accept-Encoding]
+        X-Content-Type-Options: [nosniff]
+        X-Frame-Options: [SAMEORIGIN]
+        X-Request-Id: [8dfd3c65-ccb0-45cd-b1fd-8c0fbfe390fa]
+        X-Runtime: ['0.322863']
+        X-Sort-By: [rank]
+        X-Sort-How: [asc]
+        X-Xss-Protection: [1; mode=block]
       status: {code: 200, message: OK}
 version: 1

--- a/flexget/tests/test_trakt_list_interface.py
+++ b/flexget/tests/test_trakt_list_interface.py
@@ -202,3 +202,8 @@ class TestTraktList(object):
         trakt_set.remove(entry)
         time.sleep(5)
         assert entry not in trakt_set
+
+    def test_trakt_pagination(self):
+        config = {'account': 'flexget_list_test', 'list': 'watched', 'type': 'movies'}
+        trakt_set = TraktSet(config)
+        assert len(trakt_set) == 25

--- a/flexget/tests/test_trakt_list_interface.py
+++ b/flexget/tests/test_trakt_list_interface.py
@@ -49,9 +49,9 @@ class TestTraktList(object):
     def db_auth(self, manager):
         kwargs = {
             'account': 'flexget_list_test',
-            'access_token': '7c2898cd175e28c9319f95a351873eaf7a970736cbb07ff015bf7ef652d7736a',
-            'refresh_token': '33918a6b4c3101892c79f6a13c0d15a050afe33491d7702d44bbce052923f745',
-            'created': 1526906378,
+            'access_token': 'c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9',
+            'refresh_token': 'c33d487d3c27e33896a10f0edda08f14040ee27ee195f18442dd72555f9a9b9f',
+            'created': 1546067709,
             'expires': 7776000
         }
 


### PR DESCRIPTION
### Motivation for changes:
I brokes it, I fixes it
### Detailed changes:
- If a pagination header is retrieved and the list contains more items than the pagination limit, it will fetch 1000 items per request until it has retrieved it all

### Addressed issues:
- Fixes #2254

### TODO:
- [x] Fix the damn cassettes