### PR TITLE
Limit plugin

### DIFF
--- a/flexget/components/trakt/trakt_list.py
+++ b/flexget/components/trakt/trakt_list.py
@@ -117,8 +117,7 @@ class TraktSet(MutableSet):
                 'default': 'auto',
             },
             'strip_dates': {'type': 'boolean', 'default': False},
-            'language': {'type': 'string', 'minLength': 2, 'maxLength': 2},
-            'limit': {'type': 'integer'},
+            'language': {'type': 'string', 'minLength': 2, 'maxLength': 2}
         },
         'required': ['list'],
         'anyOf': [
@@ -132,17 +131,13 @@ class TraktSet(MutableSet):
     }
 
     def __init__(self, config):
-        if config.get('list') in ['popular', 'trending']:
-            config.setdefault('limit', 1000)
-        else:
-            config.setdefault('limit', 0)
         self.config = config
         if self.config.get('account') and not self.config.get('username'):
             self.config['username'] = 'me'
         self.session = db.get_session(self.config.get('account'))
         # Lists may not have modified results if modified then accessed in quick succession.
         self.session.add_domain_limiter(TimedLimiter('trakt.tv', '2 seconds'))
-        self._items = None
+        self._cached_items = None
 
     def __iter__(self):
         return iter(self.items)
@@ -182,158 +177,154 @@ class TraktSet(MutableSet):
         if self.items:
             for item in self.items:
                 self.discard(item)
-            self._items = None
+            self._cached_items = None
 
     def get(self, entry):
         return self._find_entry(entry)
 
     # -- Public interface ends here -- #
 
+    def get_items(self):
+        """Iterator over etrieved itesms from the trakt api."""
+        if self.config['list'] in ['collection', 'watched', 'trending', 'popular'] and self.config['type'] == 'auto':
+            raise plugin.PluginError(
+                '`type` cannot be `auto` for %s list.' % self.config['list']
+            )
+
+        limit_per_page = 1000
+
+        endpoint = self.get_list_endpoint()
+
+        list_type = (self.config['type']).rstrip('s')
+
+        log.verbose('Retrieving `%s` list `%s`', self.config['type'], self.config['list'])
+        try:
+            page = 1
+            collecting_finished = False
+            while not collecting_finished:
+                result = self.session.get(
+                    db.get_api_url(endpoint), params={'limit': limit_per_page, 'page': page}
+                )
+                page = int(result.headers.get('X-Pagination-Page', 1))
+                number_of_pages = int(result.headers.get('X-Pagination-Page-Count', 1))
+                if page == 2:
+                    # If there is more than one page (more than 1000 items) warn user they may want to limit
+                    log.verbose('There are a large number of items in trakt `%s` list. You may want to enable `limit`'
+                                ' plugin to reduce the amount of entries in this task.', self.config['list'])
+
+                collecting_finished = page >= number_of_pages
+                page += 1
+
+                try:
+                    trakt_items = result.json()
+                except ValueError:
+                    log.debug(
+                        'Could not decode json from response: %s', result.text
+                    )
+                    raise plugin.PluginError('Error getting list from trakt.')
+                if not trakt_items:
+                    log.warning(
+                        'No data returned from trakt for %s list %s.',
+                        self.config['type'],
+                        self.config['list'],
+                    )
+                    return
+
+                for item in trakt_items:
+                    if self.config['type'] == 'auto':
+                        list_type = item['type']
+                    if self.config['list'] == 'popular':
+                        item = {list_type: item}
+                    # Collection and watched lists don't return 'type' along with the items (right now)
+                    if 'type' in item and item['type'] != list_type:
+                        log.debug(
+                            'Skipping %s because it is not a %s',
+                            item[item['type']].get('title', 'unknown'),
+                            list_type,
+                        )
+                        continue
+                    if list_type != 'episode' and not item[list_type]['title']:
+                        # Skip shows/movies with no title
+                        log.warning('Item in trakt list does not appear to have a title, skipping.')
+                        continue
+                    entry = Entry()
+                    if list_type == 'episode':
+                        entry['url'] = 'https://trakt.tv/shows/%s/seasons/%s/episodes/%s' % (
+                            item['show']['ids']['slug'],
+                            item['episode']['season'],
+                            item['episode']['number'],
+                        )
+                    else:
+                        entry['url'] = 'https://trakt.tv/%ss/%s' % (
+                            list_type,
+                            item[list_type]['ids'].get('slug'),
+                        )
+
+                    entry.update_using_map(field_maps[list_type], item)
+
+                    # get movie name translation
+                    language = self.config.get('language')
+                    if list_type == 'movie' and language:
+                        endpoint = ['movies', entry['trakt_movie_id'], 'translations', language]
+                        try:
+                            result = self.session.get(db.get_api_url(endpoint))
+                            try:
+                                translation = result.json()
+                            except ValueError:
+                                raise plugin.PluginError(
+                                    'Error decoding movie translation from trakt: %s.' % result.text
+                                )
+                        except RequestException as e:
+                            raise plugin.PluginError(
+                                'Could not retrieve movie translation from trakt: %s' % str(e)
+                            )
+                        if not translation:
+                            log.warning(
+                                'No translation data returned from trakt for movie %s.', entry['title']
+                            )
+                        else:
+                            log.verbose(
+                                'Found `%s` translation for movie `%s`: %s',
+                                language,
+                                entry['movie_name'],
+                                translation[0]['title'],
+                            )
+                            entry['title'] = translation[0]['title']
+                            if entry.get('movie_year'):
+                                entry['title'] += ' (' + str(entry['movie_year']) + ')'
+                            entry['movie_name'] = translation[0]['title']
+
+                    # Override the title if strip_dates is on. TODO: a better way?
+                    if self.config.get('strip_dates'):
+                        if list_type in ['show', 'movie']:
+                            entry['title'] = item[list_type]['title']
+                        elif list_type == 'episode':
+                            entry[
+                                'title'
+                            ] = '{show[title]} S{episode[season]:02}E{episode[number]:02}'.format(
+                                **item
+                            )
+                            if item['episode']['title']:
+                                entry['title'] += ' {episode[title]}'.format(**item)
+                    if entry.isvalid():
+                        if self.config.get('strip_dates'):
+                            # Remove year from end of name if present
+                            entry['title'] = split_title_year(entry['title'])[0]
+                        yield entry
+                    else:
+                        log.debug('Invalid entry created? %s', entry)
+
+        except RequestException as e:
+            raise plugin.PluginError('Could not retrieve list from trakt (%s)' % e)
+
     @property
     def items(self):
