### PR TITLE
[fix] web server inserts base_url into webui v2

### DIFF
--- a/flexget/plugins/daemon/web_server.py
+++ b/flexget/plugins/daemon/web_server.py
@@ -101,7 +101,7 @@ def register_web_server(manager):
     if web_server_config.get('web_ui'):
         if web_server_config.get('run_v2'):
             log.info('Registering WebUI v2')
-            register_web_ui_v2(manager)
+            register_web_ui_v2(web_server_config)
 
         log.info('Registering WebUI v1')
         register_web_ui_v1(manager)

--- a/flexget/ui/v2/__init__.py
+++ b/flexget/ui/v2/__init__.py
@@ -1,22 +1,21 @@
 import logging
 import os
 
-from flask import Flask, send_from_directory
+from flask import Flask, send_from_directory, render_template
 from flask_compress import Compress
 
 from flexget.webserver import register_app
 
 log = logging.getLogger('webui')
 
-manager = None
-debug = False
+config = None
 exists = True
 
 ui_base = os.path.dirname(os.path.realpath(__file__))
 ui_dist = os.path.join(ui_base, 'dist')
 ui_assets = os.path.join(ui_dist, 'assets')
 
-webui_app = Flask(__name__)
+webui_app = Flask(__name__, template_folder=ui_dist)
 Compress(webui_app)
 webui_app.url_path = '/v2/'
 
@@ -31,12 +30,12 @@ def serve_app(path):
 def root(path='index.html'):
     if not exists:
         return send_from_directory(ui_base, 'index.html')
-    return send_from_directory(ui_dist, path)
+    return render_template('index.html', base_url=config['base_url'])
 
 
-def register_web_ui(mgr):
-    global manager, exists, debug
-    manager = mgr
+def register_web_ui(cfg):
+    global config, exists
+    config = cfg
 
     if not os.path.exists(ui_dist):
         exists = False


### PR DESCRIPTION
### Motivation for changes:
Webui v2 was broken if you specify a base url. This is part of the fix,  Flexget/webui#43 is the rest

### Detailed changes:
- Really all that is happening is instead of spitting on html, webui webpack build generates a jinja template that will accept `{{ base_url }}`.
- Also fixes an issue so that  all webui paths should be using index.html.  (otherwise hard refreshes don't work)

### Addressed issues:
- Flexget/webui#24

This can (and should) be merged before the webui pr as it's basically a noop on older builds of webui.  The other way around is not the case. 

