### PR TITLE
Standardize from_deluge fields

### DIFF
--- a/flexget/plugins/clients/deluge.py
+++ b/flexget/plugins/clients/deluge.py
@@ -132,6 +132,7 @@ class InputDeluge(DelugePlugin):
 
     def on_task_input(self, task, config):
         """Generates and returns a list of entries from the deluge daemon."""
+        config = self.prepare_config(config)
         # Reset the entries list
         client = self.setup_client(config)
         client.connect()

--- a/flexget/plugins/clients/deluge.py
+++ b/flexget/plugins/clients/deluge.py
@@ -146,7 +146,7 @@ class InputDeluge(DelugePlugin):
         torrents = client.call('core.get_torrents_status', filter or {}, [])
         for hash, torrent_dict in torrents.items():
             # Make sure it has a url so no plugins crash
-            entry = Entry(url='')
+            entry = Entry(deluge_id=hash, url='')
             config_path = os.path.expanduser(config.get('config_path', ''))
             if config_path:
                 torrent_path = os.path.join(config_path, 'state', hash + '.torrent')


### PR DESCRIPTION
### Motivation for changes:
from_deluge plugin provides only a subset of fields from deluge, some come standard, some have to be specifically requested in config. Also, some come with a different name than deluge uses, and some come with some value manipulation from the raw deluge value.

### Detailed changes:
- Provide every field, as-is from deluge as entry fields with the format `deluge_<deluge_field_name>`
- Still does some processing/renaming for a few other fields outside of deluge_ namespace which we have a 'standard' for:
  - torrent_info_hash
  - torrent_peers
  - torrent_seeds
  - content_size
  - content_files
- Removes the 'keys' option from from_deluge config

### Addressed issues:
- Fixes #2257

### Config updates needed
- Time based fields from deluge were previously provided in hours, they are now provided in seconds
- Several fields will now have a new name, and fields provided may be different depending on deluge version and plugins enabled. Best bet is to run a test and see provided fields which can be used: `flexget --test execute --task my_from_deluge_task --dump`

### TODO
- [x] Test this
- [x] Maybe add deluge_id field back in. Deluge output plugin was using this to know if a given entry originated from deluge, and therefore did not need to be re-downloaded.
