### PR TITLE
[fix] exists_movie support movie same name different year

### DIFF
--- a/flexget/plugins/filter/exists_movie.py
+++ b/flexget/plugins/filter/exists_movie.py
@@ -165,27 +165,27 @@ class FilterExistsMovie(object):
             count_entries += 1
             log.debug('trying to parse entry %s' % entry['title'])
             if config.get('lookup') == 'imdb':
-                keyImdb = 'imdb_id'
-                if not entry.get(keyImdb, eval_lazy=False):
+                key_imdb = 'imdb_id'
+                if not entry.get(key_imdb, eval_lazy=False):
                     try:
                         imdb_lookup.lookup(entry)
                     except plugin.PluginError as e:
                         log.trace('entry %s imdb failed (%s)' % (entry['title'], e.value))
                         incompatible_entries += 1
                         continue
-                key = entry[keyImdb]
+                key = entry[key_imdb]
             else:
-                keyName = 'movie_name'
-                keyYear = 'movie_year'
-                if not entry.get(keyName, eval_lazy=False):
+                key_name = 'movie_name'
+                key_year = 'movie_year'
+                if not entry.get(key_name, eval_lazy=False):
                     movie = plugin.get('parsing', self).parse_movie(entry['title'])
-                    entry[keyName] = movie.name
-                    entry[keyYear] = movie.year
+                    entry[key_name] = movie.name
+                    entry[key_year] = movie.year
                     
-                if entry.get(keyYear, eval_lazy=False):
-                    key = "%s %s" % (entry[keyName], entry[keyYear])
+                if entry.get(key_year, eval_lazy=False):
+                    key = "%s %s" % (entry[key_name], entry[key_year])
                 else:
-                    key = entry[keyName]
+                    key = entry[key_name]
 
             # actual filtering
             if key in qualities:

--- a/flexget/plugins/filter/exists_movie.py
+++ b/flexget/plugins/filter/exists_movie.py
@@ -176,12 +176,14 @@ class FilterExistsMovie(object):
                 key = entry[keyImdb]
             else:
                 keyName = 'movie_name'
+                keyYear = 'movie_year'
                 if not entry.get(keyName, eval_lazy=False):
                     movie = plugin.get('parsing', self).parse_movie(entry['title'])
                     entry[keyName] = movie.name
+                    entry[keyYear] = movie.year
                     
-                if entry.get('movie_year', eval_lazy=False):
-                    key = "%s %s" % (entry[keyName], entry['movie_year'])
+                if entry.get(keyYear, eval_lazy=False):
+                    key = "%s %s" % (entry[keyName], entry[keyYear])
                 else:
                     key = entry[keyName]
 

--- a/flexget/tests/test_exists_movie.py
+++ b/flexget/tests/test_exists_movie.py
@@ -30,6 +30,16 @@ class TestExistsMovie(object):
               path: __tmp__
               type: files
 
+          test_same_name_diff_year:
+            mock:
+              - {title: 'Downloaded.2013'}
+              - {title: 'Downloaded.2019'}
+              - {title: 'Downloaded'}
+            accept_all: yes
+            exists_movie:
+              path: __tmp__
+              type: files
+
           test_lookup_imdb:
             mock:
               - {title: 'Existence.2012'}
@@ -119,6 +129,19 @@ class TestExistsMovie(object):
         assert task.find_entry(
             'accepted', title='Gone.Missing.2013'
         ), 'Gone.Missing.2013 should have been accepted'
+
+    def test_same_name_diff_year(self, execute_task):
+        """exists_movie plugin: existing with same name with different year"""
+        task = execute_task('test_same_name_diff_year')
+        assert not task.find_entry(
+            'accepted', title='Downloaded.2013'
+        ), 'Downloaded.2013 should not have been accepted (exists)'
+        assert task.find_entry(
+            'accepted', title='Downloaded'
+        ), 'Downloaded should have been accepted'
+        assert task.find_entry(
+            'accepted', title='Downloaded.2019'
+        ), 'Downloaded.2019 should have been accepted'
 
     @pytest.mark.online
     def test_lookup_imdb(self, execute_task):


### PR DESCRIPTION
### Motivation for changes:
Currently `exists_movie` has a bug on movies with the same name but different year, there cases like `The Lion King (1994)` and  `The Lion King (2019)` and currently `exists_movie` reject it due has the same name, this PR fix that bug

### Detailed changes:
- add the year of the movie to the key identifier to allow movie with same neam and different year

### Addressed issues:
- No open issue yet

### Log and/or tests output (preferably both):
```
adding: The Lion King 1994
adding: Pokémon Detective Pikachu 2019
adding: Ant-Man and the Wasp 2018
Teen Titans Go! To the Movies 2018
2019-10-14 12:34 VERBOSE  task          copy-movies     REJECTED: `Teen Titans Go! To the Movies (2018)[1080p]` by exists_movie plugin because movie exists
Steven Universe: The Movie 2019
2019-10-14 12:34 VERBOSE  task          copy-movies     REJECTED: `steven.universe.the.movie.2019.hdrip.720p.latino` by exists_movie plugin because movie exists
The Lion King 2019
El Camino: A Breaking Bad Movie 2019
2019-10-14 12:34 VERBOSE  task          copy-movies     REJECTED: `El.camino.a.breaking.bad.movie.2019.1080p-dual-lat-cinecalidad.is` by exists_movie plugin because movie exists
2019-10-14 12:34 VERBOSE  details       copy-movies     Summary - Accepted: 1 (Rejected: 19 Undecided: 0 Failed: 0)
2019-10-14 12:34 INFO     copy          copy-movies     Creating destination directory `/movies/The Lion King (2019)`
```

