### PR TITLE
Allow `set` plugin can now set entry fields to types other than str

### DIFF
--- a/flexget/entry.py
+++ b/flexget/entry.py
@@ -284,11 +284,12 @@ class Entry(LazyDict):
                 continue
             self[field] = v
 
-    def render(self, template):
+    def render(self, template, native=False):
         """
         Renders a template string based on fields in the entry.
 
         :param template: A template string or FlexGetTemplate that uses jinja2 or python string replacement format.
+        :param native: If True, and the rendering result can be all native python types, not just strings.
         :return: The result of the rendering.
         :rtype: string
         :raises RenderError: If there is a problem.
@@ -299,7 +300,7 @@ class Entry(LazyDict):
                 % repr(template)
             )
         log.trace('rendering: %s', template)
-        return render_from_entry(template, self)
+        return render_from_entry(template, self, native=native)
 
     def __eq__(self, other):
         return self.get('original_title') == other.get('original_title') and self.get(

--- a/flexget/plugins/modify/set_field.py
+++ b/flexget/plugins/modify/set_field.py
@@ -1,13 +1,12 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
-from past.builtins import basestring
 
 import logging
 from functools import partial
 
 from flexget import plugin
 from flexget.event import event
-from flexget.utils.template import RenderError, FlexGetNativeTemplate
+from flexget.utils.template import RenderError
 
 log = logging.getLogger('set')
 
@@ -34,7 +33,7 @@ class ModifySet(object):
         """This can be called from a plugin to add set values to an entry"""
         for field in config:
             # If this doesn't appear to be a jinja template, just set it right away.
-            if not isinstance(config[field], basestring) or '{' not in config[field]:
+            if not isinstance(config[field], str) or '{' not in config[field]:
                 entry[field] = config[field]
             # Store original values before overwriting with a lazy field, so that set directives can reference
             # themselves.
@@ -53,7 +52,7 @@ class ModifySet(object):
         if orig_field_value is not UNSET:
             entry[field] = orig_field_value
         try:
-            entry[field] = entry.render(FlexGetNativeTemplate(config[field]))
+            entry[field] = entry.render(config[field], native=True)
         except RenderError as e:
             logger('Could not set %s for %s: %s' % (field, entry['title'], e))
 

--- a/flexget/plugins/modify/set_field.py
+++ b/flexget/plugins/modify/set_field.py
@@ -7,7 +7,7 @@ from functools import partial
 
 from flexget import plugin
 from flexget.event import event
-from flexget.utils.template import RenderError
+from flexget.utils.template import RenderError, FlexGetNativeTemplate
 
 log = logging.getLogger('set')
 
@@ -53,7 +53,7 @@ class ModifySet(object):
         if orig_field_value is not UNSET:
             entry[field] = orig_field_value
         try:
-            entry[field] = entry.render(config[field])
+            entry[field] = entry.render(FlexGetNativeTemplate(config[field]))
         except RenderError as e:
             logger('Could not set %s for %s: %s' % (field, entry['title'], e))
 

--- a/flexget/tests/test_misc.py
+++ b/flexget/tests/test_misc.py
@@ -268,7 +268,7 @@ class TestSetPlugin(object):
         task = execute_task('test_jinja')
         entry = task.find_entry('entries', title='Entry 1')
         assert entry['field'] == 'The VALUE'
-        assert entry['otherfield'] == ''
+        assert not entry['otherfield']
         assert entry['alu'] == 'alu'
         entry = task.find_entry('entries', title='Entry 2')
         assert entry['field'] is None, '`field` should be None when jinja rendering fails'

--- a/flexget/tests/test_misc.py
+++ b/flexget/tests/test_misc.py
@@ -256,6 +256,11 @@ class TestSetPlugin(object):
             set:
               title: "{{ao"
               other: "{{eaeou}"
+          test_native_types:
+            mock:
+            - title: Entry 1
+            set:
+              int_field: "{{3}}"
     """
 
     def test_set(self, execute_task):