-        if self._items is None:
-            if self.config['list'] in ['collection', 'watched', 'trending', 'popular'] and self.config['type'] == 'auto':
-                raise plugin.PluginError(
-                    '`type` cannot be `auto` for %s list.' % self.config['list']
-                )
-
-            limit_per_page = 1000
-
-            endpoint = self.get_list_endpoint()
-
-            entries = []
-            list_type = (self.config['type']).rstrip('s')
-
-            log.verbose('Retrieving `%s` list `%s`', self.config['type'], self.config['list'])
-            try:
-                page = 1
-                number_of_pages = 1
-                collecting_finished = False
-                while not collecting_finished:
-                    result = self.session.get(
-                        db.get_api_url(endpoint), params={'limit': limit_per_page, 'page': page}
-                    )
-                    page = int(result.headers.get('X-Pagination-Page', 1))
-                    number_of_pages = int(result.headers.get('X-Pagination-Page-Count', 1))
-
-                    collecting_finished = page >= number_of_pages
-
-                    trakt_items = []
-                    try:
-                        trakt_items = result.json()
-                    except ValueError:
-                        log.debug(
-                            'Could not decode json from response: %s', result.text
-                        )
-                        raise plugin.PluginError('Error getting list from trakt.')
-
-                    page += 1
-
-                    for item in trakt_items:
-                        if self.config['type'] == 'auto':
-                            list_type = item['type']
-                        if self.config['list'] == 'popular':
-                            item = {list_type: item}
-                        # Collection and watched lists don't return 'type' along with the items (right now)
-                        if 'type' in item and item['type'] != list_type:
-                            log.debug(
-                                'Skipping %s because it is not a %s',
-                                item[item['type']].get('title', 'unknown'),
-                                list_type,
-                            )
-                            continue
-                        if list_type != 'episode' and not item[list_type]['title']:
-                            # Skip shows/movies with no title
-                            log.warning('Item in trakt list does not appear to have a title, skipping.')
-                            continue
-                        entry = Entry()
-                        if list_type == 'episode':
-                            entry['url'] = 'https://trakt.tv/shows/%s/seasons/%s/episodes/%s' % (
-                                item['show']['ids']['slug'],
-                                item['episode']['season'],
-                                item['episode']['number'],
-                            )
-                        else:
-                            entry['url'] = 'https://trakt.tv/%ss/%s' % (
-                                list_type,
-                                item[list_type]['ids'].get('slug'),
-                            )
-
-                        entry.update_using_map(field_maps[list_type], item)
-
-                        # get movie name translation
-                        language = self.config.get('language')
-                        if list_type == 'movie' and language:
-                            endpoint = ['movies', entry['trakt_movie_id'], 'translations', language]
-                            try:
-                                result = self.session.get(db.get_api_url(endpoint))
-                                try:
-                                    translation = result.json()
-                                except ValueError:
-                                    raise plugin.PluginError(
-                                        'Error decoding movie translation from trakt: %s.' % result.text
-                                    )
-                            except RequestException as e:
-                                raise plugin.PluginError(
-                                    'Could not retrieve movie translation from trakt: %s' % str(e)
-                                )
-                            if not translation:
-                                log.warning(
-                                    'No translation data returned from trakt for movie %s.', entry['title']
-                                )
-                            else:
-                                log.verbose(
-                                    'Found `%s` translation for movie `%s`: %s',
-                                    language,
-                                    entry['movie_name'],
-                                    translation[0]['title'],
-                                )
-                                entry['title'] = translation[0]['title']
-                                if entry.get('movie_year'):
-                                    entry['title'] += ' (' + str(entry['movie_year']) + ')'
-                                entry['movie_name'] = translation[0]['title']
-
-                        # Override the title if strip_dates is on. TODO: a better way?
-                        if self.config.get('strip_dates'):
-                            if list_type in ['show', 'movie']:
-                                entry['title'] = item[list_type]['title']
-                            elif list_type == 'episode':
-                                entry[
-                                    'title'
-                                ] = '{show[title]} S{episode[season]:02}E{episode[number]:02}'.format(
-                                    **item
-                                )
-                                if item['episode']['title']:
-                                    entry['title'] += ' {episode[title]}'.format(**item)
-                        if entry.isvalid():
-                            if self.config.get('strip_dates'):
-                                # Remove year from end of name if present
-                                entry['title'] = split_title_year(entry['title'])[0]
-                            entries.append(entry)
-
-                        else:
-                            log.debug('Invalid entry created? %s', entry)
-
-                        if self.config.get('limit') and len(entries) >= self.config.get('limit'):
-                            collecting_finished = True
-                            break
-
-            except RequestException as e:
-                raise plugin.PluginError('Could not retrieve list from trakt (%s)' % e)
-
-            if not entries:
-                log.warning(
-                    'No data returned from trakt for %s list %s.',
-                    self.config['type'],
-                    self.config['list'],
-                )
-                return []
-
-            self._items = entries
-        return self._items
+        if self._cached_items is None:
+            self._cached_items = list(self.get_items())
+        return self._cached_items
 
     def invalidate_cache(self):
-        self._items = None
+        self._cached_items = None
 
     def get_list_endpoint(self, remove=False, submit=False):
         if (
@@ -519,7 +510,8 @@ class TraktList(object):
     # TODO: we should somehow invalidate this cache when the list is modified
     @cached('trakt_list', persist='2 hours')
     def on_task_input(self, task, config):
-        return list(TraktSet(config))
+        # We use the generator here rather than the cached list in case limit plugin is used.
+        return TraktSet(config).get_items()
 
 
 @event('plugin.register')

--- a/flexget/components/trakt/trakt_list.py
+++ b/flexget/components/trakt/trakt_list.py
@@ -118,7 +118,7 @@ class TraktSet(MutableSet):
             },
             'strip_dates': {'type': 'boolean', 'default': False},
             'language': {'type': 'string', 'minLength': 2, 'maxLength': 2},
-            'limit': {'type': 'integer', 'default': 0},
+            'limit': {'type': 'integer'},
         },
         'required': ['list'],
         'anyOf': [
@@ -132,6 +132,10 @@ class TraktSet(MutableSet):
     }
 
     def __init__(self, config):
+        if config.get('list') in ['popular', 'trending']:
+            config.setdefault('limit', 1000)
+        else:
+            config.setdefault('limit', 0)
         self.config = config
         if self.config.get('account') and not self.config.get('username'):
             self.config['username'] = 'me'
@@ -193,145 +197,137 @@ class TraktSet(MutableSet):
                     '`type` cannot be `auto` for %s list.' % self.config['list']
                 )
 
+            limit_per_page = 1000
+
             endpoint = self.get_list_endpoint()
+
+            entries = []
+            list_type = (self.config['type']).rstrip('s')
 
             log.verbose('Retrieving `%s` list `%s`', self.config['type'], self.config['list'])
             try:
