### PR TITLE
update Dockerfile to use python3 and add webUI v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,22 @@
 FROM alpine
 MAINTAINER Rémi Alvergnat <toilal.dev@gmail.com>
 
-RUN apk add --update python py-pip ca-certificates && rm -rf /var/cache/apk/*
+RUN apk add --update python3 ca-certificates nodejs build-base python3-dev libffi-dev openssl-dev unzip && \
+    rm -rf /var/cache/apk/*
 
 ADD . /opt/flexget
 WORKDIR /opt/flexget
 
-RUN pip install paver
-RUN pip install -e .
+RUN pip3 install -e . && \
+    pip3 install transmissionrpc && \
+    pip3 install deluge-client && \
+    pip3 install cloudscraper
+
+WORKDIR /opt/flexget/flexget/ui/v2
+RUN wget https://github.com/Flexget/webui/releases/latest/download/dist.zip && \
+    unzip dist.zip && \
+    rm dist.zip
+WORKDIR /opt/flexget
 
 RUN mkdir /root/.flexget
 VOLUME /root/.flexget


### PR DESCRIPTION
This is the updated Dockerfile I use with success for a while. The one in develop uses python2 which is obviously not working anymore.

I am pulling the webUI v2 from the last release on respective GitHub, instead of building it. This could be changed if needed.

I don't build webUI v1 because it is deprecated.

I am using it mounting my config folder in /root/.flexget and with the command `daemon start`.