### PR TITLE
[fix] anilist: Larger lists no longer limited to the first 50 items

### DIFF
--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -40,6 +40,7 @@ class AniList(object):
         - <all|tv|tv_short|movie|special|ova|ona>
         - <tv|tv_short|movie|special|ova|ona>
         ...
+      title_only: <boolean>
     """
 
     schema = {
@@ -88,7 +89,6 @@ class AniList(object):
         log.debug('selected_release_status: %s' % selected_release_status)
         log.debug('selected_formats: %s' % selected_formats)
 
-        list_json = []
         req_variables = {'user': config['username']}
         req_chunk = 1
         req_fields = ('status, title{ romaji, english }, synonyms, siteUrl, idMal, format, episodes, '

--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -93,7 +93,7 @@ class AniList(object):
         req_chunk = 1
         req_fields = ('status, title{ romaji, english }, synonyms, siteUrl, idMal, format, episodes, '
                     'trailer{ site, id }, coverImage{ large }, bannerImage, genres, tags{ name }, '
-                    'externalLinks{ site, url }' if not lightweight else 'status, format, title{ romaji }')
+                    'externalLinks{ site, url }' if not lightweight else 'status, format, title{ romaji, english }')
         while req_chunk:
             req_query = ('query ($user: String){collection: MediaListCollection(userName: $user, type: ANIME, '
                         'perChunk: 500, chunk: %s, status_in: [%s]){ hasNextChunk, statuses: lists { list: entries { '

--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -105,10 +105,11 @@ class AniList(object):
                 raise plugin.PluginError('Error reading list - {url}'.format(url=e))
 
             try:
-                list_json.append(list_response.json()['data'])
+                list_response = list_response.json()['data']
+                list_json.append(list_response)
             except ValueError:
                 raise plugin.PluginError('Invalid JSON response')
-            req_chunk = req_chunk + 1 if list_response.json()['data']['collection']['hasNextChunk'] else False
+            req_chunk = req_chunk + 1 if list_response['collection']['hasNextChunk'] else False
 
         log.debug('JSON output: %s' % list_json)
         for list_index in list_json:

--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -92,12 +92,14 @@ class AniList(object):
         list_json = []
         req_variables = {'user': config['username']}
         req_chunk = 1
+        req_fields = ('status, title{ romaji, english }, synonyms, siteUrl, idMal, format, episodes, '
+                    'trailer{ site, id }, coverImage{ large }, bannerImage, genres, tags{ name }, '
+                    'externalLinks{ site, url }' if not lightweight else 'status, format, title{ romaji }')
         while req_chunk:
             req_query = ('query ($user: String){collection: MediaListCollection(userName: $user, type: ANIME, '
                         'perChunk: 500, chunk: %s, status_in: [%s]){ hasNextChunk, statuses: lists { list: entries { '
-                        'anime: media { status, title{ romaji, english }, synonyms, siteUrl, idMal, format, episodes, '
-                        'trailer{ site, id }, coverImage{ large }, bannerImage, genres, tags{ name }, externalLinks{ '
-                        'site, url }}}}}}' % (req_chunk, ', '.join([s.upper() for s in selected_list_status])))
+                        'anime: media { %s }}}}}' % (req_chunk, ', '.join([s.upper() for s in selected_list_status]), 
+                        req_fields))
 
             try:
                 list_response = task.requests.post(

--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -87,58 +87,63 @@ class AniList(object):
         log.debug('selected_release_status: %s' % selected_release_status)
         log.debug('selected_formats: %s' % selected_formats)
 
+        list_json = []
         req_variables = {'user': config['username']}
-        req_query = ('query ($user: String){collection: MediaListCollection(userName: $user, type: ANIME, '
-                    'status_in: [%s]){ statuses: lists { list: entries { anime: media { status, '
-                    'title{ romaji, english }, synonyms, siteUrl, idMal, format, episodes, trailer{ site, id }, '
-                    'coverImage{ large }, bannerImage, genres, tags{ name }, externalLinks{ site, url }}}}}}'
-                    % ', '.join([s.upper() for s in selected_list_status]))
+        req_chunk = 1
+        while req_chunk:
+            req_query = ('query ($user: String){collection: MediaListCollection(userName: $user, type: ANIME, '
+                        'perChunk: 500, chunk: %s, status_in: [%s]){ hasNextChunk, statuses: lists { list: entries { '
+                        'anime: media { status, title{ romaji, english }, synonyms, siteUrl, idMal, format, episodes, '
+                        'trailer{ site, id }, coverImage{ large }, bannerImage, genres, tags{ name }, externalLinks{ '
+                        'site, url }}}}}}' % (req_chunk, ', '.join([s.upper() for s in selected_list_status])))
 
-        try:
-            list_response = task.requests.post(
-                'https://graphql.anilist.co', json={'query': req_query, 'variables': req_variables}
-            )
-        except RequestException as e:
-            raise plugin.PluginError('Error reading list - {url}'.format(url=e))
+            try:
+                list_response = task.requests.post(
+                    'https://graphql.anilist.co', json={'query': req_query, 'variables': req_variables}
+                )
+            except RequestException as e:
+                raise plugin.PluginError('Error reading list - {url}'.format(url=e))
 
-        try:
-            list_json = list_response.json()['data']
-        except ValueError:
-            raise plugin.PluginError('Invalid JSON response')
+            try:
+                list_json.append(list_response.json()['data'])
+            except ValueError:
+                raise plugin.PluginError('Invalid JSON response')
+            req_chunk = req_chunk + 1 if list_response.json()['data']['collection']['hasNextChunk'] else False
 
         log.debug('JSON output: %s' % list_json)
-        for list_status in list_json['collection']['statuses']:
-            for anime in list_status['list']:
-                anime = anime['anime']
-                has_selected_release_status = (
-                    anime['status'].lower() in selected_release_status
-                    or 'all' in selected_release_status
-                )
-                has_selected_type = (
-                    anime['format'].lower() in selected_formats
-                    or 'all' in selected_formats
-                )
-                if has_selected_type and has_selected_release_status:
-                    entries.append(
-                        Entry(
-                            title = anime['title']['romaji'],
-                            alternate_name = [anime['title']['english']] + anime['synonyms'],
-                            url = anime['siteUrl'],
-                            al_release_status = anime['status'].capitalize(),
-                            al_list_status = list_status,
-                            al_idMal = anime['idMal'],
-                            al_format = anime['format'],
-                            al_episodes = anime['episodes'],
-                            al_trailer = (TRAILER_SOURCE[anime['trailer']['site']]
-                                + anime['trailer']['id'] if anime['trailer'] else ''),
-                            al_cover = anime['coverImage']['large'],
-                            al_banner = anime['bannerImage'],
-                            al_genres = anime['genres'],
-                            al_tags = [t['name'] for t in anime['tags']],
-                            al_title = anime['title'],
-                            al_links = anime['externalLinks']
-                        )
+        for list_index in list_json:
+            for list_status in list_index['collection']['statuses']:
+                for anime in list_status['list']:
+                    anime = anime['anime']
+                    has_selected_release_status = (
+                        anime['status'].lower() in selected_release_status
+                        or 'all' in selected_release_status
                     )
+                    has_selected_type = (
+                        anime['format'].lower() in selected_formats
+                        or 'all' in selected_formats
+                    )
+                    if has_selected_type and has_selected_release_status:
+                        entries.append(
+                            Entry(
+                                title = anime['title']['romaji'],
+                                alternate_name = [anime['title']['english']] + anime['synonyms'],
+                                url = anime['siteUrl'],
+                                al_release_status = anime['status'].capitalize(),
+                                al_list_status = list_status,
+                                al_idMal = anime['idMal'],
+                                al_format = anime['format'],
+                                al_episodes = anime['episodes'],
+                                al_trailer = (TRAILER_SOURCE[anime['trailer']['site']]
+                                    + anime['trailer']['id'] if anime['trailer'] else ''),
+                                al_cover = anime['coverImage']['large'],
+                                al_banner = anime['bannerImage'],
+                                al_genres = anime['genres'],
+                                al_tags = [t['name'] for t in anime['tags']],
+                                al_title = anime['title'],
+                                al_links = anime['externalLinks']
+                            )
+                        )
         return entries
 
 

--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -57,7 +57,8 @@ class AniList(object):
                     ),
                     'format': one_or_more(
                         {'type': 'string', 'enum': ANIME_FORMAT}, unique_items=True
-                    )
+                    ),
+                    'title_only': {'type': 'boolean'}
                 },
                 'required': ['username'],
                 'additionalProperties': False,
@@ -73,6 +74,7 @@ class AniList(object):
         selected_list_status = config['status'] if 'status' in config else ['current', 'planning']
         selected_release_status = config['release_status'] if 'release_status' in config else ['all']
         selected_formats = config['format'] if 'format' in config else ['all']
+        lightweight = config['title_only'] if 'title_only' in config else False
 
         if not isinstance(selected_list_status, list):
             selected_list_status = [selected_list_status]
@@ -125,8 +127,7 @@ class AniList(object):
                         or 'all' in selected_formats
                     )
                     if has_selected_type and has_selected_release_status:
-                        entries.append(
-                            Entry(
+                        entries.append( Entry(title = anime['title']['romaji']) if lightweight else Entry(
                                 title = anime['title']['romaji'],
                                 alternate_name = [anime['title']['english']] + anime['synonyms'],
                                 url = anime['siteUrl'],

--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -73,7 +73,7 @@ class AniList(object):
         selected_list_status = config['status'] if 'status' in config else ['current', 'planning']
         selected_release_status = config['release_status'] if 'release_status' in config else ['all']
         selected_formats = config['format'] if 'format' in config else ['all']
-        lightweight = config['title_only'] if 'title_only' in config else False
+        lightweight = config.get('title_only', False)
 
         if not isinstance(selected_list_status, list):
             selected_list_status = [selected_list_status]


### PR DESCRIPTION
### Motivation for changes:
Bug report. Previous method was limited to 50 entries, this patch handles the pagination
### Detailed changes:
- Changed query to use an object able to carry more elements (500 instead of 50)
- Handle pagination if needed
- Add optional `title_only` option to schema for slimmer result

### Schema update:
```diff
anilist:
  username: <<string | required>>
  status: <<enum | optional>>
  release_status: <<enum | optional>>
  format: <<enum | optional>>
+ title_only: <<boolean | optional>>
```
### Addressed issues:
- Fixes #2471 .

### To Do:
- [x] Test
- [x] Review
- [ ] Merge
- [ ] Update wiki - Document `title_only`
