### PR TITLE
[add] types to kitsu input

### DIFF
--- a/flexget/plugins/input/kitsu.py
+++ b/flexget/plugins/input/kitsu.py
@@ -24,6 +24,9 @@ class KitsuAnime(object):
       lists:
         - <current|planned|completed|on_hold|dropped>
         - <current|planned|completed|on_hold|dropped>
+      type:
+        - <ona|ova|tv|movie|music|special>
+        - <ona|ova|tv|movie|music|special>
       status: <airing|finished>
       latest: <yes|no>
     """
@@ -36,6 +39,12 @@ class KitsuAnime(object):
                 {
                     'type': 'string',
                     'enum': ['current', 'planned', 'completed', 'on_hold', 'dropped'],
+                }
+            ),
+            'type': one_or_more(
+                {
+                    'type': 'string',
+                    'enum': ['ona', 'ova', 'tv', 'movie', 'music', 'special'],
                 }
             ),
             'latest': {'type': 'boolean', 'default': False},
@@ -100,6 +109,12 @@ class KitsuAnime(object):
                     if status == 'finished' and anime['attributes']['endDate'] is None:
                         continue
 
+                types = config.get('type')
+                if types is not None:
+                    subType = anime['attributes']['subtype']
+                    if subType is None or not subType.lower() in types:
+                        continue
+                    
                 entry = Entry()
                 entry['title'] = anime['attributes']['canonicalTitle']
                 titles_en = anime['attributes']['titles'].get('en')


### PR DESCRIPTION
### Motivation for changes:
Kitsu input doesn't support the types from the API, so if someone needs to add the series in one list and the movies in another one are pretty hard, this adds the `type` option similar to `my_anime_list` input.

### Detailed changes:
- Adds `type` option to filter the results

### Documentation of Options:
- Types strings[]: 
  - type.ona "ONA"
  - type.ova "OVA"
  - type.TV "TV"
  - type.movie "movie"
  - type.music "music"
  - type.special "special"