-                result = self.session.get(db.get_api_url(endpoint))
-                try:
-                    data = result.json()
-                except ValueError:
-                    log.debug('Could not decode json from response: %s', result.text)
-                    raise plugin.PluginError('Error getting list from trakt.')
-
-                current_page = int(result.headers.get('X-Pagination-Page', 1))
-                current_page_count = int(result.headers.get('X-Pagination-Page-Count', 1))
-                if current_page < current_page_count:
-                    # Pagination, gotta get it all, but we'll limit it to 1000 per page
-                    # but we'll have to start over from 0
-                    data = []
-
-                    limit = 1000
-                    pagination_item_count = int(result.headers.get('X-Pagination-Item-Count', 0))
-                    number_of_pages = math.ceil(pagination_item_count / limit)
-                    log.debug(
-                        'Response is paginated. Number of items: %s, number of pages: %s',
-                        pagination_item_count,
-                        number_of_pages,
+                page = 1
+                number_of_pages = 1
+                collecting_finished = False
+                while not collecting_finished:
+                    result = self.session.get(
+                        db.get_api_url(endpoint), params={'limit': limit_per_page, 'page': page}
                     )
-                    page = int(result.headers.get('X-Pagination-Page'))
-                    while page <= number_of_pages:
-                        paginated_result = self.session.get(
-                            db.get_api_url(endpoint), params={'limit': limit, 'page': page}
+                    page = int(result.headers.get('X-Pagination-Page', 1))
+                    number_of_pages = int(result.headers.get('X-Pagination-Page-Count', 1))
+
+                    collecting_finished = page >= number_of_pages
+
+                    trakt_items = []
+                    try:
+                        trakt_items = result.json()
+                    except ValueError:
+                        log.debug(
+                            'Could not decode json from response: %s', result.text
                         )
-                        page += 1
-                        try:
-                            data.extend(paginated_result.json())
-                        except ValueError:
+                        raise plugin.PluginError('Error getting list from trakt.')
+
+                    page += 1
+
+                    for item in trakt_items:
+                        if self.config['type'] == 'auto':
+                            list_type = item['type']
+                        if self.config['list'] == 'popular':
+                            item = {list_type: item}
+                        # Collection and watched lists don't return 'type' along with the items (right now)
+                        if 'type' in item and item['type'] != list_type:
                             log.debug(
-                                'Could not decode json from response: %s', paginated_result.text
+                                'Skipping %s because it is not a %s',
+                                item[item['type']].get('title', 'unknown'),
+                                list_type,
                             )
-                            raise plugin.PluginError('Error getting list from trakt.')
+                            continue
+                        if list_type != 'episode' and not item[list_type]['title']:
+                            # Skip shows/movies with no title
+                            log.warning('Item in trakt list does not appear to have a title, skipping.')
+                            continue
+                        entry = Entry()
+                        if list_type == 'episode':
+                            entry['url'] = 'https://trakt.tv/shows/%s/seasons/%s/episodes/%s' % (
+                                item['show']['ids']['slug'],
+                                item['episode']['season'],
+                                item['episode']['number'],
+                            )
+                        else:
+                            entry['url'] = 'https://trakt.tv/%ss/%s' % (
+                                list_type,
+                                item[list_type]['ids'].get('slug'),
+                            )
+
+                        entry.update_using_map(field_maps[list_type], item)
+
+                        # get movie name translation
+                        language = self.config.get('language')
+                        if list_type == 'movie' and language:
+                            endpoint = ['movies', entry['trakt_movie_id'], 'translations', language]
+                            try:
+                                result = self.session.get(db.get_api_url(endpoint))
+                                try:
+                                    translation = result.json()
+                                except ValueError:
+                                    raise plugin.PluginError(
+                                        'Error decoding movie translation from trakt: %s.' % result.text
+                                    )
+                            except RequestException as e:
+                                raise plugin.PluginError(
+                                    'Could not retrieve movie translation from trakt: %s' % str(e)
+                                )
+                            if not translation:
+                                log.warning(
+                                    'No translation data returned from trakt for movie %s.', entry['title']
+                                )
+                            else:
+                                log.verbose(
+                                    'Found `%s` translation for movie `%s`: %s',
+                                    language,
+                                    entry['movie_name'],
+                                    translation[0]['title'],
+                                )
+                                entry['title'] = translation[0]['title']
+                                if entry.get('movie_year'):
+                                    entry['title'] += ' (' + str(entry['movie_year']) + ')'
+                                entry['movie_name'] = translation[0]['title']
+
+                        # Override the title if strip_dates is on. TODO: a better way?
+                        if self.config.get('strip_dates'):
+                            if list_type in ['show', 'movie']:
+                                entry['title'] = item[list_type]['title']
+                            elif list_type == 'episode':
+                                entry[
+                                    'title'
+                                ] = '{show[title]} S{episode[season]:02}E{episode[number]:02}'.format(
+                                    **item
+                                )
+                                if item['episode']['title']:
+                                    entry['title'] += ' {episode[title]}'.format(**item)
+                        if entry.isvalid():
+                            if self.config.get('strip_dates'):
+                                # Remove year from end of name if present
+                                entry['title'] = split_title_year(entry['title'])[0]
+                            entries.append(entry)
+
+                        else:
+                            log.debug('Invalid entry created? %s', entry)
+
+                        if self.config.get('limit') and len(entries) >= self.config.get('limit'):
+                            collecting_finished = True
+                            break
 
             except RequestException as e:
                 raise plugin.PluginError('Could not retrieve list from trakt (%s)' % e)
 
-            if not data:
+            if not entries:
                 log.warning(
                     'No data returned from trakt for %s list %s.',
                     self.config['type'],
                     self.config['list'],
                 )
                 return []
-
-            entries = []
-            list_type = (self.config['type']).rstrip('s')
-            for item in data:
-                if self.config['type'] == 'auto':
-                    list_type = item['type']
-                if self.config['list'] == 'popular':
-                    item = {list_type: item}
-                # Collection and watched lists don't return 'type' along with the items (right now)
-                if 'type' in item and item['type'] != list_type:
-                    log.debug(
-                        'Skipping %s because it is not a %s',
-                        item[item['type']].get('title', 'unknown'),
-                        list_type,
-                    )
-                    continue
-                if list_type != 'episode' and not item[list_type]['title']:
-                    # Skip shows/movies with no title
-                    log.warning('Item in trakt list does not appear to have a title, skipping.')
-                    continue
-                entry = Entry()
-                if list_type == 'episode':
-                    entry['url'] = 'https://trakt.tv/shows/%s/seasons/%s/episodes/%s' % (
-                        item['show']['ids']['slug'],
-                        item['episode']['season'],
-                        item['episode']['number'],
-                    )
-                else:
-                    entry['url'] = 'https://trakt.tv/%ss/%s' % (
-                        list_type,
-                        item[list_type]['ids'].get('slug'),
-                    )
-
-                entry.update_using_map(field_maps[list_type], item)
-
-                # get movie name translation
-                language = self.config.get('language')
-                if list_type == 'movie' and language:
-                    endpoint = ['movies', entry['trakt_movie_id'], 'translations', language]
-                    try:
-                        result = self.session.get(db.get_api_url(endpoint))
-                        try:
-                            translation = result.json()
-                        except ValueError:
-                            raise plugin.PluginError(
-                                'Error decoding movie translation from trakt: %s.' % result.text
-                            )
-                    except RequestException as e:
-                        raise plugin.PluginError(
-                            'Could not retrieve movie translation from trakt: %s' % str(e)
-                        )
-                    if not translation:
-                        log.warning(
-                            'No translation data returned from trakt for movie %s.', entry['title']
-                        )
-                    else:
-                        log.verbose(
-                            'Found `%s` translation for movie `%s`: %s',
-                            language,
-                            entry['movie_name'],
-                            translation[0]['title'],
-                        )
-                        entry['title'] = translation[0]['title']
-                        if entry.get('movie_year'):
-                            entry['title'] += ' (' + str(entry['movie_year']) + ')'
-                        entry['movie_name'] = translation[0]['title']
-
-                # Override the title if strip_dates is on. TODO: a better way?
-                if self.config.get('strip_dates'):
-                    if list_type in ['show', 'movie']:
-                        entry['title'] = item[list_type]['title']
-                    elif list_type == 'episode':
-                        entry[
-                            'title'
-                        ] = '{show[title]} S{episode[season]:02}E{episode[number]:02}'.format(
-                            **item
-                        )
-                        if item['episode']['title']:
-                            entry['title'] += ' {episode[title]}'.format(**item)
-                if entry.isvalid():
-                    if self.config.get('strip_dates'):
-                        # Remove year from end of name if present
-                        entry['title'] = split_title_year(entry['title'])[0]
-                    entries.append(entry)
-
-                    if self.config.get('limit') and len(entries) >= self.config.get('limit'):
-                        break
-                else:
-                    log.debug('Invalid entry created? %s', entry)
 
             self._items = entries
         return self._items

--- a/flexget/plugins/input/anidb_list.py
+++ b/flexget/plugins/input/anidb_list.py
@@ -71,7 +71,6 @@ class AnidbList(object):
                 'Unable to get AniDB list. Either the list is private or does not exist.'
             )
 
-        entries = []
         entry_type = ''
 
         if config['type'] == 'movies':
@@ -88,7 +87,7 @@ class AnidbList(object):
             trs = soup_table.find_all('tr')
             if not trs:
                 log.verbose('No movies were found in AniDB list: mywishlist')
-                return entries
+                return
             for tr in trs:
                 if tr.find('span', title=entry_type):
                     a = tr.find('td', class_='name').find('a')
@@ -109,7 +108,7 @@ class AnidbList(object):
                     ]  # The <tr> tag's id is "aN..." where "N..." is the anime id
                     log.debug('%s id is %s', entry['title'], entry['anidb_id'])
                     entry['anidb_name'] = entry['title']
