### PR TITLE
[add] from_transmission: Add 'transmission_error_state'

### DIFF
--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -240,6 +240,13 @@ class PluginTransmissionInput(TransmissionBase):
             entry['transmission_trackers'] = [t['announce'] for t in torrent.trackers]
             entry['transmission_seed_ratio_ok'] = seed_ratio_ok
             entry['transmission_idle_limit_ok'] = idle_limit_ok
+            st_error_to_desc = {
+                0: 'OK',
+                1: 'tracker_warning',
+                2: 'tracker_error',
+                3: 'local_error'
+            }
+            entry['transmission_error_state'] = st_error_to_desc[torrent.error]
             # Built in done_date doesn't work when user adds an already completed file to transmission
             if torrent.progress == 100:
                 entry['transmission_date_done'] = datetime.fromtimestamp(


### PR DESCRIPTION
### Motivation for changes:
Cleanup of torrents may remove finished, but not moved to final location torrents.

### Detailed changes:
I use dedicated miniserver for downloading new torrents. Miniserver uses local storage for unfinished torrents, but move fully downloaded torrents to main NAS. Sometimes torrent cannot be moved to final location due to various reasons. Currently I cannot distiguish between completed and moved to final destination torrents and finished but failed to move to proper location torrent.
This change add `transmission_error_state` attribute with human-readable status. In particular,  error status `local_error` means that files cannot be created locally or cannot be moved to final location.

