### PR TITLE
[WIP] cli-config Overhaul

### DIFF
--- a/flexget/plugins/cli/cli_config.py
+++ b/flexget/plugins/cli/cli_config.py
@@ -1,59 +1,66 @@
 from __future__ import unicode_literals, division, absolute_import
 from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
-from past.builtins import basestring
 
 import argparse
-import functools
 import logging
 
-from flexget import options
+from jinja2 import TemplateError, StrictUndefined, Undefined, UndefinedError
+from jinja2.nativetypes import NativeEnvironment
+
+from flexget import options, plugin
 from flexget.event import event
 
 log = logging.getLogger('cli_config')
 
 """
-Allows specifying yml configuration values from commandline parameters.
+Allows specifying yaml configuration values from commandline parameters.
 
-Yml variables are prefixed with dollar sign ($).
-Commandline parameter must be comma separated list of variable=values.
+Variables in the config should be surrounded by {-- --}.
 
 Configuration example::
 
   tasks:
     my task:
-      rss: $url
-      download: $path
+      rss: "{-- url --}"
+      download: "{-- path --}"
 
 Commandline example::
 
-  --cli-config url=http://some.url/ path=~/downloads
+  flexget --cli-config url=http://some.url/ --cli-config path=~/downloads execute
 
 """
 
 
-def replace_in_item(replaces, item):
-    replace = functools.partial(replace_in_item, replaces)
-    if isinstance(item, basestring):
-        # Do replacement in text objects
-        for key, val in replaces.items():
-            item = item.replace('$%s' % key, val)
-        return item
-    elif isinstance(item, list):
-        # Make a new list with replacements done on each item
-        return list(map(replace, item))
-    elif isinstance(item, dict):
-        # Make a new dict with replacements done on keys and values
-        return dict(list(map(replace, kv_pair)) for kv_pair in item.items())
-    else:
-        # We don't know how to do replacements on this item, just return it
-        return item
-
-
 @event('manager.before_config_validate')
 def substitute_cli_variables(config, manager):
-    if not manager.options.execute.cli_config:
-        return
-    return replace_in_item(dict(manager.options.execute.cli_config), config)
+    env_params = {
+        'block_start_string': '^^disabled^^',
+        'block_end_string': '^^disabled^^',
+        'variable_start_string': '{--',
+        'variable_end_string': '--}',
+    }
+    env = NativeEnvironment(**env_params)
+    if manager.options.execute.cli_config:
+        raise plugin.PluginError("--cli-config has been overhauled, check wiki for updated documentation.", logger=log)
+    variables = dict(manager.options.cli_config)
+    env.globals = variables
+    for key in config:
+        if key == 'tasks':
+            # Hacky way to disable tasks/templates which don't have their cli-config variables defined
+            env.undefined = StrictUndefined
+            for task_name in config[key]:
+                if task_name.startswith('_'):
+                    continue
+                try:
+                    config[key][task_name] = _process(config[key][task_name], env)
+                except UndefinedError as e:
+                    log.warning('Disabling task `%s` because of undefined cli-config variable.', task_name)
+                    config[key]['_'+task_name] = config[key].pop(task_name)
+        else:
+            # In other sections of the config, undefined variables will be blanked out
+            env.undefined = Undefined
+            config[key] = _process(config[key], env)
+    return config
 
 
 def key_value_pair(text):
@@ -62,12 +69,45 @@ def key_value_pair(text):
     return text.split('=', 1)
 
 
+def _process(element, environment):
+    if isinstance(element, dict):
+        for k, v in element.items():
+            new_key = _process(k, environment)
+            if new_key:
+                element[new_key] = element.pop(k)
+                k = new_key
+            val = _process(element[k], environment)
+            if val:
+                element[k] = val
+    elif isinstance(element, list):
+        for i, v in enumerate(element):
+            val = _process(v, environment)
+            if val:
+                element[i] = val
+    elif isinstance(element, str) and '{--' in element:
+        try:
+            template = environment.from_string(element)
+            return template.render()
+        except (TemplateError, TypeError, UndefinedError):
+            log.warning('Error rendering cli-config variable: %s', element)
+            return element
+    return element
+
+
 @event('options.register')
 def register_parser_arguments():
+    options.get_parser().add_argument(
+        '--cli-config',
+        action='append',
+        type=key_value_pair,
+        metavar='VARIABLE=VALUE',
+        help='configuration parameters through commandline',
+    )
+    # This format is not actually allowed, it is here so we can show a better error message for old users
     options.get_parser('execute').add_argument(
         '--cli-config',
         nargs='+',
         type=key_value_pair,
         metavar='VARIABLE=VALUE',
-        help='configuration parameters through commandline',
+        help=argparse.SUPPRESS,
     )

--- a/flexget/plugins/cli/cli_config.py
+++ b/flexget/plugins/cli/cli_config.py
@@ -42,7 +42,10 @@ def substitute_cli_variables(config, manager):
     env = NativeEnvironment(**env_params)
     if manager.options.execute.cli_config:
         raise plugin.PluginError("--cli-config has been overhauled, check wiki for updated documentation.", logger=log)
-    variables = dict(manager.options.cli_config)
+    if manager.options.cli_config:
+        variables = dict(manager.options.cli_config)
+    else:
+        variables = {}
     env.globals = variables
     for key in config:
         if key == 'tasks':

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -754,6 +754,8 @@ class Task(object):
 def register_config_key():
     task_config_schema = {
         'type': 'object',
+        # Don't validate commented out plugins
+        'patternProperties': {'^_': {}},
         'additionalProperties': plugin_schemas(interface='task'),
     }
 


### PR DESCRIPTION
### Motivation for changes:
`check` command couldn't work with cli-config (#2379). Use jinja for more versatility with cli-config replacements. Allow disabling tasks gracefully when needed cli-config variables are not defined.

### Detailed changes:
- `--cli-config` switches to being an argument to base flexget rather than of the `execute` command. Allows it to be used with other commands, such as check, and daemon
- Does not allow multiple arguments to --cli-config, this created ambiguity when parsing the command. i.e. (`--cli-config var1=a var2=b` -> `--cli-config var1=a --cli-config var2=b`)
- Switch from `$var` format for cli-config to `{-- var --}` jinja2 format
- Disabled tasks no longer have their config validated
- cli-config disables tasks which do not have their cli-config variables defined

### Addressed issues:
- Fixes #2379

### Implemented feature requests:
- Feathub #[XX](https://feathub.com/Flexget/Flexget/+XX).

### Config usage if relevant (new plugin or updated schema):
```yaml
html:
  url: "{-- url --}"
```
```sh
flexget --cli-config url=http://blah.com execute
```

#### To Do:

- [ ] Evaluate whether we like all/any of this.
- [ ] Consider template usage. Validation will still fail if cli-config variables are used in templates.
- [ ] The task disabling is pretty hacky and not so elegant, is there some better way?
- [ ] Make sure execute command works with --cli-config after daemon is already running.