### PR TITLE
Remove discover sorting

### DIFF
--- a/flexget/plugins/input/discover.py
+++ b/flexget/plugins/input/discover.py
@@ -118,8 +118,7 @@ class Discover(object):
                         continue
                     log.debug('Discovered %s entries from %s', len(search_results), plugin_name)
                     if config.get('limit'):
-                        search_results = sorted(search_results, reverse=True,
-                                                key=lambda x: x.get('search_sort', ''))[:config['limit']]
+                        search_results = search_results[:config['limit']]
                     for e in search_results:
                         e['discovered_from'] = entry['title']
                         e['discovered_with'] = plugin_name
@@ -138,7 +137,7 @@ class Discover(object):
                 continue
             result.extend(entry_results)
 
-        return sorted(result, reverse=True, key=lambda x: x.get('search_sort', -1))
+        return result
 
     def entry_complete(self, entry, query=None, search_results=None, **kwargs):
         """Callback for Entry"""

--- a/flexget/plugins/modify/urlrewrite_search.py
+++ b/flexget/plugins/modify/urlrewrite_search.py
@@ -65,7 +65,7 @@ class PluginSearch(object):
                         log.warning('Search plugin %s does not support latest search api.' % name)
                         results = plugins[name].search(entry, search_config)
                     matcher = SequenceMatcher(a=entry['title'])
-                    for result in sorted(results, key=lambda e: e.get('search_sort'), reverse=True):
+                    for result in results:
                         matcher.set_seq2(result['title'])
                         if matcher.ratio() > 0.9:
                             log.debug('Found url: %s', result['url'])

--- a/flexget/plugins/search_yts.py
+++ b/flexget/plugins/search_yts.py
@@ -52,7 +52,7 @@ class UrlRewriteYTS(object):
                             entry['torrent_seeds'] = torrent['seeds']
                             entry['torrent_leeches'] = torrent['peers']
                             entry['torrent_info_hash'] = torrent['hash']
