### PR TITLE
[change] Allow sort_by plugin to sort on multiple fields

### DIFF
--- a/flexget/plugins/modify/sort_by.py
+++ b/flexget/plugins/modify/sort_by.py
@@ -7,6 +7,7 @@ import re
 from flexget import plugin
 from flexget.config_schema import one_or_more
 from flexget.event import event
+from flexget.utils.template import evaluate_expression
 
 
 log = logging.getLogger('sort_by')
@@ -78,7 +79,7 @@ class PluginSortBy(object):
             re_articles = RE_ARTICLES if ignore_articles is True else ignore_articles
 
             def sort_key(entry):
-                val = entry.get(field)
+                val = evaluate_expression(field, entry)
                 if isinstance(val, str) and re_articles:
                     val = re.sub(re_articles, '', val, flags=re.IGNORECASE)
                 # Sort None values last no matter whether reversed or not

--- a/flexget/plugins/modify/sort_by.py
+++ b/flexget/plugins/modify/sort_by.py
@@ -1,16 +1,18 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
-from past.builtins import basestring
 
 import logging
+import re
 
 from flexget import plugin
+from flexget.config_schema import one_or_more
 from flexget.event import event
-import re
+
 
 log = logging.getLogger('sort_by')
 
-RE_ARTICLES = '^(the|a|an)\s'
+RE_ARTICLES = r'^(the|a|an)\s'
+
 
 class PluginSortBy(object):
     """
@@ -32,7 +34,7 @@ class PluginSortBy(object):
         reverse: yes
     """
 
-    schema = {
+    schema = one_or_more({
         'oneOf': [
             {'type': 'string'},
             {
@@ -50,31 +52,39 @@ class PluginSortBy(object):
                 'additionalProperties': False
             }
         ]
-    }
+    })
 
     def on_task_filter(self, task, config):
-        if isinstance(config, str):
-            field = config
-            reverse = False
-            ignore_articles = False
-        else:
-            field = config.get('field', None)
-            reverse = config.get('reverse', False)
-            ignore_articles = config.get('ignore_articles', False)
+        if not isinstance(config, list):
+            config = [config]
+        # First item in the config list should be primary sort key, so iterate in reverse
+        for item in reversed(config):
+            if isinstance(item, str):
+                field = item
+                reverse = False
+                ignore_articles = False
+            else:
+                field = item.get('field', None)
+                reverse = item.get('reverse', False)
+                ignore_articles = item.get('ignore_articles', False)
 
-        log.debug('sorting entries by: %s' % config)
+            log.debug('sorting entries by: %s', item)
 
-        if not field:
-            task.all_entries.reverse()
-            return
-        
-        re_articles = ignore_articles if not isinstance(ignore_articles, bool) else RE_ARTICLES
+            if not field:
+                if reverse:
+                    task.all_entries.reverse()
+                continue
 
-        if ignore_articles:
-            task.all_entries.sort(key=lambda e: re.sub(re_articles, '', e.get(field, 0), flags=re.IGNORECASE),
-                                  reverse=reverse)
-        else:
-            task.all_entries.sort(key=lambda e: e.get(field, 0), reverse=reverse)
+            re_articles = RE_ARTICLES if ignore_articles is True else ignore_articles
+
+            def sort_key(entry):
+                val = entry.get(field)
+                if isinstance(val, str) and re_articles:
+                    val = re.sub(re_articles, '', val, flags=re.IGNORECASE)
+                # Sort None values last no matter whether reversed or not
+                return (val is not None) == reverse, val
+
+            task.all_entries.sort(key=sort_key, reverse=reverse)
 
 
 @event('plugin.register')

--- a/flexget/tests/test_sort_by.py
+++ b/flexget/tests/test_sort_by.py
@@ -87,6 +87,15 @@ class TestSortBy(object):
             - title: B
             - title: C
               maybe_field: 2
