### PR TITLE
Remove '...' from text in sites.utils.normalize_scene()

### DIFF
--- a/flexget/components/sites/utils.py
+++ b/flexget/components/sites/utils.py
@@ -29,8 +29,9 @@ def normalize_scene(text):
     #     ABCDEFGHIJKLMNOPQRSTUVWXYZ
     #     abcdefghijklmnopqrstuvwxyz
     #     0123456789-._()
+    text = normalize('NFKD', text).encode('ASCII', 'ignore').decode()
     return re.sub(
-        r'[^a-zA-Z0-9 \-._()]', '', normalize('NFKD', text).encode('ASCII', 'ignore').decode()
+        r'[^a-zA-Z0-9 \-._()]', '', text.replace('...', '')
     )
 
 


### PR DESCRIPTION
### Motivation for changes:
Currently it's not possible to find show `Travel Man: 48 Hours In...` using discovery+rarbg, because of the ending dots. I'm not sure where is better to strip them, so I've decided to do it globally in `NextSeriesEpisodes` plugin.

### Detailed changes:
- if the show name contains `...` — the title without them would be added to `search_strings`