### PR TITLE
Add python 3.8 compatibility

### DIFF
--- a/flexget/api/app.py
+++ b/flexget/api/app.py
@@ -415,9 +415,9 @@ def pagination_headers(total_pages, total_items, page_count, request):
     LINKTEMPLATE = '<{}?per_page={}&'.format(url, per_page)
 
     # Removed page and per_page from query string
-    query_string = re.sub(b'per_page=\d+', b'', request.query_string)
-    query_string = re.sub(b'page=\d+', b'', query_string)
-    query_string = re.sub(b'&{2,}', b'&', query_string)
+    query_string = re.sub(br'per_page=\d+', b'', request.query_string)
+    query_string = re.sub(br'page=\d+', b'', query_string)
+    query_string = re.sub(br'&{2,}', b'&', query_string)
 
     # Add all original query params
     LINKTEMPLATE += query_string.decode().lstrip('&') + '&page={}>; rel="{}"'

--- a/flexget/api/core/server.py
+++ b/flexget/api/core/server.py
@@ -13,7 +13,7 @@ import traceback
 from time import sleep
 from path import Path
 import binascii
-import cherrypy
+#import cherrypy
 import yaml
 from flask import Response, jsonify, request
 from flexget.utils.tools import get_latest_flexget_version_number

--- a/flexget/components/imdb/utils.py
+++ b/flexget/components/imdb/utils.py
@@ -194,7 +194,7 @@ class ImdbSearch(object):
             movie = {}
             additional = re.findall(r'\((.*?)\)', result_text.text)
             if len(additional) > 0:
-                if re.match('^\d{4}$', additional[-1]):
+                if re.match(r'^\d{4}$', additional[-1]):
                     movie['year'] = str_to_int(additional[-1])
                 elif len(additional) > 1:
                     movie['year'] = str_to_int(additional[-2])

--- a/flexget/components/irc/api.py
+++ b/flexget/components/irc/api.py
@@ -27,7 +27,7 @@ class ObjectsContainer(object):
             'alive': {'type': 'boolean'},
             'channels': {
                 'type': 'array',
-                'items': {'type': 'object', 'patternProperties': {'\w': {'type': 'integer'}}},
+                'items': {'type': 'object', 'patternProperties': {r'\w': {'type': 'integer'}}},
             },
             'connected_channels': {'type': 'array', 'items': {'type': 'string'}},
             'port': {'type': 'integer'},
@@ -35,7 +35,7 @@ class ObjectsContainer(object):
         },
     }
 
-    connection = {'type': 'object', 'patternProperties': {'\w': connection_object}}
+    connection = {'type': 'object', 'patternProperties': {r'\w': connection_object}}
 
     return_response = {'type': 'array', 'items': connection}
 

