### PR TITLE
Add rename config on symlink as move plugin

### DIFF
--- a/flexget/tests/test_symlink.py
+++ b/flexget/tests/test_symlink.py
@@ -33,7 +33,7 @@ class TestSymlink:
               - {title: 'test1.mkv', location: '{{tmpdir_1}}/test1.mkv'}
             symlink:
               to: '{{tmpdir_1}}/hardlink'
-              rename: 'rename{{filename | pathext}}'
+              rename: 'rename.mkv'
               link_type: 'hard'
           test_hardlink_dir:
             mock:
@@ -53,6 +53,13 @@ class TestSymlink:
               - {title: 'test1', location: '{{tmpdir_1}}/test1'}
             symlink:
               to: '{{tmpdir_1}}/softlink'
+              link_type: 'soft'
+          test_softlink_rename:
+            mock:
+              - {title: 'test1.mkv', location: '{{tmpdir_1}}/test1.mkv'}
+            symlink:
+              to: '{{tmpdir_1}}/softlink'
+              rename: 'rename.mkv'
               link_type: 'soft'
           test_softlink_fail:
             mock:
@@ -74,7 +81,7 @@ class TestSymlink:
     def test_hardlink(self, execute_task, tmpdir):
         tmpdir.join(dirname).join('test1.mkv').write('')
         execute_task('test_hardlink')
-        hardlink = tmpdir.join(dirname).join('hardlink').join('rename.mkv')
+        hardlink = tmpdir.join(dirname).join('hardlink').join('test1.mkv')
 
         assert os.path.exists(hardlink.strpath), '%s should exist' % hardlink.strpath
         assert is_hard_link(tmpdir.join(dirname).join('test1.mkv').strpath, hardlink.strpath)
@@ -82,7 +89,7 @@ class TestSymlink:
     def test_hardlink_rename(self, execute_task, tmpdir):
         tmpdir.join(dirname).join('test1.mkv').write('')
         execute_task('test_hardlink_rename')
-        hardlink = tmpdir.join(dirname).join('hardlink').join('test1.mkv')
+        hardlink = tmpdir.join(dirname).join('hardlink').join('rename.mkv')
 
         assert os.path.exists(hardlink.strpath), '%s should exist' % hardlink.strpath
         assert is_hard_link(tmpdir.join(dirname).join('test1.mkv').strpath, hardlink.strpath)
@@ -117,6 +124,15 @@ class TestSymlink:
         assert os.path.exists(d.strpath), '%s should exist' % d.strpath
         assert os.path.islink(f.strpath), '%s should be a softlink' % f.strpath
         assert os.path.islink(d.strpath), '%s should be a softlink' % d.strpath
+
+    def test_softlink_rename(self, execute_task, tmpdir):
+        tmpdir.join(dirname).join('test1.mkv').write('')
+        execute_task('test_softlink_rename')
+
+        softlink = tmpdir.join(dirname).join('softlink')
+        f = softlink.join('rename.mkv')
+        assert os.path.exists(f.strpath), '%s should exist' % f.strpath
+        assert os.path.islink(f.strpath), '%s should be a softlink' % f.strpath
 
     def test_softlink_fail(self, execute_task, tmpdir):
         tmpdir.join(dirname).join('test1.mkv').write('')

--- a/flexget/tests/test_symlink.py
+++ b/flexget/tests/test_symlink.py
@@ -28,6 +28,13 @@ class TestSymlink:
             symlink:
               to: '{{tmpdir_1}}/hardlink'
               link_type: 'hard'
+          test_hardlink_rename:
+            mock:
+              - {title: 'test1.mkv', location: '{{tmpdir_1}}/test1.mkv'}
+            symlink:
+              to: '{{tmpdir_1}}/hardlink'
+              rename: 'rename{{filename | pathext}}'
+              link_type: 'hard'
           test_hardlink_dir:
             mock:
               - {title: 'test2', location: '{{tmpdir_1}}/test2'}
@@ -67,6 +74,14 @@ class TestSymlink:
     def test_hardlink(self, execute_task, tmpdir):
         tmpdir.join(dirname).join('test1.mkv').write('')
         execute_task('test_hardlink')
+        hardlink = tmpdir.join(dirname).join('hardlink').join('rename.mkv')
+
+        assert os.path.exists(hardlink.strpath), '%s should exist' % hardlink.strpath
+        assert is_hard_link(tmpdir.join(dirname).join('test1.mkv').strpath, hardlink.strpath)
+
+    def test_hardlink_rename(self, execute_task, tmpdir):
+        tmpdir.join(dirname).join('test1.mkv').write('')
+        execute_task('test_hardlink_rename')
         hardlink = tmpdir.join(dirname).join('hardlink').join('test1.mkv')
 
         assert os.path.exists(hardlink.strpath), '%s should exist' % hardlink.strpath


### PR DESCRIPTION
### Motivation for changes:
I wanted to be able to override target name when using symlink as it can be done with move plugin.

### Detailed changes:
- Add entry link_to property to set the link target name
- Add config rename in order to override target link name
- Clean target link with pathscrub

### Config usage if relevant (new plugin or updated schema):
```
symlink:
      link_type: hard
      existing: ignore
      to: /Series/{{series_name}}/Season {{series_season|pad(2)}}
      rename: '{{series_name}} - {{series_id}}{{filename | pathext}}'
```
### Log and/or tests output (preferably both):
```
2019-11-23 10:40 VERBOSE  symlink       sort_series     hardlink `/download/S.W.A.T.2017.S01E21.FRENCH.720p.WEB.H264-AMB3R/s.w.a.t.2017.s01e21.french.720p.web.h264-amb3r.mkv` to `/Series/S W A T 2017/Season 01/S W A T 2017 - S01E21.mkv`
```
