### PR TITLE
Implemented new jinja tests

### DIFF
--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import locale
+import os.path
 from copy import copy
 from datetime import datetime, date, time
 
@@ -140,6 +141,21 @@ def filter_default(value, default_value='', boolean=True):
 filter_d = filter_default
 
 
+def is_fs_file(pathname):
+    """Test whether item is existing file in filesystem"""
+    return os.path.isfile(pathname)
+
+
+def is_fs_dir(pathname):
+    """Test whether item is existing directory in filesystem"""
+    return os.path.isdir(pathname)
+
+
+def is_fs_link(pathname):
+    """Test whether item is existing link in filesystem"""
+    return os.path.islink(pathname)
+
+
 class FlexGetTemplate(Template):
     """Adds lazy lookup support when rendering templates."""
 
@@ -172,6 +188,9 @@ def make_environment(manager):
     for name, filt in list(globals().items()):
         if name.startswith('filter_'):
             environment.filters[name.split('_', 1)[1]] = filt
+    for name, test in list(globals().items()):
+        if name.startswith('is_'):
+            environment.tests[name.split('_', 1)[1]] = test
 
 
 def list_templates(extensions=None):


### PR DESCRIPTION
### Motivation for changes:
Sometimes transmission do not report any error when files are not moved to final location from 'incomplete' directory. Need simple check for presence of files on filesystem when cleaning completed torrents

### Detailed changes:
As follow-up for PR #2394. Added `is fs_file` jinja test. Also added `fs_dir` and `fs_link` tests for additional flexibility. 

### Config usage if relevant (new plugin or updated schema):
example:
``` YAML
  clean-torr:
    from_transmission:
      username: '{? trans.usr ?}'
      password: '{? trans.pwd ?}'
    disable: [seen, seen_info_hash]
    no_entries_ok: yes
    if:
      - transmission_error_state == 'local_error': reject
      - transmission_progress < 100: reject
      - ('/path/transmission/incomplete/' ~ title) is fs_file: reject
      - transmission_date_added + timedelta(minutes=95) < now: accept
    transmission:
      username: '{? trans.usr ?}'
      password: '{? trans.pwd ?}'
      action: remove
```

