### PR TITLE
Do not request more pages than required in trakt_list

### DIFF
--- a/flexget/components/trakt/trakt_list.py
+++ b/flexget/components/trakt/trakt_list.py
@@ -179,7 +179,7 @@ class TraktSet(MutableSet):
         return self._find_entry(entry) is not None
 
     def clear(self):
-        if self.items:
+        if self._items:
             for item in self.items:
                 self.discard(item)
             self._items = None

--- a/flexget/components/trakt/trakt_list.py
+++ b/flexget/components/trakt/trakt_list.py
@@ -118,7 +118,7 @@ class TraktSet(MutableSet):
             },
             'strip_dates': {'type': 'boolean', 'default': False},
             'language': {'type': 'string', 'minLength': 2, 'maxLength': 2},
-            'limit': {'type': 'integer', 'default': 0},
+            'limit': {'type': 'integer'},
         },
         'required': ['list'],
         'anyOf': [
@@ -134,6 +134,8 @@ class TraktSet(MutableSet):
     def __init__(self, config):
         if config.get('list') in ['popular', 'trending']:
             config.setdefault('limit', 1000)
+        else:
+            config.setdefault('limit', 0)
         self.config = config
         if self.config.get('account') and not self.config.get('username'):
             self.config['username'] = 'me'

--- a/flexget/components/trakt/trakt_list.py
+++ b/flexget/components/trakt/trakt_list.py
@@ -132,6 +132,8 @@ class TraktSet(MutableSet):
     }
 
     def __init__(self, config):
+        if config.get('list') in ['popular', 'trending']:
+            config.setdefault('limit', 1000)
         self.config = config
         if self.config.get('account') and not self.config.get('username'):
             self.config['username'] = 'me'

--- a/flexget/components/trakt/trakt_list.py
+++ b/flexget/components/trakt/trakt_list.py
@@ -193,145 +193,137 @@ class TraktSet(MutableSet):
                     '`type` cannot be `auto` for %s list.' % self.config['list']
                 )
 
+            limit_per_page = 1000
+
             endpoint = self.get_list_endpoint()
+
+            entries = []
+            list_type = (self.config['type']).rstrip('s')
 
             log.verbose('Retrieving `%s` list `%s`', self.config['type'], self.config['list'])
             try:
-                result = self.session.get(db.get_api_url(endpoint))
-                try:
-                    data = result.json()
-                except ValueError:
-                    log.debug('Could not decode json from response: %s', result.text)
-                    raise plugin.PluginError('Error getting list from trakt.')
-
-                current_page = int(result.headers.get('X-Pagination-Page', 1))
-                current_page_count = int(result.headers.get('X-Pagination-Page-Count', 1))
-                if current_page < current_page_count:
-                    # Pagination, gotta get it all, but we'll limit it to 1000 per page
-                    # but we'll have to start over from 0
-                    data = []
-
-                    limit = 1000
-                    pagination_item_count = int(result.headers.get('X-Pagination-Item-Count', 0))
-                    number_of_pages = math.ceil(pagination_item_count / limit)
-                    log.debug(
-                        'Response is paginated. Number of items: %s, number of pages: %s',
-                        pagination_item_count,
-                        number_of_pages,
+                page = 1
+                number_of_pages = 1
+                collecting_finished = False
+                while not collecting_finished:
+                    result = self.session.get(
+                        db.get_api_url(endpoint), params={'limit': limit_per_page, 'page': page}
                     )
-                    page = int(result.headers.get('X-Pagination-Page'))
-                    while page <= number_of_pages:
-                        paginated_result = self.session.get(
-                            db.get_api_url(endpoint), params={'limit': limit, 'page': page}
+                    page = int(result.headers.get('X-Pagination-Page', 1))
+                    number_of_pages = int(result.headers.get('X-Pagination-Page-Count', 1))
+
+                    collecting_finished = page >= number_of_pages
+
+                    trakt_items = []
+                    try:
+                        trakt_items = result.json()
+                    except ValueError:
+                        log.debug(
+                            'Could not decode json from response: %s', result.text
                         )
-                        page += 1
-                        try:
-                            data.extend(paginated_result.json())
-                        except ValueError:
+                        raise plugin.PluginError('Error getting list from trakt.')
+
+                    page += 1
+
+                    for item in trakt_items:
+                        if self.config['type'] == 'auto':
+                            list_type = item['type']
+                        if self.config['list'] == 'popular':
+                            item = {list_type: item}
+                        # Collection and watched lists don't return 'type' along with the items (right now)
+                        if 'type' in item and item['type'] != list_type:
                             log.debug(
-                                'Could not decode json from response: %s', paginated_result.text
+                                'Skipping %s because it is not a %s',
+                                item[item['type']].get('title', 'unknown'),
+                                list_type,
                             )
-                            raise plugin.PluginError('Error getting list from trakt.')
+                            continue
+                        if list_type != 'episode' and not item[list_type]['title']:
+                            # Skip shows/movies with no title
+                            log.warning('Item in trakt list does not appear to have a title, skipping.')
+                            continue
+                        entry = Entry()
+                        if list_type == 'episode':
+                            entry['url'] = 'https://trakt.tv/shows/%s/seasons/%s/episodes/%s' % (
+                                item['show']['ids']['slug'],
+                                item['episode']['season'],
+                                item['episode']['number'],
+                            )
+                        else:
+                            entry['url'] = 'https://trakt.tv/%ss/%s' % (
+                                list_type,
+                                item[list_type]['ids'].get('slug'),
+                            )
+
+                        entry.update_using_map(field_maps[list_type], item)
+
+                        # get movie name translation
+                        language = self.config.get('language')
+                        if list_type == 'movie' and language:
+                            endpoint = ['movies', entry['trakt_movie_id'], 'translations', language]
+                            try:
+                                result = self.session.get(db.get_api_url(endpoint))
+                                try:
+                                    translation = result.json()
+                                except ValueError:
+                                    raise plugin.PluginError(
+                                        'Error decoding movie translation from trakt: %s.' % result.text
+                                    )
+                            except RequestException as e:
+                                raise plugin.PluginError(
+                                    'Could not retrieve movie translation from trakt: %s' % str(e)
+                                )
+                            if not translation:
+                                log.warning(
+                                    'No translation data returned from trakt for movie %s.', entry['title']
+                                )
+                            else:
+                                log.verbose(
+                                    'Found `%s` translation for movie `%s`: %s',
+                                    language,
+                                    entry['movie_name'],
+                                    translation[0]['title'],
+                                )
+                                entry['title'] = translation[0]['title']
+                                if entry.get('movie_year'):
+                                    entry['title'] += ' (' + str(entry['movie_year']) + ')'
+                                entry['movie_name'] = translation[0]['title']
+
+                        # Override the title if strip_dates is on. TODO: a better way?
+                        if self.config.get('strip_dates'):
+                            if list_type in ['show', 'movie']:
+                                entry['title'] = item[list_type]['title']
+                            elif list_type == 'episode':
+                                entry[
+                                    'title'
+                                ] = '{show[title]} S{episode[season]:02}E{episode[number]:02}'.format(
+                                    **item
+                                )
+                                if item['episode']['title']:
+                                    entry['title'] += ' {episode[title]}'.format(**item)
+                        if entry.isvalid():
+                            if self.config.get('strip_dates'):
+                                # Remove year from end of name if present
+                                entry['title'] = split_title_year(entry['title'])[0]
+                            entries.append(entry)
+
+                        else:
+                            log.debug('Invalid entry created? %s', entry)
+
+                        if self.config.get('limit') and len(entries) >= self.config.get('limit'):
+                            collecting_finished = True
+                            break
 
             except RequestException as e:
                 raise plugin.PluginError('Could not retrieve list from trakt (%s)' % e)
 
-            if not data:
+            if not entries:
                 log.warning(
                     'No data returned from trakt for %s list %s.',
                     self.config['type'],
                     self.config['list'],
                 )
                 return []
-
-            entries = []
-            list_type = (self.config['type']).rstrip('s')
-            for item in data:
-                if self.config['type'] == 'auto':
-                    list_type = item['type']
-                if self.config['list'] == 'popular':
-                    item = {list_type: item}
-                # Collection and watched lists don't return 'type' along with the items (right now)
-                if 'type' in item and item['type'] != list_type:
-                    log.debug(
-                        'Skipping %s because it is not a %s',
-                        item[item['type']].get('title', 'unknown'),
-                        list_type,
-                    )
-                    continue
-                if list_type != 'episode' and not item[list_type]['title']:
-                    # Skip shows/movies with no title
-                    log.warning('Item in trakt list does not appear to have a title, skipping.')
-                    continue
-                entry = Entry()
-                if list_type == 'episode':
-                    entry['url'] = 'https://trakt.tv/shows/%s/seasons/%s/episodes/%s' % (
-                        item['show']['ids']['slug'],
-                        item['episode']['season'],
-                        item['episode']['number'],
-                    )
-                else:
-                    entry['url'] = 'https://trakt.tv/%ss/%s' % (
-                        list_type,
-                        item[list_type]['ids'].get('slug'),
-                    )
-
-                entry.update_using_map(field_maps[list_type], item)
-
-                # get movie name translation
-                language = self.config.get('language')
-                if list_type == 'movie' and language:
-                    endpoint = ['movies', entry['trakt_movie_id'], 'translations', language]
-                    try:
-                        result = self.session.get(db.get_api_url(endpoint))
-                        try:
-                            translation = result.json()
-                        except ValueError:
-                            raise plugin.PluginError(
-                                'Error decoding movie translation from trakt: %s.' % result.text
-                            )
-                    except RequestException as e:
-                        raise plugin.PluginError(
-                            'Could not retrieve movie translation from trakt: %s' % str(e)
-                        )
-                    if not translation:
-                        log.warning(
-                            'No translation data returned from trakt for movie %s.', entry['title']
-                        )
-                    else:
-                        log.verbose(
-                            'Found `%s` translation for movie `%s`: %s',
-                            language,
-                            entry['movie_name'],
-                            translation[0]['title'],
-                        )
-                        entry['title'] = translation[0]['title']
-                        if entry.get('movie_year'):
-                            entry['title'] += ' (' + str(entry['movie_year']) + ')'
-                        entry['movie_name'] = translation[0]['title']
-
-                # Override the title if strip_dates is on. TODO: a better way?
-                if self.config.get('strip_dates'):
-                    if list_type in ['show', 'movie']:
-                        entry['title'] = item[list_type]['title']
-                    elif list_type == 'episode':
-                        entry[
-                            'title'
-                        ] = '{show[title]} S{episode[season]:02}E{episode[number]:02}'.format(
-                            **item
-                        )
-                        if item['episode']['title']:
-                            entry['title'] += ' {episode[title]}'.format(**item)
-                if entry.isvalid():
-                    if self.config.get('strip_dates'):
-                        # Remove year from end of name if present
-                        entry['title'] = split_title_year(entry['title'])[0]
-                    entries.append(entry)
-
-                    if self.config.get('limit') and len(entries) >= self.config.get('limit'):
-                        break
-                else:
-                    log.debug('Invalid entry created? %s', entry)
 
             self._items = entries
         return self._items

--- a/flexget/tests/cassettes/test_trakt.TestTraktList.test_trakt_movies
+++ b/flexget/tests/cassettes/test_trakt.TestTraktList.test_trakt_movies
@@ -6,7 +6,7 @@ interactions:
       trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
       trakt-api-version: ['2']
     method: GET
-    uri: https://api.trakt.tv/users/flexgettest/watchlist/movies
+    uri: https://api.trakt.tv/users/flexgettest/watchlist/movies?limit=1000&page=1
   response:
     body: {string: '[{"rank":1,"listed_at":"2015-01-02T02:37:24.000Z","type":"movie","movie":{"title":"12
         Angry Men","year":1957,"ids":{"trakt":309,"slug":"12-angry-men-1957","imdb":"tt0050083","tmdb":389}}}]'}

--- a/flexget/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_show_collected_progress
+++ b/flexget/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_show_collected_progress
@@ -6,7 +6,7 @@ interactions:
       trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
       trakt-api-version: ['2']
     method: GET
-    uri: https://api.trakt.tv/users/flexgettest/lists/test/items
+    uri: https://api.trakt.tv/users/flexgettest/lists/test/items?limit=1000&page=1
   response:
     body: {string: '[{"rank":1,"listed_at":"2016-03-08T21:36:36.000Z","type":"show","show":{"title":"White
         Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}},{"rank":2,"listed_at":"2016-03-08T21:36:50.000Z","type":"show","show":{"title":"Chuck","year":2007,"ids":{"trakt":1395,"slug":"chuck","tvdb":80348,"imdb":"tt0934814","tmdb":1404,"tvrage":15614}}}]'}

--- a/flexget/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_show_watched_progress
+++ b/flexget/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_show_watched_progress
@@ -6,7 +6,7 @@ interactions:
       trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
       trakt-api-version: ['2']
     method: GET
-    uri: https://api.trakt.tv/users/flexgettest/lists/test/items
+    uri: https://api.trakt.tv/users/flexgettest/lists/test/items?limit=1000&page=1
   response:
     body: {string: '[{"rank":1,"listed_at":"2016-03-08T21:36:36.000Z","type":"show","show":{"title":"White
         Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}},{"rank":2,"listed_at":"2016-03-08T21:36:50.000Z","type":"show","show":{"title":"Chuck","year":2007,"ids":{"trakt":1395,"slug":"chuck","tvdb":80348,"imdb":"tt0934814","tmdb":1404,"tvrage":15614}}}]'}

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_get_list
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_get_list
@@ -7,7 +7,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/users/me/lists/testlist/items
+      uri: https://api.trakt.tv/users/me/lists/testlist/items?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":90056369,"listed_at":"2016-04-06T01:08:39.000Z","type":"show","show":{"title":"The
           Walking Dead","year":2010,"ids":{"trakt":1393,"slug":"the-walking-dead","tvdb":153021,"imdb":"tt1520211","tmdb":1402,"tvrage":25056}}},{"rank":2,"id":90056392,"listed_at":"2016-04-06T01:08:56.000Z","type":"movie","movie":{"title":"Deadpool","year":2016,"ids":{"trakt":190430,"slug":"deadpool-2016","imdb":"tt1431045","tmdb":293660}}},{"rank":3,"id":90056410,"listed_at":"2016-04-06T01:09:11.000Z","type":"episode","episode":{"season":8,"number":15,"title":"Fidelis

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_strip_dates
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_strip_dates
@@ -7,7 +7,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/users/me/lists/testlist/items
+      uri: https://api.trakt.tv/users/me/lists/testlist/items?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":90056369,"listed_at":"2016-04-06T01:08:39.000Z","type":"show","show":{"title":"The
           Walking Dead","year":2010,"ids":{"trakt":1393,"slug":"the-walking-dead","tvdb":153021,"imdb":"tt1520211","tmdb":1402,"tvrage":25056}}},{"rank":2,"id":90056392,"listed_at":"2016-04-06T01:08:56.000Z","type":"movie","movie":{"title":"Deadpool","year":2016,"ids":{"trakt":190430,"slug":"deadpool-2016","imdb":"tt1431045","tmdb":293660}}},{"rank":3,"id":90056410,"listed_at":"2016-04-06T01:09:11.000Z","type":"episode","episode":{"season":8,"number":15,"title":"Fidelis

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add
@@ -7,7 +7,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/shows
+      uri: https://api.trakt.tv/sync/watchlist/shows?limit=1000&page=1
     response:
       body: {string: '[]'}
       headers:
@@ -41,7 +41,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/shows
+      uri: https://api.trakt.tv/sync/watchlist/shows?limit=1000&page=1
     response:
       body: {string: '[]'}
       headers:
@@ -103,7 +103,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/shows
+      uri: https://api.trakt.tv/sync/watchlist/shows?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371589379,"listed_at":"2018-12-29T06:50:57.000Z","type":"show","show":{"title":"White
           Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}}]'}

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add
@@ -4,39 +4,6 @@ interactions:
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Type: [application/json]
-        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
-        trakt-api-version: ['2']
-      method: GET
-      uri: https://api.trakt.tv/sync/watchlist/shows?limit=1000&page=1
-    response:
-      body: {string: '[]'}
-      headers:
-        CF-RAY: [490a54b99b263d3d-CPH]
-        Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [8adeccbc16 99.99 0.029608 0030 57da]
-        Connection: [keep-alive]
-        Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:50:10 GMT']
-        Etag: [W/"4424072e99830138d0df9ea8ea2b71ec"]
-        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:22:36 GMT']
-        Server: [cloudflare]
-        Set-Cookie: ['__cfduid=df6cfde95df30cc35afff5871be2b4b1d1546066210; expires=Sun,
-            29-Dec-19 06:50:10 GMT; path=/; domain=.trakt.tv; HttpOnly']
-        Vary: [Accept-Encoding]
-        X-Content-Type-Options: [nosniff]
-        X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [fb04717c-c817-4527-9803-37403d853041]
-        X-Runtime: ['0.018469']
-        X-Sort-By: [rank]
-        X-Sort-How: [asc]
-        X-Xss-Protection: [1; mode=block]
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
-        Content-Type: [application/json]
         Cookie: [__cfduid=df6cfde95df30cc35afff5871be2b4b1d1546066210]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode
@@ -7,7 +7,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes
+      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371586023,"listed_at":"2018-12-29T06:22:33.000Z","type":"episode","episode":{"season":1,"number":5,"title":"Chapter
           Five: The Flea and the Acrobat","ids":{"trakt":2124182,"tvdb":5621929,"imdb":"tt4593128","tmdb":1205904,"tvrage":1065933149}},"show":{"title":"Stranger
@@ -109,7 +109,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes
+      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
     response:
       body: {string: '[]'}
       headers:
@@ -173,7 +173,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes
+      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371589391,"listed_at":"2018-12-29T06:50:37.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
           of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode
@@ -1,42 +1,5 @@
 interactions:
   - request:
-      body: null
-      headers:
-        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
-        Content-Type: [application/json]
-        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
-        trakt-api-version: ['2']
-      method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
-    response:
-      body: {string: '[{"rank":1,"id":371586023,"listed_at":"2018-12-29T06:22:33.000Z","type":"episode","episode":{"season":1,"number":5,"title":"Chapter
-          Five: The Flea and the Acrobat","ids":{"trakt":2124182,"tvdb":5621929,"imdb":"tt4593128","tmdb":1205904,"tvrage":1065933149}},"show":{"title":"Stranger
-          Things","year":2016,"ids":{"trakt":104439,"slug":"stranger-things","tvdb":305288,"imdb":"tt4574334","tmdb":66732,"tvrage":48493}}},{"rank":2,"id":371586024,"listed_at":"2018-12-29T06:22:33.000Z","type":"episode","episode":{"season":1,"number":6,"title":"Chapter
-          Six: The Monster","ids":{"trakt":2124184,"tvdb":5621930,"imdb":"tt4593132","tmdb":1205905,"tvrage":1065933150}},"show":{"title":"Stranger
-          Things","year":2016,"ids":{"trakt":104439,"slug":"stranger-things","tvdb":305288,"imdb":"tt4574334","tmdb":66732,"tvrage":48493}}}]'}
-      headers:
-        CF-RAY: [490a55161be23d49-CPH]
-        Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [f66211c825 99.99 0.031221 0030 57da]
-        Connection: [keep-alive]
-        Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:50:25 GMT']
-        Etag: [W/"3a636032b8adb3487e7a4e1977f5436f"]
-        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:22:33 GMT']
-        Server: [cloudflare]
-        Set-Cookie: ['__cfduid=d71718ada61310dc70242aaac8e6013361546066225; expires=Sun,
-            29-Dec-19 06:50:25 GMT; path=/; domain=.trakt.tv; HttpOnly']
-        Vary: [Accept-Encoding]
-        X-Content-Type-Options: [nosniff]
-        X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [941bcf82-58db-4ad0-a4ac-e693a2c84da8]
-        X-Runtime: ['0.020077']
-        X-Sort-By: [rank]
-        X-Sort-How: [asc]
-        X-Xss-Protection: [1; mode=block]
-      status: {code: 200, message: OK}
-  - request:
       body: '{"shows": [{"seasons": [{"number": 1, "episodes": [{"number": 5}]}],
         "title": "Stranger Things", "ids": {"trakt": 104439, "tvrage": 48493, "imdb":
         "tt4574334", "tvdb": 305288}, "year": 2016}]}'

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_simple
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_simple
@@ -7,7 +7,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes
+      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371589391,"listed_at":"2018-12-29T06:50:37.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
           of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
@@ -75,7 +75,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes
+      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
     response:
       body: {string: '[]'}
       headers:
@@ -138,7 +138,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes
+      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371589397,"listed_at":"2018-12-29T06:51:09.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
           of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_simple
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_simple
@@ -1,40 +1,5 @@
 interactions:
   - request:
-      body: null
-      headers:
-        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
-        Content-Type: [application/json]
-        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
-        trakt-api-version: ['2']
-      method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
-    response:
-      body: {string: '[{"rank":1,"id":371589391,"listed_at":"2018-12-29T06:50:37.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
-          of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
-          of Thrones","year":2011,"ids":{"trakt":1390,"slug":"game-of-thrones","tvdb":121361,"imdb":"tt0944947","tmdb":1399,"tvrage":24493}}}]'}
-      headers:
-        CF-RAY: [490a557888433d01-CPH]
-        Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [1af5c26562 1.45 0.028909 0030 57da]
-        Connection: [keep-alive]
-        Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:50:41 GMT']
-        Etag: [W/"9da3e90234f93b5f7cd3fde8ccd0a042"]
-        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:50:37 GMT']
-        Server: [cloudflare]
-        Set-Cookie: ['__cfduid=dc8d32cf3445894e466e5bcbb98b00e591546066241; expires=Sun,
-            29-Dec-19 06:50:41 GMT; path=/; domain=.trakt.tv; HttpOnly']
-        Vary: [Accept-Encoding]
-        X-Content-Type-Options: [nosniff]
-        X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [02673565-39dd-44b7-9fd3-a6a0f46b36d2]
-        X-Runtime: ['0.024268']
-        X-Sort-By: [rank]
-        X-Sort-How: [asc]
-        X-Xss-Protection: [1; mode=block]
-      status: {code: 200, message: OK}
-  - request:
       body: '{"shows": [{"year": 2011, "seasons": [{"number": 4, "episodes": [{"number":
         5}]}], "ids": {"imdb": "tt0944947", "tvdb": 121361, "trakt": 1390, "tvrage":
         24493}, "title": "Game of Thrones"}]}'

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_task
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_task
@@ -7,7 +7,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes
+      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371589397,"listed_at":"2018-12-29T06:51:09.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
           of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