-                    entries.append(entry)
+                    yield entry
                 else:
                     log.verbose('Entry does not match the requested type')
             try:
@@ -128,7 +127,6 @@ class AnidbList(object):
             if page.status_code != 200:
                 log.warning('Unable to retrieve next page of wishlist.')
                 break
-        return entries
 
 
 @event('plugin.register')

--- a/flexget/plugins/input/gazelle.py
+++ b/flexget/plugins/input/gazelle.py
@@ -316,7 +316,7 @@ class InputGazelle(object):
         self.setup(task, config)
 
         params = self.params_from_config(config)
-        return list(self.get_entries(self.search_results(params)))
+        return self.get_entries(self.search_results(params))
 
 
 class InputGazelleMusic(InputGazelle):

--- a/flexget/plugins/input/inputs.py
+++ b/flexget/plugins/input/inputs.py
@@ -36,7 +36,6 @@ class PluginInputs(object):
     }
 
     def on_task_input(self, task, config):
-        entries = []
         entry_titles = set()
         entry_urls = set()
         for item in config:
@@ -63,10 +62,9 @@ class PluginInputs(object):
                     if any(url in entry_urls for url in urls):
                         log.debug('URL for `%s` already in entry list, skipping.' % entry['title'])
                         continue
-                    entries.append(entry)
+                    yield entry
                     entry_titles.add(entry['title'])
                     entry_urls.update(urls)
-        return entries
 
 
 @event('plugin.register')

--- a/flexget/plugins/input/kitsu.py
+++ b/flexget/plugins/input/kitsu.py
@@ -56,7 +56,6 @@ class KitsuAnime(object):
 
     @cached('kitsu', persist='2 hours')
     def on_task_input(self, task, config):
-        entries = []
         user_payload = {'filter[name]': config['username']}
         try:
             user_response = task.requests.get(
@@ -132,7 +131,7 @@ class KitsuAnime(object):
                         entry['series_episode'] = item['progress']
                         entry['series_id_type'] = 'sequence'
                         entry['title'] += ' ' + str(entry['progress'])
-                    entries.append(entry)
+                    yield entry
 
             next_url = json_data['links'].get('next')
             if next_url:
@@ -149,8 +148,6 @@ class KitsuAnime(object):
                 json_data = response.json()
             else:
                 break
-
-        return entries
 
 
 @event('plugin.register')

--- a/flexget/plugins/input/letterboxd.py
+++ b/flexget/plugins/input/letterboxd.py
@@ -46,7 +46,10 @@ class Letterboxd(object):
             'username': {'type': 'string'},
             'list': {'type': 'string'},
             'sort_by': {'type': 'string', 'enum': list(SORT_BY.keys()), 'default': 'default'},
-            'max_results': {'type': 'integer'},
+            'max_results': {
+                'type': 'integer',
+                'deprecated': '`limit` plugin should be used instead of letterboxd `max_results` option'
+            },
         },
         'required': ['username', 'list'],
         'additionalProperties': False,

--- a/flexget/plugins/input/letterboxd.py
+++ b/flexget/plugins/input/letterboxd.py
@@ -109,7 +109,6 @@ class Letterboxd(object):
 
         log.verbose('Looking for films in Letterboxd list: %s' % url)
 
-        entries = []
         while next_page is not None and rcount < max_results:
             try:
                 page = requests.get(url).content
@@ -119,8 +118,7 @@ class Letterboxd(object):
 
             for film in soup.find_all(attrs={config['f_slug']: True}):
                 if rcount < max_results:
-                    entry = self.parse_film(film, config)
-                    entries.append(entry)
+                    yield self.parse_film(film, config)
                     if 'max_results' in config:
                         rcount += 1
 
@@ -129,8 +127,6 @@ class Letterboxd(object):
                 next_page = next_page.get('href')
                 if next_page is not None:
                     url = base_url + next_page
-
-        return entries
 
 
 @event('plugin.register')

