### PR TITLE
Handle merge of lists with other types. Override instead

### DIFF
--- a/flexget/tests/test_series.py
+++ b/flexget/tests/test_series.py
@@ -1548,6 +1548,19 @@ class TestFromGroup(object):
               - {title: 'Test :: h264 10-bit | Softsubs (Ignore) | Episode 3'}
             series:
               - test: {from_group: [Name, FlexGet]}
+          test_merge:
+            mock:
+              - {title: 'Test.15.HDTV-Ignored'}
+              - {title: 'Test.15.HDTV-FlexGet'}
+              - {title: 'TestMerge.13.HDTV-Ignored'}
+              - {title: 'TestMerge.13.HDTV-FlexGet'}
+              - {title: 'TestMerge.14.HDTV-Name'}
+            series:
+              settings:
+                testgroup: {from_group: [Name]}
+              testgroup:
+                - test: {from_group: FlexGet}
+                - testmerge: {from_group: [FlexGet]}
     """
 
     def test_from_group(self, execute_task):
@@ -1559,6 +1572,11 @@ class TestFromGroup(object):
         assert task.find_entry(
             'accepted', title='Test :: h264 10-bit | Softsubs (FlexGet) | Episode 3'
         )
+        # Test interaction with setting group. Merge if both are lists, override if different types
+        task = execute_task('test_merge')
+        assert task.find_entry('accepted', title='Test.15.HDTV-FlexGet')
+        assert task.find_entry('accepted', title='TestMerge.13.HDTV-FlexGet')
+        assert task.find_entry('accepted', title='TestMerge.14.HDTV-Name')
 
 
 class TestBegin(object):

--- a/flexget/tests/test_utils.py
+++ b/flexget/tests/test_utils.py
@@ -7,7 +7,7 @@ import math
 import pytest
 
 from flexget.utils import json
-from flexget.utils.tools import parse_filesize, split_title_year
+from flexget.utils.tools import parse_filesize, split_title_year, merge_dict_from_to
 
 
 def compare_floats(float1, float2):
@@ -109,3 +109,52 @@ class TestSplitYearTitle(object):
     )
     def test_split_year_title(self, title, expected_title, expected_year):
         assert split_title_year(title) == (expected_title, expected_year)
+
+class TestDictMerge(object):
+    def test_merge_dict_to_dict_list(self):
+        d1 = {'setting': {'parameter': ['item_1']}}
+        d2 = {'setting': {'parameter': ['item_2']}}
+        merge_dict_from_to(d1, d2)
+        assert d2 == {'setting': {'parameter': ['item_2', 'item_1']}}
+
+    def test_merge_dict_to_dict_override(self):
+        d1 = {'setting': {'parameter': ['item_1']}}
+        d2 = {'setting': {'parameter': 2}}
+        merge_dict_from_to(d1, d2)
+        assert d2 == {'setting': {'parameter': 2}}
+
+    def test_merge_dict_to_dict_add(self):
+        d1 = {'setting': {'parameter_1': ['item_1']}}
+        d2 = {'setting': {'parameter_2': 'item_2'}}
+        merge_dict_from_to(d1, d2)
+        assert d2 == {'setting': {'parameter_1': ['item_1'], 'parameter_2': 'item_2'}}
+
+    def test_merge_dict_to_dict_str(self):
+        d1 = {'setting': {'parameter': 'item_1'}}
+        d2 = {'setting': {'parameter': 'item_2'}}
+        merge_dict_from_to(d1, d2)
+        assert d2 == {'setting': {'parameter': 'item_2'}}
+
+    def test_merge_list_to_list(self):
+        d1 = {'setting': ['item_1']}
+        d2 = {'setting': ['item_2']}
+        merge_dict_from_to(d1, d2)
+        assert d2 == {'setting': ['item_2', 'item_1']}
+
+    def test_merge_list_to_str(self):
+        d1 = {'setting': ['list']}
+        d2 = {'setting': 'string'}
+        merge_dict_from_to(d1, d2)
+        assert d2 == {'setting': 'string'}
+
+    def test_merge_str_to_list(self):
+        d1 = {'setting': 'string'}
+        d2 = {'setting': ['list']}
+        merge_dict_from_to(d1, d2)
+        assert d2 == {'setting': ['list']}
+
+    def test_merge_str_to_str(self):
+        d1 = {'setting': 'string_1'}
+        d2 = {'setting': 'string_2'}
+        merge_dict_from_to(d1, d2)
+        assert d2 == {'setting': 'string_2'}

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -170,8 +170,8 @@ def merge_dict_from_to(d1, d2):
                     raise Exception(
                         'Unknown type: %s value: %s in dictionary' % (type(v), repr(v))
                     )
-            elif isinstance(v, (str, bool, int, float, type(None))) and isinstance(
-                d2[k], (str, bool, int, float, type(None))
+            elif isinstance(v, (str, bool, int, float, list, type(None))) and isinstance(
+                d2[k], (str, bool, int, float, list, type(None))
             ):
                 # Allow overriding of non-container types with other non-container types
                 pass


### PR DESCRIPTION
### Motivation for changes:
Handling `"Merging key from_group failed, conflicting datatypes 'list' vs. 'unicode'."` when trying to mix and match within `series` plugin (see addressed issue for further details)
### Detailed changes:
- Added `list` to the last conditional to allow for lists to override \ be overridden if a merge is not possible.

### Addressed issues:
- Fixes #2453.