+          test_jinja_field:
+            sort_by: "dict_field.b"
+            mock:
+            - title: A
+              dict_field: {a: 0, b: 2}
+            - title: B
+              dict_field: {a: 1, b: 1}
+            - title: C
+              dict_field: {a: 2, b: 0}
     """
 
     def generate_test_ids(param):
@@ -120,7 +129,9 @@ class TestSortBy(object):
         ('test_missing_field',
             ['A', 'C', 'B'], 'Entries without field should be sorted last'),
         ('test_missing_field_reverse',
-            ['C', 'A', 'B'], 'Entries without field should be sorted last')
+            ['C', 'A', 'B'], 'Entries without field should be sorted last'),
+        ('test_jinja_field',
+            ['C', 'B', 'A'], 'Entries without field should be sorted last')
     ], ids=generate_test_ids)
     def test_sort_by(self, execute_task, task_name, result_titles, fail_reason):
         task = execute_task(task_name)

--- a/flexget/tests/test_sort_by.py
+++ b/flexget/tests/test_sort_by.py
@@ -55,6 +55,20 @@ class TestSortBy(object):
               - {title: 'Owl Looked Back Goes to College', url: 'http://localhost/5'}
               - {title: 'New Series 2', url: 'http://localhost/2'}
               - {title: 'An Owl Looked Back', url: 'http://localhost/4'}
+          test_multi_field:
+            sort_by:
+            - field: number1
+            - field: number2
+            mock:
+            - title: A
+              number1: 10
+              number2: 2
+            - title: B
+              number1: 1
+              number2: 15
+            - title: C
+              number1: 10
+              number2: 1
     """
 
     def generate_test_ids(param):
@@ -82,7 +96,9 @@ class TestSortBy(object):
         ('test_ignore_articles_custom',
             ['An Owl Looked Back', 'The Cat Who Looked Back', 'A New Series', 'New Series 2',
              'Owl Looked Back Goes to College'],
-            'Entries should be sorted ignoring articles `a` and `the`')
+            'Entries should be sorted ignoring articles `a` and `the`'),
+        ('test_multi_field',
+            ['B', 'C', 'A'], 'Entries should be sorted by both fields, ascending')
     ], ids=generate_test_ids)
     def test_sort_by(self, execute_task, task_name, result_titles, fail_reason):
         task = execute_task(task_name)

--- a/flexget/tests/test_sort_by.py
+++ b/flexget/tests/test_sort_by.py
@@ -69,6 +69,24 @@ class TestSortBy(object):
             - title: C
               number1: 10
               number2: 1
+          test_missing_field:
+            sort_by: maybe_field
+            mock:
+            - title: A
+              maybe_field: 1
+            - title: B
+            - title: C
+              maybe_field: 2
+          test_missing_field_reverse:
+            sort_by:
+              field: maybe_field
+              reverse: yes
+            mock:
+            - title: A
+              maybe_field: 1
+            - title: B
+            - title: C
+              maybe_field: 2
     """
 
     def generate_test_ids(param):
@@ -98,7 +116,11 @@ class TestSortBy(object):
              'Owl Looked Back Goes to College'],
             'Entries should be sorted ignoring articles `a` and `the`'),
         ('test_multi_field',
-            ['B', 'C', 'A'], 'Entries should be sorted by both fields, ascending')
+            ['B', 'C', 'A'], 'Entries should be sorted by both fields, ascending'),
+        ('test_missing_field',
+            ['A', 'C', 'B'], 'Entries without field should be sorted last'),
+        ('test_missing_field_reverse',
+            ['C', 'A', 'B'], 'Entries without field should be sorted last')
     ], ids=generate_test_ids)
     def test_sort_by(self, execute_task, task_name, result_titles, fail_reason):
         task = execute_task(task_name)


### PR DESCRIPTION
### Motivation for changes:
In preparation to remove internal sorting from series and discover plugins, allow sort_by plugin to sort on multiple fields.

### Detailed changes:
- Allows a new config format which is a list.
- Fixes wrong behavior of just 'reverse: no' config, which previously would reverse anyway when no field was specified.
- Allows sorting of fields where some entries are missing that field (or have a None value) they will always be sorted last in this case (no matter whether 'reverse' is specified)
- Allows use of jinja expressions for field name

### Config usage if relevant (new plugin or updated schema):
```yaml
sort_by:
- field1
- field2
- field: field3
  reverse: yes
- quality.resolution
- title|lower
```
#### To Do:

- [x] We could use a jinja expression for 'field' which would allow even more flexibility for entry fields that are not just strings or numbers. Not sure if that's warranted. e.g. `quality.resolution` to sort only on quality resolution, `series_parser.identifier`, or `some_dict_field['some_key']` 