--- a/flexget/plugins/input/limit.py
+++ b/flexget/plugins/input/limit.py
@@ -10,7 +10,7 @@ from flexget.event import event
 log = logging.getLogger('limit')
 
 
-class PluginInputs(object):
+class PluginLimit(object):
     """
     Limits the number of entries an input plugin can produce.
     """
@@ -52,4 +52,4 @@ class PluginInputs(object):
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(PluginInputs, 'limit', api_ver=2)
+    plugin.register(PluginLimit, 'limit', api_ver=2)

--- a/flexget/plugins/input/limit.py
+++ b/flexget/plugins/input/limit.py
@@ -1,0 +1,55 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+import itertools
+import logging
+
+from flexget import plugin
+from flexget.event import event
+
+log = logging.getLogger('limit')
+
+
+class PluginInputs(object):
+    """
+    Limits the number of entries an input plugin can produce.
+    """
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'amount': {'type': 'integer', 'minimum': -1},
+            'plugin': {
+                'allOf': [
+                    {'$ref': '/schema/plugins?phase=input'},
+                    {
+                        'maxProperties': 1,
+                        'error_maxProperties': 'Plugin options within limit plugin must be indented 2 more spaces than '
+                        'the first letter of the plugin name.',
+                        'minProperties': 1,
+                    },
+                ]
+            },
+        },
+        'required': ['amount', 'plugin'],
+        'additionalProperties': False,
+    }
+
+    def on_task_input(self, task, config):
+        for input_name, input_config in config['plugin'].items():
+            input = plugin.get_plugin_by_name(input_name)
+            method = input.phase_handlers['input']
+            try:
+                result = method(task, input_config)
+            except plugin.PluginError as e:
+                log.warning('Error during input plugin %s: %s' % (input_name, e))
+                continue
+            # A 0 or -1 limit means don't limit.
+            if config['amount'] < 1:
+                return result
+            return itertools.islice(result, config['amount'])
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(PluginInputs, 'limit', api_ver=2)

--- a/flexget/plugins/input/limit.py
+++ b/flexget/plugins/input/limit.py
@@ -19,7 +19,7 @@ class PluginInputs(object):
         'type': 'object',
         'properties': {
             'amount': {'type': 'integer', 'minimum': -1},
-            'plugin': {
+            'from': {
                 'allOf': [
                     {'$ref': '/schema/plugins?phase=input'},
                     {
@@ -31,12 +31,12 @@ class PluginInputs(object):
                 ]
             },
         },
-        'required': ['amount', 'plugin'],
+        'required': ['amount', 'from'],
         'additionalProperties': False,
     }
 
     def on_task_input(self, task, config):
-        for input_name, input_config in config['plugin'].items():
+        for input_name, input_config in config['from'].items():
             input = plugin.get_plugin_by_name(input_name)
             method = input.phase_handlers['input']
             try:

--- a/flexget/plugins/input/next_sonarr_episodes.py
+++ b/flexget/plugins/input/next_sonarr_episodes.py
@@ -101,7 +101,6 @@ class NextSonarrEpisodes(object):
 
     def on_task_input(self, task, config):
         json = self.get_page(task, config, 1)
-        entries = []
         pages = int(
             math.ceil(json['totalRecords'] / config.get('page_size'))
         )  # Sets number of requested pages
@@ -125,16 +124,15 @@ class NextSonarrEpisodes(object):
                         tvmaze_id=record['series'].get('tvMazeId'),
                         title=record['series']['title'] + ' ' + 'S%02dE%02d' % (season, episode),
                     )
-                    if entry.isvalid():
-                        entries.append(entry)
-                    else:
-                        log.error('Invalid entry created? {}'.format(entry))
                     # Test mode logging
                     if entry and task.options.test:
                         log.verbose("Test mode. Entry includes:")
                         for key, value in list(entry.items()):
                             log.verbose('     {}: {}'.format(key.capitalize(), value))
-        return entries
+                    if entry.isvalid():
+                        yield entry
+                    else:
+                        log.error('Invalid entry created? {}'.format(entry))
 
 
 @event('plugin.register')

