### PR TITLE
[fix] Update TVDB Episode Schema

### DIFF
--- a/flexget/components/thetvdb/api_tvdb.py
+++ b/flexget/components/thetvdb/api_tvdb.py
@@ -346,7 +346,7 @@ class TVDBEpisode(Base):
         self.absolute_number = episode['absoluteNumber']
         self.name = episode['episodeName']
         self.overview = episode['overview']
-        self.director = episode['director']
+        self.director = ', '.join(episode['directors'])
         self._image = episode['filename']
         self.rating = episode['siteRating']
         self.first_aired = episode['firstAired']


### PR DESCRIPTION
### Motivation for changes:
TVDB changed the key name and type for episodes in their v3 update from `'director': 'string'` to `'directors': ['array']`

[As noted on their documentation](https://api.thetvdb.com/swagger#!/Episodes/get_episodes_id):
> Returns the full information for a given episode id. **Deprecation Warning:** The director key will be deprecated in favor of the new directors key in a future release.

Which causes the following error during episode metadata lookup:
`WARNING  api_tvdb      task     Error while updating from tvdb ('director'), using cached data.`
### Detailed changes:
- Renamed field and convert list to string
