### PR TITLE
[add] transmission plugin: added ability to move torrent data to new location

### DIFF
--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -432,6 +432,17 @@ class PluginTransmission(TransmissionBase):
                 log.info('"%s" torrent added to transmission', entry['title'])
                 # The info returned by the add call is incomplete, refresh it
                 torrent_info = self.client.get_torrent(torrent_info.id)
+            else:
+                # Torrent already loaded in transmission
+                if options['add'].get('download_dir'):
+                    log.verbose('Moving %s to "%s"', torrent_info.name, options['add']['download_dir'])
+                    # Move data even if current reported torrent location matches new location
+                    # as transmission may fail to automatically move completed file to final
+                    # location but continue reporting final location instead of real location.
+                    # In such case this will kick transmission to really move data.
+                    # If data is already located at new location then transmission just ignore
+                    # this command.
+                    self.client.move_torrent_data(torrent_info.id, options['add']['download_dir'], 120)
 
             try:
                 total_size = torrent_info.totalSize


### PR DESCRIPTION
### Motivation for changes:
Need to kick transmission to finally move downloaded torrents data to new location.

### Detailed changes:
As additional follow-up for PRs #2394 and #2410. If transmission failed to move file from 'incomplete' directory to final location, it is required to somehow push transmission to finish job.

### Config usage:
example usage (with PR #2410 merged)
Note: `isfile('/path/transmission/incomplete/' ~ title)` will match only finished, but not moved files as for incomplete files transmission add suffix (by default).
``` YAML
  kick-stalled-torrents:
    from_transmission:
      username: '{? trans.usr ?}'
      password: '{? trans.pwd ?}'
    disable: [seen, seen_info_hash]
    no_entries_ok: yes
    if:
      - transmission_error_state == 'local_error': accept
      - isfile('/path/transmission/incomplete/' ~ title): accept
    transmission:
      username: '{? trans.usr ?}'
      password: '{? trans.pwd ?}'
      action: resume
      path: '{{transmission_downloadDir}}'
```