--- a/flexget/plugins/operate/digest.py
+++ b/flexget/plugins/operate/digest.py
@@ -97,7 +97,11 @@ class FromDigest(object):
         'type': 'object',
         'properties': {
             'list': {'type': 'string'},
-            'limit': {'type': 'integer', 'default': -1},
+            'limit': {
+                'deprecated': 'The `limit` option of from_digest is deprecated. Use the `limit` plugin instead.',
+                'type': 'integer',
+                'default': -1
+            },
             'expire': {
                 'oneOf': [{'type': 'string', 'format': 'interval'}, {'type': 'boolean'}],
                 'default': True,

--- a/flexget/plugins/operate/sequence.py
+++ b/flexget/plugins/operate/sequence.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
+import itertools
 import logging
 
 from flexget import plugin
@@ -38,9 +39,9 @@ class PluginSequence(object):
                         method = plugin.get_plugin_by_name(plugin_name).phase_handlers[phase]
                         log.debug('Running plugin %s' % plugin_name)
                         result = method(task, plugin_config)
-                        if isinstance(result, list):
-                            results.extend(result)
-            return results
+                        if phase == 'input' and result:
+                            results.append(result)
+            return itertools.chain(*results)
 
         return handle_phase
 

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -491,7 +491,7 @@ class Task(object):
                         # add entries returned by input to self.all_entries
                         for e in response:
                             e.task = self
-                        self.all_entries.extend(response)
+                            self.all_entries.append(e)
                 finally:
                     fire_event('task.execute.after_plugin', self, plugin.name)
                 self.session = None

--- a/flexget/tests/cassettes/test_trakt.TestTraktList.test_trakt_movies
+++ b/flexget/tests/cassettes/test_trakt.TestTraktList.test_trakt_movies
@@ -6,7 +6,7 @@ interactions:
       trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
       trakt-api-version: ['2']
     method: GET
-    uri: https://api.trakt.tv/users/flexgettest/watchlist/movies
+    uri: https://api.trakt.tv/users/flexgettest/watchlist/movies?limit=1000&page=1
   response:
     body: {string: '[{"rank":1,"listed_at":"2015-01-02T02:37:24.000Z","type":"movie","movie":{"title":"12
         Angry Men","year":1957,"ids":{"trakt":309,"slug":"12-angry-men-1957","imdb":"tt0050083","tmdb":389}}}]'}

--- a/flexget/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_show_collected_progress
+++ b/flexget/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_show_collected_progress
@@ -6,7 +6,7 @@ interactions:
       trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
       trakt-api-version: ['2']
     method: GET
-    uri: https://api.trakt.tv/users/flexgettest/lists/test/items
+    uri: https://api.trakt.tv/users/flexgettest/lists/test/items?limit=1000&page=1
   response:
     body: {string: '[{"rank":1,"listed_at":"2016-03-08T21:36:36.000Z","type":"show","show":{"title":"White
         Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}},{"rank":2,"listed_at":"2016-03-08T21:36:50.000Z","type":"show","show":{"title":"Chuck","year":2007,"ids":{"trakt":1395,"slug":"chuck","tvdb":80348,"imdb":"tt0934814","tmdb":1404,"tvrage":15614}}}]'}

--- a/flexget/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_show_watched_progress
+++ b/flexget/tests/cassettes/test_trakt.TestTraktWatchedAndCollected.test_trakt_show_watched_progress
@@ -6,7 +6,7 @@ interactions:
       trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
       trakt-api-version: ['2']
     method: GET
-    uri: https://api.trakt.tv/users/flexgettest/lists/test/items
+    uri: https://api.trakt.tv/users/flexgettest/lists/test/items?limit=1000&page=1
   response:
     body: {string: '[{"rank":1,"listed_at":"2016-03-08T21:36:36.000Z","type":"show","show":{"title":"White
         Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}},{"rank":2,"listed_at":"2016-03-08T21:36:50.000Z","type":"show","show":{"title":"Chuck","year":2007,"ids":{"trakt":1395,"slug":"chuck","tvdb":80348,"imdb":"tt0934814","tmdb":1404,"tvrage":15614}}}]'}

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_get_list
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_get_list
@@ -7,7 +7,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/users/me/lists/testlist/items
+      uri: https://api.trakt.tv/users/me/lists/testlist/items?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":90056369,"listed_at":"2016-04-06T01:08:39.000Z","type":"show","show":{"title":"The
           Walking Dead","year":2010,"ids":{"trakt":1393,"slug":"the-walking-dead","tvdb":153021,"imdb":"tt1520211","tmdb":1402,"tvrage":25056}}},{"rank":2,"id":90056392,"listed_at":"2016-04-06T01:08:56.000Z","type":"movie","movie":{"title":"Deadpool","year":2016,"ids":{"trakt":190430,"slug":"deadpool-2016","imdb":"tt1431045","tmdb":293660}}},{"rank":3,"id":90056410,"listed_at":"2016-04-06T01:09:11.000Z","type":"episode","episode":{"season":8,"number":15,"title":"Fidelis

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_strip_dates
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_strip_dates
@@ -7,7 +7,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/users/me/lists/testlist/items
+      uri: https://api.trakt.tv/users/me/lists/testlist/items?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":90056369,"listed_at":"2016-04-06T01:08:39.000Z","type":"show","show":{"title":"The
           Walking Dead","year":2010,"ids":{"trakt":1393,"slug":"the-walking-dead","tvdb":153021,"imdb":"tt1520211","tmdb":1402,"tvrage":25056}}},{"rank":2,"id":90056392,"listed_at":"2016-04-06T01:08:56.000Z","type":"movie","movie":{"title":"Deadpool","year":2016,"ids":{"trakt":190430,"slug":"deadpool-2016","imdb":"tt1431045","tmdb":293660}}},{"rank":3,"id":90056410,"listed_at":"2016-04-06T01:09:11.000Z","type":"episode","episode":{"season":8,"number":15,"title":"Fidelis

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add
@@ -7,7 +7,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/shows
+      uri: https://api.trakt.tv/sync/watchlist/shows?limit=1000&page=1
     response:
       body: {string: '[]'}
       headers:
@@ -41,7 +41,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/shows
+      uri: https://api.trakt.tv/sync/watchlist/shows?limit=1000&page=1
     response:
       body: {string: '[]'}
       headers:
@@ -103,7 +103,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/shows
+      uri: https://api.trakt.tv/sync/watchlist/shows?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371589379,"listed_at":"2018-12-29T06:50:57.000Z","type":"show","show":{"title":"White
           Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}}]'}

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add
@@ -4,39 +4,6 @@ interactions:
       headers:
         Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
         Content-Type: [application/json]
-        trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
-        trakt-api-version: ['2']
-      method: GET
-      uri: https://api.trakt.tv/sync/watchlist/shows?limit=1000&page=1
-    response:
-      body: {string: '[]'}
-      headers:
-        CF-RAY: [490a54b99b263d3d-CPH]
-        Cache-Control: ['max-age=0, private, must-revalidate']
-        Cf-Railgun: [8adeccbc16 99.99 0.029608 0030 57da]
-        Connection: [keep-alive]
-        Content-Type: [application/json; charset=utf-8]
-        Date: ['Sat, 29 Dec 2018 06:50:10 GMT']
-        Etag: [W/"4424072e99830138d0df9ea8ea2b71ec"]
-        Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-        Last-Modified: ['Sat, 29 Dec 2018 06:22:36 GMT']
-        Server: [cloudflare]
-        Set-Cookie: ['__cfduid=df6cfde95df30cc35afff5871be2b4b1d1546066210; expires=Sun,
-            29-Dec-19 06:50:10 GMT; path=/; domain=.trakt.tv; HttpOnly']
-        Vary: [Accept-Encoding]
-        X-Content-Type-Options: [nosniff]
-        X-Frame-Options: [SAMEORIGIN]
-        X-Request-Id: [fb04717c-c817-4527-9803-37403d853041]
-        X-Runtime: ['0.018469']
-        X-Sort-By: [rank]
-        X-Sort-How: [asc]
-        X-Xss-Protection: [1; mode=block]
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Authorization: [Bearer c78844ac92c43cf81662d6a132d9412220023c5c962e1a80e519472e502e45c9]
-        Content-Type: [application/json]
         Cookie: [__cfduid=df6cfde95df30cc35afff5871be2b4b1d1546066210]
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode
@@ -7,7 +7,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes
+      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371586023,"listed_at":"2018-12-29T06:22:33.000Z","type":"episode","episode":{"season":1,"number":5,"title":"Chapter
           Five: The Flea and the Acrobat","ids":{"trakt":2124182,"tvdb":5621929,"imdb":"tt4593128","tmdb":1205904,"tvrage":1065933149}},"show":{"title":"Stranger
@@ -109,7 +109,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes
+      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
     response:
       body: {string: '[]'}
       headers:
@@ -173,7 +173,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes
+      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371589391,"listed_at":"2018-12-29T06:50:37.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
           of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_simple
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_simple
@@ -7,7 +7,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes
+      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371589391,"listed_at":"2018-12-29T06:50:37.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
           of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
@@ -75,7 +75,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes
+      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
     response:
       body: {string: '[]'}
       headers:
@@ -138,7 +138,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes
+      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371589397,"listed_at":"2018-12-29T06:51:09.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
           of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_task
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_add_episode_task
@@ -7,7 +7,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes
+      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371589397,"listed_at":"2018-12-29T06:51:09.000Z","type":"episode","episode":{"season":4,"number":5,"title":"First
           of His Name","ids":{"trakt":73674,"tvdb":4801605,"imdb":"tt3060856","tmdb":63098,"tvrage":1065501369}},"show":{"title":"Game
@@ -107,7 +107,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/episodes
+      uri: https://api.trakt.tv/sync/watchlist/episodes?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371589401,"listed_at":"2018-12-29T06:51:03.000Z","type":"episode","episode":{"season":1,"number":5,"title":"Chapter
           Five: The Flea and the Acrobat","ids":{"trakt":2124182,"tvdb":5621929,"imdb":"tt4593128","tmdb":1205904,"tvrage":1065933149}},"show":{"title":"Stranger

--- a/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_remove
+++ b/flexget/tests/cassettes/test_trakt_list_interface.TestTraktList.test_trakt_remove
@@ -7,7 +7,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/shows
+      uri: https://api.trakt.tv/sync/watchlist/shows?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371589379,"listed_at":"2018-12-29T06:50:57.000Z","type":"show","show":{"title":"White
           Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}}]'}
