### PR TITLE
GuessIt Parser -- Initialize a MatchesDict()

### DIFF
--- a/flexget/components/parsing/parsers/parser_guessit.py
+++ b/flexget/components/parsing/parsers/parser_guessit.py
@@ -227,7 +227,7 @@ class ParserGuessit(object):
             guess_result = guessit_api.guessit(native(data), options=guessit_options)
         except GuessitException:
             log.warning('Parsing %s with guessit failed. Most likely a unicode error.', data)
-            guess_result = {}
+            guess_result = MatchesDict()
 
         if guess_result.get('type') != 'episode':
             valid = False
@@ -240,7 +240,7 @@ class ParserGuessit(object):
                 valid = False
             elif country and hasattr(country, 'alpha2'):
                 name += ' (%s)' % country.alpha2
-        elif isinstance(guess_result, MatchesDict) and guess_result.matches['title']:
+        elif guess_result.matches['title']:
             # Make sure the name match is up to FlexGet standards
             # Check there is no unmatched cruft before the matched name
             title_start = guess_result.matches['title'][0].start

--- a/flexget/components/parsing/parsers/parser_guessit.py
+++ b/flexget/components/parsing/parsers/parser_guessit.py
@@ -227,7 +227,7 @@ class ParserGuessit(object):
             guess_result = guessit_api.guessit(native(data), options=guessit_options)
         except GuessitException:
             log.warning('Parsing %s with guessit failed. Most likely a unicode error.', data)
-            guess_result = MatchesDict()
+            return SeriesParseResult(data=data, valid=False)
 
         if guess_result.get('type') != 'episode':
             valid = False


### PR DESCRIPTION
### Motivation for changes:
I didn't read and the previous pull only fixed the first level of issues.

### Detailed changes:
- Instead of checking if its a special kind of dictionary, initialize as a MatchesDict and it works like magic. Passes the tests too. 
