### PR TITLE
Allow to add paused torrents to qbittorrent

### DIFF
--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -154,7 +154,7 @@ class OutputQBitTorrent(object):
                 form_data['label'] = label  # qBittorrent v3.3.3-
                 form_data['category'] = label  # qBittorrent v3.3.4+
 
-            add_paused = entry.get('paused', config.get('paused'))
+            add_paused = entry.get('add_paused', config.get('add_paused'))
             if add_paused:
                 form_data['paused'] = 'true'
 

--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -30,6 +30,7 @@ class OutputQBitTorrent(object):
         label: <LABEL> (default: (none))
         maxupspeed: <torrent upload speed limit> (default: 0)
         maxdownspeed: <torrent download speed limit> (default: 0)
+        add_paused: <ADD_PAUSED> (default: False)
     """
 
     schema = {
@@ -49,6 +50,7 @@ class OutputQBitTorrent(object):
                     'maxupspeed': {'type': 'integer'},
                     'maxdownspeed': {'type': 'integer'},
                     'fail_html': {'type': 'boolean'},
+                    'add_paused': {'type': 'boolean'},
                 },
                 'additionalProperties': False,
             },
@@ -152,6 +154,10 @@ class OutputQBitTorrent(object):
                 form_data['label'] = label  # qBittorrent v3.3.3-
                 form_data['category'] = label  # qBittorrent v3.3.4+
 
+            add_paused = entry.get('paused', config.get('paused'))
+            if add_paused:
+                form_data['paused'] = 'true'
+
             maxupspeed = entry.get('maxupspeed', config.get('maxupspeed'))
             if maxupspeed:
                 form_data['upLimit'] = maxupspeed * 1024
@@ -171,6 +177,7 @@ class OutputQBitTorrent(object):
                     log.info('Url: %s', entry.get('url'))
                 log.info('Save path: %s', form_data.get('savepath'))
                 log.info('Label: %s', form_data.get('label'))
+                log.info('Paused: %s', form_data.get('paused', 'false'))
                 if maxupspeed:
                     log.info('Upload Speed Limit: %d', form_data.get('upLimit'))
                 if maxdownspeed:


### PR DESCRIPTION
### Motivation for changes:
I switched from Transmission to qBittorrent and I found that I couldn't add torrents in a paused state.

### Detailed changes:
- Added `add_paused` token to qBittorrent configuration that allows torrents to be added in paused state

### Config usage if relevant (new plugin or updated schema):
```YAML

  my_qbittorrent_server:
    qbittorrent:
      host: 127.0.0.1
      port: 8080
      path: /download/
      add_paused: yes
```