### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -536,7 +536,7 @@ class PluginTransmission(TransmissionBase):
                         # Get new filename without ext
                         file_ext = os.path.splitext(file_list[main_id]['name'])[1]
                         file_path = os.path.dirname(
-                            os.path.join(download_dir, file_list[main_id]['name'])
+                            os.path.join(download_dir.decode('utf-8'), file_list[main_id]['name'])
                         )
                         filename = options['post']['content_filename']
                         if config['host'] == 'localhost' or config['host'] == '127.0.0.1':


### PR DESCRIPTION
### Motivation for changes:

transmission plugin crashes upon encountering a non-ascii character in an item title, or file path

### Detailed changes:
- Decodes `str` as `utf-8` to convert it to `unicode`

### Addressed issues:
- Fixes #1750 
- Fixes #2055