@@ -73,7 +73,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/shows
+      uri: https://api.trakt.tv/sync/watchlist/shows?limit=1000&page=1
     response:
       body: {string: '[]'}
       headers:
@@ -135,7 +135,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/shows
+      uri: https://api.trakt.tv/sync/watchlist/shows?limit=1000&page=1
     response:
       body: {string: '[{"rank":1,"id":371589410,"listed_at":"2018-12-29T06:51:12.000Z","type":"show","show":{"title":"White
           Collar","year":2009,"ids":{"trakt":21410,"slug":"white-collar","tvdb":108611,"imdb":"tt1358522","tmdb":21510,"tvrage":20720}}}]'}
@@ -198,7 +198,7 @@ interactions:
         trakt-api-key: [57e188bcb9750c79ed452e1674925bc6848bd126e02bb15350211be74c6547af]
         trakt-api-version: ['2']
       method: GET
-      uri: https://api.trakt.tv/sync/watchlist/shows
+      uri: https://api.trakt.tv/sync/watchlist/shows?limit=1000&page=1
     response:
       body: {string: '[]'}
       headers:

--- a/flexget/tests/test_cached_input.py
+++ b/flexget/tests/test_cached_input.py
@@ -56,5 +56,7 @@ class TestInputCache(object):
 
         task = execute_task('test_db')
         assert task.entries, 'should have created entries at the start'
+        # Clear out the memory cache to make sure we are loading from db
+        cached.cache.clear()
         task = execute_task('test_db')
         assert task.entries, 'should have created entries from the cache'

--- a/flexget/tests/test_limit.py
+++ b/flexget/tests/test_limit.py
@@ -22,7 +22,7 @@ class TestLimit(object):
           test_limit:
             limit:
               amount: 2
-              plugin:
+              from:
                 mock:
                 - title: Entry 1
                 - title: Entry 2
@@ -30,7 +30,7 @@ class TestLimit(object):
           test_limit_generator:
             limit:
               amount: 1
-              plugin:
+              from:
                 one_entry_input: yes
     """
 

--- a/flexget/tests/test_limit.py
+++ b/flexget/tests/test_limit.py
@@ -1,0 +1,43 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+from flexget import plugin
+from flexget.entry import Entry
+
+
+class OneEntryInput(object):
+    """Fake input plugin, fails if second entry is grabbed."""
+
+    def on_task_input(self, task, config):
+        yield Entry(title='Test', url='http://test.com')
+        raise Exception('Should not have tried to get second entry.')
+
+
+plugin.register(OneEntryInput, 'one_entry_input', api_ver=2)
+
+
+class TestLimit(object):
+    config = """
+        tasks:
+          test_limit:
+            limit:
+              amount: 2
+              plugin:
+                mock:
+                - title: Entry 1
+                - title: Entry 2
+                - title: Entry 3
+          test_limit_generator:
+            limit:
+              amount: 1
+              plugin:
+                one_entry_input: yes
+    """
+
+    def test_limit(self, execute_task):
+        task = execute_task('test_limit')
+        assert len(task.all_entries) == 2
+
+    def test_limit_generator(self, execute_task):
+        task = execute_task('test_limit_generator')
+        assert len(task.all_entries) == 1

--- a/flexget/utils/cached_input.py
+++ b/flexget/utils/cached_input.py
@@ -95,106 +95,113 @@ class cached(object):
         self.name = str(name)
         # Parse persist time
         self.persist = persist and parse_timedelta(persist)
+        # Will be set when wrapped function is called
+        self.config_hash = None
+        self.cache_name = None
 
     def __call__(self, func):
         def wrapped_func(*args, **kwargs):
             # get task from method parameters
             task = args[1]
-            hash = get_config_hash(args[2])
+            self.config_hash = get_config_hash(args[2])
 
             log.trace('self.name: %s' % self.name)
-            log.trace('hash: %s' % hash)
+            log.trace('hash: %s' % self.config_hash)
 
-            cache_name = self.name + '_' + hash
+            self.cache_name = self.name + '_' + self.config_hash
             log.debug(
-                'cache name: %s (has: %s)' % (cache_name, ', '.join(list(self.cache.keys())))
+                'cache name: %s (has: %s)' % (self.cache_name, ', '.join(list(self.cache.keys())))
             )
 
-            cache_value = self.cache.get(cache_name, None)
+            if not task.options.nocache:
+                cache_value = self.cache.get(self.cache_name, None)
+                if cache_value:
+                    # return from the cache
+                    log.verbose('Restored entries from cache')
+                    return cache_value
 
-            if not task.options.nocache and cache_value:
-                # return from the cache
-                log.trace('cache hit')
-                entries = []
-                for entry in cache_value:
-                    fresh = copy.deepcopy(entry)
-                    entries.append(fresh)
-                if entries:
-                    log.verbose('Restored %s entries from cache' % len(entries))
-                return entries
-            else:
-                if self.persist and not task.options.nocache:
-                    # Check database cache
-                    with Session() as session:
-                        db_cache = (
-                            session.query(InputCache)
-                            .filter(InputCache.name == self.name)
-                            .filter(InputCache.hash == hash)
-                            .filter(InputCache.added > datetime.now() - self.persist)
-                            .first()
-                        )
-                        if db_cache:
-                            entries = [e.entry for e in db_cache.entries]
-                            log.verbose('Restored %s entries from db cache' % len(entries))
-                            # Store to in memory cache
-                            self.cache[cache_name] = copy.deepcopy(entries)
-                            return entries
-
-                # Nothing was restored from db or memory cache, run the function
-                log.trace('cache miss')
-                # call input event
-                try:
-                    response = func(*args, **kwargs)
-                except PluginError as e:
-                    # If there was an error producing entries, but we have valid entries in the db cache, return those.
-                    if self.persist and not task.options.nocache:
-                        with Session() as session:
-                            db_cache = (
-                                session.query(InputCache)
-                                .filter(InputCache.name == self.name)
-                                .filter(InputCache.hash == hash)
-                                .first()
-                            )
-                            if db_cache and db_cache.entries:
-                                log.error(
-                                    'There was an error during %s input (%s), using cache instead.'
-                                    % (self.name, e)
-                                )
-                                entries = [ent.entry for ent in db_cache.entries]
-                                log.verbose('Restored %s entries from db cache' % len(entries))
-                                # Store to in memory cache
-                                self.cache[cache_name] = copy.deepcopy(entries)
-                                return entries
-                    # If there was nothing in the db cache, re-raise the error.
-                    raise
-                if not isinstance(response, list):
-                    log.warning('Input %s did not return a list, cannot cache.' % self.name)
-                    return response
-                # store results to cache
-                log.debug('storing to cache %s %s entries' % (cache_name, len(response)))
-                try:
-                    self.cache[cache_name] = copy.deepcopy(response)
-                except TypeError:
-                    # might be caused because of backlog restoring some idiotic stuff, so not neccessarily a bug
-                    log.critical(
-                        'Unable to save task content into cache, '
-                        'if problem persists longer than a day please report this as a bug'
-                    )
                 if self.persist:
-                    # Store to database
-                    log.debug('Storing cache %s to database.' % cache_name)
-                    with Session() as session:
-                        db_cache = (
-                            session.query(InputCache)
-                            .filter(InputCache.name == self.name)
-                            .filter(InputCache.hash == hash)
-                            .first()
+                    # Check database cache
+                    db_cache = self.load_from_db()
+                    if db_cache is not None:
+                        return db_cache
+
+            # Nothing was restored from db or memory cache, run the function
+            log.trace('cache miss')
+            # call input event
+            try:
+                response = func(*args, **kwargs)
+            except PluginError as e:
+                # If there was an error producing entries, but we have valid entries in the db cache, return those.
+                if self.persist and not task.options.nocache:
+                    cache = self.load_from_db(load_expired=True)
+                    if cache is not None:
+                        log.error(
+                            'There was an error during %s input (%s), using cache instead.'
+                            % (self.name, e)
                         )
-                        if not db_cache:
-                            db_cache = InputCache(name=self.name, hash=hash)
-                        db_cache.entries = [InputCacheEntry(entry=ent) for ent in response]
-                        db_cache.added = datetime.now()
-                        session.merge(db_cache)
-                return response
+                        return cache
+                # If there was nothing in the db cache, re-raise the error.
+                raise
+            # store results to cache
+            log.debug('storing entries to cache %s ', self.cache_name)
+            cache = IterableCache(response, self.store_to_db if self.persist else None)
+            self.cache[self.cache_name] = cache
+            return cache
 
         return wrapped_func
+
+    def store_to_db(self, entries):
+        # Store to database
+        log.debug('Storing cache %s to database.' % self.cache_name)
+        with Session() as session:
+            db_cache = (
+                session.query(InputCache)
+                    .filter(InputCache.name == self.name)
+                    .filter(InputCache.hash == self.config_hash)
+                    .first()
+            )
+            if not db_cache:
+                db_cache = InputCache(name=self.name, hash=self.config_hash)
+            db_cache.entries = [InputCacheEntry(entry=ent) for ent in entries]
+            db_cache.added = datetime.now()
+            session.merge(db_cache)
+
+    def load_from_db(self, load_expired=False):
+        with Session() as session:
+            db_cache = (
+                session.query(InputCache)
+                    .filter(InputCache.name == self.name)
+                    .filter(InputCache.hash == self.config_hash)
+            )
+            if not load_expired:
+                db_cache = db_cache.filter(InputCache.added > datetime.now() - self.persist)
+            db_cache = db_cache.first()
+            if db_cache:
+                entries = [ent.entry for ent in db_cache.entries]
+                log.verbose('Restored %s entries from db cache' % len(entries))
+                # Store to in memory cache
+                self.cache[self.cache_name] = copy.deepcopy(entries)
+                return entries
+
+
+class IterableCache(object):
+    """
+    Can cache any iterable (including generators) without immediately evaluating all entries.
+    If `finished_hook` is supplied, it will be called the first time the iterable is run to the end.
+    """
+    def __init__(self, iterable, finished_hook=None):
+        self.iterable = iter(iterable)
+        self.cache = []
+        self.finished_hook = finished_hook
+
+    def __iter__(self):
+        for item in self.cache:
+            yield copy.deepcopy(item)
+        for item in self.iterable:
+            self.cache.append(item)
+            yield copy.deepcopy(item)
+        # The first time we iterate through all items, call our finished hook with complete list of items
+        if self.finished_hook:
+            self.finished_hook(self.cache)
+            self.finished_hook = None

--- a/flexget/utils/cached_input.py
+++ b/flexget/utils/cached_input.py
@@ -100,22 +100,7 @@ class cached(object):
         def wrapped_func(*args, **kwargs):
             # get task from method parameters
             task = args[1]
-
-            # detect api version
-            api_ver = 1
-            if len(args) == 3:
-                api_ver = 2
-
-            if api_ver == 1:
-                # get name for a cache from tasks configuration
-                if self.name not in task.config:
-                    raise Exception(
-                        '@cache config name %s is not configured in task %s'
-                        % (self.name, task.name)
-                    )
-                hash = get_config_hash(task.config[self.name])
-            else:
-                hash = get_config_hash(args[2])
+            hash = get_config_hash(args[2])
 
             log.trace('self.name: %s' % self.name)
             log.trace('hash: %s' % hash)
@@ -182,8 +167,6 @@ class cached(object):
                                 return entries
                     # If there was nothing in the db cache, re-raise the error.
                     raise
-                if api_ver == 1:
-                    response = task.entries
                 if not isinstance(response, list):
                     log.warning('Input %s did not return a list, cannot cache.' % self.name)
                     return response


### PR DESCRIPTION
### Motivation for changes:
We needed a way to limit entries created by trakt_list plugin #2386, #2388. We added a limit option to that plugin. This is an experiment to see if we could use a more generic approach to limit any input plugin, while still allowing the optimization of not having the input plugin request more than is necessary from its source. (i.e. limiting HTTP or database requests)

### Detailed changes:
- Allows input plugins to be generators
- Adds 'limit' plugin, which takes a limit amount, as well as the configuration for another input plugin

### Config usage if relevant (new plugin or updated schema):
```
limit:
  amount: 5
  from:
    rss: http://blah.com
```

#### To Do:

- [x] Verify whether we like this idea
- [x] Convert input plugins which might take a long time to get many entries to generators
- [x] Deprecate limit options from plugins that implemented themselves (T411, Letterboxd)
- [x] Figure out how to best handle `@cached` decorator with generator inputs
