### PR TITLE
Replace cfscrape by cloudscraper

### DIFF
--- a/flexget/plugins/operate/cfscraper.py
+++ b/flexget/plugins/operate/cfscraper.py
@@ -23,16 +23,16 @@ class CFScraper(object):
     @plugin.priority(253)
     def on_task_start(self, task, config):
         try:
-            import cfscrape
+            import cloudscraper
         except ImportError as e:
-            log.debug('Error importing cfscrape: %s' % e)
+            log.debug('Error importing cloudscraper: %s' % e)
             raise plugin.DependencyError(
-                'cfscraper', 'cfscrape', 'cfscrape module required. ImportError: %s' % e
+                'cfscraper', 'cloudscraper', 'cloudscraper module required. ImportError: %s' % e
             )
 
-        class CFScrapeWrapper(Session, cfscrape.CloudflareScraper):
+        class CFScrapeWrapper(Session, cloudscraper.CloudScraper):
             """
-            This class allows the FlexGet session to inherit from CFScraper instead of the requests.Session directly.
+            This class allows the FlexGet session to inherit from CloudScraper instead of the requests.Session directly.
             """
 
         if config is True:


### PR DESCRIPTION
### Motivation for changes:
cfscrape status is unclear. Latest changes to Cloudflare [have not been integrated](https://github.com/Anorov/cloudflare-scrape/pull/206#issuecomment-487772381) breaking cfscrape.
[Cloudscraper](https://github.com/VeNoMouS/cloudscraper) is the recommended up to date alternative and works with latest Cloudflare changes

### Config usage if relevant (new plugin or updated schema):
Transparent for the user (except the dependency change of course).

