### PR TITLE
requirements.in: min version of path.py is 10.6

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ jinja2~=2.10
 requests>=2.20.0
 python-dateutil
 jsonschema>=2.0
-path.py>=8.1.1
+path.py>=10.6
 pathlib>=1.0; python_version<'3.4'
 guessit==3.0.3
 rebulk>=0.9.0


### PR DESCRIPTION
### Motivation for changes:
If system has path.py <10.6 installed, Flexget will fail at runtime.

### Detailed changes:
- Increase version of path.py dependency to 10.6
.stem property that Flexget uses was added to path.py in v10.6
https://github.com/jaraco/path.py/blob/3684c4dc4896c174852b901b033e021a6267df2e/CHANGES.rst#106

I tested with v10.4 (failure) and with v11.5 (success).
