### PR TITLE
deluge: add ability to remove/pause/resume torrents

### DIFF
--- a/flexget/plugins/clients/deluge.py
+++ b/flexget/plugins/clients/deluge.py
@@ -467,9 +467,9 @@ class OutputDeluge(DelugePlugin):
             if config['action'] in ('remove', 'purge'):
                 client.call('core.remove_torrent', torrent_id, config['action'] == 'purge')
             elif config['action'] == 'pause':
-                client.call('core.pause_torrent', torrent_id)
+                client.call('core.pause_torrent', [torrent_id])
             elif config['action'] == 'resume':
-                client.call('core.resume_torrent', torrent_id)
+                client.call('core.resume_torrent', [torrent_id])
 
         client.disconnect()
 

--- a/flexget/plugins/clients/deluge.py
+++ b/flexget/plugins/clients/deluge.py
@@ -310,8 +310,13 @@ class OutputDeluge(DelugePlugin):
         if 'download' not in task.config:
             download = plugin.get('download', self)
             for entry in task.accepted:
-                if not entry.get('deluge_id'):
-                    download.get_temp_file(task, entry, handle_magnets=True)
+                if entry.get('deluge_id'):
+                    # The torrent is already loaded in deluge, we don't need to get anything
+                    continue
+                if config['action'] != 'add' and entry.get('torrent_info_hash'):
+                    # If we aren't adding the torrent new, all we need is info hash
+                    continue
+                download.get_temp_file(task, entry, handle_magnets=True)
 
     @plugin.priority(135)
     def on_task_output(self, task, config):


### PR DESCRIPTION
### Motivation for changes:
Allow the ability to control torrents already loaded into deluge. Actions other than 'add' would (mostly) be used in a task with from_deluge as the input. This will be more useful once #2325 is merged so that all deluge fields are available and consistent for filtering on.

### Detailed changes:
- Adds 'action' option to deluge plugin
- Adds underscores to all deluge options with multiple words

### Config usage if relevant (new plugin or updated schema):
```
deluge:
  action: <add|remove|purge|pause|resume>
```

#### To Do:

- [x] Test it
- [x] Consider the downloading of torrent files. May need to be tweaked when this happens based on which action is selected.