### PR TITLE
output rss plugin: add and document options, emit enclosures, default encoding to UTF-8

### DIFF
--- a/flexget/plugins/output/rss.py
+++ b/flexget/plugins/output/rss.py
@@ -95,15 +95,18 @@ class OutputRSS(object):
 
     Generate RSS that will contain last 50 items, regardless of dates.
 
-    RSS location link:
+    RSS feed properties:
 
-    You can specify the url location of the rss file.
+    You can specify the URL, title, and description to include in tthe header
+    of the RSS feed.
 
     Example::
 
       make_rss:
         file: ~/public_html/series.rss
         rsslink: http://my.server.net/series.rss
+        rsstitle: The Flexget RSS Feed
+        rssdesc: Episodes about Flexget.
 
     **RSS item title and link**
 
@@ -140,6 +143,8 @@ class OutputRSS(object):
                     'history': {'type': 'boolean'},
                     'timestamp': {'type': 'boolean'},
                     'rsslink': {'type': 'string'},
+                    'rsstitle': {'type': 'string'},
+                    'rssdesc': {'type': 'string'},
                     'encoding': {'type': 'string'},  # TODO: only valid choices
                     'title': {'type': 'string'},
                     'template': {'type': 'string'},
@@ -250,9 +255,9 @@ class OutputRSS(object):
                 task.session.delete(db_item)
 
         # make rss
-        rss = PyRSS2Gen.RSS2(title='FlexGet',
+        rss = PyRSS2Gen.RSS2(title=config.get('rsstitle', 'FlexGet'),
                              link=config.get('rsslink', 'http://flexget.com'),
-                             description='FlexGet generated RSS feed',
+                             description=config.get('rssdesc', 'FlexGet generated RSS feed'),
                              lastBuildDate=datetime.datetime.utcnow() if config['timestamp'] else None,
                              items=rss_items)
 

--- a/flexget/plugins/output/rss.py
+++ b/flexget/plugins/output/rss.py
@@ -105,22 +105,27 @@ class OutputRSS(object):
         file: ~/public_html/series.rss
         rsslink: http://my.server.net/series.rss
 
-    **RSS link**
+    **RSS item title and link**
 
-    You can specify what field from entry is used as a link in generated rss feed.
+    You can specify the title and link for each item in the RSS feed.
+
+    The item title can be any pattern that references fields in the input entry.
+
+    The item link can be created from one of a list of fields in the input
+    entry, in order of preference. The fields should be enumerated in a list.
+    Note that the url field is always used as last possible fallback even
+    without explicitly adding it into the list.
+
+    Default field list for item URL: imdb_url, input_url, url
 
     Example::
 
       make_rss:
         file: ~/public_html/series.rss
+        title: '{{title}} (from {{task}})'
         link:
           - imdb_url
 
-    List should contain a list of fields in order of preference.
-    Note that the url field is always used as last possible fallback
-    even without explicitly adding it into the list.
-
-    Default list: imdb_url, input_url, url
     """
 
     schema = {

--- a/flexget/plugins/output/rss.py
+++ b/flexget/plugins/output/rss.py
@@ -133,6 +133,7 @@ class OutputRSS(object):
                     'days': {'type': 'integer'},
                     'items': {'type': 'integer'},
                     'history': {'type': 'boolean'},
+                    'timestamp': {'type': 'boolean'},
                     'rsslink': {'type': 'string'},
                     'encoding': {'type': 'string'},  # TODO: only valid choices
                     'title': {'type': 'string'},
@@ -156,6 +157,7 @@ class OutputRSS(object):
         config.setdefault('items', -1)
         config.setdefault('history', True)
         config.setdefault('encoding', 'iso-8859-1')
+        config.setdefault('timestamp', False)
         config.setdefault('link', ['imdb_url', 'input_url'])
         config.setdefault('title', '{{title}} (from {{task}})')
         config.setdefault('template', 'rss')
@@ -246,7 +248,7 @@ class OutputRSS(object):
         rss = PyRSS2Gen.RSS2(title='FlexGet',
                              link=config.get('rsslink', 'http://flexget.com'),
                              description='FlexGet generated RSS feed',
-                             lastBuildDate=datetime.datetime.utcnow(),
+                             lastBuildDate=datetime.datetime.utcnow() if config['timestamp'] else None,
                              items=rss_items)
 
         # don't run with --test

--- a/flexget/plugins/output/rss.py
+++ b/flexget/plugins/output/rss.py
@@ -168,7 +168,7 @@ class OutputRSS(object):
         config.setdefault('days', 7)
         config.setdefault('items', -1)
         config.setdefault('history', True)
-        config.setdefault('encoding', 'iso-8859-1')
+        config.setdefault('encoding', 'UTF-8')
         config.setdefault('timestamp', False)
         config.setdefault('link', ['imdb_url', 'input_url'])
         config.setdefault('title', '{{title}} (from {{task}})')

--- a/flexget/plugins/output/rss.py
+++ b/flexget/plugins/output/rss.py
@@ -210,6 +210,8 @@ class OutputRSS(object):
                 log.error('Error while rendering entry %s, falling back to plain title: %s', entry, e)
                 rss.description = entry['title'] + ' - (Render Error)'
             rss.file = config['file']
+            if 'rss_pubdate' in entry:
+                rss.published = entry['rss_pubdate']
 
             # TODO: check if this exists and suggest disabling history if it does since it shouldn't happen normally ...
             log.debug('Saving %s into rss database', entry['title'])


### PR DESCRIPTION
### Motivation for changes:
Features and improvements to the RSS output plugin.

### Detailed changes:
- Document the title option for entry titles
- Add rsstitle and rssdesc (to complement rsslink) options to set RSS feed properties
- Emit "enclosure" tags along with the entries for podcast apps to work
- Make timestamping optional (and default to no) to not change the file unnecessarily
- Take published date from input entry when available
- Change the default encoding to UTF-8 because Python strings are UTF-8 by default and the XML generator does not do any transcoding, so with current default encoding, the generated XML is invalid (unless the user transcodes to this default encoding or switches the encoding to the non-default UTF-8).

### Addressed issues:
- Encoding issue (see above)

### Config usage if relevant (new plugin or updated schema):
```
make_rss:
   rsslink: http://example.com
   rsstitle: Feed from Flexget
   timestamp: yes
```
### Log and/or tests output (preferably both):
```
<?xml version="1.0" encoding="UTF-8"?>
<rss version="2.0"><channel><title>The Flexget RSS Feed</title>
<link>http://my.server.net/series.rss</link>
<description>Episodes about Flexget.</description>
<generator>PyRSS2Gen-1.1.0</generator>
<docs>http://blogs.law.harvard.edu/tech/rss</docs>
```
