### PR TITLE
[fix] python 3 support to yts site component

### DIFF
--- a/flexget/components/sites/sites/yts.py
+++ b/flexget/components/sites/sites/yts.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+from future.moves.urllib.parse import urlparse
+
 import logging
-import urllib
 
 from flexget import plugin
 from flexget.entry import Entry
@@ -24,7 +26,7 @@ class UrlRewriteYTS(object):
         ]
         for search_string in search_strings:
             url = 'https://yts.am/api/v2/list_movies.json?query_term=%s' % (
-                urllib.quote(search_string.encode('utf-8'))
+                quote(search_string.encode('utf-8'))
             )
 
             log.debug('requesting: %s' % url)


### PR DESCRIPTION
### Motivation for changes:
YTS site component is broken in python 3

### Detailed changes:
- replace with a compatibility libraries

### Addressed issues:
- No open yet

### Log and/or tests output (preferably both):
```
AttributeError: module 'urllib' has no attribute 'quote'
```
