### PR TITLE
Prevent errors on PirateBay plugin when scanning ads

### DIFF
--- a/flexget/components/sites/sites/piratebay.py
+++ b/flexget/components/sites/sites/piratebay.py
@@ -164,7 +164,8 @@ class UrlRewritePirateBay(object):
                     href = self.url + href
                 entry['url'] = href
                 row = link.parent.parent.parent
-                if row.find_all('a', attrs={'class': 'detDesc'})[0].contents[0] == "piratebay ":
+                description = row.find_all('a', attrs={'class': 'detDesc'})
+                if description and description[0].contents[0] == "piratebay ":
                     log.debug('Advertisement entry. Skipping.')
                     continue
                 tds = row.find_all('td')

--- a/flexget/components/sites/sites/piratebay.py
+++ b/flexget/components/sites/sites/piratebay.py
@@ -163,7 +163,11 @@ class UrlRewritePirateBay(object):
                 if href.startswith('/'):  # relative link?
                     href = self.url + href
                 entry['url'] = href
-                tds = link.parent.parent.parent.find_all('td')
+                row = link.parent.parent.parent
+                if row.find_all('a', attrs={'class': 'detDesc'})[0].contents[0] == "piratebay ":
+                    log.debug('Advertisement entry. Skipping.')
+                    continue
+                tds = row.find_all('td')
                 entry['torrent_seeds'] = int(tds[-2].contents[0])
                 entry['torrent_leeches'] = int(tds[-1].contents[0])
                 entry['torrent_availability'] = torrent_availability(


### PR DESCRIPTION
### Motivation for changes:
Currently the Piratebay plugin gives errors when scanning their site, because of advertisements that are also marked as class="detLink". This change detects if the ULed user was piratebay, which indicates that it is an advertisement.

```
DEBUG    utils.requests Series-Trakt    GETing URL ... with args () and kwargs {'allow_redirects': True, 'timeout': 30}
DEBUG    plugin        Series-Trakt    decorator caught ValueError. handled traceback:
Traceback (most recent call last):
  File "flexget/plugin.py", line 119, in wrapped_func
    return func(*args, **kwargs)
  File "flexget/components/sites/sites/piratebay.py", line 164, in search
    entry['torrent_seeds'] = int(tds[-2].contents[0])
ERROR    discover      Series-Trakt    Error searching with piratebay: invalid literal for int() with base 10: '\n\t\t\t\t'

```

