### PR TITLE
Added 'serialize' method.

### DIFF
--- a/flexget/entry.py
+++ b/flexget/entry.py
@@ -8,7 +8,7 @@ import functools
 import logging
 from collections import Mapping
 
-from flexget.utils import qualities, json
+from flexget.utils import qualities
 from flexget.plugin import PluginError
 from flexget.utils.lazy_dict import LazyDict, LazyLookup
 from flexget.utils.template import render_from_entry, FlexGetTemplate
@@ -245,7 +245,7 @@ class Entry(LazyDict):
         return True
 
     def serialize(self):
-        """Use json to serialize python objects for file output."""
+        """Serialize Entry objects for file output."""
 
         def only_builtins(item):
             supported_types = (str, unicode, int, float, long, bool, datetime)

--- a/flexget/entry.py
+++ b/flexget/entry.py
@@ -248,7 +248,6 @@ class Entry(LazyDict):
         """Use json to serialize python objects for file output."""
 
         def only_builtins(item):
-            datetime_types = (date, datetime)
             supported_types = (str, unicode, int, float, long, bool, datetime)
             # dict, list, tuple and set are also supported, but handled separately
 


### PR DESCRIPTION
### Motivation for changes: 
Serialization was needed to output the the entry list as a `JSON` file.

### Detailed changes: 
- Added a method to the `Entry` class called `serialize`. `entry.serialize()` returns a python dictionary that is ready to be used in file outputs like `json.dump`, or for use in writing `text`, `csv`, `html`, etc. files.  It was added here, so that anywhere an entry exists, it can always be serialized easily.

#### To Do:

- [ ] Discuss if this is wanted/needed
- [ ] Discuss best location for this method

