### PR TITLE
[fix] Handle exception when api_bluray fails to get content

### DIFF
--- a/flexget/plugins/internal/api_bluray.py
+++ b/flexget/plugins/internal/api_bluray.py
@@ -126,7 +126,11 @@ class BlurayMovie(Base):
             # Used for parsing some more data, sadly with soup
             self.url = result['url']
 
-            movie_info_response = requests.get(self.url).content
+            try:
+                movie_info_response = requests.get(self.url).content
+            except (requests.RequestException, ConnectionError) as e:
+                raise LookupError('Couldn\'t connect to blu-ray.com. %s' % self.url)
+                break
 
             movie_info = get_soup(movie_info_response)
 

--- a/flexget/plugins/internal/api_bluray.py
+++ b/flexget/plugins/internal/api_bluray.py
@@ -129,8 +129,7 @@ class BlurayMovie(Base):
             try:
                 movie_info_response = requests.get(self.url).content
             except (requests.RequestException, ConnectionError) as e:
-                raise LookupError('Couldn\'t connect to blu-ray.com. %s' % self.url)
-                break
+                raise PluginError("Couldn't connect to blu-ray.com. %s" % self.url)
 
             movie_info = get_soup(movie_info_response)
 

--- a/flexget/plugins/internal/api_bluray.py
+++ b/flexget/plugins/internal/api_bluray.py
@@ -129,7 +129,7 @@ class BlurayMovie(Base):
             try:
                 movie_info_response = requests.get(self.url).content
             except (requests.RequestException, ConnectionError) as e:
-                raise PluginError("Couldn't connect to blu-ray.com. %s" % self.url)
+                raise LookupError("Couldn't connect to blu-ray.com. %s" % self.url)
 
             movie_info = get_soup(movie_info_response)
 


### PR DESCRIPTION
### Motivation for changes:
Flexget would crash if connection to blu-ray.com failed when trying to update movie data such as release date.
### Detailed changes:
- Enclosed the request line in a `try:`
```diff
+            try:
-            movie_info_response = requests.get(self.url).content
+                movie_info_response = requests.get(self.url).content
+            except (requests.RequestException, ConnectionError) as e:
+                raise LookupError('Couldn\'t connect to blu-ray.com. %s' % self.url)
+                break
```
### Addressed issues:
- Fixes #2462 .

#### To Do:

- [ ] Review by staff
- [ ] Merge

