### PR TITLE
Add case_sensitive to Crossmatch

### DIFF
--- a/flexget/plugins/filter/crossmatch.py
+++ b/flexget/plugins/filter/crossmatch.py
@@ -85,12 +85,14 @@ class CrossMatch(object):
                 log.trace('field %s is not in both entries', field)
                 continue
 
-            if case_sensitive:
-                v1 = e1[field]
-                v2 = e2[field]
-            else:
+            if not case_sensitive and isinstance(e1[field], str):
                 v1 = e1[field].lower()
+            else:
+                v1 = e1[field]
+            if not case_sensitive and isinstance(e1[field], str):
                 v2 = e2[field].lower()
+            else:
+                v2 = e2[field]
 
             try:
                 if v1 == v2 or not exact and (v2 in v1 or v1 in v2):

--- a/flexget/plugins/filter/crossmatch.py
+++ b/flexget/plugins/filter/crossmatch.py
@@ -23,6 +23,7 @@ class CrossMatch(object):
           - title
         action: reject
         exact: yes
+        case_sensitive: yes
     """
 
     schema = {
@@ -33,6 +34,7 @@ class CrossMatch(object):
             'from': {'type': 'array', 'items': {'$ref': '/schema/plugins?phase=input'}},
             'exact': {'type': 'boolean', 'default': True},
             'all_fields': {'type': 'boolean', 'default': False},
+            'case_sensitive': {'type': 'boolean', 'default': True}
         },
         'required': ['fields', 'action', 'from'],
         'additionalProperties': False,
@@ -50,7 +52,7 @@ class CrossMatch(object):
         for entry in task.entries:
             for generated_entry in match_entries:
                 log.trace('checking if %s matches %s', entry['title'], generated_entry['title'])
-                common = self.entry_intersects(entry, generated_entry, fields, config.get('exact'))
+                common = self.entry_intersects(entry, generated_entry, fields, config.get('exact'), config.get('case_sensitive'))
                 if common and (not all_fields or len(common) == len(fields)):
                     msg = 'intersects with %s on field(s) %s' % (
                         generated_entry['title'],
@@ -64,7 +66,7 @@ class CrossMatch(object):
                     if action == 'accept':
                         entry.accept(msg)
 
-    def entry_intersects(self, e1, e2, fields=None, exact=True):
+    def entry_intersects(self, e1, e2, fields=None, exact=True, case_sensitive=True):
         """
         :param e1: First :class:`flexget.entry.Entry`
         :param e2: Second :class:`flexget.entry.Entry`
@@ -83,8 +85,12 @@ class CrossMatch(object):
                 log.trace('field %s is not in both entries', field)
                 continue
 
-            v1 = e1[field]
-            v2 = e2[field]
+            if case_sensitive:
+                v1 = e1[field]
+                v2 = e2[field]
+            else:
+                v1 = e1[field].lower()
+                v2 = e2[field].lower()
 
             try:
                 if v1 == v2 or not exact and (v2 in v1 or v1 in v2):


### PR DESCRIPTION
### Motivation for changes:
- Currently the crossmatch comparison is always case sensitive.  This will add the ability to do a case insensitive comparison with crossmatch

### Detailed changes:
- Add case_sensitive to config schema - default to yes to maintain backward compatibility 
- Add case_sensitive parameter to entry_intersects function
- Add conditional to convert strings to lower case

### Addressed issues:
- N/A

### Implemented feature requests:
- Feathub #[74](https://feathub.com/Flexget/Flexget/+74).

### Config usage if relevant (new plugin or updated schema):
```
    crossmatch:
      case_sensitive: no
```
### Log and/or tests output (preferably both):
```
flexget@vm1:/media/main/flexget$ flexget -c config.new.yml  --test execute
2019-03-27 23:06 INFO     manager                       Test mode, creating a copy from database ...
2019-03-27 23:06 INFO     manager                       Test database created
2019-03-27 23:06 VERBOSE  task_queue                    There are 1 tasks to execute. Shutdown will commence when they have completed.
2019-03-27 23:06 VERBOSE  html          ********       Requesting: http://********.***/
2019-03-27 23:06 VERBOSE  html          ********       Response: 200 (OK)
2019-03-27 23:06 VERBOSE  details       ********       Produced 30 entries.
2019-03-27 23:06 VERBOSE  task          ********       REJECTED: `*****************************************` by regexp plugin because regexp '**' matched field 'title'
2019-03-27 23:06 VERBOSE  task          ********       REJECTED: `****************************************************` by regexp plugin because regexp '**' matched field 'title'
2019-03-27 23:06 VERBOSE  details       ********       Summary - Accepted: 0 (Rejected: 2 Undecided: 28 Failed: 0)
2019-03-27 23:06 INFO     manager                       Removed test database
flexget@vm1:/media/main/flexget$ nano config.new.yml
flexget@vm1:/media/main/flexget$ flexget -c config.new.yml  --test execute
2019-03-27 23:06 INFO     manager                       Test mode, creating a copy from database ...
2019-03-27 23:06 INFO     manager                       Test database created
2019-03-27 23:06 VERBOSE  task_queue                    There are 1 tasks to execute. Shutdown will commence when they have completed.
2019-03-27 23:06 VERBOSE  html          ********       Requesting: http://********.***/
2019-03-27 23:06 VERBOSE  html          ********       Response: 200 (OK)
2019-03-27 23:06 VERBOSE  details       ********       Produced 30 entries.
2019-03-27 23:06 VERBOSE  task          ********       REJECTED: `*****************************************` by regexp plugin because regexp '**' matched field 'title'
2019-03-27 23:06 VERBOSE  task          ********       REJECTED: `****************************************************` by regexp plugin because regexp '**' matched field 'title'
2019-03-27 23:06 VERBOSE  task          ********       ACCEPTED: `****************************************` by crossmatch plugin because intersects with *********** on field(s) title
2019-03-27 23:06 VERBOSE  task          ********       ACCEPTED: `******************** The Wings Of War ******` by crossmatch plugin because intersects with The Wings of War on field(s) title
2019-03-27 23:06 INFO     download      ********       Would download: ****************************************
2019-03-27 23:06 INFO     download      ********       Would download: ********************************************
2019-03-27 23:06 VERBOSE  details       ********       Summary - Accepted: 2 (Rejected: 2 Undecided: 26 Failed: 0)
2019-03-27 23:06 INFO     manager                       Removed test database

```