@@ -107,7 +107,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes
+      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371589401,"listed_at":"2018-12-29T06:51:03.000Z","type":"episode","episode":{"season":1,"number":5,"title":"Chapter
           Five: The Flea and the Acrobat","ids":{"trakt":2124182,"tvdb":5621929,"imdb":"tt4593128","tmdb":1205904,"tvrage":1065933149}},"show":{"title":"Stranger

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_task
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_task
@@ -1,40 +1,5 @@
 interactions:
   - request:
-      body: null
-      headers:
-        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
-        Content-Type: [application/json]
-        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
-        trakt-api-version: ['2']
-      method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
-    response:
-      body: {string: '[{"rank":1,"id":371589397,"listed_at":"2018-12-29T06:51:09.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
-          of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
-          of Thrones","year":2011,"ids":{"trakt":1390,"slug":"game-of-thrones","tvdb":121361,"imdb":"tt0944947","tmdb":1399,"tvrage":24493}}}]'}
-      headers:
-        CF-RAY: [490a55d8ae9f3d07-CPH]
-        Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [544b1da8d3 1.44 0.033414 0030 57da]
-        Connection: [keep-alive]
-        Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:50:56 GMT']
-        Etag: [W/"6b2bfcc4d121ea7fd3c3476977803c6b"]
-        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:51:09 GMT']
-        Server: [cloudflare]
-        Set-Cookie: ['__cfduid=d31b2ebe16023a27f5b4cf2a89ddef78a1546066256; expires=Sun,
-            29-Dec-19 06:50:56 GMT; path=/; domain=.trakt.tv; HttpOnly']
-        Vary: [Accept-Encoding]
-        X-Content-Type-Options: [nosniff]
-        X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [19b98b59-2ccc-4b7d-b834-179f1c485de9]
-        X-Runtime: ['0.030775']
-        X-Sort-By: [rank]
-        X-Sort-How: [asc]
-        X-Xss-Protection: [1; mode=block]
-      status: {code: 200, message: OK}
-  - request:
       body: '{"shows": [{"year": 2011, "seasons": [{"episodes": [{"number": 5}], "number":
         4}], "title": "Game of Thrones", "ids": {"imdb": "tt0944947", "trakt": 1390,
         "tvdb": 121361, "tvrage": 24493}}]}'

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_remove
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_remove
@@ -7,7 +7,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/shows
+      uri: https://api.trakt.tv/sync/watchlist/shows?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371589379,"listed_at":"2018-12-29T06:50:57.000Z","type":"show","show":{"title":"White
           Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}}]'}
