### PR TITLE
[Fix] cfscraper failing to parse due to reCaptcha

### DIFF
--- a/flexget/plugins/operate/cfscraper.py
+++ b/flexget/plugins/operate/cfscraper.py
@@ -6,6 +6,7 @@ import logging
 from flexget import plugin
 from flexget.event import event
 from flexget.utils.requests import Session
+from collections import OrderedDict
 
 log = logging.getLogger('cfscraper')
 
@@ -36,6 +37,18 @@ class CFScraper(object):
             """
 
         if config is True:
+            task.requests.headers = (
+                OrderedDict(
+                    [
+                        ('User-Agent', task.requests.headers['User-Agent']),
+                        ('Accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'),
+                        ('Accept-Language', 'en-US,en;q=0.5'),
+                        ('Accept-Encoding', 'gzip, deflate'),
+                        ('Connection',  'close'),
+                        ('Upgrade-Insecure-Requests', '1')
+                    ]
+                )
+            )
             task.requests = CFScrapeWrapper.create_scraper(task.requests)
 
 


### PR DESCRIPTION
Include ordered headers to prevent CloudScraper from hitting ReCaptcha, per https://github.com/VeNoMouS/cloudscraper/issues/38#issuecomment-491100011

### Addressed issues:
- Fixes #2387 .