### PR TITLE
[change] Add pagination headers to history api even if no items are present

### DIFF
--- a/flexget/components/history/api.py
+++ b/flexget/components/history/api.py
@@ -75,7 +75,11 @@ class HistoryAPI(APIResource):
         total_items = query.count()
 
         if not total_items:
-            return jsonify([])
+            pagination = pagination_headers(0, 0, 0, request)
+            rsp = jsonify([])
+            rsp.headers.extend(pagination)
+            return rsp
+
 
         total_pages = int(ceil(total_items / float(per_page)))
 

--- a/flexget/components/history/api.py
+++ b/flexget/components/history/api.py
@@ -80,7 +80,6 @@ class HistoryAPI(APIResource):
             rsp.headers.extend(pagination)
             return rsp
 
-
         total_pages = int(ceil(total_items / float(per_page)))
 
         if page > total_pages:


### PR DESCRIPTION
### Motivation for changes:
Making Total Count explicitly 0 makes it easier for me to handle infinite scroll for this plugin from the web-ui. 

### Detailed changes:
- Add pagination headers in empty response from GET history api endpoint

