### PR TITLE
Remove obsolete mirror from rutracker

### DIFF
--- a/flexget/components/sites/sites/rutracker.py
+++ b/flexget/components/sites/sites/rutracker.py
@@ -25,7 +25,7 @@ __author__ = 'asm0dey'
 log = logging.getLogger('rutracker_auth')
 Base = versioned_base('rutracker_auth', 0)
 
-MIRRORS = ['https://rutracker.cr', 'https://rutracker.net', 'https://rutracker.org']
+MIRRORS = ['https://rutracker.net', 'https://rutracker.org']
 
 
 class JSONEncodedDict(TypeDecorator):


### PR DESCRIPTION
### Motivation for changes:

The rutracker.cr domain isn't a mirror of Rutracker anymore

### Detailed changes:
- Removed rutracker.cr from mirrors list for rutracker

### Addressed issues:
- Fixes #2358