### PR TITLE
Fix NoneType on self.requests. Add support to https url.

### DIFF
--- a/flexget/components/sites/sites/descargas2020.py
+++ b/flexget/components/sites/sites/descargas2020.py
@@ -32,7 +32,7 @@ class UrlRewriteDescargas2020(object):
     # urlrewriter API
     def url_rewritable(self, task, entry):
         url = entry['url']
-        rewritable_regex = r'^http:\/\/(www.)?(descargas2020|tvsinpagar|tumejortorrent|torrentlocura|torrentrapid).com\/.*'
+        rewritable_regex = r'^(http|https):\/\/(www.)?(descargas2020|tvsinpagar|tumejortorrent|torrentlocura|torrentrapid).com\/.*'
         return re.match(rewritable_regex, url) and not url.endswith('.torrent')
 
     def session(self):
@@ -52,6 +52,9 @@ class UrlRewriteDescargas2020(object):
     @plugin.internet(log)
     def parse_download_page(self, url, task):
         log.verbose('Descargas2020 URL: %s', url)
+
+        if not self.requests:
+            self.requests = Session()
 
         try:
             page = self.requests.get(url)


### PR DESCRIPTION
### Motivation for changes:
- https urls are not currently supported
- self.requests in `parse_download_page` should never be `None`

### Detailed changes:
- Changed regexp to accept both http and https url
- Update `self.requests` with value from `Session()`. This property when used in `parse_download_page` should never be `None`

### Addressed issues:
- Fixes # .

### Implemented feature requests:
- Feathub #[XX](https://feathub.com/Flexget/Flexget/+XX).

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
```
paste output here
```
#### To Do:

- [ ] Stuff..