@@ -293,3 +298,9 @@ class TestSetPlugin(object):
             entry['title'] == 'Entry 1'
         ), 'should fall back to original value when template fails'
         assert entry['other'] is None
+
+    def test_native_types(self, execute_task):
+        task = execute_task('test_native_types')
+        entry = task.find_entry('entries', title='Entry 1')
+        assert (isinstance(entry['int_field'], int)), 'should allow setting values as integers rather than strings'
+        assert entry['int_field'] == 3

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals, division, absolute_import
 from future.utils import text_to_native_str
 from flexget.utils.tools import native_str_to_text
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
-from past.builtins import basestring
 
 import logging
 import os
@@ -73,7 +72,7 @@ def filter_re_replace(val, pattern, repl):
 
 def filter_re_search(val, pattern):
     """Perform a search for given regexp pattern, return the matching portion of the text."""
-    if not isinstance(val, basestring):
+    if not isinstance(val, str):
         return val
     result = re.search(pattern, val, re.IGNORECASE)
     if result:
@@ -215,17 +214,21 @@ def get_template(template_name, scope='task'):
         raise ValueError(err)
 
 
-def render(template, context):
+def render(template, context, native=False):
     """
     Renders a Template with `context` as its context.
 
     :param template: Template or template string to render.
     :param context: Context to render the template from.
+    :param native: If True, and the rendering result can be all native python types, not just strings.
     :return: The rendered template text.
     """
-    if isinstance(template, basestring):
+    if isinstance(template, str):
+        template_class = None
+        if native:
+            template_class = FlexGetNativeTemplate
         try:
-            template = environment.from_string(template)
+            template = environment.from_string(template, template_class=template_class)
         except TemplateSyntaxError as e:
             raise RenderError('Error in template syntax: ' + e.message)
     try:
@@ -238,7 +241,7 @@ def render(template, context):
     return result
 
 
-def render_from_entry(template_string, entry):
+def render_from_entry(template_string, entry, native=False):
     """Renders a Template or template string with an Entry as its context."""
 
     # Make a copy of the Entry so we can add some more fields
@@ -251,7 +254,7 @@ def render_from_entry(template_string, entry):
         # Since `task` has different meaning between entry and task scope, the `task_name` field is create to be
         # consistent
         variables['task_name'] = entry.task.name
-    return render(template_string, variables)
+    return render(template_string, variables, native=native)
 
 
 def render_from_task(template, task):

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -22,6 +22,7 @@ from jinja2 import (
     TemplateNotFound,
     TemplateSyntaxError,
 )
+from jinja2.nativetypes import NativeTemplate
 from dateutil import parser as dateutil_parse
 
 from flexget.event import event
@@ -140,7 +141,6 @@ def filter_default(value, default_value='', boolean=True):
 filter_d = filter_default
 
 
-# TODO: In Jinja 2.8 we will be able to override the Context class to be used explicitly
 class FlexGetTemplate(Template):
     """Adds lazy lookup support when rendering templates."""
 
@@ -148,6 +148,11 @@ class FlexGetTemplate(Template):
         context = super(FlexGetTemplate, self).new_context(vars, shared, locals)
         context.parent = LazyDict(context.parent)
         return context
+
+
+class FlexGetNativeTemplate(FlexGetTemplate, NativeTemplate):
+    """Lazy lookup support and native python return types."""
+    pass
 
 
 @event('manager.initialize')


### PR DESCRIPTION
### Motivation for changes:
If you want to manipulate a number field it is not currently possible.

### Detailed changes:
- If set plugin templates evaluate to a type other than string, the type is not cast to a string.

### Addressed issues:
- https://discuss.flexget.com/t/content-size-for-magnet-links-from-xml-feed/4572

### Config usage if relevant (new plugin or updated schema):
```
set:
  some_field: {{some_int_field/2}}
```
#### To Do:

- [x] Should a 'native' parameter be added to the Entry.render method rather than constructing the NativeTemplate in set plugin?

