### PR TITLE
[fix] remove horriblesubs scraper in favour of cfscraper plugin

### DIFF
--- a/flexget/components/sites/sites/horriblesubs.py
+++ b/flexget/components/sites/sites/horriblesubs.py
@@ -83,25 +83,12 @@ class HorribleSubs(object):
             )
         return entries
 
-    @staticmethod
-    def scraper():
-        try:
-            import cfscrape
-        except ImportError as e:
-            log.debug('Error importing cfscrape: %s', e)
-            raise plugin.DependencyError(
-                'cfscraper', 'cfscrape', 'cfscrape module required. ImportError: %s' % e
-            )
-        else:
-            return cfscrape.create_scraper()
-
     @cached('horriblesubs')
     def on_task_input(self, task, config):
         if not config:
             return
-        scraper = HorribleSubs.scraper()
         return HorribleSubs.horrible_entries(
-            scraper, 'https://horriblesubs.info/api.php?method=getlatest'
+            task.requests, 'https://horriblesubs.info/api.php?method=getlatest'
         )
 
     # Search API method
@@ -109,11 +96,10 @@ class HorribleSubs(object):
         if not config:
             return
         entries = []
-        scraper = HorribleSubs.scraper()
         for search_string in entry.get('search_strings', [entry['title']]):
             log.debug('Searching `%s`', search_string)
             results = HorribleSubs.horrible_entries(
-                scraper,
+                task.requests,
                 'https://horriblesubs.info/api.php?method=search&value={0}'.format(search_string),
             )
             entries.extend(results)


### PR DESCRIPTION
### Motivation for changes:
`horriblesubs` fail because it requires the old scraper lib as dependence, so not make sense have tow different libs to do the same, also it should use the `cfscraper` plugin to have that responsibility unify

### Detailed changes:
- Remove custom horriblesubs scraper and use task request that has `cfscraper` instance

### Addressed issues:
- No Yet

