### PR TITLE
[fix] regexp: Fix edge cases with 'rest' operation

### DIFF
--- a/flexget/tests/test_regexp.py
+++ b/flexget/tests/test_regexp.py
@@ -48,6 +48,20 @@ class TestRegexp(object):
                 - regexp1
               rest: reject
 
+          test_rest2:
+            template: no_global
+            mock:
+            - title: accept
+            regexp:
+              accept:
+              - accept
+              reject:
+              - reject
+              rest: reject
+              
+          test_only_rest:
+            regexp:
+              rest: reject
 
           # test excluding
           test_excluding:
@@ -122,6 +136,14 @@ class TestRegexp(object):
         task = execute_task('test_rest')
         assert task.find_entry('accepted', title='regexp1'), 'regexp1 should have been accepted'
         assert task.find_entry('rejected', title='regexp3'), 'regexp3 should have been rejected'
+
+    def test_rest2(self, execute_task):
+        task = execute_task('test_rest2')
+        assert task.find_entry('accepted', title='accept'), 'regexp1 should have been accepted'
+
+    def test_only_rest(self, execute_task):
+        task = execute_task('test_only_rest')
+        assert len(task.all_entries) == len(task.rejected), 'all entries should have been rejected'
 
     def test_excluding(self, execute_task):
         task = execute_task('test_excluding')


### PR DESCRIPTION
### Motivation for changes:
As discovered on the forum, there are cases where the regexp 'rest' operation does not work correctly. https://discuss.flexget.com/t/accepted-entries-are-rejected/4833

### Detailed changes:
There were 2 edge cases I identified and fixed:
- If the first regexp operation(s) run matched _all_ of the entries, any entries not matched by subsequent operations would be considered 'rest' (even though there should not be _any_ 'rest' in this case.)
- If there were no operations defined, and only rest was used, (stupid case I know,) the 'rest' operation would be ignored.

### Addressed issues:
- Fixes https://discuss.flexget.com/t/accepted-entries-are-rejected/4833