### PR TITLE
Eliminate rpc timeout. Remove --timeout option

### DIFF
--- a/flexget/ipc.py
+++ b/flexget/ipc.py
@@ -160,7 +160,7 @@ class IPCServer(threading.Thread):
 
 
 class IPCClient(object):
-    def __init__(self, port, password, sync_request_timeout=300):
+    def __init__(self, port, password):
         channel = rpyc.Channel(rpyc.SocketStream.connect('127.0.0.1', port))
         channel.send(password.encode('utf-8'))
         response = channel.recv()
@@ -168,7 +168,7 @@ class IPCClient(object):
             # TODO: What to raise here. I guess we create a custom error
             raise ValueError('Invalid password for daemon')
         self.conn = rpyc.utils.factory.connect_channel(
-            channel, service=ClientService, config={'sync_request_timeout': sync_request_timeout})
+            channel, service=ClientService, config={'sync_request_timeout': None})
 
     def close(self):
         self.conn.close()

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -339,7 +339,7 @@ class Manager(object):
             console('There is a FlexGet process already running for this config, sending execution there.')
             log.debug('Sending command to running FlexGet process: %s' % self.args)
             try:
-                client = IPCClient(ipc_info['port'], ipc_info['password'], sync_request_timeout=self.options.timeout)
+                client = IPCClient(ipc_info['port'], ipc_info['password'])
             except ValueError as e:
                 log.error(e)
             else:

--- a/flexget/options.py
+++ b/flexget/options.py
@@ -406,7 +406,6 @@ manager_parser.add_argument('--ipc-port', type=int, help=SUPPRESS)
 manager_parser.add_argument('--cron', action=CronAction, default=False, nargs=0,
                             help='use when executing FlexGet non-interactively: allows background '
                                  'maintenance to run, disables stdout and stderr output, reduces logging level')
-manager_parser.add_argument('--timeout', default=300, help='number of seconds to run before timing out', type=int)
 
 
 class CoreArgumentParser(ArgumentParser):


### PR DESCRIPTION
### Motivation for changes:
The timeout on rpc connections put a hard limit on how long a cli client would stay connected to the daemon. It would abort streaming the results back after this timeout was reached (regardless of activity.)

The user should not need to specify --timeout parameter for long running client sessions. The --timeout name was also very non-intuitive as to what it did, how was one to know this was the length of time you would stay connected to daemon?

### Detailed changes:
- Removes --timeout parameter from CLI
- CLI client connections to daemon may last as long as needed.

### Addressed issues:
- Fixes #2319