-                            entry['search_sort'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
+                            entry['torrent_availability'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
                             entry['quality'] = torrent['quality']
                             entry['imdb_id'] = item['imdb_code']
                             if entry.isvalid():

--- a/flexget/plugins/sites/btn.py
+++ b/flexget/plugins/sites/btn.py
@@ -124,7 +124,7 @@ class SearchBTN(object):
                     entry['torrent_seeds'] = int(item['Seeders'])
                     entry['torrent_leeches'] = int(item['Leechers'])
                     entry['torrent_info_hash'] = item['InfoHash']
-                    entry['search_sort'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
+                    entry['torrent_availability'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
                     entry['btn_origin'] = item['Origin']
                     if item['TvdbID'] and int(item['TvdbID']):
                         entry['tvdb_id'] = int(item['TvdbID'])

--- a/flexget/plugins/sites/fuzer.py
+++ b/flexget/plugins/sites/fuzer.py
@@ -115,7 +115,7 @@ class UrlRewriteFuzer(object):
 
             e['torrent_seeds'] = seeders
             e['torrent_leeches'] = leechers
-            e['search_sort'] = torrent_availability(e['torrent_seeds'], e['torrent_leeches'])
+            e['torrent_availibility'] = torrent_availability(e['torrent_seeds'], e['torrent_leeches'])
 
             size = re.search('(\d+(?:[.,]\d+)*)\s?([KMGTP]B)', raw_size)
             e['content_size'] = parse_filesize(size.group(0))
@@ -162,7 +162,7 @@ class UrlRewriteFuzer(object):
                 text = quote_plus(query.encode('windows-1255'))
                 soup = self.get_fuzer_soup(text, c_list)
                 entries += self.extract_entry_from_soup(soup)
-        return sorted(entries, reverse=True, key=lambda x: x.get('search_sort')) if entries else []
+        return sorted(entries, reverse=True, key=lambda x: x.get('torrent_availability')) if entries else []
 
 
 @event('plugin.register')

--- a/flexget/plugins/sites/iptorrents.py
+++ b/flexget/plugins/sites/iptorrents.py
@@ -173,8 +173,8 @@ class UrlRewriteIPTorrents(object):
                 leechers = torrent.findNext('td', {'class': 'ac t_leechers'}).text
                 entry['torrent_seeds'] = int(seeders)
                 entry['torrent_leeches'] = int(leechers)
-                entry['search_sort'] = torrent_availability(entry['torrent_seeds'],
-                                                            entry['torrent_leeches'])
+                entry['torrent_availability'] = torrent_availability(entry['torrent_seeds'],
+                                                                     entry['torrent_leeches'])
 
                 size = torrent.findNext(text=re.compile('^([\.\d]+) ([GMK]?)B$'))
                 size = re.search('^([\.\d]+) ([GMK]?)B$', size)

--- a/flexget/plugins/sites/limetorrents.py
+++ b/flexget/plugins/sites/limetorrents.py
@@ -95,7 +95,7 @@ class Limetorrents(object):
                     e['title'] = title
                     e['torrent_seeds'] = seeds
                     e['torrent_leeches'] = leeches
-                    e['search_sort'] = torrent_availability(e['torrent_seeds'], e['torrent_leeches'])
+                    e['torrent_availability'] = torrent_availability(e['torrent_seeds'], e['torrent_leeches'])
                     e['content_size'] = size
 
                     entries.add(e)

--- a/flexget/plugins/sites/newtorrents.py
+++ b/flexget/plugins/sites/newtorrents.py
@@ -107,9 +107,9 @@ class NewTorrents(object):
 
             # TODO: also parse content_size and peers from results
             torrents.append(Entry(title=release_name, url=torrent_url, torrent_seeds=seed,
-                                  search_sort=torrent_availability(seed, 0)))
+                                  torrent_availability=torrent_availability(seed, 0)))
         # sort with seed number Reverse order
-        torrents.sort(reverse=True, key=lambda x: x.get('search_sort', 0))
+        torrents.sort(reverse=True, key=lambda x: x.get('torrent_availability', 0))
         # choose the torrent
         if not torrents:
             dashindex = name.rfind('-')

--- a/flexget/plugins/sites/nyaa.py
+++ b/flexget/plugins/sites/nyaa.py
@@ -97,7 +97,7 @@ class UrlRewriteNyaa(object):
                 entry['torrent_seeds'] = int(item.nyaa_seeders)
                 entry['torrent_leeches'] = int(item.nyaa_leechers)
                 entry['torrent_info_hash'] = item.nyaa_infohash
-                entry['search_sort'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
+                entry['torrent_availability'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
                 if item.nyaa_size:
                     entry['content_size'] = parse_filesize(item.nyaa_size)
 

--- a/flexget/plugins/sites/piratebay.py
+++ b/flexget/plugins/sites/piratebay.py
@@ -164,7 +164,7 @@ class UrlRewritePirateBay(object):
                 tds = link.parent.parent.parent.find_all('td')
                 entry['torrent_seeds'] = int(tds[-2].contents[0])
                 entry['torrent_leeches'] = int(tds[-1].contents[0])
-                entry['search_sort'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
+                entry['torrent_availability'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
                 # Parse content_size
                 size_text = link.find_next(attrs={'class': 'detDesc'}).get_text()
                 if size_text:

--- a/flexget/plugins/sites/ptn.py
+++ b/flexget/plugins/sites/ptn.py
@@ -83,7 +83,7 @@ class SearchPTN(object):
             entry['url'] = 'http://piratethenet.org' + dl_href
             entry['torrent_seeds'] = int(row.find(title='Number of Seeders').text)
             entry['torrent_leeches'] = int(row.find(title='Number of Leechers').text)
-            entry['search_sort'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
+            entry['torrent_availability'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
 
             entry['content_size'] = parse_filesize(str(row.find(title='Torrent size').text), si=False)
 

--- a/flexget/plugins/sites/site_1337x.py
+++ b/flexget/plugins/sites/site_1337x.py
@@ -122,7 +122,7 @@ class Site1337x(object):
                     e['title'] = title
                     e['torrent_seeds'] = seeds
                     e['torrent_leeches'] = leeches
-                    e['search_sort'] = torrent_availability(e['torrent_seeds'], e['torrent_leeches'])
+                    e['torrent_availability'] = torrent_availability(e['torrent_seeds'], e['torrent_leeches'])
                     e['content_size'] = size
 
                     entries.add(e)

--- a/flexget/plugins/sites/torrentday.py
+++ b/flexget/plugins/sites/torrentday.py
@@ -175,7 +175,7 @@ class UrlRewriteTorrentday(object):
                 leechers = tr.find('td', { 'class': 'ac leechersInfo'})
                 entry['torrent_seeds'] = int(seeders.contents[0].replace(',', ''))
                 entry['torrent_leeches'] = int(leechers.contents[0].replace(',', ''))
-                entry['search_sort'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
+                entry['torrent_availability'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
 
                 # use tr object for size
                 size = tr.find('td', text=re.compile('([\.\d]+) ([TGMKk]?)B')).contents[0]
@@ -185,7 +185,7 @@ class UrlRewriteTorrentday(object):
 
                 entries.add(entry)
 
-        return sorted(entries, reverse=True, key=lambda x: x.get('search_sort'))
+        return sorted(entries, reverse=True, key=lambda x: x.get('torrent_availability'))
 
 
 @event('plugin.register')

--- a/flexget/plugins/sites/torrentleech.py
+++ b/flexget/plugins/sites/torrentleech.py
@@ -156,11 +156,11 @@ class UrlRewriteTorrentleech(object):
                 # seeders/leechers
                 entry['torrent_seeds'] = torrent['seeders']
                 entry['torrent_leeches'] = torrent['leechers']
-                entry['search_sort'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
+                entry['torrent_availability'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
                 entry['content_size'] = parse_filesize(str(torrent['size']) + ' b')
                 entries.add(entry)
 
-        return sorted(entries, reverse=True, key=lambda x: x.get('search_sort'))
+        return sorted(entries, reverse=True, key=lambda x: x.get('torrent_availability'))
 
 
 @event('plugin.register')

--- a/flexget/plugins/sites/torrentz.py
+++ b/flexget/plugins/sites/torrentz.py
@@ -109,7 +109,7 @@ class Torrentz(object):
                 entry['torrent_seeds'] = int(m.group(2).replace(',', ''))
                 entry['torrent_leeches'] = int(m.group(3).replace(',', ''))
                 entry['torrent_info_hash'] = m.group(4).upper()
-                entry['search_sort'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
+                entry['torrent_availability'] = torrent_availability(entry['torrent_seeds'], entry['torrent_leeches'])
                 entries.add(entry)
 
         log.debug('Search got %d results' % len(entries))

--- a/flexget/tests/test_discover.py
+++ b/flexget/tests/test_discover.py
@@ -41,19 +41,6 @@ plugin.register(EstRelease, 'test_release', interfaces=['estimate_release'], api
 class TestDiscover(object):
     config = """
         tasks:
-          test_sort:
-            discover:
-              release_estimations: ignore
-              what:
-              - mock:
-                - title: Foo
-                  search_sort: 1
-                - title: Bar
-                  search_sort: 3
-                - title: Baz
-                  search_sort: 2
-              from:
-              - test_search: yes
           test_interval:
             discover:
               release_estimations: ignore
@@ -99,13 +86,6 @@ class TestDiscover(object):
             max_reruns: 3
 
     """
-
-    def test_sort(self, execute_task):
-        task = execute_task('test_sort')
-        assert len(task.entries) == 3
-        # Entries should be ordered by search_sort
-        order = list(e.get('search_sort') for e in task.entries)
-        assert order == sorted(order, reverse=True)
 
     def test_interval(self, execute_task, manager):
         task = execute_task('test_interval')


### PR DESCRIPTION
### Motivation for changes:
Stop overriding search order returned from search plugins with discover plugin.

This should probably be released alongside #2312 so the upgrade actions can be combined. #2311 should be released either before, or with this.

### Detailed changes:
- Discover plugin on longer does any sorting of entries.
- Search plugins that were filling search_sort field were all using torrent_availability as the metric. Change all those search plugins to provide that field directly, so user can sort by that if desired.
- Behavior of 'limit' option in discover plugin is now changed. Entry which urlrewrite_search returns may also change. See TODO below.

### Upgrade action needed:
To maintain same behavior of current release, the following can be added to tasks:
```
sort_by:
  field: torrent_availability
  reverse: true
```

### TODO:
- [ ] Many of the search plugins were sorting entries by torrent_availability before returning them. Should this be expanded to all the search plugins that provide it? That would maintain current behavior with regards to `limit` option in discover plugin, and which entry was chosen by urlrewrite_search.