### PR TITLE
[fix] thetvdb component retrieve first aired date

### DIFF
--- a/flexget/components/thetvdb/api_tvdb.py
+++ b/flexget/components/thetvdb/api_tvdb.py
@@ -211,6 +211,13 @@ class TVDBSeries(Base):
         self._banner = series['banner']
         self._genres = [TVDBGenre(id=name) for name in series['genre']] if series['genre'] else []
 
+        if self.first_aired is None:
+            try:
+                episode = TVDBRequest().get('series/%s/episodes/query?absoluteNumber=1' % self.id, language=language)
+                self.first_aired = episode[0]['firstAired']
+            except requests.RequestException as e:
+                raise LookupError('Error updating first_aired from tvdb first episode: %s' % e)
+
         # Actors and Posters are lazy populated
         self._actors = None
         self._posters = None


### PR DESCRIPTION
- fallback to retrieve the first episode's aired date when series's first aired date not specified

### Motivation for changes:
TheTVDB stopped providing the series's first aired date correctly. This fix is to fallback to getting the aired date from the first episode if it is not available.

### Detailed changes:
- If `first_aired` is not set, query TheTVDB API for the first episode and use it's `first_aired` value
