### PR TITLE
Update `get_marker` to `get_closest_marker` to fix pytest

### DIFF
--- a/flexget/tests/conftest.py
+++ b/flexget/tests/conftest.py
@@ -189,10 +189,10 @@ def pytest_configure(config):
 
 def pytest_runtest_setup(item):
     # Add the filcopy fixture to any test marked with filecopy
-    if item.get_marker('filecopy'):
+    if item.get_closest_marker('filecopy'):
         item.fixturenames.append('filecopy')
     # Add the online marker to tests that will go online
-    if item.get_marker('online'):
+    if item.get_closest_marker('online'):
         item.fixturenames.append('use_vcr')
     else:
         item.fixturenames.append('no_requests')


### PR DESCRIPTION
### Motivation for changes:
Without this change the tests fail if pytest is up to date, because `get_marker` has been removed