### PR TITLE
Make disable plugin work on all plugins

### DIFF
--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -469,7 +469,7 @@ def load_plugins(extra_dirs=None):
     log.debug('Plugins took %.2f seconds to load. %s plugins in registry.', took, len(plugins.keys()))
 
 
-def get_plugins(phase=None, interface=None, category=None, name=None, min_api=None):
+def get_plugins(phase=None, interface=None, category=None, name=None, min_api=None, exclude=None):
     """
     Query other plugins characteristics.
 
@@ -478,6 +478,7 @@ def get_plugins(phase=None, interface=None, category=None, name=None, min_api=No
     :param string category: Type of plugin, phase names.
     :param string name: Name of the plugin.
     :param int min_api: Minimum api version.
+    :param list exclude: A list of plugin names to be excluded. (Useful to pass task.disabled_plugins here.)
     :return: List of PluginInfo instances.
     :rtype: list
     """
@@ -485,6 +486,8 @@ def get_plugins(phase=None, interface=None, category=None, name=None, min_api=No
     def matches(plugin):
         if phase is not None and phase not in phase_methods:
             raise ValueError('Unknown phase %s' % phase)
+        if exclude and plugin.name in exclude:
+            return False
         if phase and phase not in plugin.phase_handlers:
             return False
         if interface and interface not in plugin.interfaces:

--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -256,7 +256,6 @@ class PluginInfo(dict):
             warnings.warn('Api versions <2 are no longer supported. Plugin %s' % name, DeprecationWarning, stacklevel=2)
 
         # Set basic info attributes
-        self.enabled = True
         self.api_ver = api_ver
         self.name = name
         self.interfaces = interfaces
@@ -486,8 +485,6 @@ def get_plugins(phase=None, interface=None, category=None, name=None, min_api=No
     def matches(plugin):
         if phase is not None and phase not in phase_methods:
             raise ValueError('Unknown phase %s' % phase)
-        if not plugin.enabled:
-            return False
         if phase and phase not in plugin.phase_handlers:
             return False
         if interface and interface not in plugin.interfaces:

--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -256,6 +256,7 @@ class PluginInfo(dict):
             warnings.warn('Api versions <2 are no longer supported. Plugin %s' % name, DeprecationWarning, stacklevel=2)
 
         # Set basic info attributes
+        self.disabled = False
         self.api_ver = api_ver
         self.name = name
         self.interfaces = interfaces
@@ -485,6 +486,8 @@ def get_plugins(phase=None, interface=None, category=None, name=None, min_api=No
     def matches(plugin):
         if phase is not None and phase not in phase_methods:
             raise ValueError('Unknown phase %s' % phase)
+        if plugin.disabled:
+            return False
         if phase and phase not in plugin.phase_handlers:
             return False
         if interface and interface not in plugin.interfaces:

--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -256,7 +256,7 @@ class PluginInfo(dict):
             warnings.warn('Api versions <2 are no longer supported. Plugin %s' % name, DeprecationWarning, stacklevel=2)
 
         # Set basic info attributes
-        self.disabled = False
+        self.enabled = True
         self.api_ver = api_ver
         self.name = name
         self.interfaces = interfaces
@@ -486,7 +486,7 @@ def get_plugins(phase=None, interface=None, category=None, name=None, min_api=No
     def matches(plugin):
         if phase is not None and phase not in phase_methods:
             raise ValueError('Unknown phase %s' % phase)
-        if plugin.disabled:
+        if not plugin.enabled:
             return False
         if phase and phase not in plugin.phase_handlers:
             return False

--- a/flexget/plugins/estimators/est_released.py
+++ b/flexget/plugins/estimators/est_released.py
@@ -12,7 +12,7 @@ class EstimateRelease(object):
     for various things (series, movies).
     """
 
-    def estimate(self, entry):
+    def estimate(self, task, entry):
         """
         Estimate release schedule for Entry
 
@@ -21,7 +21,8 @@ class EstimateRelease(object):
         """
 
         log.debug(entry['title'])
-        estimators = [e.instance.estimate for e in plugin.get_plugins(interface='estimate_release')]
+        estimators = [e.instance.estimate for e in
+                      plugin.get_plugins(interface='estimate_release', exclude=task.disabled_plugins)]
         for estimator in sorted(
                 estimators, key=lambda e: getattr(e, 'priority', plugin.DEFAULT_PRIORITY), reverse=True
         ):

--- a/flexget/plugins/input/discover.py
+++ b/flexget/plugins/input/discover.py
@@ -150,7 +150,7 @@ class Discover(object):
         if not search_results:
             query.complete()
 
-    def estimated(self, entries, estimation_mode):
+    def estimated(self, task, entries, estimation_mode):
         """
         :param dict estimation_mode: mode -> loose, strict, ignore
         :return: Entries that we have estimated to be available
@@ -158,7 +158,7 @@ class Discover(object):
         estimator = get_plugin_by_name('estimate_release').instance
         result = []
         for entry in entries:
-            est_date = estimator.estimate(entry)
+            est_date = estimator.estimate(task, entry)
             if est_date is None:
                 log.debug('No release date could be determined for %s', entry['title'])
                 if estimation_mode['mode'] == 'strict':
@@ -246,7 +246,7 @@ class Discover(object):
         entries = self.interval_expired(config, task, entries)
         estimation_mode = config['release_estimations']
         if estimation_mode['mode'] != 'ignore':
-            entries = self.estimated(entries, estimation_mode)
+            entries = self.estimated(task, entries, estimation_mode)
         return self.execute_searches(config, entries, task)
 
 

--- a/flexget/plugins/internal/change_warn.py
+++ b/flexget/plugins/internal/change_warn.py
@@ -31,10 +31,6 @@ class ChangeWarn(object):
             log.critical('Plugin nzb_size is deprecated, use content_size instead')
             found_deprecated = True
 
-        if 'disable_urlrewriters' in task.config:
-            log.critical('Plugin disable_urlrewriters is deprecated, use disable instead')
-            found_deprecated = True
-
         if found_deprecated:
             task.manager.shutdown(finish_queue=False)
             task.abort('Deprecated config.')

--- a/flexget/plugins/internal/change_warn.py
+++ b/flexget/plugins/internal/change_warn.py
@@ -31,6 +31,10 @@ class ChangeWarn(object):
             log.critical('Plugin nzb_size is deprecated, use content_size instead')
             found_deprecated = True
 
+        if 'disable_urlrewriters' in task.config:
+            log.critical('Plugin disable_urlrewriters is deprecated, use disable instead')
+            found_deprecated = True
+
         if found_deprecated:
             task.manager.shutdown(finish_queue=False)
             task.abort('Deprecated config.')

--- a/flexget/plugins/internal/urlrewriting.py
+++ b/flexget/plugins/internal/urlrewriting.py
@@ -74,7 +74,28 @@ class PluginUrlRewriting(object):
                     raise UrlRewritingError('%s: Internal error with url %s' % (name, entry['url']))
 
 
+class DisableUrlRewriter(object):
+    """Disable certain urlrewriters."""
+
+    schema = {
+        'deprecated': '`disable_urlrewriters` plugin is deprecated, use `disable` plugin instead',
+        'type': 'array',
+        'items': {'type': 'string'}
+    }
+
+    def on_task_start(self, task, config):
+        disable = plugin.get_plugin_by_name('disable')['instance']
+        disable.on_task_start(task, config)
+
+    def on_task_exit(self, task, config):
+        disable = plugin.get_plugin_by_name('disable')['instance']
+        disable.on_task_exit(task, config)
+
+    on_task_abort = on_task_exit
+
+
 @event('plugin.register')
 def register_plugin():
     plugin.register(PluginUrlRewriting, 'urlrewriting', builtin=True, api_ver=2)
+    plugin.register(DisableUrlRewriter, 'disable_urlrewriters', api_ver=2)
     plugin.register_task_phase('urlrewrite', before='download')

--- a/flexget/plugins/internal/urlrewriting.py
+++ b/flexget/plugins/internal/urlrewriting.py
@@ -35,9 +35,7 @@ class PluginUrlRewriting(object):
     # API method
     def url_rewritable(self, task, entry):
         """Return True if entry is urlrewritable by registered rewriter."""
-        for urlrewriter in plugin.get_plugins(interface='urlrewriter'):
-            if urlrewriter.name in task.disabled_plugins:
-                continue
+        for urlrewriter in plugin.get_plugins(interface='urlrewriter', exclude=task.disabled_plugins):
             log.trace('checking urlrewriter %s', urlrewriter.name)
             if urlrewriter.instance.url_rewritable(task, entry):
                 return True
@@ -53,10 +51,8 @@ class PluginUrlRewriting(object):
             if tries > 20:
                 raise UrlRewritingError('URL rewriting was left in infinite loop while rewriting url for %s, '
                                         'some rewriter is returning always True' % entry)
-            for urlrewriter in plugin.get_plugins(interface='urlrewriter'):
+            for urlrewriter in plugin.get_plugins(interface='urlrewriter', exclude=task.disabled_plugins):
                 name = urlrewriter.name
-                if name in task.disabled_plugins:
-                    continue
                 try:
                     if urlrewriter.instance.url_rewritable(task, entry):
                         old_url = entry['url']

--- a/flexget/plugins/internal/urlrewriting.py
+++ b/flexget/plugins/internal/urlrewriting.py
@@ -36,6 +36,8 @@ class PluginUrlRewriting(object):
     def url_rewritable(self, task, entry):
         """Return True if entry is urlrewritable by registered rewriter."""
         for urlrewriter in plugin.get_plugins(interface='urlrewriter'):
+            if urlrewriter.name in task.disabled_plugins:
+                continue
             log.trace('checking urlrewriter %s', urlrewriter.name)
             if urlrewriter.instance.url_rewritable(task, entry):
                 return True
@@ -53,6 +55,8 @@ class PluginUrlRewriting(object):
                                         'some rewriter is returning always True' % entry)
             for urlrewriter in plugin.get_plugins(interface='urlrewriter'):
                 name = urlrewriter.name
+                if name in task.disabled_plugins:
+                    continue
                 try:
                     if urlrewriter.instance.url_rewritable(task, entry):
                         old_url = entry['url']

--- a/flexget/plugins/modify/urlrewrite_search.py
+++ b/flexget/plugins/modify/urlrewrite_search.py
@@ -56,6 +56,8 @@ class PluginSearch(object):
                 if isinstance(name, dict):
                     # the name is the first/only key in the dict.
                     name, search_config = list(name.items())[0]
+                if name in task.disabled_plugins:
+                    continue
                 log.verbose('Searching `%s` from %s' % (entry['title'], name))
                 try:
                     try:

--- a/flexget/plugins/operate/disable.py
+++ b/flexget/plugins/operate/disable.py
@@ -57,13 +57,13 @@ class DisablePlugin(object):
                 del (task.config[p])
             # Disable built-in plugins.
             if p in plugin.plugins:
-                plugin.plugins[p].disabled = True
+                plugin.plugins[p].enabled = False
                 self.disabled_plugins.append(p)
 
         # Disable all builtins mode.
         if 'builtins' in config:
             for p in all_builtins():
-                p.disabled = True
+                p.enabled = False
                 self.disabled_plugins.append(p.name)
 
         if self.disabled_plugins:
@@ -77,7 +77,7 @@ class DisablePlugin(object):
             return
 
         for name in self.disabled_plugins:
-            plugin.plugins[name].disabled = False
+            plugin.plugins[name].enabled = True
         log.debug('Re-enabled plugin(s): %s' % ', '.join(self.disabled_plugins))
         self.disabled_plugins = []
 

--- a/flexget/plugins/operate/disable.py
+++ b/flexget/plugins/operate/disable.py
@@ -40,11 +40,12 @@ class DisablePlugin(object):
     """
 
     schema = one_or_more({'type': 'string'})
-    disabled_plugins = None
+
+    def __init__(self):
+        self.disabled_plugins = []
 
     @plugin.priority(254)
     def on_task_start(self, task, config):
-        self.disabled_plugins = []
         disabled_in_task = []
 
         if isinstance(config, str):

--- a/flexget/plugins/operate/disable.py
+++ b/flexget/plugins/operate/disable.py
@@ -46,13 +46,14 @@ class DisablePlugin(object):
         if isinstance(config, str):
             config = [config]
 
-        for p in config:
-            task.disable_plugin(p)
-
         # Disable all builtins mode.
         if 'builtins' in config:
             for p in all_builtins():
                 task.disable_plugin(p.name)
+            config.remove('builtins')
+
+        for p in config:
+            task.disable_plugin(p)
 
         if task.disabled_plugins:
             log.debug('Disabled plugin(s): %s' % ', '.join(task.disabled_plugins))

--- a/flexget/plugins/operate/template.py
+++ b/flexget/plugins/operate/template.py
@@ -125,7 +125,7 @@ def register_plugin():
 def register_config():
     root_config_schema = {
         'type': 'object',
-        'additionalProperties': plugin.plugin_schemas(interface='task')
+        'additionalProperties': {'$ref': '/schema/plugins?interface=task'}
     }
     register_config_key('templates', root_config_schema)
 

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -400,7 +400,7 @@ class Task(object):
             plugins = sorted(get_plugins(phase=phase), key=lambda p: p.phase_handlers[phase], reverse=True)
         else:
             plugins = iter(all_plugins.values())
-        return (p for p in plugins if p.name in self.config or p.builtin and not p.disabled)
+        return (p for p in plugins if p.name in self.config or p.builtin and p.enabled)
 
     def __run_task_phase(self, phase):
         """Executes task phase, ie. call all enabled plugins on the task.

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -696,7 +696,7 @@ class Task(object):
 def register_config_key():
     task_config_schema = {
         'type': 'object',
-        'additionalProperties': plugin_schemas(interface='task')
+        'additionalProperties': {'$ref': '/schema/plugins?interface=task'}
     }
 
     config_schema.register_config_key('tasks', task_config_schema, required=True)

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -412,7 +412,7 @@ class Task(object):
             plugins = sorted(get_plugins(phase=phase), key=lambda p: p.phase_handlers[phase], reverse=True)
         else:
             plugins = iter(all_plugins.values())
-        return (p for p in plugins if p.name not in self.disabled_plugins and p.name in self.config or p.builtin)
+        return (p for p in plugins if p.name not in self.disabled_plugins and (p.name in self.config or p.builtin))
 
     def __run_task_phase(self, phase):
         """Executes task phase, ie. call all enabled plugins on the task.

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -412,7 +412,7 @@ class Task(object):
             plugins = sorted(get_plugins(phase=phase), key=lambda p: p.phase_handlers[phase], reverse=True)
         else:
             plugins = iter(all_plugins.values())
-        return (p for p in plugins if p.name in self.config or p.builtin and p.name not in self.disabled_plugins)
+        return (p for p in plugins if p.name not in self.disabled_plugins and p.name in self.config or p.builtin)
 
     def __run_task_phase(self, phase):
         """Executes task phase, ie. call all enabled plugins on the task.

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -400,7 +400,7 @@ class Task(object):
             plugins = sorted(get_plugins(phase=phase), key=lambda p: p.phase_handlers[phase], reverse=True)
         else:
             plugins = iter(all_plugins.values())
-        return (p for p in plugins if p.name in self.config or p.builtin)
+        return (p for p in plugins if p.name in self.config or p.builtin and not p.disabled)
 
     def __run_task_phase(self, phase):
         """Executes task phase, ie. call all enabled plugins on the task.

--- a/flexget/tests/conftest.py
+++ b/flexget/tests/conftest.py
@@ -218,8 +218,6 @@ def register_plugin(request):
         result = register(*args, **kwargs)
         result.initialize()
         loaded_plugins.append(result.name)
-        # Make sure the config schema updates with the new plugins
-        fire_event('config.register')
 
     for marker in request.node.iter_markers('register_plugin'):
         load_plugin(*marker.args, **marker.kwargs)
@@ -228,8 +226,6 @@ def register_plugin(request):
 
     for p in loaded_plugins:
         plugins.pop(p, None)
-    # Make sure config schema removes the temporary plugins
-    fire_event('config.register')
 
 
 @pytest.yield_fixture()

--- a/flexget/tests/conftest.py
+++ b/flexget/tests/conftest.py
@@ -211,7 +211,6 @@ def register_plugin(request):
     A function which loads a plugin only for the test function it is called from.
     """
     from flexget.plugin import plugins, register
-    from flexget.event import fire_event
     loaded_plugins = []
 
     def load_plugin(*args, **kwargs):

--- a/flexget/tests/notifiers/conftest.py
+++ b/flexget/tests/notifiers/conftest.py
@@ -3,8 +3,6 @@ from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 import pytest
 
-from flexget import plugin
-from flexget.event import event
 from flexget.plugin import get_plugin_by_name
 
 

--- a/flexget/tests/notifiers/conftest.py
+++ b/flexget/tests/notifiers/conftest.py
@@ -18,9 +18,12 @@ class DebugNotification(object):
         self.notifications.append((title, message, config))
 
 
-@event('plugin.register')
-def register_plugin():
-    plugin.register(DebugNotification, 'debug_notification', interfaces=['notifiers'], api_ver=2, debug=True)
+def pytest_collection_modifyitems(items):
+    """
+    Add our debug_notification plugin to all tests in this directory.
+    """
+    for item in items:
+        item.add_marker(pytest.mark.register_plugin(DebugNotification, 'debug_notification', interfaces=['notifiers'], api_ver=2, debug=True))
 
 
 @pytest.fixture()

--- a/flexget/tests/test_cached_input.py
+++ b/flexget/tests/test_cached_input.py
@@ -23,11 +23,9 @@ class InputPersist(object):
         return [Entry(title='Test', url='http://test.com')]
 
 
-plugin.register(InputPersist, 'test_input', api_ver=2)
-
-
 @pytest.mark.filecopy('rss.xml', '__tmp__/cached.xml')
 @pytest.mark.usefixtures('tmpdir')
+@pytest.mark.register_plugin(InputPersist, 'test_input', api_ver=2)
 class TestInputCache(object):
     config = """
         tasks:

--- a/flexget/tests/test_disable.py
+++ b/flexget/tests/test_disable.py
@@ -15,7 +15,7 @@ class PluginFakeUrlrewriter(object):
         entry['url'] = self.URL
 
 
-class TestDelay(object):
+class TestDisable(object):
     config = """
         tasks:
           disable_from_config:
@@ -40,7 +40,7 @@ class TestDelay(object):
         task = execute_task('disable_from_config')
         assert len(task.entries) == 0
 
-    def test_disable_builtin(self, execute_task, manager):
+    def test_disable_builtins(self, execute_task, manager):
         task = execute_task('disable_builtins')
         assert len(task.accepted) == 1
         task = execute_task('disable_builtins')

--- a/flexget/tests/test_disable.py
+++ b/flexget/tests/test_disable.py
@@ -1,0 +1,44 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+from flexget import plugin
+from flexget.event import event
+
+
+class TestDelay(object):
+    config = """
+        tasks:
+          disable_from_config:
+            mock:
+              - title: entry 1
+          disable_builtins:
+            mock:
+              - title: entry 1
+            accept_all: yes
+          disable_urlrewriter:
+            mock:
+              - title: entry 1
+                url: blah://aoeu
+            accept_all: yes
+            disable: [seen]
+        """
+
+    def test_disable_config_plugin(self, execute_task, manager):
+        task = execute_task('disable_from_config')
+        assert len(task.entries) == 1
+        manager.config["tasks"]["disable_from_config"]["disable"] = ["mock"]
+        task = execute_task('disable_from_config')
+        assert len(task.entries) == 0
+
+    def test_disable_builtin(self, execute_task, manager):
+        task = execute_task('disable_builtins')
+        assert len(task.accepted) == 1
+        task = execute_task('disable_builtins')
+        assert len(task.accepted) == 0
+        # Make sure builtins special command works
+        manager.config["tasks"]["disable_builtins"]["disable"] = ["builtins"]
+        task = execute_task('disable_builtins')
+        assert len(task.accepted) == 1, "seen builtin should have been disabled with 'builtins' keyword"
+        # Make sure builtins are also disabled with their specific name
+        manager.config["tasks"]["disable_builtins"]["disable"] = ["seen"]
+        assert len(task.accepted) == 1, "seen builtin should have been disabled"

--- a/flexget/tests/test_disable.py
+++ b/flexget/tests/test_disable.py
@@ -42,3 +42,26 @@ class TestDelay(object):
         # Make sure builtins are also disabled with their specific name
         manager.config["tasks"]["disable_builtins"]["disable"] = ["seen"]
         assert len(task.accepted) == 1, "seen builtin should have been disabled"
+
+    def test_disable_urlrewriter(self, execute_task, manager):
+        task = execute_task('disable_urlrewriter')
+        assert task.accepted[0]['url'] == PluginFakeUrlrewriter.URL
+        manager.config["tasks"]["disable_urlrewriter"]["disable"] = ["seen", "fake_urlrewriter"]
+        task = execute_task('disable_urlrewriter')
+        assert task.accepted[0]['url'] == "blah://aoeu"
+
+
+class PluginFakeUrlrewriter(object):
+    URL = "fake://url.com"
+
+    def url_rewritable(self, task, entry):
+        if entry['url'] != self.URL:
+            return True
+
+    def url_rewrite(self, task, entry):
+        entry['url'] = self.URL
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(PluginFakeUrlrewriter, 'fake_urlrewriter', interfaces=['urlrewriter'], api_ver=2)

--- a/flexget/tests/test_discover.py
+++ b/flexget/tests/test_discover.py
@@ -3,6 +3,8 @@ from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 from datetime import datetime, timedelta
 
+import pytest
+
 from flexget.entry import Entry
 from flexget import plugin
 
@@ -25,9 +27,6 @@ class SearchPlugin(object):
         return [Entry(entry)]
 
 
-plugin.register(SearchPlugin, 'test_search', interfaces=['search'], api_ver=2)
-
-
 class EstRelease(object):
     """Fake release estimate plugin. Just returns 'est_release' entry field."""
 
@@ -35,7 +34,10 @@ class EstRelease(object):
         return entry.get('est_release')
 
 
-plugin.register(EstRelease, 'test_release', interfaces=['estimate_release'], api_ver=2)
+pytestmark = [
+    pytest.mark.register_plugin(SearchPlugin, 'test_search', interfaces=['search'], api_ver=2),
+    pytest.mark.register_plugin(EstRelease, 'test_release', interfaces=['estimate_release'], api_ver=2)
+]
 
 
 class TestDiscover(object):

--- a/flexget/tests/test_misc.py
+++ b/flexget/tests/test_misc.py
@@ -12,42 +12,6 @@ import pytest
 from flexget.entry import EntryUnicodeError, Entry
 
 
-class TestDisableBuiltins(object):
-    """
-        Quick a hack, test disable functionality by checking if seen filtering (builtin) is working
-    """
-
-    config = """
-        tasks:
-          test:
-            mock:
-              - {title: 'dupe1', url: 'http://localhost/dupe', 'imdb_score': 5}
-              - {title: 'dupe2', url: 'http://localhost/dupe', 'imdb_score': 5}
-            accept_all: yes
-            disable: builtins
-
-          test2:
-            mock:
-              - {title: 'dupe1', url: 'http://localhost/dupe', 'imdb_score': 5,
-                description: 'http://www.imdb.com/title/tt0409459/'}
-              - {title: 'dupe2', url: 'http://localhost/dupe', 'imdb_score': 5}
-            accept_all: yes
-            disable:
-              - seen
-              - cli_config
-    """
-
-    def test_disable_builtins(self, execute_task):
-        # Execute the task once, then we'll make sure seen plugin isn't rejecting on future executions
-        execute_task('test')
-        task = execute_task('test')
-        assert task.find_entry('accepted', title='dupe1') and task.find_entry('accepted', title='dupe2'), \
-            'disable is not working?'
-        task = execute_task('test2')
-        assert task.find_entry(title='dupe1').accepted and task.find_entry('accepted', title='dupe2'), \
-            'disable is not working?'
-
-
 @pytest.mark.online
 class TestInputHtml(object):
     config = """

--- a/flexget/tests/test_remember_rejected.py
+++ b/flexget/tests/test_remember_rejected.py
@@ -1,26 +1,21 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
-from past.builtins import basestring
 
-from flexget import plugin
-from flexget.event import event
+import pytest
+
 from flexget.utils.tools import parse_timedelta
 
 
 class RejectRememberPlugin(object):
     def on_task_filter(self, task, config):
         for entry in task.all_entries:
-            if isinstance(config, basestring):
+            if isinstance(config, str):
                 entry.reject(remember_time=parse_timedelta(config))
             else:
                 entry.reject(remember=True)
 
 
-@event('plugin.register')
-def register_plugin():
-    plugin.register(RejectRememberPlugin, 'test_remember_reject', api_ver=2, debug=True)
-
-
+@pytest.mark.register_plugin(RejectRememberPlugin, 'test_remember_reject', api_ver=2, debug=True)
 class TestRememberRejected(object):
     config = """
         tasks:


### PR DESCRIPTION
### Motivation for changes:
Right now, it's hard or impossible to disable certain plugins like estimators or urlrewriters which don't get configured directly in a task.

### Detailed changes:
- Creates a new property on the task class called disabled_plugins. A new method, disable_plugin can be called to add to it.
- Adds a parameter to get_plugins, exclude, which can be used to easily get a list of plugins with task.disable_plugins being passed as the exclude argument.
- Just realized there was disable_urlrewriters plugin. Deprecated that in favor of this
- There is a bit of creep here because I realized plugins registered within the test functions were staying registered for every test. Added a new way to register plugins for specific tests using `pytest.mark.register_plugin(<args to flexget.plugin.register here>)`

TODO:
- [ ] Make this work for estimators
- [ ] Make it work for parsers
- [ ] Make it work for the movie_metainfo plugins?