--- a/flexget/components/irc/irc.py
+++ b/flexget/components/irc/irc.py
@@ -39,7 +39,7 @@ URL_MATCHER = re.compile(
 
 channel_pattern = {
     'type': 'string',
-    'pattern': '^([#&][^\x07\x2C\s]{0,200})',
+    'pattern': '^([#&][^\x07\x2C\\s]{0,200})',
     'error_pattern': 'channel name must start with # or & and contain no commas and whitespace',
 }
 schema = {

--- a/flexget/components/sites/sites/allyoulike.py
+++ b/flexget/components/sites/sites/allyoulike.py
@@ -25,7 +25,7 @@ log = logging.getLogger('rlsbb')
 
 
 class UrlRewriteAllyoulike(object):
-    """
+    r"""
     allyoulike.com urlrewriter
     Version 0.1
 
@@ -63,7 +63,7 @@ class UrlRewriteAllyoulike(object):
     # urlrewriter API
     def url_rewritable(self, task, entry):
         url = entry['url']
-        rewritable_regex = '^https?:\/\/(www.)?allyoulike\.com\/.*'
+        rewritable_regex = r'^https?:\/\/(www.)?allyoulike\.com\/.*'
         return re.match(rewritable_regex, url) is not None
 
     def _get_soup(self, task, url):
@@ -81,7 +81,7 @@ class UrlRewriteAllyoulike(object):
     def url_rewrite(self, task, entry):
         soup = self._get_soup(task, entry['url'])
 
-        link_re = re.compile('rarefile\.net.*\.rar$')
+        link_re = re.compile(r'rarefile\.net.*\.rar$')
 
         # grab links from the main entry:
         blog_entry = soup.find('div', class_="entry")

--- a/flexget/components/sites/sites/alpharatio.py
+++ b/flexget/components/sites/sites/alpharatio.py
@@ -267,18 +267,18 @@ class SearchAlphaRatio(object):
                 group_info = result.find('td', attrs={'class': 'big_info'}).find(
                     'div', attrs={'class': 'group_info'}
                 )
-                title = group_info.find('a', href=re.compile('torrents.php\?id=\d+')).text
+                title = group_info.find('a', href=re.compile(r'torrents.php\?id=\d+')).text
                 url = (
                     self.base_url
                     + group_info.find(
-                        'a', href=re.compile('torrents.php\?action=download(?!usetoken)')
+                        'a', href=re.compile(r'torrents.php\?action=download(?!usetoken)')
                     )['href']
                 )
 
                 torrent_info = result.findAll('td')
                 size_col = torrent_info[size_idx].text
                 log.debug('AlphaRatio size: %s', size_col)
-                size = re.search('(\d+(?:[.,]\d+)*)\s?([KMGTP]B)', size_col)
+                size = re.search(r'(\d+(?:[.,]\d+)*)\s?([KMGTP]B)', size_col)
                 torrent_tags = ', '.join(
                     [tag.text for tag in group_info.findAll('div', attrs={'class': 'tags'})]
                 )

--- a/flexget/components/sites/sites/deadfrog.py
+++ b/flexget/components/sites/sites/deadfrog.py
@@ -36,7 +36,7 @@ class UrlRewriteDeadFrog(object):
             soup = get_soup(page.text)
         except Exception as e:
             raise UrlRewritingError(e)
-        down_link = soup.find('a', attrs={'href': re.compile("download/\d+/.*\.torrent")})
+        down_link = soup.find('a', attrs={'href': re.compile(r"download/\d+/.*\.torrent")})
         if not down_link:
             raise UrlRewritingError('Unable to locate download link from url %s' % url)
         return 'http://www.deadfrog.us/' + down_link.get('href')

--- a/flexget/components/sites/sites/morethantv.py
+++ b/flexget/components/sites/sites/morethantv.py
@@ -284,7 +284,7 @@ class SearchMoreThanTV(object):
                 title = group_info.find('a', href=re.compile(r'torrents.php\?id=\d+')).text
                 url = (
                     self.base_url
-                    + group_info.find('a', href=re.compile('torrents.php\?action=download'))[
+                    + group_info.find('a', href=re.compile(r'torrents.php\?action=download'))[
                         'href'
                     ]
                 )

--- a/flexget/components/sites/sites/ptn.py
+++ b/flexget/components/sites/sites/ptn.py
@@ -137,7 +137,7 @@ class SearchPTN(object):
             # html5parser doesn't work properly for some reason
             soup = get_soup(r.text, parser='html.parser')
             for movie in soup.select('.torrentstd'):
-                imdb_id = movie.find('a', href=re.compile('.*imdb\.com/title/tt'))
+                imdb_id = movie.find('a', href=re.compile(r'.*imdb\.com/title/tt'))
                 if imdb_id:
                     imdb_id = extract_id(imdb_id['href'])
                 if imdb_id and 'imdb_id' in entry and imdb_id != entry['imdb_id']:

--- a/flexget/components/sites/sites/rlsbb.py
+++ b/flexget/components/sites/sites/rlsbb.py
@@ -16,7 +16,7 @@ log = logging.getLogger('rlsbb')
 
 
 class UrlRewriteRlsbb(object):
-    """
+    r"""
     rlsbb.ru urlrewriter
     Version 0.1
 

--- a/flexget/components/sites/sites/rmz.py
+++ b/flexget/components/sites/sites/rmz.py
@@ -16,7 +16,7 @@ log = logging.getLogger('rmz')
 
 
 class UrlRewriteRmz(object):
-    """
+    r"""
     rmz.cr (rapidmoviez.com) urlrewriter
     Version 0.1
 

--- a/flexget/components/sites/urlrewrite.py
+++ b/flexget/components/sites/urlrewrite.py
@@ -12,7 +12,7 @@ log = logging.getLogger('urlrewrite')
 
 
 class UrlRewrite(object):
-    """
+    r"""
     Generic configurable urlrewriter.
 
     Example::

--- a/flexget/components/variables/variables.py
+++ b/flexget/components/variables/variables.py
@@ -96,7 +96,7 @@ def process_variables(config, manager):
 
 def _process(element, environment):
     if isinstance(element, dict):
-        for k, v in element.items():
+        for k, v in list(element.items()):
             new_key = _process(k, environment)
             if new_key:
                 element[new_key] = element.pop(k)

--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -260,7 +260,7 @@ def is_url(instance):
     regexp = (
         '('
         + '|'.join(['ftp', 'http', 'https', 'file', 'udp', 'socks5h?'])
-        + '):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?'
+        + r'):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?'
     )
     return re.match(regexp, instance)
 

--- a/flexget/plugins/filter/exists_movie.py
+++ b/flexget/plugins/filter/exists_movie.py
@@ -47,8 +47,8 @@ class FilterExistsMovie(object):
         ]
     }
 
-    dir_pattern = re.compile('\b(cd.\d|subs?|samples?)\b', re.IGNORECASE)
-    file_pattern = re.compile('\.(avi|mkv|mp4|mpg|webm)$', re.IGNORECASE)
+    dir_pattern = re.compile(r'\b(cd.\d|subs?|samples?)\b', re.IGNORECASE)
+    file_pattern = re.compile(r'\.(avi|mkv|mp4|mpg|webm)$', re.IGNORECASE)
 
     def __init__(self):
         self.cache = TimedDict(cache_time='1 hour')

--- a/flexget/plugins/input/apple_trailers.py
+++ b/flexget/plugins/input/apple_trailers.py
@@ -89,8 +89,8 @@ class AppleTrailers(object):
         if rss.get('bozo_exception', False):
             raise plugin.PluginError('Got bozo_exception (bad feed)')
 
-        filmid_regex = re.compile('(FilmId\s*\=\s*\')(\d+)(?=\')')
-        studio_regex = re.compile('(?:[0-9]*\s*)(.+)')
+        filmid_regex = re.compile(r'(FilmId\s*\=\s*\')(\d+)(?=\')')
+        studio_regex = re.compile(r'(?:[0-9]*\s*)(.+)')
         # use the following dict to save json object in case multiple trailers have been released for the same movie
         # no need to do multiple requests for the same thing!
         trailers = {}

--- a/flexget/plugins/input/html.py
+++ b/flexget/plugins/input/html.py
@@ -172,7 +172,7 @@ class InputHtml(object):
         parts = parse.urlsplit(url)
         name = ''
         if parts.scheme == 'magnet':
-            match = re.search('(?:&dn(?:\.\d)?=)(.+?)(?:&)', parts.query)
+            match = re.search(r'(?:&dn(?:\.\d)?=)(.+?)(?:&)', parts.query)
             if match:
                 name = match.group(1)
         else:

--- a/flexget/plugins/input/regexp_parse.py
+++ b/flexget/plugins/input/regexp_parse.py
@@ -15,7 +15,7 @@ log = logging.getLogger('regexp_parse')
 
 
 class RegexpParse(object):
-    """This plugin is designed to take input from a web resource or a file.
+    r"""This plugin is designed to take input from a web resource or a file.
     It then parses the text via regexps supplied in the config file.
 
     source: is a file or url to get the data from. You can specify a username:password

--- a/flexget/plugins/modify/manipulate.py
+++ b/flexget/plugins/modify/manipulate.py
@@ -11,7 +11,7 @@ log = logging.getLogger('manipulate')
 
 
 class Manipulate(object):
-    """
+    r"""
     Usage:
 
       manipulate:

--- a/flexget/plugins/modify/regex_extract.py
+++ b/flexget/plugins/modify/regex_extract.py
@@ -13,7 +13,7 @@ log = logging.getLogger('regex_extract')
 
 
 class RegexExtract(object):
-    """
+    r"""
     Updates an entry with the values of regex matched named groups
 
     Usage:

--- a/flexget/plugins/output/subtitles_periscope.py
+++ b/flexget/plugins/output/subtitles_periscope.py
@@ -12,7 +12,7 @@ log = logging.getLogger('subtitles')
 
 
 class PluginPeriscope(object):
-    """
+    r"""
     Search and download subtitles using Periscope by Patrick Dessalle
     (http://code.google.com/p/periscope/).
 

--- a/flexget/plugins/output/subtitles_subliminal.py
+++ b/flexget/plugins/output/subtitles_subliminal.py
@@ -23,7 +23,7 @@ AUTHENTICATION_SCHEMA = dict((provider, {'type': 'object'}) for provider in PROV
 
 
 class PluginSubliminal(object):
-    """
+    r"""
     Search and download subtitles using Subliminal by Antoine Bertin
     (https://pypi.python.org/pypi/subliminal).
 

--- a/flexget/tests/conftest.py
+++ b/flexget/tests/conftest.py
@@ -173,7 +173,7 @@ def link_headers(manager):
         links = {}
         for link in requests.utils.parse_header_links(response.headers.get('link')):
             url = link['url']
-            page = int(re.search('(?<!per_)page=(\d)', url).group(1))
+            page = int(re.search(r'(?<!per_)page=(\d)', url).group(1))
             links[link['rel']] = dict(url=url, page=page)
         return links
 

--- a/flexget/tests/test_abort_if_exists.py
+++ b/flexget/tests/test_abort_if_exists.py
@@ -7,7 +7,7 @@ from flexget.task import TaskAbort
 
 
 class TestAbortIfExists(object):
-    config = """
+    config = r"""
         templates:
           global:
             disable: [seen]

--- a/flexget/tests/test_filesystem.py
+++ b/flexget/tests/test_filesystem.py
@@ -54,7 +54,7 @@ class TestFilesystem(object):
             filesystem:
               path: """
         + test1
-        + """
+        + r"""
               regexp: '.*\.(mkv)$'
 
           recursive_true:

--- a/flexget/tests/test_manipulate.py
+++ b/flexget/tests/test_manipulate.py
@@ -3,7 +3,7 @@ from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 
 class TestManipulate(object):
-    config = """
+    config = r"""
         tasks:
 
           test_1:

--- a/flexget/tests/test_manipulate.py
+++ b/flexget/tests/test_manipulate.py
@@ -54,7 +54,7 @@ class TestManipulate(object):
               - title:
                   replace:
                     regexp: (1234)\-(7890)
-                    format: 'e\\2'
+                    format: 'e\2'
     """
 
     def test_replace(self, execute_task):

--- a/flexget/tests/test_regex_extract.py
+++ b/flexget/tests/test_regex_extract.py
@@ -3,7 +3,7 @@ from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 
 
 class TestRegexExtract(object):
-    config = """
+    config = r"""
         tasks:
 
           test_1:

--- a/flexget/tests/test_seriesparser.py
+++ b/flexget/tests/test_seriesparser.py
@@ -642,7 +642,7 @@ class TestSeriesParser(object):
         assert not s.proper, 'detected proper'
 
     def test_episode_with_season_pack_match_is_not_season_pack(self, parse):
-        """SeriesParser: Github issue #1986, s\d{1} parses as invalid season"""
+        r"""SeriesParser: Github issue #1986, s\d{1} parses as invalid season"""
         s = parse(name='The Show', data='The.Show.S01E01.eps3.0.some.title.720p.x264-NOGRP')
         assert s.valid
         assert not s.season_pack

--- a/flexget/tests/test_sort_by.py
+++ b/flexget/tests/test_sort_by.py
@@ -5,7 +5,7 @@ import pytest
 
 
 class TestSortBy(object):
-    config = """
+    config = r"""
         tasks:
           test_title:
             sort_by: title

--- a/flexget/tests/test_urlrewriting.py
+++ b/flexget/tests/test_urlrewriting.py
@@ -75,7 +75,7 @@ class TestURLRewriters(object):
 class TestRegexpurlrewriter(object):
     # TODO: this test is broken?
 
-    config = """
+    config = r"""
         tasks:
           test:
             mock:

--- a/flexget/utils/bittorrent.py
+++ b/flexget/utils/bittorrent.py
@@ -96,7 +96,7 @@ def is_torrent_file(metafilepath):
     return bool(magic_marker)
 
 
-def tokenize(text, match=re.compile(b'([idel])|(\d+):|(-?\d+)').match):
+def tokenize(text, match=re.compile(br'([idel])|(\d+):|(-?\d+)').match):
     i = 0
     while i < len(text):
         m = match(text, i)

--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -33,7 +33,7 @@ class QualityComponent(object):
         # compile regexp
         if regexp is None:
             regexp = re.escape(name)
-        self.regexp = re.compile('(?<![^\W_])(' + regexp + ')(?![^\W_])', re.IGNORECASE)
+        self.regexp = re.compile(r'(?<![^\W_])(' + regexp + r')(?![^\W_])', re.IGNORECASE)
 
     def matches(self, text):
         """Test if quality matches to text.
@@ -135,20 +135,20 @@ _sources = [
     QualityComponent('source', 30, 'ts', '(?:hd)?ts|telesync', modifier=-6),
     QualityComponent('source', 40, 'tc', 'tc|telecine', modifier=-5),
     QualityComponent('source', 50, 'r5', 'r[2-8c]', modifier=-4),
-    QualityComponent('source', 60, 'hdrip', 'hd[\W_]?rip', modifier=-3),
-    QualityComponent('source', 70, 'ppvrip', 'ppv[\W_]?rip', modifier=-2),
+    QualityComponent('source', 60, 'hdrip', r'hd[\W_]?rip', modifier=-3),
+    QualityComponent('source', 70, 'ppvrip', r'ppv[\W_]?rip', modifier=-2),
     QualityComponent('source', 80, 'preair', modifier=-1),
-    QualityComponent('source', 90, 'tvrip', 'tv[\W_]?rip'),
-    QualityComponent('source', 100, 'dsr', 'dsr|ds[\W_]?rip'),
-    QualityComponent('source', 110, 'sdtv', '(?:[sp]dtv|dvb)(?:[\W_]?rip)?'),
-    QualityComponent('source', 120, 'dvdscr', '(?:(?:dvd|web)[\W_]?)?scr(?:eener)?', modifier=0),
+    QualityComponent('source', 90, 'tvrip', r'tv[\W_]?rip'),
+    QualityComponent('source', 100, 'dsr', r'dsr|ds[\W_]?rip'),
+    QualityComponent('source', 110, 'sdtv', r'(?:[sp]dtv|dvb)(?:[\W_]?rip)?'),
+    QualityComponent('source', 120, 'dvdscr', r'(?:(?:dvd|web)[\W_]?)?scr(?:eener)?', modifier=0),
     QualityComponent('source', 130, 'bdscr', 'bdscr(?:eener)?'),
-    QualityComponent('source', 140, 'webrip', 'web[\W_]?rip'),
-    QualityComponent('source', 150, 'hdtv', 'a?hdtv(?:[\W_]?rip)?'),
-    QualityComponent('source', 160, 'webdl', 'web(?:[\W_]?(dl|hd))?'),
-    QualityComponent('source', 170, 'dvdrip', 'dvd(?:[\W_]?rip)?'),
+    QualityComponent('source', 140, 'webrip', r'web[\W_]?rip'),
+    QualityComponent('source', 150, 'hdtv', r'a?hdtv(?:[\W_]?rip)?'),
+    QualityComponent('source', 160, 'webdl', r'web(?:[\W_]?(dl|hd))?'),
+    QualityComponent('source', 170, 'dvdrip', r'dvd(?:[\W_]?rip)?'),
     QualityComponent('source', 175, 'remux'),
-    QualityComponent('source', 180, 'bluray', '(?:b[dr][\W_]?rip|blu[\W_]?ray(?:[\W_]?rip)?)'),
+    QualityComponent('source', 180, 'bluray', r'(?:b[dr][\W_]?rip|blu[\W_]?ray(?:[\W_]?rip)?)'),
 ]
 _codecs = [
     QualityComponent('codec', 10, 'divx'),
@@ -158,7 +158,7 @@ _codecs = [
     QualityComponent('codec', 40, 'h265', '[hx].?265|hevc'),
     QualityComponent('codec', 50, '10bit', '10.?bit|hi10p'),
 ]
-channels = '(?:(?:[^\w+]?[1-7][\W_]?(?:0|1|ch)))'
+channels = r'(?:(?:[^\w+]?[1-7][\W_]?(?:0|1|ch)))'
 _audios = [
     QualityComponent('audio', 10, 'mp3'),
     # TODO: No idea what order these should go in or if we need different regexps
@@ -168,7 +168,7 @@ _audios = [
     QualityComponent('audio', 45, 'dd+5.1', 'dd[p+]%s' % channels),
     QualityComponent('audio', 50, 'flac', 'flac%s?' % channels),
     # The DTSs are a bit backwards, but the more specific one needs to be parsed first
-    QualityComponent('audio', 60, 'dtshd', 'dts[\W_]?hd(?:[\W_]?ma)?%s?' % channels),
+    QualityComponent('audio', 60, 'dtshd', r'dts[\W_]?hd(?:[\W_]?ma)?%s?' % channels),
     QualityComponent('audio', 70, 'dts'),
     QualityComponent('audio', 80, 'truehd', 'truehd%s?' % channels),
 ]

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -473,7 +473,7 @@ def parse_filesize(text_size, si=True):
     prefix_order = {'': 0, 'k': 1, 'm': 2, 'g': 3, 't': 4, 'p': 5}
 
     parsed_size = re.match(
-        '(\d+(?:[.,\s]\d+)*)(?:\s*)((?:[ptgmk]i?)?b)', text_size.strip().lower(), flags=re.UNICODE
+        r'(\d+(?:[.,\s]\d+)*)(?:\s*)((?:[ptgmk]i?)?b)', text_size.strip().lower(), flags=re.UNICODE
     )
     if not parsed_size:
         raise ValueError('%s does not look like a file size' % text_size)

--- a/flexget/webserver.py
+++ b/flexget/webserver.py
@@ -7,7 +7,7 @@ import random
 import socket
 import threading
 
-import cherrypy
+#import cherrypy
 import zxcvbn
 from flask import Flask, abort, redirect
 from flask_login import UserMixin

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 FeedParser>=5.2.1
-SQLAlchemy >=1.0.9, <1.999
+SQLAlchemy >=1.3.10, <1.999
 PyYAML>=4.2b1
 # Beautifulsoup 4.5+ is required to support different versions of html5lib
 beautifulsoup4>=4.5

--- a/requirements.in
+++ b/requirements.in
@@ -30,5 +30,5 @@ flask-login>=0.4.0
 flask-cors>=2.1.2
 pyparsing>=2.0.3
 zxcvbn-python
-future>=0.15.2
+future>=0.18.0
 progressbar==2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ rebulk==0.9.0
 requests==2.21.0
 rpyc==4.0.1
 six==1.10.0               # via apscheduler, cheroot, cherrypy, flask-cors, flask-restful, flask-restplus, html5lib, python-dateutil, rebulk, tempora
-sqlalchemy==1.3.3
+sqlalchemy==1.3.10
 tempora==1.8              # via portend
 terminaltables==3.1.0
 tzlocal==1.4              # via apscheduler

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ flask-login==0.4.0
 flask-restful==0.3.6
 flask-restplus==0.10.1
 flask==1.0.2
-future==0.16.0
+future==0.18.0
 guessit==3.0.3
 html5lib==0.999999999
 idna==2.5                 # via requests


### PR DESCRIPTION
### Motivation for changes:
Make flexget python 3.8 compatible

### Detailed changes:
- Update version on deps than need to be updated for 3.8
- Fix our invalid escape sequences to prevent SyntaxWarnings

#### To Do:

- [ ] cherrypy on windows install fails due to no pywin32 release for 3.8 yet
- [ ] Declare compatibility in setup.py
- [ ] Add 3.8 to CI testing matrix

