### PR TITLE
Fix possible TypeError when series_id is None

### DIFF
--- a/flexget/plugins/metainfo/media_id.py
+++ b/flexget/plugins/metainfo/media_id.py
@@ -51,7 +51,8 @@ class MetainfoMediaId(object):
                 series_id = (entry['series_season'], 0)
             elif entry.get('series_date'):
                 series_id = entry['series_date']
-            entry_id += ' ' + series_id
+            if series_id:
+                entry_id += ' ' + series_id
 
         if entry_id:
             entry_id = entry_id.strip().lower()


### PR DESCRIPTION
### Motivation for changes:
Fix possible TypeError when series_id is None

### Detailed changes:
If series_id is None: 
    TypeError: coercing to Unicode: need string or buffer, NoneType found