@@ -73,7 +73,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/shows
+      uri: https://api.trakt.tv/sync/watchlist/shows?limit=1000&page=1
     response:
       body: {string: '[]'}
       headers:
@@ -135,7 +135,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/shows
+      uri: https://api.trakt.tv/sync/watchlist/shows?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371589410,"listed_at":"2018-12-29T06:51:12.000Z","type":"show","show":{"title":"White
           Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}}]'}
@@ -198,7 +198,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/shows
+      uri: https://api.trakt.tv/sync/watchlist/shows?limit=1000&page=1
     response:
       body: {string: '[]'}
       headers:

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_remove
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_remove
@@ -1,39 +1,5 @@
 interactions:
   - request:
-      body: null
-      headers:
-        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
-        Content-Type: [application/json]
-        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
-        trakt-api-version: ['2']
-      method: GET
-      uri: https://api.trakt.tv/sync/watchlist/shows?limit=1000&page=1
-    response:
-      body: {string: '[{"rank":1,"id":371589379,"listed_at":"2018-12-29T06:50:57.000Z","type":"show","show":{"title":"White
-          Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}}]'}
-      headers:
-        CF-RAY: [490a561dab7c3d49-CPH]
-        Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [3d8e294756 2.05 0.020890 0030 57da]
-        Connection: [keep-alive]
-        Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:51:07 GMT']
-        Etag: [W/"f43e8c8c125db97c38bf93c228dfea27"]
-        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:50:57 GMT']
-        Server: [cloudflare]
-        Set-Cookie: ['__cfduid=d4ec0b278e20fe58622a0ac7cd1e2dd4a1546066267; expires=Sun,
-            29-Dec-19 06:51:07 GMT; path=/; domain=.trakt.tv; HttpOnly']
-        Vary: [Accept-Encoding]
-        X-Content-Type-Options: [nosniff]
-        X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [40fcb3ee-4afa-4722-b829-9aac0b9f1ce9]
-        X-Runtime: ['0.017451']
-        X-Sort-By: [rank]
-        X-Sort-How: [asc]
-        X-Xss-Protection: [1; mode=block]
-      status: {code: 200, message: OK}
-  - request:
       body: '{"shows": [{"ids": {"tvrage": 20720, "imdb": "tt1358522", "trakt": 21410,
         "tmdb": 21510, "tvdb": 108611}, "year": 2009, "title": "White Collar"}]}'
       headers:

--- a/flexget/tests/test_trakt_list_interface.py
+++ b/flexget/tests/test_trakt_list_interface.py
@@ -138,7 +138,6 @@ class TestTraktList(object):
         assert entry not in trakt_set
 
         trakt_set.add(entry)
-        time.sleep(5)
         assert entry in trakt_set
 
     def test_trakt_add_episode(self):
@@ -223,11 +222,9 @@ class TestTraktList(object):
         assert entry not in trakt_set
 
         trakt_set.add(entry)
-        time.sleep(5)
         assert entry in trakt_set
 
         trakt_set.remove(entry)
-        time.sleep(5)
         assert entry not in trakt_set
 
     def test_trakt_pagination(self):


### PR DESCRIPTION
### Motivation for changes:

ATM list `popular` returns 160k items, and we request them all, even if there is a `limit` set in config. See #2386 for details.

### Detailed changes:
- Combined code responsible for pagination and the actual entries processing
- Pagination processing stops as soon as we reach the limit of required entries
- No more extra request to detect whether pagination is required

### Addressed issues:
- Fixes #2386

### Config usage if relevant (new plugin or updated schema):
```
tasks:
    task:
        trakt_list:
            list: popular
            type: movies
            limit: 10
```

#### To Do:

- [x] Set default limit to something
- [ ] Update wiki