### PR TITLE
[add] passthepopcorn sort by individual torrents

### DIFF
--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -117,6 +117,7 @@ class SearchPassThePopcorn(object):
             'order_desc': {'type': 'boolean', 'default': True},
             'freeleech': {'type': 'boolean'},
             'release_type': {'type': 'string', 'enum': list(RELEASE_TYPES.keys())},
+            'grouping': {'type': 'boolean', 'default': True},
         },
         'required': ['username', 'password', 'passkey'],
         'additionalProperties': False,
@@ -246,6 +247,8 @@ class SearchPassThePopcorn(object):
 
         ordering = 'desc' if config['order_desc'] else 'asc'
 
+        grouping = int(config['grouping'])
+
         entries = set()
 
         params.update(
@@ -254,6 +257,7 @@ class SearchPassThePopcorn(object):
                 'order_way': ordering,
                 'action': 'advanced',
                 'json': 'noredirect',
+                'grouping': grouping,
             }
         )
 


### PR DESCRIPTION
Lets user configure grouping search parameter,
as compared to default implicit 'grouping=1'

### Motivation for changes:
By default, passthepopcorn groups search results by movie id, influencing how results are returned using the original `order_by` parameter.

For example, searching for a movie by string, ordering by seeders, will return the first entry in the highest seeded group. So searching for 'get', sorted by seeders, returns 
'Get Out (2017)  x264 / MKV / Blu-ray / 720x302 / Scene ', rather than 
'Get Out (2017) x264 / MKV / Blu-ray / 1080p / With Commentary'


### Config usage if relevant (new plugin or updated schema):
```
passthepopcorn:
  grouping: no (default yes)
```
#### To Do:

- [ ] Add corresponding documentation on https://flexget.com/Searches/passthepopcorn

This is my first pull request for the project, feel free to let me know of any problems.