### PR TITLE
Remove internal sorting from series plugin

### DIFF
--- a/flexget/plugins/filter/series.py
+++ b/flexget/plugins/filter/series.py
@@ -1811,10 +1811,6 @@ class FilterSeries(FilterSeriesBase):
 
             reason = None
 
-            # sort entities in order of quality
-            entries.sort(key=lambda e: (e['quality'], e['series_parser'].episodes, e['series_parser'].proper_count),
-                         reverse=True)
-
             log.debug('start with entities: %s', [e['title'] for e in entries])
 
             season_packs = self.season_pack_opts(config.get('season_packs', False))

--- a/flexget/tests/test_reorder_quality.py
+++ b/flexget/tests/test_reorder_quality.py
@@ -16,16 +16,16 @@ class TestQualityPriority(object):
             reorder_quality:
               webrip:
                 above: hdtv
-            series:
-              - Some Show:
-                  identified_by: ep
+            sort_by:
+              field: quality
+              reverse: yes
           test_normal_quality_priority:
             mock:
               - {title: 'Some Show S01E02 WEBRip'}
               - {title: 'Some Show S01E02 HDTV'}
-            series:
-              - Some Show:
-                  identified_by: ep
+            sort_by:
+              field: quality
+              reverse: yes
           test_invalid_reorder_quality:
             reorder_quality:
               h264:
@@ -35,10 +35,10 @@ class TestQualityPriority(object):
     def test_reorder_quality(self, execute_task):
         task = execute_task('test_reorder_quality')
 
-        assert task.find_entry('accepted', title='Some Show S01E01 WEBRip'), 'WEBRip should have been accepted'
+        assert task.all_entries[0]['title'] == 'Some Show S01E01 WEBRip', 'WEBRip should have been accepted'
 
         task = execute_task('test_normal_quality_priority')
-        assert task.find_entry('accepted', title='Some Show S01E02 HDTV'), 'HDTV should have been accepted'
+        assert task.all_entries[0]['title'] == 'Some Show S01E02 HDTV', 'HDTV should have been accepted'
 
     def test_invalid_reorder_quality(self, execute_task):
         with pytest.raises(TaskAbort) as e:

--- a/flexget/tests/test_series.py
+++ b/flexget/tests/test_series.py
@@ -1,17 +1,14 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
-from datetime import datetime, timedelta
 from io import StringIO
 
 import pytest
 from jinja2 import Template
-from sqlalchemy.sql import select
 
 from flexget.entry import Entry
 from flexget.logger import capture_output
-from flexget.manager import Session, get_parser
-from flexget.plugins.filter.series import Series, SeriesTask, Episode, EpisodeRelease, Season, SeasonRelease
+from flexget.manager import get_parser
 from flexget.task import TaskAbort
 
 
@@ -298,7 +295,9 @@ class TestFilterSeries(object):
                 - name 2
             - paren title (US):
                 alternate_name: paren title 2013
-
+          test_input_order_preserved:
+            series:
+            - Some Show
     """
 
     def test_smoke(self, execute_task):
@@ -368,6 +367,18 @@ class TestFilterSeries(object):
     def test_alternate_name(self, execute_task):
         task = execute_task('test_alternate_name')
         assert all(e.accepted for e in task.all_entries), 'All releases should have matched a show'
+
+    @pytest.mark.parametrize('reverse', [False, True])
+    def test_input_order_preserved(self, manager, execute_task, reverse):
+        """If multiple versions of an episode are acceptable, make sure the first one is accepted."""
+        entries = [
+            Entry(title='Some Show S01E01 720p proper', url='http://a'),
+            Entry(title='Some Show S01E01 1080p', url='http://b')
+        ]
+        if reverse:
+            entries.reverse()
+        task = execute_task('test_input_order_preserved', options={'inject': entries})
+        assert task.accepted[0] == entries[0], 'first entry should have been accepted'
 
 
 class TestEpisodeAdvancement(object):
@@ -1776,13 +1787,6 @@ class TestDoubleEps(object):
               - title: double S01E03
             series:
               - double
-
-          test_double_prefered:
-            mock:
-              - title: double S02E03
-              - title: double S02E03-04
-            series:
-              - double
     """
 
     def test_double(self, execute_task):
@@ -1793,12 +1797,6 @@ class TestDoubleEps(object):
         # We already got ep 3 as part of double, should not be accepted
         task = execute_task('test_double2')
         assert not task.find_entry('accepted', title='double S01E03')
-
-    def test_double_prefered(self, execute_task):
-        # Given a choice of single or double ep at same quality, grab the double
-        task = execute_task('test_double_prefered')
-        assert task.find_entry('accepted', title='double S02E03-04')
-        assert not task.find_entry('accepted', title='S02E03')
 
 
 class TestAutoLockin(object):

--- a/flexget/tests/test_series.py
+++ b/flexget/tests/test_series.py
@@ -866,7 +866,6 @@ class TestDuplicates(object):
               - {title: 'Foo.Bar.S02E04.DSRIP.XviD-2HD[ASDF]'}
               - {title: 'Foo.Bar.S02E04.HDTV.1080p.XviD-2HD[ASDF]'}
               - {title: 'Foo.Bar.S02E03.HDTV.XviD-FlexGet'}
-              - {title: 'Foo.Bar.S02E05.HDTV.XviD-ZZZ'}
               - {title: 'Foo.Bar.S02E05.720p.HDTV.XviD-YYY'}
             series:
               - foo bar
@@ -978,7 +977,6 @@ class TestQualities(object):
               - title: FooBum.S03E01.720p-ver2 # Duplicate ep
           target_1:
             mock:
-              - title: Food.S06E11.sdtv
               - title: Food.S06E11.hdtv
           target_2:
             mock:
@@ -1277,7 +1275,6 @@ class TestTimeframe(object):
                     - 720p
 
             mock:
-              - {title: 'Q Test.S01E02.hdtv-FlexGet'}
               - {title: 'Q Test.S01E02.1080p-FlexGet'}
 
           test_with_quality_1:


### PR DESCRIPTION
### Motivation for changes:
The series plugin internal sorting means you are currently unable to prioritize certain entries when there are multiple in the task that are acceptable. Removing the internal sorting allows the user to use sort_by plugin to prioritize based on other criteria than best quality. e.g. Grab worst (acceptable) quality, grab from one tracker over another, from one input plugin over another.

This should wait for #2311, to allow duplication of current behavior.

#### To Do:

- [x] Figure out propers. The series plugin used to sort by proper count after quality, to make sure it grabbed a proper version over the nuked one. (because it will download the proper anyway on the next run)
- [x] Double (or any multi eps) were sorted first, in an attempt to make it grab the double rather than ending up getting a single ep and then getting a double-ep that contained that single ep. Not 100% sure if this really needs to be fixed or not. Result: Double eps are no longer preferred unless they are first in task.
- [x] Add a test to explicitly verify we are respecting incoming entry order.