### PR TITLE
Added 'encoding' to schema, so that configs will pass schema te…

### DIFF
--- a/flexget/plugins/input/regexp_parse.py
+++ b/flexget/plugins/input/regexp_parse.py
@@ -110,6 +110,7 @@ class RegexpParse(object):
                     {'type': 'string', 'format': 'file'},
                 ]
             },
+            'encoding': {'type': 'string'},
             'sections': {'$ref': '#/definitions/regex_list'},
             'keys': {
                 'type': 'object',


### PR DESCRIPTION
### Motivation for changes:
`encoding` is referenced on the webpage regarding this plugin, but was missing from the schema. Using it in a config would cause a schema failure.
### Detailed changes:
- added a single line to the schema to prevent schema test failure.

### Addressed issues:
- schema failure when config should pass schema test

