### PR TITLE
[change] `tvdb_lookup` - Always have the main poster as the first entry of `tvdb_posters`

### DIFF
--- a/flexget/components/thetvdb/api_tvdb.py
+++ b/flexget/components/thetvdb/api_tvdb.py
@@ -24,7 +24,7 @@ SEARCH_RESULT_EXPIRATION_DAYS = 3
 class TVDBRequest:
     API_KEY = '4D297D8CFDE0E105'
     BASE_URL = 'https://api.thetvdb.com/'
-    BANNER_URL = 'https://artworks.thetvdb.com/banners/'
+    BANNER_URL = 'http://thetvdb.com/banners/'
 
     def __init__(self, username=None, account_id=None, api_key=None):
         self.username = username

--- a/flexget/components/thetvdb/api_tvdb.py
+++ b/flexget/components/thetvdb/api_tvdb.py
@@ -24,7 +24,7 @@ SEARCH_RESULT_EXPIRATION_DAYS = 3
 class TVDBRequest:
     API_KEY = '4D297D8CFDE0E105'
     BASE_URL = 'https://api.thetvdb.com/'
-    BANNER_URL = 'http://thetvdb.com/banners/'
+    BANNER_URL = 'https://artworks.thetvdb.com/banners/'
 
     def __init__(self, username=None, account_id=None, api_key=None):
         self.username = username
@@ -257,10 +257,12 @@ class TVDBSeries(Base):
         if not self._posters:
             log.debug('Getting top 5 posters for series %s', self.name)
             try:
+                poster_main = TVDBRequest().get('series/%s' % self.id).get('poster')
                 poster_query = TVDBRequest().get(
                     'series/%s/images/query' % self.id, keyType='poster'
                 )
-                self.posters_list = (
+                self.posters_list = [poster_main] if poster_main else []
+                self.posters_list += (
                     [p['fileName'] for p in poster_query[:5]] if poster_query else []
                 )
             except requests.RequestException as e:
@@ -269,7 +271,7 @@ class TVDBSeries(Base):
                 else:
                     raise LookupError('Error updating posters from tvdb: %s' % e)
 
-        return [TVDBRequest.BANNER_URL + p for p in self.posters_list]
+        return [TVDBRequest.BANNER_URL + p for p in self.posters_list[:5]]
 
     def to_dict(self):
         return {

--- a/flexget/components/thetvdb/thetvdb_lookup.py
+++ b/flexget/components/thetvdb/thetvdb_lookup.py
@@ -71,12 +71,11 @@ class PluginThetvdbLookup:
         'tvdb_language': 'language',
         'tvdb_airs_day_of_week': 'airs_dayofweek',
         'imdb_url': lambda series: series.imdb_id
-        and 'http://www.imdb.com/title/%s' % series.imdb_id,
+        and f'http://www.imdb.com/title/{series.imdb_id}',
         'imdb_id': 'imdb_id',
         'zap2it_id': 'zap2it_id',
         'tvdb_id': 'id',
-        'tvdb_url': lambda series: 'http://thetvdb.com/index.php?tab=series&id=%s'
-        % str(series.id),
+        'tvdb_url': lambda series: f'http://thetvdb.com/index.php?tab=series&id={str(series.id)}',
     }
 
     series_actor_map = {'tvdb_actors': 'actors'}
@@ -93,7 +92,7 @@ class PluginThetvdbLookup:
         'tvdb_absolute_number': 'absolute_number',
         'tvdb_season': 'season_number',
         'tvdb_episode': 'episode_number',
-        'tvdb_ep_id': lambda ep: 'S%02dE%02d' % (ep.season_number, ep.episode_number),
+        'tvdb_ep_id': lambda ep: f'S{ep.season_number:02d}E{ep.episode_number:02d}',
     }
 
     schema = {
@@ -140,8 +139,8 @@ class PluginThetvdbLookup:
                 episode_offset = 0
             if season_offset != 0 or episode_offset != 0:
                 log.debug(
-                    'Using offset for tvdb lookup: season: %s, episode: %s'
-                    % (season_offset, episode_offset)
+                    f'Using offset for tvdb lookup: season: {season_offset}, '
+                    f'episode: {episode_offset}'
                 )
 
             lookupargs = {

--- a/flexget/tests/cassettes/test_series_api.TestSeriesRootAPI.test_series_lookup_param
+++ b/flexget/tests/cassettes/test_series_api.TestSeriesRootAPI.test_series_lookup_param
@@ -1,347 +1,716 @@
 interactions:
-  - request:
-      body: '{"apikey": "4D297D8CFDE0E105"}'
-      headers:
-        Accept: ['*/*']
-        Accept-Encoding: ['gzip, deflate']
-        Connection: [keep-alive]
-        Content-Length: ['30']
-        Content-Type: [application/json]
-        User-Agent: [FlexGet/2.10.20.dev (www.flexget.com)]
-      method: POST
-      uri: https://api.thetvdb.com/login
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAAwTByZKiMAAA0Ht/heWdLhBcmBsNaEIjO0G5UGyyhBgUIcDU/Pu89/drs9l+KC6f
-          2z+bbbkYdXbJG7sx/HCFgtXAAT69fa7CA8T9DamG/F0uRlcCpbFbnbcDZXcN8sXSlAGSDsOWNh6Z
-          u1IvukKFAyTykkbFI43OPGzpbGmYWcGV2ZrLHu53/qJzbIK8b4vYz09vc1QFi1me6axPEZ3TXipa
-          XxJli9uTgGk9YNIyLeEgxTp2iE7XWWBhdJKyi1m54u0qvHQVR0gNfmfFWdLoVuyN9yNiJ1SadpMa
-          iDePshMmx0r6+Jw2t3cU8ahp6wpQrzRDK6T16yR7KAU0qfKdswclEtVpPCbyytJ70RgKEcvDdRxi
-          Oc2o3XQSuQs4Ll+tqxQJyXRKn1Qk6jnjAu242/MgZYmrOuzqJdieSF/gEdbURQbrwgnZ8cfjHqIf
-          uurnAagW3g7KOgwZQnXaRUP+s7zkCwaaPvrvoSeCaQSd2054ke4e93sGgVwVF7pWEnCRZ8P4pxlG
-          tv369x8AAP//AwAXRh371wEAAA==
-      headers:
-        CF-RAY: [345a10b29ad2355a-LHR]
-        Connection: [keep-alive]
-        Content-Encoding: [gzip]
-        Content-Type: [application/json; charset=utf-8]
-        Date: ['Sun, 26 Mar 2017 12:20:40 GMT']
-        Server: [cloudflare-nginx]
-        Set-Cookie: ['__cfduid=d48100fdd734efa4b25d6a7c75cde31f61490530839; expires=Mon,
-            26-Mar-18 12:20:39 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-        Vary: [Accept-Language]
-        X-Powered-By: [Thundar!]
-        X-Thetvdb-Api-Version: [2.1.2]
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: ['*/*']
-        Accept-Encoding: ['gzip, deflate']
-        Accept-Language: [en]
-        Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0OTA2MTcyNDAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDkwNTMwODQwfQ.cqoxZLHcpjdZSc8rLuC1NwNRLPzn3VFap4djS439N-5mTwDpHw4yvyUs4ZEkPmEozx1wUW84bGLgQ3XM1qECkWVCTKxAPyaWXd5JrfWw8VeLOiaJV0L79PU_7g4tS-DxjYVW0VijhgHoReLUNUohq89RVaHo_gc2P5HeV3Cvu7_9zwaYdiJAm3e6MusZ9aboOil4mY1kZeqjQAd_mbEoono3mCFb-TD7250Haw_QCPwMR_kOvmpdkuIhoQVJwlUvVOZtR-f3SUQCtfHoDUX6AzssbVVhalWscByq9GkHDEuSrspm1LJTlQjvky4YR-KFHT9gdGozg4HQVROIZBisuw]
-        Connection: [keep-alive]
-        User-Agent: [FlexGet/2.10.20.dev (www.flexget.com)]
-      method: GET
-      uri: https://api.thetvdb.com/search/series?name=Suits
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAA0yRMU/DMBCF9/6KpywsbWkLAsSGWFjoQGFAiOGaXJKjji+yr7UixH9HDqWwWPL7
-          3p2fnj8nQFGRUXGLtwkAfI4nUJATihwzeJ/+ilvynkNxi6IJ1LdSkjtfXV7fLG5mzfJ6/tE3xclb
-          S4h2J4Gr7F8tlsvZ4mq2uvhzSCY/4yfNsyUNuzzysrnD+ng9cT1wOAinbNjsxSJqdU5TRKnOccOo
-          gvYz3RseZcd40hinSK2CylIq9kbODXDkqwjCh26RxFqoZ2iNNSe8atidRWw5Ghw35FA6jRziFA8U
-          Djxg03NpHOZ4bnlAVPXYcqkdg5DEe/ENjKn7WZ1znEUESjBy7A3kK/Stmh5bRMedhmE6gjH2uDNw
-          Jznm8VWtkdoBLSPlJeJNYS2jFnZVpo4SxB+1EA29o5Lnf+VFDsJxTR2f6vsHjWyf/7u4V2/i9+Kb
-          YoRfE+B98vUNAAD//wMAtqiHFC0CAAA=
-      headers:
-        CF-RAY: [345a10b908cc134d-LHR]
-        Cache-Control: ['private, max-age=600']
-        Connection: [keep-alive]
-        Content-Encoding: [gzip]
-        Content-Type: [application/json; charset=utf-8]
-        Date: ['Sun, 26 Mar 2017 12:20:41 GMT']
-        Server: [cloudflare-nginx]
-        Set-Cookie: ['__cfduid=d667f536536831a13fe3c6912019e4cef1490530840; expires=Mon,
-            26-Mar-18 12:20:40 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-        Vary: [Accept-Language]
-        X-Powered-By: [Thundar!]
-        X-Thetvdb-Api-Version: [2.1.2]
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: ['*/*']
-        Accept-Encoding: ['gzip, deflate']
-        Accept-Language: [en]
-        Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0OTA2MTcyNDAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDkwNTMwODQwfQ.cqoxZLHcpjdZSc8rLuC1NwNRLPzn3VFap4djS439N-5mTwDpHw4yvyUs4ZEkPmEozx1wUW84bGLgQ3XM1qECkWVCTKxAPyaWXd5JrfWw8VeLOiaJV0L79PU_7g4tS-DxjYVW0VijhgHoReLUNUohq89RVaHo_gc2P5HeV3Cvu7_9zwaYdiJAm3e6MusZ9aboOil4mY1kZeqjQAd_mbEoono3mCFb-TD7250Haw_QCPwMR_kOvmpdkuIhoQVJwlUvVOZtR-f3SUQCtfHoDUX6AzssbVVhalWscByq9GkHDEuSrspm1LJTlQjvky4YR-KFHT9gdGozg4HQVROIZBisuw]
-        Connection: [keep-alive]
-        User-Agent: [FlexGet/2.10.20.dev (www.flexget.com)]
-      method: GET
-      uri: https://api.thetvdb.com/series/247808
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAA2RTy27bMBC8+ysGvORip5LsWLZuaVKgPSQN8mhQBD2spbXFhCIFch1BDfLvhWTJ
-          SNDjzixnl5zh2wRQBQmpDG8TAFC6UBmSRbqKVtMDEthrDtdUscqg7vZaghooMpoCB5Xh6c8Abcha
-          9l3nzlNd6pzMl4PcbBenp8/1Tn3S/dHNU+k6SuMjIST7TlRdOCva7rU9HtpqH+Rce+6PJVEcz6Ll
-          LJmPvGVpnH/pyIe7c1wP5Wf2MHME/d6KPlxucTaCO7a+g576ElCXnipSfTVe1b2yf9XcHJ8FW2eM
-          awJyZwzvGIV39cztBVf6hXHrQpiiKR0oz3XBVsiYFoZsEUB4dhs0Wko4y3BbXHOD386/nARsOAgM
-          78ggNy6wD1N8J//KLe5qzoX9Ke5LbhGcs9hw7ioGodHWaruDMFUH6W6PkwBPDYQMWwHZAnXpxA12
-          oeLK+XbaE/3avabnSndrDlPdFk3ZomQ0nYi24iAlY6vZFB1rqIG2A+aDoDaU8+n4vIaCPNQFSe9j
-          vFhHi+VqmZyNudI+XFL7c/vI3Hv5yIXlUFCrPnTcD67FURZFuLk6GkrSJSaDuv81ixcjrKtic3Be
-          JF7OkzQ6Ju4v1YmWA/ntJooXUbo8Wx1nFcXHuC1m0RpJlM2TLEk/9XxtVYb5fL1O4jHKWvh2XGf9
-          H3jh9la6/5YuJ8D75P0fAAAA//8DAAMPkQuRAwAA
-      headers:
-        CF-RAY: [345a10c019ae6a31-LHR]
-        Cache-Control: ['private, max-age=600']
-        Connection: [keep-alive]
-        Content-Encoding: [gzip]
-        Content-Type: [application/json; charset=utf-8]
-        Date: ['Sun, 26 Mar 2017 12:20:42 GMT']
-        Last-Modified: ['Sat, 25 Mar 2017 19:03:45 GMT']
-        Server: [cloudflare-nginx]
-        Set-Cookie: ['__cfduid=d608440456dad6a296a96ff1144d9fe181490530841; expires=Mon,
-            26-Mar-18 12:20:41 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-        Vary: [Accept-Language]
-        X-Powered-By: [Thundar!]
-        X-Thetvdb-Api-Version: [2.1.2]
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: ['*/*']
-        Accept-Encoding: ['gzip, deflate']
-        Accept-Language: [en]
-        Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0OTA2MTcyNDAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDkwNTMwODQwfQ.cqoxZLHcpjdZSc8rLuC1NwNRLPzn3VFap4djS439N-5mTwDpHw4yvyUs4ZEkPmEozx1wUW84bGLgQ3XM1qECkWVCTKxAPyaWXd5JrfWw8VeLOiaJV0L79PU_7g4tS-DxjYVW0VijhgHoReLUNUohq89RVaHo_gc2P5HeV3Cvu7_9zwaYdiJAm3e6MusZ9aboOil4mY1kZeqjQAd_mbEoono3mCFb-TD7250Haw_QCPwMR_kOvmpdkuIhoQVJwlUvVOZtR-f3SUQCtfHoDUX6AzssbVVhalWscByq9GkHDEuSrspm1LJTlQjvky4YR-KFHT9gdGozg4HQVROIZBisuw]
-        Connection: [keep-alive]
-        User-Agent: [FlexGet/2.10.20.dev (www.flexget.com)]
-      method: GET
-      uri: https://api.thetvdb.com/series/247808/images/query?keyType=poster
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAA8yZz24aMRDG7zyFteeUeGb8Z8wbVJV66q2qqk2yIbQEECxVUZR3r6gocLA6K8uD
-          9sLBa1jrp28+fzO8TYxpntq+bWbm68QYY97+fhrTLJ6amQGL6Dnd/Vv82R2+HDZdMzPNZr3ru21z
-          frTbP3zqDscnl7XnxbL73L5e7d/do4ts+QPE6Y/N/LJ12+3Wy32/WK+OmwPb32CtvXre9ovVfPdx
-          9bxuZudTGtO0v7ptOz++wk3p7rL+uN6v+mZm6LT0fv6p/mX/+rBqF8vjm74/to8v3X3+dJOrL+bA
-          RA0wYdRgggAmRSALClywOhY/jRksUMQFh2CxGnJRwOIzWFyRWoZQIQUq7kZiSSVUnESFLEcNrSQF
-          Z6mmlSRSQQcaxgJWAUuoJZbT6QQuqMFFw1og57hl3iKaSyCfggYYjaso5cDYIjDiXRQcRqcApn5y
-          CfnkgiVc5ORigTUuIyAFvVA1gyGJS7LWeQUuUQEL5+RS5C9RxgIqnRHfKNEBlGBhuTFKNmi4C7gb
-          gUFfVEdOJAOJQMVgfHUyOXspct3T2f4rGBdVmgBQqKRqnZFcR56TV5m81G8DsqmuCEsSscTgnQYW
-          tArppZ7votQHAACTyj2NMF7BIMiCYaeSdhEV+sZYa1CHOAQMq4ChMU9fkMRCQvCkMdpFp2Ax2VIK
-          RWScTCZ4ryKZMGKLCSIWh1FlBIP1W6SYbZHK9CL+SQLBJdQYwSDf6LIuCnfIg8CoWEy6SeYtagVQ
-          DHfA3qvoheqHO5vBUjSvIznZMfqoMfomGDEWGIRFw3YJR4wFB2CJrIKFRoyFBmBJTqWI6qc6sLXa
-          AJIzHbNjFS5+xHK5nkpNjPk2ef8DAAD//wMAjMrCrQsjAAA=
-      headers:
-        CF-RAY: [345a10c6a97e3476-LHR]
-        Cache-Control: ['private, max-age=600']
-        Connection: [keep-alive]
-        Content-Encoding: [gzip]
-        Content-Type: [application/json; charset=utf-8]
-        Date: ['Sun, 26 Mar 2017 12:20:43 GMT']
-        Server: [cloudflare-nginx]
-        Set-Cookie: ['__cfduid=dddaf0086381ceb582401d198a3dfd8841490530842; expires=Mon,
-            26-Mar-18 12:20:42 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-        Vary: [Accept-Language]
-        X-Powered-By: [Thundar!]
-        X-Thetvdb-Api-Version: [2.1.2]
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: ['*/*']
-        Accept-Encoding: ['gzip, deflate']
-        Accept-Language: [en]
-        Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0OTA2MTcyNDAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDkwNTMwODQwfQ.cqoxZLHcpjdZSc8rLuC1NwNRLPzn3VFap4djS439N-5mTwDpHw4yvyUs4ZEkPmEozx1wUW84bGLgQ3XM1qECkWVCTKxAPyaWXd5JrfWw8VeLOiaJV0L79PU_7g4tS-DxjYVW0VijhgHoReLUNUohq89RVaHo_gc2P5HeV3Cvu7_9zwaYdiJAm3e6MusZ9aboOil4mY1kZeqjQAd_mbEoono3mCFb-TD7250Haw_QCPwMR_kOvmpdkuIhoQVJwlUvVOZtR-f3SUQCtfHoDUX6AzssbVVhalWscByq9GkHDEuSrspm1LJTlQjvky4YR-KFHT9gdGozg4HQVROIZBisuw]
-        Connection: [keep-alive]
-        User-Agent: [FlexGet/2.10.20.dev (www.flexget.com)]
-      method: GET
-      uri: https://api.thetvdb.com/search/series?name=Stranger+Things
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAA0yQQU/CQBCF7/0VL3suCChKuBnPctHEg+EwtNPtSDvbzG5BQvjvpqDgZQ7v+17y
-          MscMcCUlckt8ZgBwPF/AUSMUOV7BOXwNmqjfut9knf/ZG1Jlc0s4b9TVUlBzdz+ZzxaLkX8Yf3Xe
-          XdVKLKZnMS4HfTaZPo4mT6Pp/GbIQC7ta6ac9sG2Q2XFqWrk++aHHdtOeD/Aj5oVhEPo1WMTDigl
-          UtcxWcxRS0QbUs2Wg9CFRgpGUQtXOUjLM69MWMuIto8JRdDKgiYkNpPqIOpRBSs4QhTBSjakAM8J
-          tbTYULEd33ZFNuG4opaHZW/JSD0b3mtRH/9piVI/PNq9BE2ivai/fPiUAevs9AMAAP//AwAf/1DY
-          pgEAAA==
-      headers:
-        CF-RAY: [345a10cd48db355a-LHR]
-        Cache-Control: ['private, max-age=600']
-        Connection: [keep-alive]
-        Content-Encoding: [gzip]
-        Content-Type: [application/json; charset=utf-8]
-        Date: ['Sun, 26 Mar 2017 12:20:44 GMT']
-        Server: [cloudflare-nginx]
-        Set-Cookie: ['__cfduid=d286bba32051a38b10fe8b77163f6a6221490530843; expires=Mon,
-            26-Mar-18 12:20:43 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-        Vary: [Accept-Language]
-        X-Powered-By: [Thundar!]
-        X-Thetvdb-Api-Version: [2.1.2]
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: ['*/*']
-        Accept-Encoding: ['gzip, deflate']
-        Accept-Language: [en]
-        Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0OTA2MTcyNDAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDkwNTMwODQwfQ.cqoxZLHcpjdZSc8rLuC1NwNRLPzn3VFap4djS439N-5mTwDpHw4yvyUs4ZEkPmEozx1wUW84bGLgQ3XM1qECkWVCTKxAPyaWXd5JrfWw8VeLOiaJV0L79PU_7g4tS-DxjYVW0VijhgHoReLUNUohq89RVaHo_gc2P5HeV3Cvu7_9zwaYdiJAm3e6MusZ9aboOil4mY1kZeqjQAd_mbEoono3mCFb-TD7250Haw_QCPwMR_kOvmpdkuIhoQVJwlUvVOZtR-f3SUQCtfHoDUX6AzssbVVhalWscByq9GkHDEuSrspm1LJTlQjvky4YR-KFHT9gdGozg4HQVROIZBisuw]
-        Connection: [keep-alive]
-        User-Agent: [FlexGet/2.10.20.dev (www.flexget.com)]
-      method: GET
-      uri: https://api.thetvdb.com/series/305288
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAA2RSwXKbQAy9+ys0e7ZdwBDb3NKkmfaQtNOkzaHTgwwCVJtdRiuS0kz+vQM2jt0e
-          9d7bfdKTXiYAJkdFk8LLBADAcG5SWARJtFpN94gnYfJ3WJNJwdyroC1J4KFiW3pzEOGO0ZM3KfwY
-          AABz66xiuzVD/fOg26C1JP1HpWBTcYa7d3u3WRnPfzWlOXP91Hdjjpiitr2HuXJW2bZsj/qCxesl
-          Cw0voiC8mAXLWZiMvCV9drLtyTvSYse//2HOraS1yvuJk2AES7JCpyNeC9Z4YAHMDVpF370BH52I
-          k7f6vvUNWU/nmbgnkiem597ssSILCJ1rbQkb10HOHpuGUPwUKvZQO61IpoDQuB1nBFnFVEwBbT7w
-          hTDZ3EPdeoXM2UKcVVAS4aJjW0LhJCMPbMFJTgLqoCSFimvYYLadj8Pu0Ou3JkcdEg3jdbBYrYP1
-          eBXI4q+x+1w8Eg2p3gjn2JkT+uEQYBilQQCXt8dsUfvFpWAevs/CeIS5zjf7JajGyTJeLI7UH2wi
-          1j354UsQxUm4Xh5Xi3l+uvVwFkQQXqTxIo3ONe87k0IcR0mYjBfFSl/Hdtbz6D/4yrVWTQrLcALw
-          Onn9CwAA//8DAMDi7b8yAwAA
-      headers:
-        CF-RAY: [345a10d2fd5c3506-LHR]
-        Cache-Control: ['private, max-age=600']
-        Connection: [keep-alive]
-        Content-Encoding: [gzip]
-        Content-Type: [application/json; charset=utf-8]
-        Date: ['Sun, 26 Mar 2017 12:20:44 GMT']
-        Last-Modified: ['Fri, 24 Mar 2017 20:58:18 GMT']
-        Server: [cloudflare-nginx]
-        Set-Cookie: ['__cfduid=df714eca446ee7997fe8e09633a84044d1490530844; expires=Mon,
-            26-Mar-18 12:20:44 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-        Vary: [Accept-Language]
-        X-Powered-By: [Thundar!]
-        X-Thetvdb-Api-Version: [2.1.2]
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: ['*/*']
-        Accept-Encoding: ['gzip, deflate']
-        Accept-Language: [en]
-        Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0OTA2MTcyNDAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDkwNTMwODQwfQ.cqoxZLHcpjdZSc8rLuC1NwNRLPzn3VFap4djS439N-5mTwDpHw4yvyUs4ZEkPmEozx1wUW84bGLgQ3XM1qECkWVCTKxAPyaWXd5JrfWw8VeLOiaJV0L79PU_7g4tS-DxjYVW0VijhgHoReLUNUohq89RVaHo_gc2P5HeV3Cvu7_9zwaYdiJAm3e6MusZ9aboOil4mY1kZeqjQAd_mbEoono3mCFb-TD7250Haw_QCPwMR_kOvmpdkuIhoQVJwlUvVOZtR-f3SUQCtfHoDUX6AzssbVVhalWscByq9GkHDEuSrspm1LJTlQjvky4YR-KFHT9gdGozg4HQVROIZBisuw]
-        Connection: [keep-alive]
-        User-Agent: [FlexGet/2.10.20.dev (www.flexget.com)]
-      method: GET
-      uri: https://api.thetvdb.com/series/305288/images/query?keyType=poster
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAA8zYX2vbMBAA8Hd/ikPPa6o7/fc3GIU+9W2U4aZu6i21Q+yUhdLvPjK2NAyBhfAV
-          veRBkmPx406n81sFIB6bqRE1fKsAAN7+/AKI7lHUgOhRe/Pl3+DP9nh33LWiBrEbxqndi/PUeHi4
-          aY+nmY+xp27b3jYvF+vHayUNeX+FtPqx23ws3bfjsD1M3dCfFlsvf6GU8mK+mbp+M37tnwZRn3cJ
-          IJrXdt9sTq/A1XmjAGI9HPpJ1EB/h97PfzU9H14e+qbbnt70fd2sn9vr+O6qiwf/h9HBWs8Aoxd3
-          sVEXF3JgdJJLYHAxDC424uJVjouZdTHSomVwWT6PYtGSFSzzSWRIKmRAccujRJMIs04XN++ipHYM
-          Lp7BJZZEJHNcfIqL4ahGgcHFx+LF5biEFBfLkUcoGaq0isDorCot52G09pIDhiFgdCxgshIJU1wc
-          R5XG5WEomkk2yyUBxpigGGDs4i5quUSysyze8BQkXP66KyMqeVmkk1g4mgA0BbOYFBZDHCyuYBaX
-          xMJxtqAvmMUnsGirOTojWS4LySQWjiOX8JOao6xSRJgC4zguu0SfdKkzWTCUAGN5vtWFgs+XkMDi
-          iOPYJbU4i16F2Ke6rHhRKTCWJV5UwfGSwGKJpQVAWzCLTWJhKdMFtwCkk1g4kogKbgHosgWoAO6r
-          998AAAD//wMAvaJGWkoaAAA=
-      headers:
-        CF-RAY: [345a10d608cd6ab5-LHR]
-        Cache-Control: ['private, max-age=600']
-        Connection: [keep-alive]
-        Content-Encoding: [gzip]
-        Content-Type: [application/json; charset=utf-8]
-        Date: ['Sun, 26 Mar 2017 12:20:45 GMT']
-        Server: [cloudflare-nginx]
-        Set-Cookie: ['__cfduid=d53e8ade698a51ba118a00e58896ecd211490530845; expires=Mon,
-            26-Mar-18 12:20:45 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-        Vary: [Accept-Language]
-        X-Powered-By: [Thundar!]
-        X-Thetvdb-Api-Version: [2.1.2]
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: ['*/*']
-        Accept-Encoding: ['gzip, deflate']
-        Connection: [keep-alive]
-        User-Agent: [FlexGet/2.10.20.dev (www.flexget.com)]
-      method: GET
-      uri: https://api.tvmaze.com/singlesearch/shows?embed=seasons&q=Suits
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAA91Ya2/bNhT9KwS/7ItlPfyQawQFgmXAPqzd0KAotqEIaOnGYkORAknZc4P89x1K
-          cmNv7ZoMDhCkCNqQvDy8j8Nzqd5yWfJlmmcj3lrFl7zyvlnG8Xa7HftNLT7TuDB17CqzdTHMYtdK
-          7/iIa1ETzC+Hod813bCwsvFUwkAJvW7FOsz+pNdKugqTa9KWHF/+yS+sqAVmfqG1UPzjiDsvfIsl
-          /q7VWuo11myrvQzHzJMRbyzVkiywlzxL0jRK5lE2gZUrKipbBbNb3pvzLFsmCZZKsesO+0ClJocR
-          /3gHWOEDPszFhmzn4mI8w8KW5LrySAeyoclvjb0JViFDE3gwhPz+8py9HVZHvDBw0u6C3X5dS2SA
-          XSIehBosypCE95f4Pfj32egwPq/JykLEb2l79Xs46a7zYPVjJbQmlEK3So04/eXJaqEQB8Lb9O5m
-          +SxdAK0ivylXfJlN80WCCVmHEfc+nU+yPEk5IGXdRXjLayplW2N5KHFIuCwOq9w2yojSxd0WF/cb
-          rhpjvRXSx0mcTSfZ+FMTamOsXEv49Qi8/ZYrZMy0oWqHkHDVtXUtQi75WfP6zHlr9Pp1x7CzeBix
-          ktSGHJOAYIifXQvno0YUVI5YhfJFCOsGBiieKpm5ZoJ507A3QlfCe6FZYSwiQm2YElt2LW3NthV4
-          xSrjQXPPhHOmkMHgZ2E3tGOXDRUoAqs7YMGsdDc7VpsNsdUOh1qwib2RN8TeGedw4MpKpaTQnq1a
-          z1pdGy83ACxxuFK0JlZa05jWj3AYALBnf+aYnWMGwIRrhzBI429kCgEjXFi2+lrUEui2D3HUn2xJ
-          SZhXJDZS7ZgJ1kgOovvBAcx51ggrcLZQ7J1A7hX7Q2hiQpdDmLDTJtJGO8JP8EgilYjhwmgt2G+i
-          VVhBMnGIauB1zRwhP+xT68AjGrMP0leIvkESzdqKppIFq6k2dtcdExxCFYk8cyizd311KmxXZIc4
-          Gou0unDKCj6w3mFMlnK9Q+1dg7vVhSZW8KaggLEyWlzLEgXtwiugEQThwJ0Zn8XNa5C1bcqQftzs
-          6WIxSyeTcFmulNQ33bVypK7D9aos4d/9/RCNPLwcXyQwXCqI0Uaa1lEjXXe9v7N5sIOEJtN8MsXF
-          BMgV1Ssqy+DXLXckHHIPaewFJ5+/+o4k9xtiGPaiHPUQUYqAdQtoi3i/qBYmByd+tWVY6uVlr6oX
-          yA9CPxJW0uXR9KsoWQTsZ6KMpxO2bBrPk1dZclJpOwI9Ejfk8LHcu681mHM3GiiSoyn9Z9feb8uT
-          Y4pkBxQJva7v5Q+mSBZ6bzoN9ocUmURJFmUd/V4qRdKnoEgPeiqK5MkRRaAAD6NIekyR8LLaq8jk
-          8RQBF/Ionf+TItMomUZpeJq9WBU57QNpUJEe9GQUCf3nXkW+9/b/oiLD63/faIIA7CkyfTxFwAWo
-          SJCLIxWZRQnI02G/VBWZPIWK9KAno0h2QJH5fPHAThMsj3VkdkCS2bdJks7vv/DuHx3gAj7y/tVo
-          5h1Fuib2UikyfQqK9KAnokgo9QFHpviDGj6k13SmxywJjWIvJUD51oPk6ywBHdBrQsM6EpK8Y8kz
-          fI70L+/7j104/j/fg10mD4owS+Y5vmweUoTO9LgI+UER8m8X4WsfDsP/Vexfg/3wmbX406W9y11I
-          +8e7u78BbA3DFUETAAA=
-      headers:
-        Access-Control-Allow-Origin: ['*']
-        Cache-Control: ['public, max-age=3600']
-        Connection: [keep-alive]
-        Content-Encoding: [gzip]
-        Content-Type: [application/json; charset=UTF-8]
-        Date: ['Sun, 26 Mar 2017 12:20:45 GMT']
-        Server: [nginx/1.10.0 (Ubuntu)]
-        Vary: [Accept-Encoding]
-      status: {code: 200, message: OK}
-  - request:
-      body: null
-      headers:
-        Accept: ['*/*']
-        Accept-Encoding: ['gzip, deflate']
-        Connection: [keep-alive]
-        User-Agent: [FlexGet/2.10.20.dev (www.flexget.com)]
-      method: GET
-      uri: https://api.tvmaze.com/singlesearch/shows?embed=seasons&q=Stranger+Things
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAA81W227bRhD9lcW+5IUSqRstCYYBo2nQPjQF6gRBURvGilyRGy13ib2IYQwB/Zp+
-          WL+kZyg7sZ1L6yIPeZI0Mzs7e+acGd1wVfL1dLWaJTw6zde8DqFdp2nXdeOwb8R7OS5sk/radj6l
-          uNQHJ0wl3SjUylSeJ9yIRuLkxa2DvbpzhL4dHIVTbZAlQjWORlGR9UdTaeVrGCtpnPR8/Qd/7kQj
-          YLkolDSFHL1QRVDWwPJL74N0Pb9KuA8iRITz36IxKAFeF01QVESeJbx1slHS4b41n2aTfJSdjCYL
-          RPmilmXUCLvhx3AOayn64e4XTuErvzognQiUF2FiL91Q7nK8hKOTqqoDXy/waBk663Z8baLW5Nn8
-          UAtjJDC8GUCdfADmpQxbrd7hrsKiULwCIbegvTYKyLALvAkQUERJ4Ly+wHeq8b019Pu8kU4VIn0p
-          u+vf6doDqpHvAIkRGuXjQftjofPlnJoZahn25YavZ9liulwmXDX0i4cwX5zMZ7M5RwLVDG+74Y0s
-          VWzgvu0+QayK+wSIrbai9OlwxKfHA9etdWi6Cmm+SCf5bDLPx29baoh1qlIo7Qkp745cAyIbqVWP
-          sqJgH5tGEH78tD07Z9ruJdMyAAYWLMOb2bNl5lmhhfeq8LCIwArRBrUHviUTDFxDR4lUCTsFla2p
-          zh4R95QoTnamPPMyMGXYZLWcsZ9NqYQRCetq0AvJerSzYhvbs70w4LL0iEUhl4a0wYRyY3bu2daB
-          zaVP2FY0SvdMmBKlF0Kz1mpVSFwiXFGzrXXw+U46xOIxPRIJXFQ60ZljZmEYuu6EdSXgdT1rjrqA
-          d2/1Hqy9NICiHXlZOJReASFnGmkCzrXgEH2l7NI5te0Rz3yE3UBSDgWhhAKvoAovDajHcLxnwIMk
-          z7QKQUtWKafHp2l7hkbHtiRk+XoyX+arLMsXq4Rfa2V2Ayu91FtiZ+0kPu/oJVp1n1sfhwuREvLd
-          Kxu9bJUfxPAvp2/jfLo4Web5ilIYUsZTj6+y1WyeDcK6ls1GliU964ajOd4aGhFHXa/yDNL+6rA8
-          nkgp8vG4RGMo3WgC7EzENQ7QfZgUMN7W/asryQXh3o2z58AZED6YaKDV58zfwWz6hqPlBKNluZov
-          vu1oeZD18Wh5U0vI9zP6TmD1jdAaIoMmoylIYBDMp0KEqgcJPkF3yA7hkey+oriniuseGUHuQ3Jk
-          8WI6z7HF/guNh9Av8Xh6j8fTL/MYQ+FTHmMtZ6MZKeEBjz+avx8eH5f8o/XTY2wzsaXt80Zp/cwz
-          jNzosFkkjc3h/xFYIBvPNqLY0Yoy1oE9f//5F9vEANaUwu2M9J7p6HaevY0+sA1WlAj1sM58dFtR
-          SFoHDkZJ/3cY0c9u2U+i2ynj7ybx/+TF0F0ixtXh8A+H6fNeDgoAAA==
-      headers:
-        Access-Control-Allow-Origin: ['*']
-        Cache-Control: ['public, max-age=3600']
-        Connection: [keep-alive]
-        Content-Encoding: [gzip]
-        Content-Type: [application/json; charset=UTF-8]
-        Date: ['Sun, 26 Mar 2017 12:20:46 GMT']
-        Server: [nginx/1.10.0 (Ubuntu)]
-        Vary: [Accept-Encoding]
-      status: {code: 200, message: OK}
+- request:
+    body: '{"apikey": "4D297D8CFDE0E105"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FlexGet/2.10.20.dev (www.flexget.com)
+    method: POST
+    uri: https://api.thetvdb.com/login
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwTByZKiMAAA0Ht/heWdLhBcmBsNaEIjO0G5UGyyhBgUIcDU/Pu89/drs9l+KC6f
+        2z+bbbkYdXbJG7sx/HCFgtXAAT69fa7CA8T9DamG/F0uRlcCpbFbnbcDZXcN8sXSlAGSDsOWNh6Z
+        u1IvukKFAyTykkbFI43OPGzpbGmYWcGV2ZrLHu53/qJzbIK8b4vYz09vc1QFi1me6axPEZ3TXipa
+        XxJli9uTgGk9YNIyLeEgxTp2iE7XWWBhdJKyi1m54u0qvHQVR0gNfmfFWdLoVuyN9yNiJ1SadpMa
+        iDePshMmx0r6+Jw2t3cU8ahp6wpQrzRDK6T16yR7KAU0qfKdswclEtVpPCbyytJ70RgKEcvDdRxi
+        Oc2o3XQSuQs4Ll+tqxQJyXRKn1Qk6jnjAu242/MgZYmrOuzqJdieSF/gEdbURQbrwgnZ8cfjHqIf
+        uurnAagW3g7KOgwZQnXaRUP+s7zkCwaaPvrvoSeCaQSd2054ke4e93sGgVwVF7pWEnCRZ8P4pxlG
+        tv369x8AAP//AwAXRh371wEAAA==
+    headers:
+      CF-RAY:
+      - 345a10b29ad2355a-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 26 Mar 2017 12:20:40 GMT
+      Server:
+      - cloudflare-nginx
+      Set-Cookie:
+      - __cfduid=d48100fdd734efa4b25d6a7c75cde31f61490530839; expires=Mon, 26-Mar-18
+        12:20:39 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      Vary:
+      - Accept-Language
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 2.1.2
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0OTA2MTcyNDAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDkwNTMwODQwfQ.cqoxZLHcpjdZSc8rLuC1NwNRLPzn3VFap4djS439N-5mTwDpHw4yvyUs4ZEkPmEozx1wUW84bGLgQ3XM1qECkWVCTKxAPyaWXd5JrfWw8VeLOiaJV0L79PU_7g4tS-DxjYVW0VijhgHoReLUNUohq89RVaHo_gc2P5HeV3Cvu7_9zwaYdiJAm3e6MusZ9aboOil4mY1kZeqjQAd_mbEoono3mCFb-TD7250Haw_QCPwMR_kOvmpdkuIhoQVJwlUvVOZtR-f3SUQCtfHoDUX6AzssbVVhalWscByq9GkHDEuSrspm1LJTlQjvky4YR-KFHT9gdGozg4HQVROIZBisuw
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.10.20.dev (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/search/series?name=Suits
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yRMU/DMBCF9/6KpywsbWkLAsSGWFjoQGFAiOGaXJKjji+yr7UixH9HDqWwWPL7
+        3p2fnj8nQFGRUXGLtwkAfI4nUJATihwzeJ/+ilvynkNxi6IJ1LdSkjtfXV7fLG5mzfJ6/tE3xclb
+        S4h2J4Gr7F8tlsvZ4mq2uvhzSCY/4yfNsyUNuzzysrnD+ng9cT1wOAinbNjsxSJqdU5TRKnOccOo
+        gvYz3RseZcd40hinSK2CylIq9kbODXDkqwjCh26RxFqoZ2iNNSe8atidRWw5Ghw35FA6jRziFA8U
+        Djxg03NpHOZ4bnlAVPXYcqkdg5DEe/ENjKn7WZ1znEUESjBy7A3kK/Stmh5bRMedhmE6gjH2uDNw
+        Jznm8VWtkdoBLSPlJeJNYS2jFnZVpo4SxB+1EA29o5Lnf+VFDsJxTR2f6vsHjWyf/7u4V2/i9+Kb
+        YoRfE+B98vUNAAD//wMAtqiHFC0CAAA=
+    headers:
+      CF-RAY:
+      - 345a10b908cc134d-LHR
+      Cache-Control:
+      - private, max-age=600
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 26 Mar 2017 12:20:41 GMT
+      Server:
+      - cloudflare-nginx
+      Set-Cookie:
+      - __cfduid=d667f536536831a13fe3c6912019e4cef1490530840; expires=Mon, 26-Mar-18
+        12:20:40 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      Vary:
+      - Accept-Language
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 2.1.2
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0OTA2MTcyNDAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDkwNTMwODQwfQ.cqoxZLHcpjdZSc8rLuC1NwNRLPzn3VFap4djS439N-5mTwDpHw4yvyUs4ZEkPmEozx1wUW84bGLgQ3XM1qECkWVCTKxAPyaWXd5JrfWw8VeLOiaJV0L79PU_7g4tS-DxjYVW0VijhgHoReLUNUohq89RVaHo_gc2P5HeV3Cvu7_9zwaYdiJAm3e6MusZ9aboOil4mY1kZeqjQAd_mbEoono3mCFb-TD7250Haw_QCPwMR_kOvmpdkuIhoQVJwlUvVOZtR-f3SUQCtfHoDUX6AzssbVVhalWscByq9GkHDEuSrspm1LJTlQjvky4YR-KFHT9gdGozg4HQVROIZBisuw
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.10.20.dev (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/series/247808
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA2RTy27bMBC8+ysGvORip5LsWLZuaVKgPSQN8mhQBD2spbXFhCIFch1BDfLvhWTJ
+        SNDjzixnl5zh2wRQBQmpDG8TAFC6UBmSRbqKVtMDEthrDtdUscqg7vZaghooMpoCB5Xh6c8Abcha
+        9l3nzlNd6pzMl4PcbBenp8/1Tn3S/dHNU+k6SuMjIST7TlRdOCva7rU9HtpqH+Rce+6PJVEcz6Ll
+        LJmPvGVpnH/pyIe7c1wP5Wf2MHME/d6KPlxucTaCO7a+g576ElCXnipSfTVe1b2yf9XcHJ8FW2eM
+        awJyZwzvGIV39cztBVf6hXHrQpiiKR0oz3XBVsiYFoZsEUB4dhs0Wko4y3BbXHOD386/nARsOAgM
+        78ggNy6wD1N8J//KLe5qzoX9Ke5LbhGcs9hw7ioGodHWaruDMFUH6W6PkwBPDYQMWwHZAnXpxA12
+        oeLK+XbaE/3avabnSndrDlPdFk3ZomQ0nYi24iAlY6vZFB1rqIG2A+aDoDaU8+n4vIaCPNQFSe9j
+        vFhHi+VqmZyNudI+XFL7c/vI3Hv5yIXlUFCrPnTcD67FURZFuLk6GkrSJSaDuv81ixcjrKtic3Be
+        JF7OkzQ6Ju4v1YmWA/ntJooXUbo8Wx1nFcXHuC1m0RpJlM2TLEk/9XxtVYb5fL1O4jHKWvh2XGf9
+        H3jh9la6/5YuJ8D75P0fAAAA//8DAAMPkQuRAwAA
+    headers:
+      CF-RAY:
+      - 345a10c019ae6a31-LHR
+      Cache-Control:
+      - private, max-age=600
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 26 Mar 2017 12:20:42 GMT
+      Last-Modified:
+      - Sat, 25 Mar 2017 19:03:45 GMT
+      Server:
+      - cloudflare-nginx
+      Set-Cookie:
+      - __cfduid=d608440456dad6a296a96ff1144d9fe181490530841; expires=Mon, 26-Mar-18
+        12:20:41 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      Vary:
+      - Accept-Language
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 2.1.2
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0OTA2MTcyNDAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDkwNTMwODQwfQ.cqoxZLHcpjdZSc8rLuC1NwNRLPzn3VFap4djS439N-5mTwDpHw4yvyUs4ZEkPmEozx1wUW84bGLgQ3XM1qECkWVCTKxAPyaWXd5JrfWw8VeLOiaJV0L79PU_7g4tS-DxjYVW0VijhgHoReLUNUohq89RVaHo_gc2P5HeV3Cvu7_9zwaYdiJAm3e6MusZ9aboOil4mY1kZeqjQAd_mbEoono3mCFb-TD7250Haw_QCPwMR_kOvmpdkuIhoQVJwlUvVOZtR-f3SUQCtfHoDUX6AzssbVVhalWscByq9GkHDEuSrspm1LJTlQjvky4YR-KFHT9gdGozg4HQVROIZBisuw
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.10.20.dev (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/series/247808/images/query?keyType=poster
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA8yZz24aMRDG7zyFteeUeGb8Z8wbVJV66q2qqk2yIbQEECxVUZR3r6gocLA6K8uD
+        9sLBa1jrp28+fzO8TYxpntq+bWbm68QYY97+fhrTLJ6amQGL6Dnd/Vv82R2+HDZdMzPNZr3ru21z
+        frTbP3zqDscnl7XnxbL73L5e7d/do4ts+QPE6Y/N/LJ12+3Wy32/WK+OmwPb32CtvXre9ovVfPdx
+        9bxuZudTGtO0v7ptOz++wk3p7rL+uN6v+mZm6LT0fv6p/mX/+rBqF8vjm74/to8v3X3+dJOrL+bA
+        RA0wYdRgggAmRSALClywOhY/jRksUMQFh2CxGnJRwOIzWFyRWoZQIQUq7kZiSSVUnESFLEcNrSQF
+        Z6mmlSRSQQcaxgJWAUuoJZbT6QQuqMFFw1og57hl3iKaSyCfggYYjaso5cDYIjDiXRQcRqcApn5y
+        CfnkgiVc5ORigTUuIyAFvVA1gyGJS7LWeQUuUQEL5+RS5C9RxgIqnRHfKNEBlGBhuTFKNmi4C7gb
+        gUFfVEdOJAOJQMVgfHUyOXspct3T2f4rGBdVmgBQqKRqnZFcR56TV5m81G8DsqmuCEsSscTgnQYW
+        tArppZ7votQHAACTyj2NMF7BIMiCYaeSdhEV+sZYa1CHOAQMq4ChMU9fkMRCQvCkMdpFp2Ax2VIK
+        RWScTCZ4ryKZMGKLCSIWh1FlBIP1W6SYbZHK9CL+SQLBJdQYwSDf6LIuCnfIg8CoWEy6SeYtagVQ
+        DHfA3qvoheqHO5vBUjSvIznZMfqoMfomGDEWGIRFw3YJR4wFB2CJrIKFRoyFBmBJTqWI6qc6sLXa
+        AJIzHbNjFS5+xHK5nkpNjPk2ef8DAAD//wMAjMrCrQsjAAA=
+    headers:
+      CF-RAY:
+      - 345a10c6a97e3476-LHR
+      Cache-Control:
+      - private, max-age=600
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 26 Mar 2017 12:20:43 GMT
+      Server:
+      - cloudflare-nginx
+      Set-Cookie:
+      - __cfduid=dddaf0086381ceb582401d198a3dfd8841490530842; expires=Mon, 26-Mar-18
+        12:20:42 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      Vary:
+      - Accept-Language
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 2.1.2
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0OTA2MTcyNDAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDkwNTMwODQwfQ.cqoxZLHcpjdZSc8rLuC1NwNRLPzn3VFap4djS439N-5mTwDpHw4yvyUs4ZEkPmEozx1wUW84bGLgQ3XM1qECkWVCTKxAPyaWXd5JrfWw8VeLOiaJV0L79PU_7g4tS-DxjYVW0VijhgHoReLUNUohq89RVaHo_gc2P5HeV3Cvu7_9zwaYdiJAm3e6MusZ9aboOil4mY1kZeqjQAd_mbEoono3mCFb-TD7250Haw_QCPwMR_kOvmpdkuIhoQVJwlUvVOZtR-f3SUQCtfHoDUX6AzssbVVhalWscByq9GkHDEuSrspm1LJTlQjvky4YR-KFHT9gdGozg4HQVROIZBisuw
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.10.20.dev (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/search/series?name=Stranger+Things
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQQU/CQBCF7/0VL3suCChKuBnPctHEg+EwtNPtSDvbzG5BQvjvpqDgZQ7v+17y
+        MscMcCUlckt8ZgBwPF/AUSMUOV7BOXwNmqjfut9knf/ZG1Jlc0s4b9TVUlBzdz+ZzxaLkX8Yf3Xe
+        XdVKLKZnMS4HfTaZPo4mT6Pp/GbIQC7ta6ac9sG2Q2XFqWrk++aHHdtOeD/Aj5oVhEPo1WMTDigl
+        UtcxWcxRS0QbUs2Wg9CFRgpGUQtXOUjLM69MWMuIto8JRdDKgiYkNpPqIOpRBSs4QhTBSjakAM8J
+        tbTYULEd33ZFNuG4opaHZW/JSD0b3mtRH/9piVI/PNq9BE2ivai/fPiUAevs9AMAAP//AwAf/1DY
+        pgEAAA==
+    headers:
+      CF-RAY:
+      - 345a10cd48db355a-LHR
+      Cache-Control:
+      - private, max-age=600
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 26 Mar 2017 12:20:44 GMT
+      Server:
+      - cloudflare-nginx
+      Set-Cookie:
+      - __cfduid=d286bba32051a38b10fe8b77163f6a6221490530843; expires=Mon, 26-Mar-18
+        12:20:43 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      Vary:
+      - Accept-Language
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 2.1.2
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0OTA2MTcyNDAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDkwNTMwODQwfQ.cqoxZLHcpjdZSc8rLuC1NwNRLPzn3VFap4djS439N-5mTwDpHw4yvyUs4ZEkPmEozx1wUW84bGLgQ3XM1qECkWVCTKxAPyaWXd5JrfWw8VeLOiaJV0L79PU_7g4tS-DxjYVW0VijhgHoReLUNUohq89RVaHo_gc2P5HeV3Cvu7_9zwaYdiJAm3e6MusZ9aboOil4mY1kZeqjQAd_mbEoono3mCFb-TD7250Haw_QCPwMR_kOvmpdkuIhoQVJwlUvVOZtR-f3SUQCtfHoDUX6AzssbVVhalWscByq9GkHDEuSrspm1LJTlQjvky4YR-KFHT9gdGozg4HQVROIZBisuw
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.10.20.dev (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/series/305288
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA2RSwXKbQAy9+ys0e7ZdwBDb3NKkmfaQtNOkzaHTgwwCVJtdRiuS0kz+vQM2jt0e
+        9d7bfdKTXiYAJkdFk8LLBADAcG5SWARJtFpN94gnYfJ3WJNJwdyroC1J4KFiW3pzEOGO0ZM3KfwY
+        AABz66xiuzVD/fOg26C1JP1HpWBTcYa7d3u3WRnPfzWlOXP91Hdjjpiitr2HuXJW2bZsj/qCxesl
+        Cw0voiC8mAXLWZiMvCV9drLtyTvSYse//2HOraS1yvuJk2AES7JCpyNeC9Z4YAHMDVpF370BH52I
+        k7f6vvUNWU/nmbgnkiem597ssSILCJ1rbQkb10HOHpuGUPwUKvZQO61IpoDQuB1nBFnFVEwBbT7w
+        hTDZ3EPdeoXM2UKcVVAS4aJjW0LhJCMPbMFJTgLqoCSFimvYYLadj8Pu0Ou3JkcdEg3jdbBYrYP1
+        eBXI4q+x+1w8Eg2p3gjn2JkT+uEQYBilQQCXt8dsUfvFpWAevs/CeIS5zjf7JajGyTJeLI7UH2wi
+        1j354UsQxUm4Xh5Xi3l+uvVwFkQQXqTxIo3ONe87k0IcR0mYjBfFSl/Hdtbz6D/4yrVWTQrLcALw
+        Onn9CwAA//8DAMDi7b8yAwAA
+    headers:
+      CF-RAY:
+      - 345a10d2fd5c3506-LHR
+      Cache-Control:
+      - private, max-age=600
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 26 Mar 2017 12:20:44 GMT
+      Last-Modified:
+      - Fri, 24 Mar 2017 20:58:18 GMT
+      Server:
+      - cloudflare-nginx
+      Set-Cookie:
+      - __cfduid=df714eca446ee7997fe8e09633a84044d1490530844; expires=Mon, 26-Mar-18
+        12:20:44 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      Vary:
+      - Accept-Language
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 2.1.2
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0OTA2MTcyNDAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDkwNTMwODQwfQ.cqoxZLHcpjdZSc8rLuC1NwNRLPzn3VFap4djS439N-5mTwDpHw4yvyUs4ZEkPmEozx1wUW84bGLgQ3XM1qECkWVCTKxAPyaWXd5JrfWw8VeLOiaJV0L79PU_7g4tS-DxjYVW0VijhgHoReLUNUohq89RVaHo_gc2P5HeV3Cvu7_9zwaYdiJAm3e6MusZ9aboOil4mY1kZeqjQAd_mbEoono3mCFb-TD7250Haw_QCPwMR_kOvmpdkuIhoQVJwlUvVOZtR-f3SUQCtfHoDUX6AzssbVVhalWscByq9GkHDEuSrspm1LJTlQjvky4YR-KFHT9gdGozg4HQVROIZBisuw
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.10.20.dev (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/series/305288/images/query?keyType=poster
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA8zYX2vbMBAA8Hd/ikPPa6o7/fc3GIU+9W2U4aZu6i21Q+yUhdLvPjK2NAyBhfAV
+        veRBkmPx406n81sFIB6bqRE1fKsAAN7+/AKI7lHUgOhRe/Pl3+DP9nh33LWiBrEbxqndi/PUeHi4
+        aY+nmY+xp27b3jYvF+vHayUNeX+FtPqx23ws3bfjsD1M3dCfFlsvf6GU8mK+mbp+M37tnwZRn3cJ
+        IJrXdt9sTq/A1XmjAGI9HPpJ1EB/h97PfzU9H14e+qbbnt70fd2sn9vr+O6qiwf/h9HBWs8Aoxd3
+        sVEXF3JgdJJLYHAxDC424uJVjouZdTHSomVwWT6PYtGSFSzzSWRIKmRAccujRJMIs04XN++ipHYM
+        Lp7BJZZEJHNcfIqL4ahGgcHFx+LF5biEFBfLkUcoGaq0isDorCot52G09pIDhiFgdCxgshIJU1wc
+        R5XG5WEomkk2yyUBxpigGGDs4i5quUSysyze8BQkXP66KyMqeVmkk1g4mgA0BbOYFBZDHCyuYBaX
+        xMJxtqAvmMUnsGirOTojWS4LySQWjiOX8JOao6xSRJgC4zguu0SfdKkzWTCUAGN5vtWFgs+XkMDi
+        iOPYJbU4i16F2Ke6rHhRKTCWJV5UwfGSwGKJpQVAWzCLTWJhKdMFtwCkk1g4kogKbgHosgWoAO6r
+        998AAAD//wMAvaJGWkoaAAA=
+    headers:
+      CF-RAY:
+      - 345a10d608cd6ab5-LHR
+      Cache-Control:
+      - private, max-age=600
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 26 Mar 2017 12:20:45 GMT
+      Server:
+      - cloudflare-nginx
+      Set-Cookie:
+      - __cfduid=d53e8ade698a51ba118a00e58896ecd211490530845; expires=Mon, 26-Mar-18
+        12:20:45 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      Vary:
+      - Accept-Language
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 2.1.2
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.10.20.dev (www.flexget.com)
+    method: GET
+    uri: https://api.tvmaze.com/singlesearch/shows?embed=seasons&q=Suits
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA91Ya2/bNhT9KwS/7ItlPfyQawQFgmXAPqzd0KAotqEIaOnGYkORAknZc4P89x1K
+        cmNv7ZoMDhCkCNqQvDy8j8Nzqd5yWfJlmmcj3lrFl7zyvlnG8Xa7HftNLT7TuDB17CqzdTHMYtdK
+        7/iIa1ETzC+Hod813bCwsvFUwkAJvW7FOsz+pNdKugqTa9KWHF/+yS+sqAVmfqG1UPzjiDsvfIsl
+        /q7VWuo11myrvQzHzJMRbyzVkiywlzxL0jRK5lE2gZUrKipbBbNb3pvzLFsmCZZKsesO+0ClJocR
+        /3gHWOEDPszFhmzn4mI8w8KW5LrySAeyoclvjb0JViFDE3gwhPz+8py9HVZHvDBw0u6C3X5dS2SA
+        XSIehBosypCE95f4Pfj32egwPq/JykLEb2l79Xs46a7zYPVjJbQmlEK3So04/eXJaqEQB8Lb9O5m
+        +SxdAK0ivylXfJlN80WCCVmHEfc+nU+yPEk5IGXdRXjLayplW2N5KHFIuCwOq9w2yojSxd0WF/cb
+        rhpjvRXSx0mcTSfZ+FMTamOsXEv49Qi8/ZYrZMy0oWqHkHDVtXUtQi75WfP6zHlr9Pp1x7CzeBix
+        ktSGHJOAYIifXQvno0YUVI5YhfJFCOsGBiieKpm5ZoJ507A3QlfCe6FZYSwiQm2YElt2LW3NthV4
+        xSrjQXPPhHOmkMHgZ2E3tGOXDRUoAqs7YMGsdDc7VpsNsdUOh1qwib2RN8TeGedw4MpKpaTQnq1a
+        z1pdGy83ACxxuFK0JlZa05jWj3AYALBnf+aYnWMGwIRrhzBI429kCgEjXFi2+lrUEui2D3HUn2xJ
+        SZhXJDZS7ZgJ1kgOovvBAcx51ggrcLZQ7J1A7hX7Q2hiQpdDmLDTJtJGO8JP8EgilYjhwmgt2G+i
+        VVhBMnGIauB1zRwhP+xT68AjGrMP0leIvkESzdqKppIFq6k2dtcdExxCFYk8cyizd311KmxXZIc4
+        Gou0unDKCj6w3mFMlnK9Q+1dg7vVhSZW8KaggLEyWlzLEgXtwiugEQThwJ0Zn8XNa5C1bcqQftzs
+        6WIxSyeTcFmulNQ33bVypK7D9aos4d/9/RCNPLwcXyQwXCqI0Uaa1lEjXXe9v7N5sIOEJtN8MsXF
+        BMgV1Ssqy+DXLXckHHIPaewFJ5+/+o4k9xtiGPaiHPUQUYqAdQtoi3i/qBYmByd+tWVY6uVlr6oX
+        yA9CPxJW0uXR9KsoWQTsZ6KMpxO2bBrPk1dZclJpOwI9Ejfk8LHcu681mHM3GiiSoyn9Z9feb8uT
+        Y4pkBxQJva7v5Q+mSBZ6bzoN9ocUmURJFmUd/V4qRdKnoEgPeiqK5MkRRaAAD6NIekyR8LLaq8jk
+        8RQBF/Ionf+TItMomUZpeJq9WBU57QNpUJEe9GQUCf3nXkW+9/b/oiLD63/faIIA7CkyfTxFwAWo
+        SJCLIxWZRQnI02G/VBWZPIWK9KAno0h2QJH5fPHAThMsj3VkdkCS2bdJks7vv/DuHx3gAj7y/tVo
+        5h1Fuib2UikyfQqK9KAnokgo9QFHpviDGj6k13SmxywJjWIvJUD51oPk6ywBHdBrQsM6EpK8Y8kz
+        fI70L+/7j104/j/fg10mD4owS+Y5vmweUoTO9LgI+UER8m8X4WsfDsP/Vexfg/3wmbX406W9y11I
+        +8e7u78BbA3DFUETAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - public, max-age=3600
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sun, 26 Mar 2017 12:20:45 GMT
+      Server:
+      - nginx/1.10.0 (Ubuntu)
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.10.20.dev (www.flexget.com)
+    method: GET
+    uri: https://api.tvmaze.com/singlesearch/shows?embed=seasons&q=Stranger+Things
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA81W227bRhD9lcW+5IUSqRstCYYBo2nQPjQF6gRBURvGilyRGy13ib2IYQwB/Zp+
+        WL+kZyg7sZ1L6yIPeZI0Mzs7e+acGd1wVfL1dLWaJTw6zde8DqFdp2nXdeOwb8R7OS5sk/radj6l
+        uNQHJ0wl3SjUylSeJ9yIRuLkxa2DvbpzhL4dHIVTbZAlQjWORlGR9UdTaeVrGCtpnPR8/Qd/7kQj
+        YLkolDSFHL1QRVDWwPJL74N0Pb9KuA8iRITz36IxKAFeF01QVESeJbx1slHS4b41n2aTfJSdjCYL
+        RPmilmXUCLvhx3AOayn64e4XTuErvzognQiUF2FiL91Q7nK8hKOTqqoDXy/waBk663Z8baLW5Nn8
+        UAtjJDC8GUCdfADmpQxbrd7hrsKiULwCIbegvTYKyLALvAkQUERJ4Ly+wHeq8b019Pu8kU4VIn0p
+        u+vf6doDqpHvAIkRGuXjQftjofPlnJoZahn25YavZ9liulwmXDX0i4cwX5zMZ7M5RwLVDG+74Y0s
+        VWzgvu0+QayK+wSIrbai9OlwxKfHA9etdWi6Cmm+SCf5bDLPx29baoh1qlIo7Qkp745cAyIbqVWP
+        sqJgH5tGEH78tD07Z9ruJdMyAAYWLMOb2bNl5lmhhfeq8LCIwArRBrUHviUTDFxDR4lUCTsFla2p
+        zh4R95QoTnamPPMyMGXYZLWcsZ9NqYQRCetq0AvJerSzYhvbs70w4LL0iEUhl4a0wYRyY3bu2daB
+        zaVP2FY0SvdMmBKlF0Kz1mpVSFwiXFGzrXXw+U46xOIxPRIJXFQ60ZljZmEYuu6EdSXgdT1rjrqA
+        d2/1Hqy9NICiHXlZOJReASFnGmkCzrXgEH2l7NI5te0Rz3yE3UBSDgWhhAKvoAovDajHcLxnwIMk
+        z7QKQUtWKafHp2l7hkbHtiRk+XoyX+arLMsXq4Rfa2V2Ayu91FtiZ+0kPu/oJVp1n1sfhwuREvLd
+        Kxu9bJUfxPAvp2/jfLo4Web5ilIYUsZTj6+y1WyeDcK6ls1GliU964ajOd4aGhFHXa/yDNL+6rA8
+        nkgp8vG4RGMo3WgC7EzENQ7QfZgUMN7W/asryQXh3o2z58AZED6YaKDV58zfwWz6hqPlBKNluZov
+        vu1oeZD18Wh5U0vI9zP6TmD1jdAaIoMmoylIYBDMp0KEqgcJPkF3yA7hkey+oriniuseGUHuQ3Jk
+        8WI6z7HF/guNh9Av8Xh6j8fTL/MYQ+FTHmMtZ6MZKeEBjz+avx8eH5f8o/XTY2wzsaXt80Zp/cwz
+        jNzosFkkjc3h/xFYIBvPNqLY0Yoy1oE9f//5F9vEANaUwu2M9J7p6HaevY0+sA1WlAj1sM58dFtR
+        SFoHDkZJ/3cY0c9u2U+i2ynj7ybx/+TF0F0ixtXh8A+H6fNeDgoAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - public, max-age=3600
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sun, 26 Mar 2017 12:20:46 GMT
+      Server:
+      - nginx/1.10.0 (Ubuntu)
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0OTA2MTcyNDAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDkwNTMwODQwfQ.cqoxZLHcpjdZSc8rLuC1NwNRLPzn3VFap4djS439N-5mTwDpHw4yvyUs4ZEkPmEozx1wUW84bGLgQ3XM1qECkWVCTKxAPyaWXd5JrfWw8VeLOiaJV0L79PU_7g4tS-DxjYVW0VijhgHoReLUNUohq89RVaHo_gc2P5HeV3Cvu7_9zwaYdiJAm3e6MusZ9aboOil4mY1kZeqjQAd_mbEoono3mCFb-TD7250Haw_QCPwMR_kOvmpdkuIhoQVJwlUvVOZtR-f3SUQCtfHoDUX6AzssbVVhalWscByq9GkHDEuSrspm1LJTlQjvky4YR-KFHT9gdGozg4HQVROIZBisuw
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/series/247808
+  response:
+    body:
+      string: '{"Error":"Not authorized","authorizer":"cloudfront"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '52'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 23:54:43 GMT
+      Server:
+      - CloudFront
+      Via:
+      - 1.1 ac6d83e68fe20e1748535144bdfba005.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - i7hMyGCKJQwASTFe2JLTLuh-8bk3rUIxcp2byJam6otWO8Rcrv22Gg==
+      X-Amz-Cf-Pop:
+      - GRU50-C1
+      X-Cache:
+      - LambdaGeneratedResponse from cloudfront
+    status:
+      code: 401
+      message: ''
+- request:
+    body: '{"apikey": "4D297D8CFDE0E105"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: POST
+    uri: https://api.thetvdb.com/login
+  response:
+    body:
+      string: '{"token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1NDA0ODMsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTM1NjgzfQ.Hk08S32enMtKp1GgilHhGXF06FAFJ4zCzfUT9TCLKJaj0TLicstxeE8i9DB0NpfuBrs2WTARb8h1UIq-XA9aPv-yz5S606TeVBDwiPzCfgzozJGWpiCADQgIwnZXTEJr9PpoxN9GNmdz9Viu1zD4o8REKdJpCd2_F4WPxEMdJHgAI_vBIxvz7KsnqWUms1UBcvLg0o-Jj19nRxuLy0Fqtc-3U3HiI7lUnH7ADq2sborf4_M9WQD9MTJpgCdXeCqJQQy7X9rJzS7e8yl_VEr1wbOYxfklGjq2SFEq1LdRwXLlOFr_NSDZ-Dtn0pfktAWTyfVViiBhfC2aR8c3OSdAjA"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '466'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 23:54:43 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 c5a23bba638aac9b23d8122f80be84e6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - liSkUdSdXrL35jYlQPUlXfvy8OaMFYy3B3x8lSy8tuVIk522NbNFzQ==
+      X-Amz-Cf-Pop:
+      - GRU50-C1
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1NDA0ODMsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTM1NjgzfQ.Hk08S32enMtKp1GgilHhGXF06FAFJ4zCzfUT9TCLKJaj0TLicstxeE8i9DB0NpfuBrs2WTARb8h1UIq-XA9aPv-yz5S606TeVBDwiPzCfgzozJGWpiCADQgIwnZXTEJr9PpoxN9GNmdz9Viu1zD4o8REKdJpCd2_F4WPxEMdJHgAI_vBIxvz7KsnqWUms1UBcvLg0o-Jj19nRxuLy0Fqtc-3U3HiI7lUnH7ADq2sborf4_M9WQD9MTJpgCdXeCqJQQy7X9rJzS7e8yl_VEr1wbOYxfklGjq2SFEq1LdRwXLlOFr_NSDZ-Dtn0pfktAWTyfVViiBhfC2aR8c3OSdAjA
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/series/305288
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA1xTy1bbMBD9FR2vk+AnId7xKAcWpT2FtovSxSQe2yqO5DOSE1wO/94rB0rLxtbM
+        XM2dx9VTVJGnqHyKdBWVWVykJyezyLFodtfwRNGrdUNbhn3rhUzDou5abRqHMHWaHLuo/PE+qFKE
+        z3i0plLv7/0MeclZg5w5YL11ngXG4eCODrXM88WvvkF8TcZM8Uaob/WGuldE8wqpyZB4QA6HIyu6
+        0eYNuHrBOU9+QL3RuTVemwH1hNtanD/VwqHrNE6O5/FynhSIGPZ7Kw9w37CvO/345ptGVOTH8MiA
+        ZNOIihhmh24HaoLNBnbDRjjM6LTasfEDjFl0IbQl/C/JeHIjTldWxAoOt4Pr2TgOg7I7lp3mPXLd
+        iV4PnpW3yresNh05pzfKDT2LQVtCndqOYYJYmbL1hDqJ3Uzdv9/OfaS0m+LOWxkDmNTajmrfWlVp
+        R33PJE5pcwBtqevAuzcBeUX7B22Q9tpUGuOeqb32rR08coBmw+FasjrJFkCoFkQVoyEh1I69y6ad
+        gcu3U6hGsaZyiqCTmra6G6djYO0sNq1ci35q1Cch7852O64CARnFj6CzUmHR6IGNbrZUosx+7ngj
+        7AEALRZjPKrFXJBoRPuqJ0zDCrpStZUNH+hJYdbjbPoqCXyNlk4tFotpp85/7fFggkaSYlks0yTP
+        lngC0M4FjZ/q78xBJ5eiKwrrDIG7gyqyMo7V6cegFPJBcljmt3kStK+31XpSkvd5scyzLDh/U59q
+        P7k/fI7TvEhWy6BGqqp/JJrM41Qlx2Welenf6NmI8rJVkacQu/b85YVwtfjPcW4h2ajMkzyGuxtC
+        Se5FI3N/eKbPz38AAAD//wMATVP/UyIEAAA=
+    headers:
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 00:32:48 GMT
+      Last-Modified:
+      - Sat, 07 Dec 2019 12:23:57 GMT
+      Vary:
+      - Accept-Encoding,Accept-Language
+      Via:
+      - 1.1 2b11627cc37f6d5514f6ba11e7fc6034.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 98toxmlp-DJiotHL9kZjCRbAP7Xp18-7urvJxz7iBIM2lD6-B9EpHw==
+      X-Amz-Cf-Pop:
+      - GRU50-C1
+      X-Cache:
+      - Hit from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1NDA0ODMsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTM1NjgzfQ.Hk08S32enMtKp1GgilHhGXF06FAFJ4zCzfUT9TCLKJaj0TLicstxeE8i9DB0NpfuBrs2WTARb8h1UIq-XA9aPv-yz5S606TeVBDwiPzCfgzozJGWpiCADQgIwnZXTEJr9PpoxN9GNmdz9Viu1zD4o8REKdJpCd2_F4WPxEMdJHgAI_vBIxvz7KsnqWUms1UBcvLg0o-Jj19nRxuLy0Fqtc-3U3HiI7lUnH7ADq2sborf4_M9WQD9MTJpgCdXeCqJQQy7X9rJzS7e8yl_VEr1wbOYxfklGjq2SFEq1LdRwXLlOFr_NSDZ-Dtn0pfktAWTyfVViiBhfC2aR8c3OSdAjA
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/series/247808
+  response:
+    body:
+      string: '{"data":{"id":247808,"seriesId":"79071","seriesName":"Suits","aliases":[],"season":"9","poster":"posters/247808-6.jpg","banner":"graphical/247808-g9.jpg","fanart":"fanart/original/247808-5.jpg","status":"Ended","firstAired":"2011-06-23","network":"USA
+        Network","networkId":"306","runtime":"45","language":"en","genre":["Comedy","Drama"],"overview":"Suits
+        follows college drop-out Mike Ross, who accidentally lands a job with one
+        of New York''s best legal closers, Harvey Specter. They soon become a winning
+        team with Mike''s raw talent and photographic memory, and Mike soon reminds
+        Harvey of why he went into the field of law in the first place.","lastUpdated":1575831375,"airsDayOfWeek":"Wednesday","airsTime":"9:00
+        PM","rating":"TV-14","imdbId":"tt1632701","zap2itId":"EP01407658","added":"2011-04-09
+        20:32:27","addedBy":41829,"siteRating":8.9,"siteRatingCount":8251,"slug":"suits"}}'
+    headers:
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '884'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 07:00:30 GMT
+      Last-Modified:
+      - Sun, 08 Dec 2019 18:56:15 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 c48d56e625b781495c1f519297290474.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - u9qJKL_Go3Vkonbu7uxKmiC4MNFQpd0U2xFCAI_1qlgXH8gWirO1bA==
+      X-Amz-Cf-Pop:
+      - GRU1-C1
+      X-Cache:
+      - Hit from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/flexget/tests/cassettes/test_thetvdb.TestTVDBLookup.test_lookup
+++ b/flexget/tests/cassettes/test_thetvdb.TestTVDBLookup.test_lookup
@@ -2,1110 +2,1218 @@ interactions:
 - request:
     body: '{"apikey": "4D297D8CFDE0E105"}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
     method: POST
     uri: https://api.thetvdb.com/login
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAAwTByZKiMAAA0Ht/heWdLtZG54ZBJVEBaVDDhWIJECCoBNQwNf8+7/39WiyW470l
-        /fLPYkkEqrN9Tj2KfqMZKi6FHPaBkQP4A9vH7QLQ+psI1BHHol6zlT0bq+580k9hziHrWtjcacA+
-        HdkWXQEgh2wt0mtRptedDJv7x7Ur1Q0rzbW3Wnn+btKjcb48lTHagyy5OVOnXIHDo04AS87UJw8+
-        VCaKkLe9DqaG/cTwtZEoMKN4rkzF9coGB3T1JtAYrr84xPc2QS6TtRjgFyjJczYMnDjyq+/t4Vkr
-        uoORXpZ1TuNaRaLLa+hrGdASMR6SoWwf1vF6Pj8kZgPO+FCpfi9BZ2hr073NiuWWgcXeUSYklG3M
-        fOWnu1If5hZvJnxixlQXesXXrN/n4SEkMOS3gXwI3yth8d4KzyhOVrOrmIQSZRR5uxnGRgFIbaaD
-        pkVp1AYXQXMzw455MrrSM/uX3fmrC1o3QCSmp9eJSM6zrx8kc63F/SaLxze1Hh5fWX4KPqA38dHb
-        vZdf//4DAAD//wMArBdOpdcBAAA=
+      string: '{"token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzM0NzQsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4Njc0fQ.gZO1DaMXesZ9tiVBZOA7S1hBq2NfBUSQ6wcZwDr3H2yGLrbhLMiUQVXW2shD89cCzJxs4Tjf0ap4dB8KwFRBpmcU-VEpyY9Z3tZf5Q9fAEnxjQXc6FVfR7LeXRLcupBy5AQpE23X3roJek6F--77l01Q_YZU8yjyr4QB7_namYS1MuZ9apCI98sMII_ojR7gdk75HwVCZZyOYoEuzVoRLS8I7NNWpnKDSwIPuwx9detMGJB37KRdeMgp2nDYDz28pl6nUe1EpWh2_wX8cxKDfybMszKu9u-883ohO5hP_yumAFS2g_nfaspuda00kQ4vp8EE517WfdgeyxPSnHO6eg"}'
     headers:
-      CF-RAY: [32e1fdb8dcc66581-SYD]
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:56:57 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d7080d24933b81cf8164e8c9c64333a0a1486587416; expires=Thu,
-          08-Feb-18 20:56:56 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '466'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 21:57:54 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 5e7b840a88d950743b5369729f00b867.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - tS0gq2es23MpI0vd3Nk5LOy51Da4nL8hfSlJLXyaU4L1e8wyA2Y3Bw==
+      X-Amz-Cf-Pop:
+      - GIG51-C2
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODY2NzM4MTcsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDg2NTg3NDE3fQ.jaL5QVq1tUGCb_XHul1WCHsUlyCA0b2qsRxi0e1y0En4Cujm6ZIvB-iC7UZzg71NOfjYRi8weI5rWSYTYok_JNm03ZCYvCfeqz55Y_H0vnnDrqh14HYJ4ffhciZh2JylchIP3bC3_ytK_rfkpALWQQp-mDCsmsrg2Pn-IHrkh7NXz1ANfRAmwUby-JbB7c8PaFf4rzkYBuYMm5uhd4gs9mnGcTKTeITsXrexesG1TdwEyO5dMAjFgm-J_1tyckBrtj1CJ2juK33UaUkRVyic7bYH7M5lfO7nvDlP8VJ9jCy_7O4h_y_QzP4K-793ZnBbZtwiApOs8APaCxCn7YLOFw]
-      Connection: [keep-alive]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzM0NzQsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4Njc0fQ.gZO1DaMXesZ9tiVBZOA7S1hBq2NfBUSQ6wcZwDr3H2yGLrbhLMiUQVXW2shD89cCzJxs4Tjf0ap4dB8KwFRBpmcU-VEpyY9Z3tZf5Q9fAEnxjQXc6FVfR7LeXRLcupBy5AQpE23X3roJek6F--77l01Q_YZU8yjyr4QB7_namYS1MuZ9apCI98sMII_ojR7gdk75HwVCZZyOYoEuzVoRLS8I7NNWpnKDSwIPuwx9detMGJB37KRdeMgp2nDYDz28pl6nUe1EpWh2_wX8cxKDfybMszKu9u-883ohO5hP_yumAFS2g_nfaspuda00kQ4vp8EE517WfdgeyxPSnHO6eg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/search/series?name=House
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA3yUT28bNxDF7/kUD3tpCljbXTmusrkJsNM/aNIAdpwiTQ7UciROzOUI5EgLJeh3
-        L8hVrMBwcuFh+B7J+XFmvjwBKmvUVC/w7xMA+FJWoDKeTaKUNz6efQ2uTAgUqxeoNtFsHffG/9Ke
-        d+fP2tmm/rTdVPfKNcekS45ks7rtnjeztp013UnBeWcy38cC6SjxLltubt/genmSy57inmnMe0uv
-        TnYbB3WccHM7SxSZEnoJiZOShawhwR8wvwBtOYmlBFZwgjqCl7ChpN84aU8RyYmCA96IN8HWeJlz
-        QKI9hdMpI0XCYCxlZdstOphgs3UMU+R5U2MZRB1FrHlPD6xr9gPZo3SO1U6xloiteNbME5FMknBU
-        B1Gsohjbm6TYBWWffQuMjkLJpZ2r+3oFRpNgfJLpgfcPq/HHJB7YWk+ZTtt1DSxH6lUi/jQBf8kQ
-        uL/jYstcx8hKEctg42f6hFc7b2L/+XCH3gyElenvoFKOTSrxkE9d05jpcXJYm4F9Rut5z2GTEzYB
-        4i2c7FKh996LGlxrJCrc35mYzFjjijdOHyO+Ih2JMrnuojyz7brFQ/5dV+PGGcWBTJy+O7N75CvK
-        f2e3OjpMoRNrDpg3TVPjyvQOygPhQ3Upw4eqUJYJaClz9C73hc8EjtlvdyvPPZQ87TmxhFx9kUzv
-        qFyHPcUDVLbZU35GkmI0WgS5Lp2MqT6V/1Snr81ApTkc4feM8RuBGt3ldq2ugiVblfh/Z99t6mMI
-        qMpBeFVfnq47RS+rY+jHQ2BxPr+4mG0WPxoC86Z5lodA++uDIVDMj82Al3//g6dvr39+fAr8JrBE
-        W4rgcCzEgWzpoeGQdGpsWU+gznBz+1OaMPcybMn7XJU2muF/AAAA//+8WGFvG8kN/StsUSAtoDUk
-        2U7s3KdK6fly6KVpzmh6QL5QM9Quo9nhdmZW6vrXF5xZya67ZyNtGsCALWuHyyEfHx+JZ/CDksmf
-        sQ+sYMYQAQtTbAI7x+hTLtSIQbHBBt6EM7gJVCvuR/sILe4psNlB1wyRDaOHQyNKOpb2wpmVNmQj
-        W8WzBvEMPjbsKJfbhhrcswQw6GEjwVJQlKFPHMUwull+a8lLagLv6QRD06Bz5Otc2lFcrriHAen6
-        uztHeidMULjJipZ+hFoLo+9A/BncSk35ywOnJnvVoLdVx2anuCVs9QWD9L4+maZ/dhRSnEFDL5wD
-        K3BoMGVC5QQJd0q9xc2AhgBrZB9T8dtJYRH1mcq/MNKv4v5/xPwUhn8NrY8wurx6df7qahKkv7yd
-        xmfJ1D4ec8YREDwdoJFWAbAjfbqgMXFSkhi70aFRLsIWE/UhM1QOMpM3ZCGQlz3m5zUjcbRAuY+M
-        aPCGNKwH9vC7xXw2n89hM0AX5IiMIcPMBMJU4r6hpGz/5u0v+thnMumYNg7Z4zP4PkgLHbJPakTd
-        smQkoH6c6evEUyXbCqsdezsDbrFmj0kBdrQ5AyXBU8PaEqY+KDAPMt7mwM5BLdAQ2ipJpb/Vkzr0
-        lGv2BPZ4BrfoB4SfzF97Iq81qP5bilz7EZiz7Ogb3LOFVdCa/Bm9pRD1C8BgGk5k0ngdPUhhVpyw
-        lCi07AkODWsTUPxrsB0live0zW0XKEa9Zgro41ZCW/KjRvGAwR6h3UAX+O4ZgN9jZgrqXxXli+vr
-        i2p+Wc0Xjzl5fnExn4L729u/LabxfitdJoTIyUgLWzF9jKrFSvF3QZIYcaXjBrQZ8hX5FMjntkd+
-        z0Glj2xh1Zsd+7rBFt6jy7xRGjV8kAFdCU8jzj7fI9XcR/Y2Svg21LGcz5fV/GoiqIvFclLsrlZr
-        +Iunybj63rlnr5gFz48qyVY9u/T1ZMGHXtvG4vr66ikh8AS8rqr5+UQkzs/PJ9n03Wo9ja6P5Izy
-        5tjpH3pX99pRUfU83CpTfQqf/A9KodrA5ADvVmutbRN4M8ovlVevAT799o+w6a0dtKzJDoAb6bU1
-        BSK4IQ9/pxBzE48NKiXfi9c35PcUXsP3Sss2QkuUItzqyRcR1tJ26AdVonRkddME8WzcSB1o9+QL
-        +WUNqK90vCUdTmYQd1y5wtbb8obXsMZIg5Kcpa5PA1iOKbByV0oSPA3fwU9m3cddfujYn2PqLfn0
-        XS6gD+yKiUCdhJQVCI0Km1TmJIEtl0prlWmV/2o3AIdAsdP5auNKLW4DURU71inBZjOWrQ4sedow
-        4lNQHX0cEbhlh8EN2bJmQbm4dnSM/O1B4KYflJbhhkOhCYT3fHeH8F4ZYFbGvTwJWHI4kAW04iga
-        bYwQidoZHMi5GZiGneXYnGmONQe953/0dIxlw13JqNW2iOqMaBbysUbEgmn6NmYfgkirnTjCVvtf
-        yftxkswkV/KXxZLbVo30YbyUpj/kQTVIqz05zuCzbJQKN45G+2pGg+HGj4E3vcvtIxu2yG7IwNDI
-        HNROmdAo5KbZoqMHPmY114ql4I8vzYAxbMm6jHM2EDv2OTQvHtaRCpSCf7VLY/sa33nSAi3bKh3I
-        p6JUZAa4VeWwnOeJKztdBzkodPsO0igpZ1AL+/rpxlf8+L3Sxh++GVdfVPrzHwx1uby4nmKotfRB
-        qeYLaEq2sHb9FFNpqfybIDrOK/dnNBlHKaiKxKSs/FOeH5UDTJaR5DPQTD7DHqK0JF65qBn9GcWe
-        4seYPujfXZAtl4WAluUZKF/5og+V0PId9LwcvK4zsMjK7bEfO8LgM8WeTJ5m6cx9hYO9AFnWRUOR
-        qBwzAZ/B2zxMwEF6Z8HxLlvfFEE6nnAiO8iG9KylhOziM/rpGLtvAyFdAlWL5QSEXl2+Wk5CaPXz
-        l7b6crE1OveVb3U/w18tF8uXT+/xlnOVNZfV4vEeL5/9MrmYV1IZHL46yUF0UOt2SeGhfNchB01n
-        IzFFkI58zKRymkpixqNSblTtXR/7dRbwn3tbU2llcj/KxDK+bFg3bjpEPA2mm55i+r8L8cd70cX8
-        4uWkVPzvgCNb+BHvWvZf7SIPFsCXi4vLxbPAeVkt5tV8+fii+fDURf/0m2ncrNDsYtkZrmSAd7pw
-        WaNqGe2dBRCBes+p7FXyInLQPj9uIo8dSVlSPMG/AAAA///EW8tuG0cW/ZWabGQDpEDqYVueRSDJ
-        8iNj2cHYiRFgNtXdl80yq6saVdWk2yv/RoBkFWCA+Y3Mn/hLBufeapKyZEvxxM7CC8lqsroe955X
-        CaRbKx68mVjigCRsCnDOOFLGlbar8HzrWxaJ1LEO3uXvHq3Zt0iCLBgaJy1xVx1zi1z3x0itDhuK
-        2FpySQRUGWwKvgPOurX5Vtm9rQ7kUtxRugym8c74LqrKLH0APsJc7ESlgdXS+3f/Vuc+180HPzwR
-        Isxj3onK6lXsTFqrMXhzSKgNi0O3R/lVljTM7cJU66YTqPTOMWuGppEHvWIpq+1C7DYDxmfmtwUB
-        DkQiaADQqNrrG9VyHkH8WoCAt+l479JOvXM4ufeH2ds3UBUZnj61tCLbu/GJX5FTkIVTzLift2BU
-        LctBnUv9CO+trQVKbUmQYTRvaTRIaduq0YDZn/mAxXPqSSA4GDtxgyXwzE+kw/WzPfzlXyKzHR0d
-        /HGGnMf+YqVbkABwsaagEIe3yWJ8QdiWAMjuA5kskPUlgxeft20VoPW0wUNC6hXjkFIObNGruNJt
-        u3Uohz/jGgLgVfiqV2QjXddcMOYv1c/3ptODe9fW5emE6/Lhh3onP3zVSjx/09fkPlKb1dPeOfUo
-        +K4F8EN5zYsw9ykRi2W6hghMrjQbZZhcopC0cQ2x1h6Noxjv89+lOKBp+CUzHecslabemghBEUpq
-        1yodEn4WcqTxlvIHSgffuWo85tU5CdpVRr0wTbswLgKL8+jINkLW1+fgkdUNRPJu8AjXWuU81zCm
-        YKQb1hvw7+WcIn3GCNc2GtpDbAlqv3nL/aP0fpGZlA8Gcqow487NfKgpJY0+AZAcudBj9w1TXpia
-        bU6nG5nppoumFPIuYxyPoxfEHhN+DfJnnHrsre1XoMH4ZUG9hx16zGQ1Y/cs7AO9p8xx85ny8Ecq
-        3cvxC720XPQ4HUHcGywAZFxrsLYjfBJ+xkcVNM/igwKpH6QRpp261m+No3FtfYy9Wvlgq1110iVV
-        ebfDLmqdGQu7On/LTVdDD9iMe01yG/TGNGeTRrNOsSId7vMmEAcwsv3KPjLKbTBRnOXSW0u67kDn
-        YQux41pgprO8IFNsKJSkglmiyV1TB57LfvuKLQ6E5ejSod+bXn3oT7PDeXD1uX+oGwCRmalFzNcL
-        5pnU+AzqUzDt2jJuKJmys3giELPSQewY6Ga8aMl28INRUdwIqr71ARuGd2FGRfDp0SkrBv/8MPS6
-        5Cvd30AhZvn0HMLS+V9jL0339o4Ob473v2GdcbDe+FXXrki1reEBUswA1EyihkUAti+4ympRBtDS
-        wJMSr8Dvv03hFo3U77/tTya8kX//7d5kpAqayYEhJWKAaEoxeyO+gL2Db1gQtddyKjP76pRq73Bv
-        Mr1z8yl+Rqus3O6qB77sMGc69GrmrRV16ySYBLOf8AI09Kq5b3PJi2TtJgehM6hg5MsCTZfm4xXK
-        xsMAJDLiAsUMI3h0ATbOiq4HlJEmNkCN3DnZwCLNjuDKUcUdAKhyaRz1OuRKVMKP1d2ba7Df485x
-        9ZfRXLU8px7WH9D9n63BHY0n0/H0MuS+t3d1Ouj45PQTyYDNwX6+tn7uq+NsHT3onY6p3/ixjMHH
-        rQ5pkOrZJpeFjlumkxAdsCesIVIvvDteDuVm5YEtOY0AVhRLdj+xGQDiQZ4ipQsGeKNf+4D0kZPj
-        5+A2VlTqKn+wcjoEsVCREYC5gxMbqNFhwb1/PKh9bJ1H1QZaghbaXnUuIi4zFptzKeGjLSYbMOjp
-        0f4EHrIF7515n7TECLQ69cE7Ls6QYl4YC53xu64wlihrwzIvCY8yUXO60ms49MokoLhB4e6adr6u
-        8mWQHQt3N6pS28YChBCFDa5mKgTGOQCMlZe2r1Ya/m0GBr4ZZi8D/Qg+XWFMtzIhJ+ybvKxR2w4R
-        sUcEwKCQCrni1XjMRgRZ6zmbgGdX1CZ1Zs1bXVCaqydPlLZ+xksCNPjI24rc8EG3hyEOaKilELkd
-        vva9uvV9MOAfrzhh0uxEVQdddUIyKt2PVP6DxzoEbLpWx2hcPQZ4AaGu6PYw1K3viD4Ev8pvro2l
-        SjU6BKNr2vgNFekkayHfEaM616HWgcQIX//2gdFO394GuMN5UlU+RkhDFT7k9NX0rqq6YQ1VpcMC
-        BW4Y3CtevVc6gMvtqlMU0JJhFSqXEDStCgvoCQ7Lc5F3zCMK8CHIUdOLPBHI1A6PnHuHHT5ar+lI
-        xa6qiJHbXEtT5PlgoQJ4WMycF/oNjU990YV6AOGBIiqtuF5nrkacazS89A2gxCcqzldDd3vwXKf3
-        LjXAOwf7V1oaPz7+iEb7/t0vGxUG5l/NBO39u1831XM6GcyL0ZYBFkhbk3p1gTthrU5BTmuv2Pdv
-        A7kh4jLQJqSo3AjFJxh1Xj7UWMjRmnA1JsYseiB34XNsaKVBCWBaxblvd9UJMwQmFlnZq+djQjMU
-        2gHih4+LlmgxUk+NK7116nsdFiqwycD1nUaKHgTfjp/PZnlM79/9nJOm9UW2qlIXXFS2e9OFXhUg
-        mgy7onQE9loSEl86qYJqNO+49ZGRHNJfOSiD0zTMSM6zxHLuvVVzLd9EMh+527BgiW1f4tzOOrsZ
-        1sYzFODGtb3wHs6uajqbzLhBDcI3eWu1RJLYvX6FQOJ6mBdILx9L2ID9GM0nzdmqlhGbmHTMJy8f
-        vHLNSrenTqo5VNDscxY6mrg7lJotoilpMVPCOGf69v7dL88d5+h49mA2z4cKktO3m/8jHbtA2LZc
-        AXmdpCtpnG6TrQg0UPWQIBAUupZy+Z1pml6dzr1nERgQWsNX/iEyB+EVcIB/kZwcFNB6aSLrJYh6
-        uew/3NMoNWRt3OzNYcFl13DHmWtgQJK/LjtUShQuzuiRtmneDzv6/bufFc7uLKPT0vpIKe6qE2PR
-        BXTEnDHKMVBbgDm4tfOvhq+2FKN379/9OlIm8ewxu908pgWW4pQxzt0k08ARSs35JUMrNmJgwhRY
-        MSvOnuHFLkXqya/JECWtV1t6vaQwMKkIQ99AIt5sqi8mpx0e3b17cK2ctjee3BlP7l6qvXj4M5g1
-        H4OS53dQR4zLS5e3yHaHQxlsybfQhMxScuacEj86nAAxDfG0nH0tRqqwulyMkfJcIQmnWh/TeKUD
-        sxteJSkwL6mcOwOYGIZjK+d51kEV20WvNA7y/kkgV2nEue2CgpgFMYUOicIcoBlBB+LfCj7GyrMN
-        btw62zj4KUxSOU5iCgZuHBeFRDZUmPyOK4PIrOhCqCDX92o8dTiJH89M/d9b5t7h3cObbJmD8f7k
-        0pbBw1dfjTj5bBfwsQ6Nd736VzeZ7N1RP0Ix+Bjd+5NOzeTg86cAD/+RKeDFfaldvWZ5EtbndzcN
-        SpW2wCBOS3ZTqHaAFoX/9BVX+SHwiW4DgWUGcmTiHEEnfEPYooNcG6FncbqJ3GvPwSRVA8RWEsBx
-        VdZeIccgHepKzkd0HHdCejSZmr28bV8HQ5+T3RJ0NIxCPtWVWZqqQ2go736MU/IbSP06znBL9a2D
-        5oe0SiZJ2GON7wvOY6kzzIwP8nImn1Yc9DnjlrILQ30xzgmhtdy/81dA/PQrqG/AWut5xtGvnVn7
-        nKZpuElK59pVOKXHKpu5TRclMi+jxfFvOqTgR+rEF0Wvjjv1EzHK0TF2WSRUBuE2I+6pdurJ8N3n
-        PN8nXSDdKT+bGa4Yt86WFOqAlnOuF7dZmEYbDksxi6OeUep31YOOGxZ+xcsL1b1xFI0eqc1HQHLG
-        FRIGJPjb9Zujisoru5hIVyNeQNQ/5L/YNV0YXPZwqpzTjOsVT8cZ9g+XRMjPtJqx7CMTNkwE3/KZ
-        BW2qjBFIFiJ6aHkwfLus5UuaBumtBiMavFcf5W0hY+yCiilrCGGeir2IAT9ZQ7v5KyPLg/kTA+kF
-        ppQ/g1ytaxEUefE3s1NQCvigCrcowA6eGldpdTqXNdx+AUzdsI78KjyAlYl04X1kxzz2K9wuGD5v
-        0CGTV699PgxX7wIwvICWNrSWri0FBYvKgYsja4dETu72cURcgG9lJK/gNDDA4p/kqpdoeKu5b1Tk
-        u1YR0NXFvAoXN/FuHn1Bg2dw3nuswqsOJWFG0J5kEEF96q3kzK5AwPnuWxA5mFGbeA94nCUMpgCw
-        lLqQ/i7zLIOSFeXzDQoVt2OS4v4gL6pN+Jb3aT4c8iyfRczheuE3a4k3Kb2bdYyVeQy4cCa5Tz9T
-        nSuRIJOgImyjgfPjm/nWDFmQuc2eitavbK8CsYbGG6ehhnW4kXDOt0z55lgUlUJnRedzlQwXcZAg
-        tZf9NlAL+DrDfZ8bbYQq6FWU5f+gWSA7wlIcloB0Ldtjg3UoizWb+p0radzW17e7C/hiTjNRQxA3
-        8khnbAVKqf+WRSSxPbbgNvIDlpVDp+a574szxQYk8DvF+O03N8UMePYLAYZPSMP7EDP2LgHqO/tH
-        R1dKw88goT7LP18vD590tpY8r1aNcUZFjxgBc7gcTeYalf1Dx1XOON5AD71PvXrBUcaTzH3klqke
-        2AxTOPzcWp/AqfhHk3YkbsOBUOxGEzkdNFJXDQ40W3A4PxiBqKvMjUQZQUsIBGGrGh46f3AjsUr+
-        +kvBv7vT/YPJdXeDj6a4LbF/+bbE/tVXUD6ZBXkhd0mfeld5t6E/e5OdmG1gYqB2NNmJCp/EZjGL
-        6xpCZDZa5MYKpSTbXjcFzn4X10X2bGmkop6QRgqf1K2nvkMpeeqbAld+8J8vElmr1SPvKN3OR7dX
-        VVcupLbgdEpqpEQsnnsFazhC3eQtduJGGXBVx0bChRf7uN12IdFwZo1PX44f353uHdy7Funvgx9P
-        9z88zvzwVYv96kyl5dVL/Q9yvU5Jq++8I7nPdZysdkmPZS0vCmgkeHaTr+DOKP+XBZM0J4lRtLaL
-        YwSupCOOhrz/6dlzTgDgT/EMkB9fLDjhdf4nuf/+Z6TkHEosnoUowVNMA4RSLwGYw66M/IKuNsrt
-        RFyanDaB88H9Zp0wYBWIgwh19mIgJ2Jz6gGJ6ZQM7n4gec+YBU67gkcM7T95SDeDIcBqpaQZGgMn
-        PWb0OpZ0ZIEboOK6G8cYiGMWCL9wxYKK2HB/I7lgK7cYZZOu783xtTlM7zYxyCnMrCYwfd+JHPUp
-        OZ/LD+SVvK/gyv7kw+IGklAXljeKgP8PAAD//8RdS3bcxhXdCuyJnHO6Zf5EUskgR5YsyZIY+0i0
-        lORoUg0Uu5EGUO0qgE145D1kkiwh68hOvJKce9+rAkg21ZRiykPLBLpQqHr13n33Xnziat8/2Hlw
-        m9V+tAGJ58Uf0Yr+8e337TnROCDuY1LS+xHB1/Xvv8TaKjHNEYPjsfHMm7rup7F6W3lXdEgsX7ui
-        sT1wwSfGL6l+AUj6wgI5D7/+8i+qh0qXPAFMtTZ9mM46IVEPRCGgNHHpEsszIIJwHSa+7Bpd0xcO
-        bRWPTfPzRAHhblVZgdUxAq/Kkxeu5z9qIjTuQVFv2Ym4wDX6GBPtqLLOYf7mKjcvQxuBM64toETZ
-        Ak3yWZ+9sE1TnlmfvXIrDOcbJLvI4k/KfGFsRUld0Or1lSn67JmZG2pdQ+4oCOPT1QCfsU4xR6lK
-        X7O8OrGmITV2kp6odrWmlsUke24r2xhRZ5mm6LOvPPwP/jDJPIJLY9nEsvmSMd+JiLewI3JN6FYQ
-        c8ktHVJrkqJqS6m6Kc5xOgldgNVaVO+6sxZEVDgRnHVN09OdQboMU8rZpoDdbL1yHsSHHN0HKHux
-        2NamT2gBhouOQ9GBXwIphzUByAjB6xEPGBwz8ODQ3jjTo7AsANKDROUtJpjXmOysq6opSdTzEjB7
-        FUkVoJdcW7AnpnEsk2SiTIgrm3WrcuvmQoXGAiTnE2EfHPG4WkylEW1raHnh+rvDy/Z3H+5sJdM/
-        JGlz9xpehotvH1fkgd55zNlrtheYnQaLbqpVCAGEH1+UDZaAQsssr/CeCkroUFd3vrlEnYVyTco3
-        6em2XT2rbIFlMINmyI2rvi7CzNo1jNIhVFEUNyE1lw6VrVdtf4UGo0j1JPtHRxONstW1MhsJsplQ
-        tXL8t4ZwnVDNqMEyA4kXxAryCHlYGmitGkeFHZeP9d75yYjYyEc32drLFiVYDmORdEPWn73mC12L
-        zdHfz546nzVWFZEgc1EcMEl8oclwA51IlvYs35LAQMlBvgxLnf1LFfQkdaA0yTB4deSLtnhDtcMe
-        MS32eJwzaTPp3fhQQZX/UZTAoA4mClT0nGbTLK0SMhDgBBPERlemi7Q9VXShXaWscOc2d63IGsum
-        qIn7CBkGAaAMnLHWm3UFtGfDYhXUy9oYTX795d/nUBW0QumM9hORugpGoZNogyq5Qtrx6y//zNCv
-        RoaVJjxZWvy9rFZmwal7hvXPBdnQFIN+B2dnkgqVPoZZEvVjPKbRUOzL3M/eCTiqpgh6qhQw8phk
-        pqoFMuyHYdAI5PISZtp3ZbFh02Rzuy1ujWfuDrOi/eP922RFDzdmRfvH+zcVfKdrd4Piku19PuIK
-        dZjglJpO0nKHS50zK+GLrVnTLFEyKzbVOiTGzIB7CVhsO2mV9eNL1odW0cKIp4oWWrPgN+R82TVS
-        adL22iFsBtdVAssBf6xmlVGUCt07HpiqeQyu6lLzC/ANQLKQTUfhhhtvdKjKk3NdhNyjX58ypUfR
-        3KLz5Bx1vjEgnAspkNyb7GVpPc2fNCegW0VKFAd7jB9KbPZT06P/Z6gqijTIYKuzaYoHscYlB1it
-        HyIRfW5wCAycboBT4X4cA4lHZeobq9YIR7+q0QezkkVs3/X3ztXOix0D4YNj4ng8VcI+Mw1orTs7
-        4jSz4nuuypa9EE9xauphD9qkYCAWSw47FVClKULKmmzzmZU4fktusf7+jY3G/5NZOdqBhw8Ojo8+
-        vAOvQWm45GO4x1fNCwwE391KDn0DyXy+FDXDhJVA3FFqncB2FYpj9h+2ZluvXb78bNSpfUBRu9ca
-        kUcH+8cfwR1+4rO/mL4x2Q+mtVXmOyhNQNRoyhwz4Lkjv2uK0kiiYdoWzAqtgLhupSzSSp+x4Fzr
-        bpU+IINAyLGTwdBnZXrGDqiVKiVE4ZAQqV7ovHdz+ARMZB8MXEsA9p6F1bwxTd4jEPTKNdFIWDhf
-        a0lHXX92vKNWUnpVO/qBKLbEKTun4xUF5qMiTvM7SX5mZoZkrrAICcgpLcuS2jUEMiL9pylzASkw
-        afdEnyHyoURHEC+6afbOog5sEE4wMVKKOKzKXodvaTO3tnbJLFLehoA2DFpmxtyN3MaYVMbO0cqs
-        rMcakKlvrKbBCHoyobycUyewT9NHlX2GCitIf3EokNLUieJdxkFo17bTpvNKV+BtdRS1GgK2C9sM
-        pFuqMCW6B8ryg82eeF2J7kwEFJoi40kc0tlAB6iqtOeR/Yx/AVhar9w6kXIvrSuuBGzhKXkYfNs1
-        KLsh5ZYf5GGkDf4mrZrfzreGFkLzednc0r/uaOfhg604NXySNsn8dx5+gn3dTU4RMux7G7wirv0J
-        G8HoNPh2KnSfc+NLC9olexK/pwGDjvGztYkebLSx2jt6uHN8YxOBKpoPCWyCqmLE8S5GZCmAGLEA
-        BcFSU0sz/buEYmH2iccxOlwC40/Lps9OrfEItKSBKDBdIewV5Vlpi8SA9xYhFPmJWMNJLYMsSRw4
-        GPiWJciEl+PRUJYz19LuRgoWr+2chTA5EGD3ZY8r0yEOviubZWVp/BLYVxerHMKyeLxsFfp8oQBb
-        YNv7anUUgSrQBhtxR1tYb1YpfiFjFz37iMcOnblKKtxMiRki9Orh/+DFwoR/3SQio02ZYkDhpbgF
-        jrWL1ts6/o5in/TeuYwn6jDiKTHjSbiK6AYPDU1cNN92Pnv/pQlS4bGjJ7Xm+y918LF4k53DMzyC
-        APwvFJykxaOOFIwDRxG8nfRg1szTXrRo/6Wk+fqjCDrr1jKYZLo4ev91fPHQv+YW69QjbZc6Q+ke
-        0vjC7wgSgU6Cjy5IM++WJKGO4IX7929nvnZ5qX9GFjxkjofXG8d7mzWOz5/dYOqzlVf33PwMsdVd
-        VdW7O8f7+7u3wARpznJVQ8WLNz0vrBI/2CfHhIh74vCXWn/q2lS6eZJulq30vf+G/udjkKsRGWd9
-        1PjKySOdCwDHRTrV0h8DLatnXViMfS4J5gTSzHBBLGHpMSYGxi4sslMLbSN2a7XEwTgr59OZu9AE
-        VsQCJCqR2c+DLeZ0XRM6kdyhLrd2adlU9750Cmw1Yz2YJsXSZssqA15G7u1a8yuKMonWr0cc+tB2
-        DVn70U9JnGpYl9s+4pMxhxWjpfICB0PJ56qsWfbZmely2zLj7VYDH49YB3y/KqHawMxTDQnY4G6R
-        OdveTlfK2yagedmuctupHt/RnRawR/v7D7f21SBv2dnoKrg5Ezu9wXDpo1wFs+z51YVE1WyiBp1b
-        6XmefvMme9MBr21l+a4Gpw/xOEXNrJZeXEj66phGKGYqwFX0qSE3ya6vympG452kQ5wH9Su3tvfC
-        2H8wdueYNngbuqqNvVc2aMdLSSzDFF7RfWiLifgpBv2JE2hlXmGBVzPr59lX2H/6xN8FGJCIPm3l
-        bV2yqHvqSwrbvs/b+9ANmTY7/voonyCcXJ005bKOZy1fuGAH9l7ZmG7OQtqKedRgniZv0Hj7J8ly
-        Chw/9R+zl6YtbeQ+PyrQbW/suurXthjZRrE0TnZRje1rR9ocX/NwMEsG/U3VWb374xLtO707VBeT
-        oVNCCQeFeMpt3d2N3kCqPpR7vLYzm+cm3uWFC3a1uHof9PJ42E8LNvxhMzA6mHl/7S0Y/sr9TGzM
-        1xQ7xZ58QN+rTfbB6hes5Sj9LontjOKKQQSMrinA+IMkSBF2kDAUw3YAt5T+g+l3NWslO1E6fU3m
-        iJbDsKkXgK7HDA/rH9JH7+Zo+SZ0kf93Qc90a5cV+ojkPK8u+dbc5DB4h827vcPtjiu7cEHfO7je
-        vNvbbPk1+9S85BGNoH4fv+wHuzubCT03plnJEW6Qo1v6oZQNyMYxijErmbOaqbqcJ6Iq7C+b+sSk
-        nd6VubcF0fpzozY+DHFMf7mEBifGQcOYZI1rOpuvF2izERdLnldswMys6doSHfB09wK9d+3yoGkN
-        kzLYX0y4US+ip3dFDoHg/ELitwYGXtBYqTkdd5AaWqBVpGgYGq3Db0xkL5yapuwNoEfQeZNubhgr
-        hdrXOqAxsLJ9GrElOTp+gvldGT92IPfB2CO7hAHENGENK9x3wv5gZkRAgcOOqEJ8H8Oc/zn7bpAQ
-        GAxuviCdO4jkPCgKOPJX4lSd8UxMr7S3bVaU+FccydGlZ5sFRVxersne6lu7CwXQ4d7OdlNFerFc
-        98aTiz+N4xofMswM6GI55bbJRoIed2nfMEtkHrDQL3Xkrq7xCpgLxHvwBUYzUW9KRSQj2rHVXUJu
-        c7fdj+Ojg8PtHMQDGLzt7l63+D84PP4YK8LTxeD2VNu5EZbTIlqtFtkccnRqi3w5gjmyYC/6idrl
-        TM8qdOAJsa69WaGhSNWup9fYSwAeJ/xuS4tXAmaSrSqbfT8DbxV3PDGFaxozyQQvplt1SV5hkOiU
-        S25EJFd5fQIz2PidAAK63G0CMIEGAuFLw7xNhB1fiPgD44zbv2tW3ua2kLTTSDGogojKkAt4jblK
-        f09R7iEvgcOAzc5dkz3tfGhtw1xS4vuorzQQcAVj0xFftN6kNivW+H//Y+MAbL0qIeAeAk6YEiFJ
-        ZEWBj0qrRG2GF8V9RpzEOiH7GgeT/DE+GxunMKwqYiFBl/8ie/L2afascjNTifFY9qiemRBMwS/+
-        hFIT3bHM/snbp2A0UbQ1sPjsRV51xNB0kqV63jx7IienudhCBivWMrkJMcFXO2xihkA5KW3GN1Hm
-        qQva8XsQ+HJJq9+vSbASO+EI2Xi+eekrIaF/+0WK5gJ7sYKt6ujwJg0mh/HfrjHw5O3Tz2tDc7AZ
-        4N872GxW/0iy9G8/WY35BNyB3zgdbe1F+/Xe8fGDvZ2tYRB56DUqNi/dCBip13SfnTz66yc/82Nz
-        xwjC8d7h3sF0frjdyPjouuSUF9/QL7j5EMAnURhRUmh4Y4rC1Dj1gi2bxJ8liZtfl0K1kpc+r9ig
-        8fbcmkpI/0maofcARQmRsBTgBme3mBWJcgHhTQkySQ/ulfUo0iY6C0iSOWJak28E7vv/AAAA//+8
-        Xd1u2zYUfhX3bgPsAIqbNtldjK1oh6QtUqC7pmXaJiKJHiW59a72GHu+PcnwfeeQkiNndtZmF71o
-        qx+SosnDc74ft3Q5iredBVnUcUOl2iJ0QNtRV01J84dtZFBGLdhgYXJiQxKw0kVz4fLGNKg1rtnf
-        PtEroYtzobUrXpeDBUgrc3BzlEEa9W1SxSRm0nUpTK5aa4vBSQCglVNHCPyZ2ZWmOaJ7GzM22gvo
-        F5SCLiaFDQ95F8zv5O305aBcuUFJ3QsFshs43aUqhpWU1C0QpRMcVrMXcQIojn8cg+ooWcqPLTw9
-        bdTalUjV91WV1pHxDjnw2Aq/acnJTa0nD1W8U+DdQFGRWvY8Earitr4EAc/U8W32K5OXTK16xRwI
-        8FtAiZzEWpUSgZNaYVUd7AicBT7BVW3UY4aAiYCaOO/OL1QM2VV7AiGsH8vnQfVexS5RAuFfIu5b
-        vgI+jRt9jP3FwYmi3pJGaMNWVbPij4tEwqppUWPDiUlppHvV1zQTVk6Ym3kgcjV9GHQYTFkbdBus
-        5SzCvZVsQ18w9uPcnPtmrckqdkER24ivmfAYp7mvnG2BdhwvmbOZ36Nc/rOrK7vrSwXf7jkPpUsG
-        V5xWWH+ZXV5NVtMji3F2UP+NNz+yEwG5qtoZ/3YC+qCt7Qw7QolPBxzuVkjKCHNuwW/Z6aW/QSzs
-        rE+t4L+DXEHRI+BG8qKdT5rdhuuOoQC4RM76JP3VjmyZQ5GY94DN+alRCXA52mpHGCXRMk2MGwOV
-        T5pOvwNFWdFYEdB+wiJuemudUg4t3rwlIaqOzYmzLNKHkt7u8UL+7ff3XOtn+7PL8yPTA5aOOB8P
-        9mre/LQU0/7ZXwLaGGMPxWdR1+2UFsYJACA7avS3ZAU+asgSLSFV1YVS0zExmMcn2DDpbpK6jH23
-        y7i8gZtMv/SbKB49hCLOHU4qxMyutyFfS2Dfucs9dFnTrcsMlSXF4gYI4r6K5Z6mLx44UVyshu9j
-        BZw2mH2iTgGznZMyLv9jRP8wsr3KXh0W4XlqMLufovxpNIOxJ5CxH83hDMe3q6hMX58fXUYp5H2I
-        FoK7H/uhqGrjI8K+mCiyUzNdDw1CCyl6zMRZ2Cls95MJZq3qlKrd2NaNL5UM0sdS5+R3XJNHhgqm
-        nM4xcZOC7XjwZCyIVA+GdBoK0JzuqJSNJoT8Mm8MSkQiIQQwEIL3TYdxjK5EGnIJDEObFA/uq+DA
-        +dUQRyrU18Q/WClhs2lCVjNMPADeKaBm/aFI8xAvvJcAgwt7obFwDc6RSiSaXrHkxT6AT1KnPsED
-        2Ub5aeMkTgUzwFxkpEgxlyHliItOdbC4TnHjrLyXOAY0gI1jZOoukYf/pcODfqWtqZsx/VZG9cbk
-        ttPtlIE5G72FQzCA0vKFdMWSguWaZFLNjpDByr3QSC+QMOiVxfULg0nNvqj1o2RxzKJzbumJJoin
-        bk8dXEZGQAGbVJiPlW+iFJXSL5JRsY5Umx2Feua7VAPOfbn0QXTVcw+tLa67fBnbfxpqmZ153mTn
-        VXaZHaegXkzoRjhcCy+zi2/JLVMYospp4GoVeYYdJ4fsRs8TmuG1Xhg1QxPt2P0BsxKd6NERjqdY
-        UbtYJM/nG4g66XPkGLIw0AWH6irUnO5cZXHwTaFOV5V54wq3wTXEbt2LZ/AdILg3Jj9JXk7f+2wA
-        n4vpNDulbgjqfDZw0MHNh79kfm8Lv7C++s/Zmuuqnbt69APwRT8+H23oVfZ6ekraPptkg7opb34y
-        bUh1ImZ+DpccbB2Bq7qGT4zOB6ZsH5bQ/ChqsRnBvcvQirILIRGYd20VIZ+FX6zIi6PXi1eMKHwD
-        GkEbUBjPVE3BE0Ahhst40dnoRh742eXY4axdQvyplnXy1xZCQfcVNoLoZWRjeZ/pfOr5rM3W51g+
-        Z36eDud44J0lzFtPRMJRs0EoyTidUzlaZbjYWh0oHR9xu5bdpqF6f4SSM9fAep/aCY0jSJxkG6j2
-        BEE/xKd9gahaDTGkA2wBtDBe+N6HL3YFfTBqnvwS3H1EReDYT+IUmNKVF2akERpQ5GT//edfJdSs
-        IZK5NEmNobJfm9E/AAAA///EXUlyG0mWvYpXbUi0gTACnLMWZRAltSiKIk2UUqay2jgiHIAnAuGo
-        GAShVnWB2vU5+hBt1hfpk7S99909AiQoQplk5k4iGbMPf3gD6ku4FF+rnFTAsoRZTPU/vXgceHsU
-        lcgrXbI3O0zTQAL13heCX4sfltpmwoat86XHGsXRUDl+Xy9OJFz3TFc9NZzjNVTNSzBmTJxZutoD
-        KJYxGCQodGFdV1gQxGOI2FLo2GDA0E7ToEUCJCkI3c1rE+kL1qrmYjVqqUkLC83H10ROhOdbEU7h
-        qrfVinBfG4gHb1oRbn/+2P+NxXoshf3Dzh+ZxRwc/IhVxBWN75dm5DFjhRk5F2sGNoEnrajhXH38
-        WWoITZkJMdPjQ4F/9gxpz+nh4enjjoRkZdwv5OPY7wmu9vcfEL0eqkSThYmeIsQcvMBfkjkG00B2
-        qXNXjlDO0TRVBeYkkxU7MxNULROhcSLFuCp68uexlPuoFwz//Bkn10n/ZH9vMnh8dh3cl2WSoze9
-        WYyfh/kuQwnH96xfokJHdQz5kI8/B9P7puUrjV5Ni2GyKszYYxVyxzoeCql1Jr1fCvsJZRWGX9F3
-        OPZ6Y3a57sns5iO2ygVpnwgvCvWQPbJA29hOI74pkgiE63pRbt5WtB5CylGaSsCC40h9jODNQM4J
-        3sxlC9u3DnIUc5syUIKDGxQLULQprjOgXbotAgXy5AlhHl4JsBRWUOqTHpzS+xB4iNFnuXkALdez
-        PG5JNDaSlx9PUCHcCKSXmEK7sXrnSjXMJyYzrb9OMl2WwBt7AS642EKCGOEFP7YwWezXtqlsjGzI
-        pIaSP3pX/Multz5ZLMiESAxBj3zR+GjY/7coob92Ln2OUs3J2dHhdpNrsDc4vs9XOtosenZBzSg7
-        EUxZbMU+kKFdf7p9pa5fqzfXHz5cf7j9SV1evHw/vLl59bKVrMWWoncyEYuKqPBB96WZTXO9gLGS
-        MKO/emIRQgTBlIYgWbosIrYrzRcnEXVlisKOV+ti4U31Rfw7+PlGaZ0EyJzn2iB8TkmQgh4s6KAy
-        //SCELlYtzFlohfGVzPl1bD+XTni0GI1E5ygldmCv/YGPhqo7V2GN/As8LCzE6DdDx4XTDjakPnw
-        6I1xDnsb303ib+03NazL0gYs8CKSpgQU2Ca+N6tLYJl5Qz6fHECuA2Ra0faKtI2yBvZbJ15D7w5Z
-        lBiZHnHPkfKvv5qsvQJ1hU0Wqc8zsyobl0a5Ub9mNKWyllSnV0AV5VehOvjcjvwH27gC1+yUr6ig
-        LkBlnVd/UhdoK/orC9pTFFRQsBT5XJQfefe2koIZtwHkFOtukqWKS/rSQcGFPaG5LsxftzJFH37q
-        PGs5qX96cNjfxsZ3ozkqD/6xXgxFLwO6N8i/gf2+gqgW4amsT6/3bCaZoyaKC+3/W+3UjXYZNe5u
-        Cvjy9YSpMfWHNKP3XqOj9IpRzstGgD4o9Iw17QzWDuVEnvTdtEdsal25ypOCSSGO9b2S9sVAtOBu
-        JuPaBtmhfKUynU9qjao3y+T+YG8+uGai16ye23Va1EW76fy7IqlQdTzesGKdHZ8MTjcLulOHevf9
-        3x4IHy9kGl7apW0kptwy99aRQQwF3uEVKQYx3HKFIJtpyQVAYiruB0bP/7qOZxEHNLoUAEMyNlnF
-        iS5E1NC8f8gjzBO5OAQg7AnKvu8Ydls2cAjd2iKOGHZLMtZgNYWgMxanq6KeTLyWbzIFOd8TgXTR
-        VqBBq4HKMCs/zEUhKnRdIJn4N6NByOF+jLc6le7yHdGrsrfhfSTTAili5oNkmqyzgS3jMrwIlH7u
-        Xql1H6JU9Rd55BRwFDJ5uWDKVxPRsdKL5WeVRRziHay0xAVlV2X4hHOb15VIIOfBCEKC+yBbab5a
-        qeCv8WJQHslsUnVj1PBtqusyajG1HKfac9GzHLt+AQcmUgdqFzArtpSmbV213h9qUOOxK9KASUHF
-        JWcriHF+WaP9AUI1kUO2LGsfxjOX8FFVSWiAIddP5P2W+fr+2PpSZNWIFayXzPCBP08OIcWE7a+7
-        X4XiHhFAD8TU41xAXPB5t6P9/sGgvwURENiRk3ukVxy8aZ35YFJDSK57GM1HoVRmPfarxeSEp4n+
-        p82kk4ehngbnhIWzErwSRhyAGAy/BKIcfySO72Xl0UM7UdhyKw41ziFR3Wec9imQP9czNOiQTF9s
-        CeY52O8fHva36Dj19/cGd+sGcvDGtd/NVk69KJxOYbyLMXq7KiszfyBy1bO60FZ91IVTu9epntjC
-        qrfOdOBsUAXTBu7ungRHvfPYIpUsxtuC0XYvT71E73BmZ07tfsFyO6lLrS61K+pOEyj6Una5hD5m
-        sAiTO1ppbvPQRtA+iuCTiSDADjA9sqC3lSwt4+doFIU75XNZhEEkIpaC1PQoPxa3pQgC/ZqRq4sp
-        CgGypeBWDO/7jS3czKrdS12V9S9WfVi5Diu/QMnlTVWlTAq7qJaFJYRJ0ifRhJAOPpYHVvRHuppK
-        lDzXOZXtb6d2rks9s3hrhVa7/EGq1eWqLvWs7oi1xEu94iPteHGj1u2qSzuvC8gm861f505d4c3P
-        /L1KFLQkBZqdQflKXS8wHPyEZU9svw2vnoNt2EHuv7dFDZNf9HcTJzgi4+fk/hw56v+45vnrqMXm
-        pU7HY+wAL0yGiGenBFCuwAb+BiQBaHSBajy1CwE/kr+O5U4XVIa0uXpVIzLoxlDEa0QKkCDkiaVm
-        UICj197cw7hvFs+Pnq+P2D87HmzVR92A8peDf00flSs1tQ8kMpzBjbctJC+ocBm0lVOfblE/MQJi
-        6KmhhPmR4TFyBJZMQm0RnyOfZJJCAzzh9cUhZDtxpgwBiJe5FJgKZbnYj7OlGs5NAYy3P/C9zXUP
-        glAFTHFkpmGa0VnQeeqvlgyZSw0OUNW0hmQi/02V2Oj6B4sL561/KibEXU8AwYnos17C57sKVih1
-        zgpNG+4eW82Pz1T5u+caQ2cn+0dbZcFn96t3PPZXjSBK0EZkUyo9VcbK/TO4cSd1gQ0tI/NfWqXk
-        dq0Pla7XNJPKecsHrqmm1lG9XcKQUDqVhaOwSYWENM1ckXbRnaRK/Wdg5HOzxAgu1Htr8hm+q/RI
-        m1od+8JBTMaDsil6TW/rYMia2hLlNFLf+bsdX2MOW1gYmCp1poTWYoUee7islL6LJCjje0XHgMuN
-        gNmqskmPAljdeMeEe+qIOklDEfUnTxVI4O8DVwYt0BVvq+kpTgQqNf3hdE0RqCsSbwKVEy+Xnhyx
-        00QjS5kTkBYPykmc3ZPVouJ55wh7Cu/enFpA1q+9hj4cpLveXSSyRRpBIjEZkWkW2Bro/coZvYdJ
-        7kYuXXF9amkSs7vVU7fMbKKXko31ZmDqwvDxlAGaE0WWxGs9sh6uJzpCbj7nYUNwGtYU0OO3jeme
-        YGVLInClzxYGRRwowVgJuLj10VXelRiPkki03dHSmOk1sDrCJOKNT2OLgsYueuUVLLNoGxvmVaRr
-        RCOlACasF0FQAc5HI0cOoH9b9IDHc0ZxhGBFqqaWFqDeTOaNqdSbGiu1h9usxf7yw47admlUu+/f
-        dZ4iQ6DHDSGO53XVZgR8dOomk0Kpuoy53qNcgLPTx9QR+mdn+2Cl3RMH5rE/HBjhAW6uPKie2qSg
-        2ogxlzB/phHTyhrzaww2W6pPxT9qoMl8c0woS2RCpWQxNjZ+YRWYmNxQiyQziafkYxBPnN8hKcmm
-        xaUpFoCQyAPyaGTbjJdtRGbtJHeFpJs6Xzlfi+dujdNjvkjR/av0NofB2LamTMv51JoxiPkL3A8H
-        PEFGJHQ7T/lVk6KGlVfIbWQRsXkgNpWtugQMOvkeWnLCV1hsjbpFFykH0MWy9YklrNBLL+2Oyy7N
-        iK8lo7nyQnFJijEEPNWWwc8O7Nee+APSoVQa8W6M5BxKNIkrinoRKzcjD3QNBKyeekEHmCBAjP2l
-        9Nyx3KHJAAEbb/Lw0o1GVODz5BBNAJJrLNEh4Yt+Z2+bIPf5dMAGhydn+2d7k8PH1QT6GxCfPHpj
-        t2jqlsgrN88h5A6gmnSlfApxLXqua9QNL7VukRsLfihfm5U0kb09wKHqrCKjecaxC6KKQ4C68tWs
-        AiYTlRF2uCflULlZRj3pf8KNkCGbWlwem8kszMARqBckszuhugP7ef7qWrJqsc+Z1hPDFV7q73IY
-        QGnYtEAy1AX/JYPKpPIfHx8Jf95kFntbawACbBoT+FLVZR14a7hVl7cnakPPkTpcT733M4Duk0kR
-        4gr8N9H8VVfZAhOc5blSk0eNHmh8aT6+hxYldOav66rQ1B1A2DVCJTr01n1/hXYfXRXbxO8uXt2K
-        YLMaJjo185UaQgj8f/5b5eAZGaNeulydA5DtBdQvCxhh5TQ+enxevLPPp7pz0D84Ojp5NOs7Rkfi
-        HlZMDv4hi1lGwzcOAIJc7QZbx70VbB073ueTiyx5qF440YMOb5x6V89EJVsCmraysFSjEItECVEw
-        EFGp5e5EAVYSBbty9RDRLgo3tyIpPK6ziCWVi+6UUjUH1pIT0+tLEiQdfZ2iSIzELtxJCkP9F1lH
-        5dZ3pFXb9ejKugiT48YpdCOomU5VmPW8wwoftqjzNDZqKFOF9rLv6zcWiCKfiQWbGeWwkskCqGMe
-        wBuwRQtX7OLyX3Sudhk80gG401XDvJrCuPDG4Re55oJyPpUPRbl5p75YfsPmxxMKjrn1+xfVaSkr
-        hbQhwl59E2WHoh3cI70TEY1E8KKQK9Ep0la0Np+a0nqZs8cLU6jUVU8ijYx8xO6t4Ee3+t9/twO6
-        9m9cfe838ZCt4rz+0fHpFmWYfXg+39PnlIM3yimjjvlQM/k/IOe2aJoyqCW+R+1zbtrcVvKZ3omr
-        y+76Q3ewY010Q2Oe2aqs1ZUude7KemakM1jZucV2kVM7T8IaTWjAq9S1OEUNgSgGmjpJmHdQ49fk
-        /BNhzWMjHLmVr8980TaZWq+pW86wmsx95YRz1qWrSa2LVGLGNToQ0zw5XgmhnmznVsJ/R68fmjyg
-        NCdooElC+fc/t95S9+9/9ondDrDf4sKEi7TeC9EPwXt33rvzygqT1QnB0G03Bz+hZL0r2166EB1P
-        qFdkE+GFuflC59L+k8cocs8qz3QVeDvzmJVJaUQwbmEuBtmRx1FhzaM/qRg5A0OWPw86282iwfHg
-        7HR/b3L0ODZosKGayaM31qJMNc7st83T6ENdTbPQiEhqSiV01bnLKb8HOeiYIaGQROu3EP6RDXae
-        actOx73wPnH5P2pTSFDEn3rf0yX2oLSloiC6FguTGzIrvIHXVKduuWoUNnwiUJpvnvfVxGPAs6em
-        yNXL3vmWMfsd4OrvAZE4YZh+F0lzMBjsH/SfgqT6HSyIOodzZPKQ6NkTupEMjg8PtpM/uy9Ew4N/
-        nYQg1g2vDNnWDdy5Ky74oQGrBSjHwlVePKPdIo+2NjSLIlZ27Io9tEBaMLTg7DA1Xk9NjIO5Apli
-        DAmOsf1mir16sUCMxbLv+h35QIfIJ6iRFOxblo6QR1SOJEVGZQymItGuInDKPR/cAzbXBTmxDP6C
-        mxB5izsAzqCcF8VmW0LF4fGDFmwjwS61SF9Gw1Hki24JUGpe/x/HpzgYHByd7j/3hHthpIfL5fPp
-        uBI/8ozPvaj8FB9ySE5cZvUf8pyD3+05LyqdrZ4uTLjStlU8QuwN1FlelVsGDKenR0fbsCihjD/Y
-        oPp1tHGx/eXjQ8pXF7n6YtxI7b5Fk+SLc+rKdiRKbsi3OQryS1g9Mp4NmjmajSxEhTijtG58nFyE
-        ZJl6JWKlDIivHpFjo8n1YF/qVqx/REdAS3XP5lKj9xRw36vwF+uqK9zlCve7ez1Vb6164zoBahBV
-        sbwbE0LBcJf09QP22URdeDYvdb7SiGTeSHqAhVq32jgqPPeUfRWpIwPuRYEmz4SGzzgfQ2L8+GrW
-        Oiev6lz9JwAddo5azER9dm7m33a8SJBMbflMrOn6eYGSMtyv0BZJOJlEh8vwWX29iCRKVMQETB1U
-        5eOLfJhqsT6ef8P0oMb2C1ukYf9uT5KGcZ/VZmSLdMvZcjY4PBo8Xkwlff4emEmO3jRdLl/cqo8/
-        Dx4wcjZGzL3QGYISesB7BuG04Og9KXRaEzhcEppnQfTpKtN4xOBLwTLT5JbVzHOy4aPKRuHKcqpt
-        Ud41Dil3WI4VPOtX05ZqY0eA+GZCDWvKU93lYy0KNzZkJAFY/3//+i+AeDCRPqP88s7A4dnl6s2q
-        nnW6mB8cubfOqd3zqTb81wubd7rqLRn9qzpXL50ceYufYOx1pONwyf/zsm9xgktOXJzhrc07vPh6
-        lantvim9Eu+87sOXr1aqThDesfkE65NYbGXZ3kLbNIpylpKfopiHBHuKEjGdTjPt9ZjXBSmmju1Z
-        D/QX7Z/SFt8hmoTRem9IP3V1dP+0f3y4TXV0sDc4uodHwsHfY1Eebh7ooBxPmA0WMxOcCfyqT8lh
-        SkXTSMEDiIltJGNvApx0JX1tMW8TqB5KByI7xILoGlNtR0TZ1jwry7vmqR42942ViByA6RSdt+9J
-        kX5CF0tWmMqpd+gchf/zbGvP+Rtj2GZJe+9MFjKVG/RZtuyv9gebxI//HwAA///EXctyGzcW3ecr
-        YG+UVJEckiIlMrNI6WHFb6sk2d54FiAbJNtqNhh0t2imaqryGfm+fMnUufcCDYqkJCeWZ2dZbLGB
-        RgP3cR63+qukPr+pcYprv7a/ekf8hCHsrY/hsSTEOof93j18u85weLhd2hUXf8Nho+H8EQY5//Cd
-        Xu/BH6dTmUlo1D5wMXS7w3tfewje9rYJ3naHW2fl6PhkN8P3nmmpBwExkd6jgQAPu/324UNw471m
-        dwNlgGu3Dfx8l4EMO8/zuCj6E/BfofYw6GcJ2mhAx5yIaCZ9VKz7cpSEM51ic4KJORo08zRPm8Ei
-        yZsYs6rlDVAGADQtnE0qQaGHnThUrqGqrz37AuW4JDYyztXRwqUZllKXTz/YmEHCEL0qhmCHz7cu
-        WwgKwCNANHt+TG1C5n2kOf7GPqkM1rPgdRBJmhsk5VJPDQ83SUxtPSfd10CmMepdlqWTSfPEop0S
-        zAacITHwXLhWFDYLzwpl76adNMuZaY7JjhafB/YJRsjeFo3I5mmOewTejUTUyXWE5VIvx7akifeq
-        prN4FOJgcGOkeYu6j3SrZIrqJ0wksRbR/ck0y7VuDUlksy9T+FXN8vXfNtRxyVHPa52s1n8XTVpp
-        nKntr4jNQlUf9toLtIROzycRMAayrnR6xb+NBA3lNEXGoG9xkFqCHNFzcTAv+Bk+B+vtWTLVBBaP
-        /KGZigeU4oobF/h0vJScDc7PCK2yaFQ4HtJxuiB8AGA2gq4DXH4cIB6IHSjrdsSHHK0kiGCyJi85
-        BLJMUNajNDEBdpVULnSGmPcDJh2wCS31RtD1+P+//vizWhQl4mYoxSziGzP5Z+sJVoTCX4f/8c0E
-        UUdqT0jcQx9jZGBnCCLvsNND7Rulwr/++HNkKEMN38q+OBEjp+b9/VtGZGsj5cwusSAc/MwbcsfA
-        70vTR7hLlMqOqywjV13kZT73YCimpJ5A6mTGgTnV2p3VhXf98bbwwf7gIVv4wbaza7BdrP0eyvwb
-        SPYYv5U7c2Ozm9gww5EZ5mUJEt5HXaK3VOtwBvO3vgpG6LQCWGJHJD9Z8yGqqgLxhM5IXTVGI8t4
-        i2MTaR1KRjENS7iGffKjy8ykFGNjvskalWPY6HXtDxJKB521zPgOy2c7wls1TxMux7Bbl3dtygX+
-        UkL2pyXeXEbsjYP3Hdsy4c5ugKGlXSGoUsFmZ+eqiqf/b5UN65DpyJXqNfmXllS9e2AgvTt47LM/
-        y6bdXGd7p/rkgXZz6ze6Hi5v8Z87CrzoRK9oC4rtfjmNGpmppsb0yfGlcjpJLX54qfMKz6PTb6jO
-        sNdvqUPZkPjgh9q4WZSkQa46+Ey/26BnfBWICnSMsLfRqBJMyMnxZfPqg2iZ4B5CD+FITcxSfbbX
-        3l8GYxVWohczrpsIWkmFkJi7hAaufQ9/q9LfuWAV7DqAmSRhMjZblPqgtELAiijVNJ2UvE5zdRRI
-        Ted2QS3v6ArYy6u9t3vqwpI4JpXgaFdEsVFa6qwpQn8MIzixc5Os1OXCMqqL8FReB135aPeMJyP2
-        i8MB8enpKyhtXgr27VS7nETir1C0Kz495W/0ZwcjkGtLYXBc+7jNTpvOueIaQgqQHyqKYNckOTXP
-        pAFeNG8KQBUi1C+gfX/Qa7BB9J6EZvXDS/NxVlE0kVH8IZECP20FuGABObo8T406dwTs3ytIOn5M
-        KCSxoGMCJD1knV3zuWy+NKE1ZhhtRvD29cV50G/c/V5gqCPHDAkgF7ptrK48J8Y1Afdzigg1tHBE
-        PJJfBCLX1esZP/5Kq4gcRS90tphJOCcDpvZ0WqAE5dRrHJcCuMqBPMRbwLS8eW3sM7PLXVvcXaP6
-        PryzzvCwvWMnG27vOb+4+tB50FYmNAUe0ubW9X9wIo/v6HtN74A9eDubOvbdw3/sEP8OXPkdE8xG
-        1pG5LtXrzY2ee+keB0kUdC8IDmojYjJdcFqZcvdUhm/+XhN5cLhVyfqw1xnuf8NyzclMzxeYjMcN
-        Z3v9+3V62+3t4Syu/aqKBDi3kjxPhXLnSTK1GppOyAkDtQQW3cFuSnxapBUILQKS7UUeDILV0TSs
-        RuaGIe995vSaplqsiXFsl1lI5lnMp7lgvA/garQGbVUwHWGCczcjM5qiESCYWxJvQtXpEL5mwCUQ
-        FTupb6tpnPZiqldsn2jYv5TOQ0EINRHhiuJzwUqaVIgmFgeYSuVK/ZhyPaW0luIN9rJn3XKZ6NBj
-        IamzJz9F8tYUkCSW+3IUTxOkb2lYAA9/hry+TPKzl3eDSww3KBp8N7psErwjuDbMiVkXROeo3Sdf
-        NdOJ0jc6zUj+glxu2m2qLsHtQX2iWhz93/Pa1IL9/mgeJ8aJ6z20uY1GovOOQbfnx5d7hbfF+PRU
-        nndLvSvZuZujhvViUGfYaxf+hxMLCUWd+Z+xL505VMh95H+nGEJ914/2pvYfoMPcJt+s9m24El37
-        VW+qlMBKRCe+OrE+zsb6ZK7PFU3f7SlFhS60Wy4M2r6rONBo1D0YGElENqdU0eIqRqcdvx4+iONw
-        bmrENlqqOnMNCT4veOnjIOHSUYmBA+jVIp2kgjD192Wwc2y5SSlaAnR+fKk+miQ3BUTgeFN6C/dt
-        JCr7WKXhp26vQeXxlnrn0ilYaxCSqr2nzchxmCmfU1yBZcYs2aisV13fv6IMx1dXuQZF93WJMJnu
-        R5dq+HO7v5gjOUOTkCoMNWI1cFKikxbm3NV4pV7qqa0xA+GNpXRa5zGOq1RHc/27zVvjIFkGDjn7
-        CcovWtV1feO4my68ocfq9MOpr5vF98BGV/W31rO4r368IAUY1flp59u45Zl9r8gAXjDbIoP+/nAr
-        uQmA3q8NC6JIi7t8GY4UoIHyFJI+3y1aH25vWh10Ot2vbs88PZca4chaYfRRtZCN0hn0B3k8LW4a
-        cna+K0kZ5LRJzu2kVZ1VZWkpFaKCU80l96vszOlQovYC5yhHe2krHPouD2/aQlPx6NRoqNswBS9g
-        F7k4O9bzRUVwIACxuANAzX7rrBMZ0ytJJlwp/Ow6FmaCbsj8CvBasn9Bew7OdZHzA7J6zk/pJE/H
-        6ujtizdHr5kq1fKoIlFJJ3Q6keLWp8NfCyc+PaYa1K/Uw0C+ynfoqpzY3Ags7OiGuiu0UfqMSIH1
-        KPslaJQCJi0LuT8fxs90svM1PTVZqb9zBtRvkibTxpI93N5e3lUqu+PtPDWlOBil3yTFqwuHb64+
-        FHQCH/qY5a56IRlt7g8Gg879AtVIZ25PyWCwHd18t4wyfsu+VZ0uW7bIS4fFyICgPK3msU6C97Bl
-        hd1CpZOoaSJziNLAXtFSxHXdK5TDsYiAWKXnFt2CMchYi5nNDQuhZXpR2kXxRFEhK/JQEeg9B9aR
-        fQq9rnCQBiIPHxw0gbK75t84W2qidWr/LU+Uem6XhEu7WT3ZWTcmUDee2V790B4rOhz2+/e3JbrU
-        WR5u8Nf7/cFXRYdnPgEzX8y4YqwWt32dlHpJg7K8FTJylYv+K4q863LnWsN6I4DEZnk7yhwxsYgz
-        MHq2tfcZ2zawTuwk9Pc6g8F+LTqD/pTkYJyIWgaZsVmnd4SYYICeCOi7FGM9SoHFWmSabSHHzi6w
-        GGfC9x5VfDyNZ5aljMFIQZ7pSL0CLEd/bLGxs6daLqmY7Ff/G5uXOtdEjzUORN4WK78Wlu31tJqn
-        X5jIShx5AR3y1edOpy7l6bwU5eOde/L67D7eUiXbxYcs1U1bveEO18UzNnTaAW3U1zXOIKwlDRhe
-        EzrO1G/IUDMnBKMaxfx8nedA0V3BogO88JktLQ1mFav5ttTVEtTp6Pc4WhHeVgvFouBV3kzzmR6R
-        Actc5yyxRDwH9MqCkDhTKxr074yYFGS6Sn3qjD32srmsWu5q6Rsmdcx0NuERkVYSvBQoskZAnSP/
-        xUsCg6uIp/EL/wRBG2+kTa9Bmv8CgQ0uhnjat0xzXan2OYjPa9Q57QN30kc3H8dj+DN0+wf9h2gl
-        bQnY6dqv2hCvSKpMJKcLsChJXCClLJH0Rn17zPups5G6wFdFFCeKCq/MF12oC52PZ1J92PwvVRAy
-        O1R61mpkWKq2KJsnpBP5UTu5PsKORIrn1LVFcyF4Hn+2rBbrmGiHkpZmpxzcABfV+HtZuHX02Xsq
-        ez3sqDAGAIurxSI91SflTjR1sSU87bbbYq028V9Ih7NhdRJKAURxVcpcAP2S2xCLFooOLApck8zC
-        sQZEpkSqGBJNn1h7HSqRkKg95uZeol6nhY4dC3gQ3s6rUB9Sk+e6AXcuI5v3c53nesZKt0FZTBOS
-        oaGK9Isa2+XIror4z0rPfrf238bD/lZ4vY8Axcj6UcdsK3rCZtanMLN+GIJvsD94gPvJgEzcb7Oo
-        6dqHe8Tcuumf+fDTIPKbau7Xs60cSVb5pkQBw4jKRRjcSHiKxedIDVukMfivxODdILQK3ang6JeY
-        OQBc41XkisEKPlAHk9UVQhA7Ub1ObXrNGlkzT5qji2P0RfxogJsybqYXEfUjOlpgsTTWnlFKlZWc
-        jpXLklipDNIgKM6c2rJOO8NVdzUyKyspLJlXp6CrvLXLRm1XTSv1DXqgx1UB0QCYhgUz2tLWjGp/
-        SjKgL82biVmg8ssHBBVrvQ6DlzP1GldjI16dL/UYOS/UFl6ZPEee623KPMtQ6upUMj7otnbeKesD
-        Rppb4iZCf2A6K0UUbsn5Kj0Legy+qZeF1C31KyYd+3KDDw/YJY2ltUbOcoX5tSkyibNeo26HodgG
-        wfcFd8ldi3By7kFRq0zRFlcXVidIrBs8sfV4Ssv29d4eIp/qKTOJZDiy5ETfO8DW7ipVx8usuXUL
-        +Ba0mHSqTnWSrB6QrN65g2AT2fRPag+3yzCA832ntQT3Psid1N8hO89HwCWxHU5WTA2310/o9XwL
-        dH78DWSYvRc6ET3ETKR/cqSdzdWb8Yl2U9tQL12rwSuzEAHg2jVnlE5R9coS2KvdeB++CSowcjx5
-        Xx0RdEAq7SE2nj4chuIb9y25hZGj5osmbe5maZuQfZmpm3RkBLe41G6uinmahebZdQo9qdxLwMzE
-        h6VaqLmtyllziVSNPQTG6YJq0hDsZQRnJDQYOxFFkUZw+67yZsbObqI1rZ4RRhJTwgZCpHOEHyqq
-        6W+Ocid/5fYnHyuVGfTacILr3n8OAqW1uYq3O8Hdw1+58ssgeDYJTpkqL8TvzhJ1oeeFxgS8kuf5
-        1lt6FGxQxVsndTUl8md9XupZis3KxKu7NnZN9Rp0XF2YYlw94mx3u4N7DWl4tjdcQOjiXe35M1u5
-        Xc5g0xnOXo7Pud6gIXmK3bJu4a79j2qqX41eSDmjqZas6VJLL1JMWf9dzD8SRXFeJt4Omtd4x+WY
-        6Qy77drRyuOvoKi188E4xLjJY6x/Ki522vv9/fuqi5CR3ty++dK/sfJPGVaDdVksMpMniC1Y2wDb
-        WIAF1Lh3NNqbfr54i8J+ShdFn8rLWVWkqJYTiPwMMi6ZWTVxVKJSU8DDoaGuEBMW275n/TUQn03f
-        aPPvp1V30C52U1Uf+K3f4tSOSnXvXz0wEwDs5e5MYONN3AGUuXff85gNEkREnwZFRqhmRqU/6u0W
-        6ZcGl5ALQksAQIjpo9y0125Hlie1Evb7VxTBm/lIu2scOBp+ub9VRhJqNoCSSItQjsN2u6XObmNA
-        2B9lqaX9VH2pWLEX/UHJWX1BsnIjnUdwlQTbbknQjp0vdvSMfnz/6qdHKJ10ut39+8RQb7/SdMnf
-        0EBNQ6H2Vg2EyJELsjwSSRP/yGJp/UuEJOojib2Prc4mqcnqtgPtmlGpgjZaeTCp88uGnlAqcr9S
-        CClmtUXPRCUa66rmQ+Ob5mzpKLGLj7vFKzjN/WcITAkaD2VhtcYaYUQbobpCQVUDHTdix8/hNEDd
-        jKsP0qycL6qSVv5ahhkFViA1AfO+wARHPuaxUw9735naFiep7xMD48itFm75VYRjL0uHBInSr+4B
-        jfZMJssjMEZUL8L71elFdRBycCY8QrCHwbdRlV1mCqq1DQh0Eh5wbHOu1RQSgbJI/Zx0CqVS5Qzo
-        UYQq5kczdVSonPD5O0P8M55Z5w3YvDNlGNc97iYn1vcc7ttUf1DqPz/8938AAAD//wMAfnq7lKv6
-        AAA=
+      string: "{\"data\":[{\"aliases\":[\"House M.D.\",\"Dr House\",\"\u91AB\u795E\"],\"banner\":\"/banners/posters/73255-24.jpg\",\"firstAired\":\"2004-11-16\",\"id\":73255,\"network\":\"FOX\",\"overview\":\"Dr.
+        Gregory House is a maverick physician who is devoid of bedside manner. While
+        his behavior can border on antisocial, Dr. House thrives on the challenge
+        of solving the medical puzzles that other doctors give up on. Together with
+        his hand-picked team of young medical experts, he'll do whatever it takes
+        in the race against the clock to solve the case.\",\"seriesName\":\"House\",\"slug\":\"house\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2009-6-15\",\"id\":99421,\"network\":\"BBC
+        One\",\"overview\":\"House Swap sees members of the public being given the
+        chance to relocate to their dream property or location by swapping their property
+        with somebody else. \",\"seriesName\":\"House Swap\",\"slug\":\"house-swap\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/84486-1.jpg\",\"firstAired\":\"2005-1-30\",\"id\":84486,\"network\":\"Channel
+        101\",\"overview\":\"A cautionary tale about cloning Bill Cosby. Sadly canceled
+        by legal action from Mr. Cosby himself.\",\"seriesName\":\"House Of Cosbys\",\"slug\":\"house-of-cosbys\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/82624-3.jpg\",\"firstAired\":\"2008-7-30\",\"id\":82624,\"network\":\"BBC
+        Two\",\"overview\":\"The intimate world of Saddam Hussein and his closest
+        inner circle is revealed in House Of Saddam \u2013 a gripping four-part drama
+        for BBC Two that charts the rise and fall of one of the most significant political
+        figures in recent history.\\r\\n\\r\\nHouse Of Saddam offers a fresh perspective
+        on the dictator, his relationships and his actions behind closed doors, by
+        retelling events from inside the very heart of the regime.\\r\\n\\r\\nBeginning
+        in 1979 when Saddam became president of Iraq, it follows the impact of his
+        political ambitions on his oldest advisors, closest friends, family members
+        \u2013 and on Saddam himself.\\r\\n\\r\\nWithin the walls of his opulent presidential
+        palace respect is interwoven with fear as Saddam exerts control over his allies,
+        his country and its people.\\r\\n\\r\\nAs he continues to reign for almost
+        25 years in the face of mounting internal and external pressures the Iraqi
+        President's ability to survive is revealed. Eventually, however, the House
+        of Saddam begins to crumble \u2013 and its leader becomes increasingly isolated
+        from both the international community, and his inner world. \",\"seriesName\":\"House
+        of Saddam\",\"slug\":\"house-of-saddam\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/movie.jpg\",\"firstAired\":null,\"id\":82126,\"network\":null,\"overview\":\"In
+        this non-traditional game show, a pair of hosts opens up their homes to four
+        strangers who will judge them on their hosting abilities. \",\"seriesName\":\"House
+        Guest\",\"slug\":\"house-guest\",\"status\":\"Ended\"},{\"aliases\":[\"To
+        Play the King\",\"The Final Cut\"],\"banner\":\"/banners/posters/79861-3.jpg\",\"firstAired\":\"1990-11-18\",\"id\":79861,\"network\":\"BBC
+        One\",\"overview\":\"The PM made a deadly mistake when he passed over Francis
+        Urquhart. With his recent dire performance in the general election, he's going
+        to need all the friends he can get. But Urquhart won't be ignored by anyone
+        and now he's out for revenge. As the trusted Chief Whip, he has his hands
+        on every grubby little secret in politics, and with innocent journalist Mattie
+        Storin unwittingly drawn into his web, he'll stop at nothing to get what he
+        wants.\\r\\nA black tale of greed, corruption and burning ambition. Based
+        on the best selling novel by Michael Dobbs, a former aide to Margaret Thatcher.\",\"seriesName\":\"House
+        of Cards\",\"slug\":\"house-of-cards\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/77572-1.jpg\",\"firstAired\":\"1979-12-13\",\"id\":77572,\"network\":\"CBS\",\"overview\":\"British-born
+        Ann Atkinson (Lynn Redgrave), as hospital administrator, had three unruly
+        doctors to cope with, and the comedy arose from their interactions. Dr. Charley
+        Michaels (Wayne Rogers) became the main problem for her, because of the romantic
+        angle.\",\"seriesName\":\"House Calls\",\"slug\":\"house-calls\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"1995-1-8\",\"id\":77095,\"network\":\"FOX\",\"overview\":\"Welcome
+        to the House of Buggin' guide at TV Tome. House of Buggin' was a short-lived
+        variety show. There is no editor for this show. If you would like to be the
+        editor look here for details.\",\"seriesName\":\"House of Buggin'\",\"slug\":\"house-of-buggin\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2004-4-30\",\"id\":75249,\"network\":\"Court
+        TV\",\"overview\":\"Welcome to the House of Clues guide at TV Tome. In each
+        episode of House of Clues two amateur detectives try to discover enough clues
+        in someone's home to create an accurate profile of them.  Then they meet the
+        homeowner face to face and learn how accurate they were. There is no editor
+        for this show. If you would like to be the editor look here for details.\",\"seriesName\":\"House
+        of Clues\",\"slug\":\"house-of-clues\",\"status\":\"Ended\"},{\"aliases\":[\"Disney's
+        House of Mouse\"],\"banner\":\"/banners/posters/74189-2.jpg\",\"firstAired\":\"2001-1-12\",\"id\":74189,\"network\":\"Disney
+        Channel\",\"overview\":\"House of Mouse is the former but even better Mickey
+        Mouse Works. \\\"House of Mouse\\\" is a nightclub-type theater, where Mickey
+        himself emcees nightly. Stars of every Disney film ever made are seated in
+        the audience, often becoming part of the show themselves, as Mickey and his
+        friends entertain.\",\"seriesName\":\"House of Mouse\",\"slug\":\"house-of-mouse\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/5cc59348eccb6.jpg\",\"firstAired\":\"2003-10-10\",\"id\":73395,\"network\":\"TBS\",\"overview\":\"Welcome
+        to the House Rules guide at TV Tome.  Home improvement gets competitive when
+        TBS Superstation pits three teams of amateur home remodelers against each
+        other in the new reality series House Rules, presented by Lowe's. The series,
+        which will result in one team winning the home they've renovated, is hosted
+        by Mark L. Walberg (Temptation Island) and premiered Friday, Oct. 10 at 8/7c,
+        on TBS Superstation.  The three teams chosen for the inaugural edition of
+        House Rules are;\\r\\nRed Team: Katie \\u0026 Adam, newlyweds who will spend
+        their honeymoon competing on the show. Blue Team: Cindy \\u0026 Bill, who
+        have been married for 11 years. Silver Team: Rebecca \\u0026 Joseph, who have
+        been in a long-distance relationship for nearly a year.  Each week, the teams
+        must compete to win their share of a remodeling allowance to be used to pay
+        for the renovations. Once a week, they will also have an opportunity to spy
+        on each other's progress as they each host weekly dinner par\",\"seriesName\":\"House
+        Rules\",\"slug\":\"house-rules\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"1998-3-9\",\"id\":73338,\"network\":\"NBC\",\"overview\":\"Welcome
+        to the House Rules guide at TV Tome.\\r\\nHere is how NBC described the show:
+        \ \\\"A buddy comedy about three Gen Xers who share a house in Denver: Friends
+        meets Three's Company. The series chronicles the adventures of three lifelong,
+        ski-loving friends: Casey, a deputy district attorney; McCusky, a medical
+        student; and Riley, a reporter. We were meant to find them charmingly irresponsible
+        and free-spirited. We did not. In contrast to the similarly themed triangle
+        comedy Two Guys, a Girl and a Pizza Place, this made delayed adolescence seem,
+        well, childish.  \\\"The unique friendship shared by a trio of childhood chums
+        and roommates from Denver is the focus of this half-hour comedy. Through romances,
+        job problems and the trials and tribulations of daily life, a woman and her
+        two male roommates give modern romance a decidedly comic spin.  \\\"'House
+        Rules is about two men and a woman in their mid-twenties who, after 20 years
+        of growing up together, going\",\"seriesName\":\"House Rules (1998)\",\"slug\":\"house-rules-1998\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/73182-2.jpg\",\"firstAired\":\"1999-9-30\",\"id\":73182,\"network\":\"HGTV\",\"overview\":\"House
+        Hunters takes viewers behind the scenes as individuals, couples and families
+        learn what to look for and decide whether or not a home is meant for them.
+        Focusing on the emotional experience of finding and purchasing a new home,
+        each episode follows a prospective buyer and real estate agent through the
+        home-buying process, from start to finish.\",\"seriesName\":\"House Hunters\",\"slug\":\"house-hunters\",\"status\":\"Continuing\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2004-1-5\",\"id\":72438,\"network\":\"A\\u0026E\",\"overview\":\"Sixteen
+        people compete for a house that they build together. A contestant is voted
+        out in each episode.\",\"seriesName\":\"House of Dreams\",\"slug\":\"house-of-dreams\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2017-1-1\",\"id\":372935,\"network\":null,\"seriesName\":\"House
+        Hunters - Poszukiwacze dom\xF3w (Poland production)\",\"slug\":\"house-hunters-poszukiwacze-domow-poland-production\",\"status\":\"Continuing\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2019-11-10\",\"id\":372441,\"network\":null,\"overview\":\"Six
+        strangers share a rented house and ALL their money!\",\"seriesName\":\"HouseShare\",\"slug\":\"houseshare\",\"status\":\"Upcoming\"},{\"aliases\":[],\"banner\":\"/banners/posters/5db8dbce60f60.jpg\",\"firstAired\":null,\"id\":371572,\"network\":null,\"overview\":\"The
+        story of House Targaryen, 300 years before the events of Game of Thrones.\",\"seriesName\":\"House
+        of the Dragon \",\"slug\":\"house-of-the-dragon\",\"status\":\"Upcoming\"},{\"aliases\":[],\"banner\":\"/banners/posters/5d1e6799c5063.jpg\",\"firstAired\":\"1979-2-23\",\"id\":366177,\"network\":\"ITV
+        Granada\",\"overview\":\"The story is about a long-established and highly
+        respected family firm of auctioneers, the House Of Caradus, in Chester, England,
+        which is now in serious financial trouble. The series captures the drama of
+        the auction room, the excitement of bid and counter-bid, taking in dealers'
+        rings, forged art treasures and the growing invasion of the antiques scene
+        by London-based auction houses starved of pieces to sell. As the House of
+        Caradus struggles to stay alive, by fair means or foul, its clients cover
+        the whole spectrum of need and greed from international dealers to hard-pressed
+        housewives. Starring in this series are Sarah Bullen, Robert Grange. Anthony
+        Smee and Madeline Hinde. The firm is run by Victor Caradus, 40, with the help
+        of his cousins, Helena, 31, and Lionel, 26. Helena, who studied Impressionist
+        art in Paris, has a love of beauty and high ideals and Victor regards her
+        with some resentment. Lionel is a spoiled young charmer who is deeply in debt
+        to his bookmakers. \\r\\n\",\"seriesName\":\"House of Caradus\",\"slug\":\"house-of-caradus\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/5d754242d8767.jpg\",\"firstAired\":\"1998-8-24\",\"id\":364905,\"network\":\"Channel
+        5 (UK)\",\"overview\":\"House Doctor is a television programme, originally
+        broadcast on Channel 5 in the UK. Each week, the House Doctor - Californian
+        real-estate stylist, Ann Maurice - helps UK home-owners sell their houses
+        with her industry know-how and style tips. The popularity of the show has
+        lent the word \\\"house doctoring\\\" to the British English lexicon, which
+        is similar to the American term home staging. This program is now shown in
+        many countries around the globe, which is broadening the use and familiarity
+        of this term.\",\"seriesName\":\"House Doctor\",\"slug\":\"house-doctor\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/5c605bb39ffb9.jpg\",\"firstAired\":\"2019-2-10\",\"id\":359449,\"network\":\"YouTube\",\"seriesName\":\"HouseHold
+        Hacker\",\"slug\":\"household-hacker\",\"status\":\"Continuing\"},{\"aliases\":[],\"banner\":\"/banners/posters/5bf93db2b128b.jpg\",\"firstAired\":\"2018-11-15\",\"id\":355880,\"network\":\"TVNZ\",\"overview\":\"Hosted
+        by iconic Kiwi drag queens Kita and Anita, this brand-new elimination style
+        reality series follows nine dragstars competing in outrageous challenges each
+        week to keep their place in the stunning House of Drag mansion!\",\"seriesName\":\"House
+        of Drag\",\"slug\":\"house-of-drag\",\"status\":\"Continuing\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":null,\"id\":353327,\"network\":null,\"seriesName\":\"Houseki
+        no kuni\",\"slug\":\"houseki-no-kuni\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/5b75d3b62f681.jpg\",\"firstAired\":\"2018-8-16\",\"id\":351535,\"network\":\"\u0422\u041D\u0422\",\"seriesName\":\"House
+        Arrest (Domashniy Arest)\",\"slug\":\"domashniy-arest\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/5b744ae041d0f.jpg\",\"firstAired\":\"2018-8-6\",\"id\":351411,\"network\":\"SBS
+        6\",\"seriesName\":\"House of Talent\",\"slug\":\"house-of-talent\",\"status\":\"Continuing\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":null,\"id\":349863,\"network\":null,\"seriesName\":\"House
+        Cook Master Baek\",\"slug\":\"house-cook-master-baek\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":null,\"id\":349798,\"network\":null,\"seriesName\":\"House
+        In A Box\",\"slug\":\"house-in-a-box2\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":null,\"id\":347165,\"network\":null,\"seriesName\":\"House
+        In A Box\",\"slug\":\"house-in-a-box\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/347107-1.jpg\",\"firstAired\":\"2005-3-9\",\"id\":347107,\"network\":\"D8\",\"seriesName\":\"House
+        of Crades\",\"slug\":\"347107\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2016-5-26\",\"id\":344433,\"network\":\"ABC2\",\"overview\":\"Housemates
+        uncovers the unique, unusual, and sometimes crazy ways Australians have made
+        share housing work. Series 1 consisted of 3 episodes and was available to
+        stream from iView. Series 2 aired 5 episodes on ABC2, plus were made available
+        to stream on iView.\",\"seriesName\":\"Housemates\",\"slug\":\"344433\",\"status\":\"Continuing\"},{\"aliases\":[],\"banner\":\"/banners/posters/340560-1.jpg\",\"firstAired\":\"2018-1-9\",\"id\":340560,\"network\":\"BBC
+        Two\",\"overview\":\"Saudi Arabia stands at a crucial crossroads facing unprecedented
+        change. The Kingdom has long enjoyed seemingly inexhaustible wealth and untold
+        power and influence. But the House of Saud is accused of spreading extremist
+        ideology and even supporting violent extremists. This series looks at the
+        challenges facing the new Crown Prince, 32-year-old Mohammed bin Salman, who
+        has pledged to transform the country.\",\"seriesName\":\"House of Saud: A
+        Family at War\",\"slug\":\"house-of-saud-a-family-at-war\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/339231-1.jpg\",\"firstAired\":\"2017-12-11\",\"id\":339231,\"network\":\"HGTV\",\"overview\":\"Couples
+        search for nontraditional structures to convert into homes.\",\"seriesName\":\"House
+        Hunters: Outside the Box\",\"slug\":\"339231\",\"status\":\"Continuing\"},{\"aliases\":[],\"banner\":\"/banners/posters/335469-1.jpg\",\"firstAired\":\"1997-11-2\",\"id\":335469,\"network\":\"CBS\",\"overview\":\"Detective
+        Coyle is trying to solve several bizarre murders and is having no luck finding
+        a suspect. But when his girlfriend turns into a werewolf and gets kidnapped
+        by a vampire, things start to fall into place.\",\"seriesName\":\"House of
+        Frankenstein\",\"slug\":\"house-of-frankenstein\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/5ba37d15af343.jpg\",\"firstAired\":\"2017-8-21\",\"id\":334238,\"network\":\"VIER\",\"overview\":\"Reality
+        show in which real estate agents hunt for some of the nicest houses in Flanders.\",\"seriesName\":\"House
+        Hunters\",\"slug\":\"334238\",\"status\":\"Continuing\"},{\"aliases\":[],\"banner\":\"/banners/posters/332934-1.jpg\",\"firstAired\":\"2017-7-31\",\"id\":332934,\"network\":\"HGTV\",\"overview\":\"Searching
+        for the perfect home is a challenge. And when you consider an entire family's
+        needs, it's even harder. For the first time ever, the whole family is getting
+        involved. On House Hunters Family , the parents and their kids house hunt
+        together to select which house suits them best. But kids have minds of their
+        own and they will certainly make their opinions heard. Will the whole family
+        agree on which house to choose? Find out on House Hunters Family.\",\"seriesName\":\"House
+        Hunters Family\",\"slug\":\"house-hunters-family\",\"status\":\"Continuing\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2017-8-12\",\"id\":332910,\"network\":null,\"seriesName\":\"House
+        Hunters Asia\",\"slug\":\"house-hunters-asia\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2016-6-26\",\"id\":331579,\"network\":\"TVN\",\"seriesName\":\"House
+        Crashers (PL)\",\"slug\":\"331579\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2016-8-27\",\"id\":330303,\"network\":null,\"seriesName\":\"House
+        Hunters International Renovation\",\"slug\":\"house-hunters-international-renovation\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/329819-1.jpg\",\"firstAired\":\"2012-12-17\",\"id\":329819,\"network\":\"HGTV\",\"overview\":\"You've
+        seen which one they chose, but what happens to the house hunters after they
+        buy? From incredible renovations to new additions and relocations, even total
+        rebuilds! Follow along as we check in on memorable House Hunters families
+        to see what happened after they found the perfect \u2014 or not-so-perfect
+        \u2014 place.\\r\\n\\r\\nhttp://www.hgtv.com/shows/house-hunters-where-are-they-now\",\"seriesName\":\"House
+        Hunters: Where Are They Now?\",\"slug\":\"house-hunters-where-are-they-now\",\"status\":\"Continuing\"},{\"aliases\":[],\"banner\":\"/banners/posters/327627-1.jpg\",\"firstAired\":\"2017-4-24\",\"id\":327627,\"network\":\"Nine
+        Network\",\"overview\":\"House of Bond is a dramatised account of the life
+        of Alan Bond, from the 1960s to the 2000s. \\r\\n\\r\\nThe outrageous rags-to-riches-to-rags
+        tale of controversial business tycoon Alan Bond and how he fought his way
+        from the back alleys of Fremantle to become the richest man in Australia and
+        one of our greatest sporting heroes.\\r\\n\\r\\nPart One details Bond\u2019s
+        prominence as a property investor and entrepreneur finishing with his greatest
+        triumph as head of the syndicate that won the 1983 America\u2019s Cup. Part
+        Two sees him expand on a global scale before his hubris saw his empire spectacularly
+        falling down becoming embroiled in a number of WA Inc. scandals including
+        the bailout of the Rothwells Bank and the stripping of Bell Resources.\",\"seriesName\":\"House
+        of Bond\",\"slug\":\"house-of-bond\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":null,\"id\":324647,\"network\":null,\"seriesName\":\"House
+        Hunters International: Best of Mexico\",\"slug\":\"house-hunters-international-best-of-mexico\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/324523-1.jpg\",\"firstAired\":\"2017-2-24\",\"id\":324523,\"network\":\"TTV\",\"seriesName\":\"House
+        of Toy Bricks\",\"slug\":\"house-of-toy-bricks\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":null,\"id\":323582,\"network\":null,\"seriesName\":\"House
+        Hunters International: Best of Italy\",\"slug\":\"house-hunters-international-best-of-italy\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":null,\"id\":323581,\"network\":null,\"seriesName\":\"House
+        Hunters International: Best of Australia\",\"slug\":\"house-hunters-international-best-of-australia\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":null,\"id\":323580,\"network\":null,\"seriesName\":\"House
+        Hunters International Best of France\",\"slug\":\"house-hunters-international-best-of-france\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2016-12-14\",\"id\":321151,\"network\":\"Canale
+        5\",\"seriesName\":\"House Party\",\"slug\":\"321151\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/308494-1.jpg\",\"firstAired\":\"2015-10-21\",\"id\":308494,\"network\":\"Tokyo
+        Broadcasting System\",\"overview\":\"Taro (Joe Odagiri) struggles to keep
+        open a small candy store run by his grandmother, Akiko (Kaoru Yachigusa),
+        and himself. Taro\u2019s parents died when he was young and he was then raised
+        by his grandparents. There are supporters of the small candy store including
+        Taro's neighbor and bath house operator Akira (Kyusaku Shimada) and Taro\u2019s
+        friend Hiroki (Ryo Katsuji).  While eating candies, they talk about silly
+        things with Taro. \\r\\n\\r\\nTaro meets again Reiko (Machiko Ono). She is
+        a childhood friend. After Reiko divorced, she returned with her son to the
+        neighborhood where she grew up.\",\"seriesName\":\"House of Sweets\",\"slug\":\"308494\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2015-9-7\",\"id\":301510,\"network\":\"BBC
+        One\",\"overview\":\"Following the staff at Belfast's Charles Hurst dealership,
+        the largest car lot in Europe, as they attempt to hit their sales targets\",\"seriesName\":\"House
+        of Cars (2015)\",\"slug\":\"house-of-cars-2015\",\"status\":\"Ended\"},{\"aliases\":[\"Okashi
+        no Ie\"],\"banner\":\"/banners/posters/301441-1.jpg\",\"firstAired\":\"2015-10-21\",\"id\":301441,\"network\":\"Tokyo
+        Broadcasting System\",\"overview\":\"Sakurai Taro (Odagiri Joe) lost his parents
+        early and has always lived with his grandmother Akiko (Yachigusa Kaoru) in
+        their little sweets store, Sakuraya in old parts of Tokyo. They're struggling
+        to keep it in business and Taro idly spends most of his time with neighbourhood
+        friend, Saegusa Hiroki (Katsuji Ryo), who's an aspiring scriptwriter, and
+        regular customers like bathhouse manager Shimasaki Akira (Shimada Kyusaku).
+        One Day Taro's childhood friend Kimura Reiko (Ono Machiko), who is now a single
+        mother, comes back to the neighbourhood after a divorce...\",\"seriesName\":\"House
+        of Sweets\",\"slug\":\"house-of-sweets\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/300178-1.jpg\",\"firstAired\":\"2015-9-1\",\"id\":300178,\"network\":\"NET
+        5\",\"overview\":\"In House Rules NL we follow five Dutch couples who rigorously
+        renovate each other's houses. The main prize: two years of mortgage-free living!
+        Presenter Airen Mylene keeps a close eye on everything and a professional
+        jury determines the winning couple together with the viewers. If you missed
+        an episode, check it out here!\",\"seriesName\":\"House Rules NL  \",\"slug\":\"300178\",\"status\":\"Continuing\"},{\"aliases\":[],\"banner\":\"/banners/posters/296728-1.jpg\",\"firstAired\":\"2015-6-14\",\"id\":296728,\"network\":\"TV
+        One (NZ)\",\"overview\":\"Is the Kiwi dream of owning your own home still
+        a reality or just a fast fading dream?\\r\\n\\r\\nHouse Hunt is a heartfelt
+        new observational series that follows the journeys of diverse couples, families
+        and friends from all walks of life as they struggle to achieve the near impossible
+        \u2013 to buy their first home in New Zealand\u2019s overheated property markets.\\r\\n\\r\\nHouse
+        Hunt chronicles the range of emotions that face New Zealand\u2019s first home
+        buyers; from desperate open home searches and multiple failed auctions, last
+        minute financial challenges and inevitable relationship conflict, to the exhaustion
+        and elation of home buying success, or the devastation of missing out.\\r\\n\\r\\nHome
+        affordability has never been such a topical issue, and with episodes filmed
+        up and down the country, House Hunt also looks at the varied issues facing
+        first home buyers in different regions.\",\"seriesName\":\"House Hunt\",\"slug\":\"house-hunt\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2012-10-19\",\"id\":293351,\"network\":null,\"overview\":\"MTV's
+        webseries reboot of the iconic 90's MTV show House of Style.\",\"seriesName\":\"House
+        of Style\",\"slug\":\"house-of-style\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/291815-1.jpg\",\"firstAired\":\"2015-2-8\",\"id\":291815,\"network\":\"Nine
+        Network\",\"overview\":\"House of Hancock tells the epic true story of the
+        Hancock dynasty and the bizarre love triangle that emerged between Lang Hancock,
+        his daughter Gina Rinehart and his beautiful Filipina housekeeper Rose Lacson.\",\"seriesName\":\"House
+        of Hancock\",\"slug\":\"house-of-hancock\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2011-10-13\",\"id\":291674,\"network\":null,\"seriesName\":\"
+        House Hunters: Bachelor Pads\",\"slug\":\"house-hunters-bachelor-pads\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":null,\"id\":289711,\"network\":null,\"seriesName\":\"Househusbands
+        of Hollywood\",\"slug\":\"househusbands-of-hollywood\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/288520-1.jpg\",\"firstAired\":\"2014-11-23\",\"id\":288520,\"network\":\"Discovery
+        MAX\",\"seriesName\":\"House of Cars\",\"slug\":\"house-of-cars\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/287468-1.jpg\",\"firstAired\":\"2014-11-2\",\"id\":287468,\"network\":\"E!\",\"overview\":\"The
+        fashion megastar who created gorgeous prints and the sexy, figure-flattering
+        wrap dress worn by Kate Middleton, Michelle Obama and Madonna,  and who shines
+        as a beacon of power and independence to women everywhere has partnered with
+        E! to bring viewers unprecedented access to her latest fashion industry game
+        changer.  Diane von Furstenberg gives a group of ambitious young women extraordinary
+        entr\xE9e to her empire, for a weeks-long ultimate interview that will prepare
+        one of them to take on the world of fashion and ascend to the prized DVF Global
+        Brand Ambassador position.  \u201CHouse of DVF\u201D grants viewers exclusive
+        access inside Diane von Furstenberg\u2019s stylish world, showcasing the unique
+        skill set, intelligence and utter devotion it takes to become a DVF girl,
+        and E! will be there to film the entire process.\\r\\n\",\"seriesName\":\"House
+        of DVF\",\"slug\":\"house-of-dvf\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":null,\"id\":287378,\"network\":\"FYI\",\"overview\":\"House
+        vs. House is a new home makeover competition series where amateur and experienced
+        renovation teams compete for the chance to win $10,000 by proving they can
+        create the better DIY projects in their home. From painting and decorating,
+        to one-of-a-kind, imaginative projects, each episode features two teams will
+        go head-to-head in grueling challenges. Tanya McQueen, a DIY design expert,
+        and David Brian Sanders, an architect and designer, will determine which team
+        completes the most impressive transformation and award the cash prize.\",\"seriesName\":\"House
+        vs. House\",\"slug\":\"house-vs-house\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2010-9-22\",\"id\":282459,\"network\":\"MBC
+        Plus Media\",\"seriesName\":\"Housewife Kim Kwang Ja's 3rd Activities\",\"slug\":\"housewife-kim-kwang-jas-3rd-activities\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/279540-2.jpg\",\"firstAired\":\"2014-2-26\",\"id\":279540,\"network\":\"Investigation
+        Discovery\",\"overview\":\"HOUSE OF HORRORS: KIDNAPPED tells the gripping
+        stories of people who were kidnapped and lived to tell. Each episode reveals
+        one survivor\u2019s terrifying experience from the moment of abduction to
+        the hours, days, or months of captivity to the escape and recovery, as told
+        through their eyes.\",\"seriesName\":\"House of Horrors: Kidnapped\",\"slug\":\"house-of-horrors-kidnapped\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/277170-1.jpg\",\"firstAired\":\"2014-3-31\",\"id\":277170,\"network\":\"MTV\",\"overview\":\"A
+        drama-infused take on food TV where a group of young aspiring chefs with no
+        formal culinary training are put to the ultimate challenge. The series combines
+        the exciting real-life competitive elements of culinary school with the dramatic
+        setting of a house reality show. The students have been chosen for their passion
+        for cooking and food culture, and their backgrounds are as varied as their
+        personalities. With three of the country\u2019s best chefs as their teachers
+        and the city of Los Angeles as their classroom, this determined group will
+        live and learn together but only one will win an apprenticeship of a lifetime.
+        \",\"seriesName\":\"House of Food\",\"slug\":\"house-of-food\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/276173-2.jpg\",\"firstAired\":\"2014-1-14\",\"id\":276173,\"network\":\"BBC
+        Two\",\"overview\":\"Set in Bob Mortimer\u2019s home, every episode of House
+        Of Fools sees Bob frustrated by his uninvited lodgers, visitors and guests
+        who constantly fill his house. Led by Vic - Beef, Bosh and Julie knit together
+        each week to wreak havoc on Bob.\\r\\n\\r\\nVic Reeves is the long term and
+        mostly unwanted guest in Bob\u2019s house, always treating the place like
+        his own, with little regard for Bob\u2019s wishes. Living alongside them is
+        Bob\u2019s Norwegian son, Erik, who has absolutely no time at all for his
+        \u2018moron\u2019 father and next door is Julie, who lives in a haze of imagined
+        fantasies. Adding to the chaos is a constant stream of unwelcome visitors
+        to Vic and Bob\u2019s flat. Amongst them is Beef a lady-obsessed lothario,
+        not to be confused with Bosh, a Geordie ex-con, who has designs on moving
+        in as well.\",\"seriesName\":\"House of Fools\",\"slug\":\"house-of-fools\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":null,\"id\":274386,\"network\":null,\"overview\":\"Dr
+        Nayna Patel runs a clinic in rural India that attracts childless couples from
+        all over the world. For a fee, they can pay for local women to act as surrogates,
+        spending their entire pregnancy away from home in dorms with up to 80 other
+        pregnant surrogates living alongside them.\\r\\n\\r\\nThere are three babies
+        delivered every month at the clinic, but that's not the end of the story -
+        Westerners can have to stay up to eight weeks in India after the baby is born
+        waiting for the paperwork they need to take their baby home and many of them
+        choose to have their surrogate look after and wet-nurse the baby for them
+        until then.\\r\\n\\r\\nWhile critics accuse Dr Patel of exploiting the poor,
+        she believes that she is empowering the local women with life-changing amounts
+        of money.\\r\\n\",\"seriesName\":\"House of Surrogates\",\"slug\":\"house-of-surrogates\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2013-7-18\",\"id\":273405,\"network\":null,\"overview\":\"NUVOtv\u2019s
+        new docu-series \\\"House of Joy\\\" invites viewers into Grammy-winning producer
+        Rodney \u201CDarkchild\u201D Jerkins\u2018 studio and his always-busting Hollywood
+        home, which he shares with pop star wife Joy Enriquez, the couple\u2019s children
+        and Joy\u2019s family.\\r\\n\\r\\nThe pressure is on Rodney, the master musicologist
+        behind worldwide hits by Jennifer Lopez, Beyonce, Michael Jackson and Lady
+        Gaga, to score a pop smash for his talented wife. Meanwhile, Joy\u2019s mom
+        and dad, Helena and Randy (right), routinely check in to provide emotional
+        support and dole out domestic advice in an engaging and often very funny old
+        school-meets-contemporary cool kind of way. The insightful duo could easily
+        have their own standup act if they didn\u2019t already have a full-time gig
+        helping to keep \u201CDarkchild\u201D Manor in check as Rodney sets the stage
+        for Joy to reignite her musical dream.\",\"seriesName\":\"House of Joy\",\"slug\":\"house-of-joy\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2013-6-13\",\"id\":271248,\"network\":\"WE
+        tv\",\"overview\":\"Kenyatta Jones, an Atlanta-based fashion designer who
+        specializes in designing clothes for plus-size women, is the CEO of clothing
+        boutique Bella Ren\xE9, named after her mother and main investor. Jones and
+        her team, which includes her two close friends from college and an assistant
+        with attitude, go to great lengths to expand the brand, but mishaps and in-house
+        bickering hinder the dream. The ultimate test comes when the team competes
+        for recognition in one of the world's top cities for fashion: New York.\",\"seriesName\":\"House
+        of Curves\",\"slug\":\"house-of-curves\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/269795-1.jpg\",\"firstAired\":\"2013-5-14\",\"id\":269795,\"network\":\"Seven
+        Network\",\"overview\":\"Six Aussie teams put their homes on the line and
+        their skills to the test in a fight for renovation supremacy and a life-changing
+        prize. Teams will travel the country, hand over the keys to their homes and
+        leave their competition rivals to transform every room in their house any
+        way they want! It's the key to a whole new life. But will it open the door
+        to their dreams or their worst nightmare? In a brand-new season, renovation
+        meets innovation with aspirational reveals which will inspire and educate
+        like never-before.\",\"seriesName\":\"House Rules (AU)\",\"slug\":\"house-rules-au\",\"status\":\"Continuing\"},{\"aliases\":[],\"banner\":\"/banners/posters/265487-1.jpg\",\"firstAired\":\"2001-11-21\",\"id\":265487,\"network\":\"Channel
+        4\",\"overview\":\"The adventures of a group of dead rock stars, sharing a
+        house in the afterlife.\",\"seriesName\":\"House of Rock\",\"slug\":\"house-of-rock\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2012-10-16\",\"id\":263281,\"network\":\"HGTV\",\"seriesName\":\"House
+        Hazards\",\"slug\":\"house-hazards\",\"status\":\"Ended\"},{\"aliases\":[\"House
+        of Cards (2013)\",\"\u7D19\u724C\u5C4B\"],\"banner\":\"/banners/posters/262980-3.jpg\",\"firstAired\":\"2013-2-1\",\"id\":262980,\"network\":\"Netflix\",\"overview\":\"Ruthless
+        and cunning, Congressman Francis Underwood and his wife Claire stop at nothing
+        to conquer everything. This wicked political drama penetrates the shadowy
+        world of greed, sex and corruption in modern D.C.\",\"seriesName\":\"House
+        of Cards (US)\",\"slug\":\"house-of-cards-us\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/262643-2.jpg\",\"firstAired\":\"2012-9-23\",\"id\":262643,\"network\":\"HGTV\",\"overview\":\"In
+        this new weekly series, HGTV's House Hunters Renovation follows potential
+        home buyers as they tour three for-sale homes and choose the one that is the
+        perfect fixer-upper. In a House Hunters first, HGTV cameras also capture what
+        happens after the home is purchased and the renovation project begins. Each
+        episode features the new homeowners as they renovate and then reveal their
+        new space.\",\"seriesName\":\"House Hunters Renovation\",\"slug\":\"house-hunters-renovation\",\"status\":\"Continuing\"},{\"aliases\":[],\"banner\":\"/banners/posters/262026-1.jpg\",\"firstAired\":\"2012-9-2\",\"id\":262026,\"network\":\"Nine
+        Network\",\"overview\":\"House Husbands centres around four families with
+        one thing in common, the husbands stay home to raise the children.\",\"seriesName\":\"House
+        Husbands\",\"slug\":\"house-husbands\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/259372-1.jpg\",\"firstAired\":\"2010-1-7\",\"id\":259372,\"network\":\"HGTV
+        Canada\",\"overview\":\"Five years have passed since Bryan and Sarah built
+        their custom dream home in the city. Always up for a new challenge, Bryan
+        and Sarah are back at building again - But this time, they\u2019re uprooting
+        their growing family from the city to the gritty countryside. And breaking
+        Bryan\u2019s cardinal rule of home-building\u2013 Never, ever live on site
+        during a renovation!\\r\\n\\r\\nWhile they love their city home, it turns
+        out Bryan has always dreamed of returning to his small town roots to raise
+        his kids in the vast, open spaces of the country. His wife Sarah on the other
+        hand, fashions herself a city girl. Watch as Sarah and Bryan go head to head
+        on their individual visions of their home, and cope with a dramatic lifestyle
+        change as they say goodbye to the comfortable conveniences of city life.\",\"seriesName\":\"House
+        of Bryan\",\"slug\":\"house-of-bryan\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2011-9-9\",\"id\":258659,\"network\":null,\"seriesName\":\"House
+        Ibiza\",\"slug\":\"258659\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/258575-1.jpg\",\"firstAired\":\"2012-4-5\",\"id\":258575,\"network\":\"TVB\",\"seriesName\":\"House
+        of Harmony \\u0026 Vengeance\",\"slug\":\"house-of-harmony-and-vengeance-1\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2012-3-18\",\"id\":256439,\"network\":\"VH1\",\"overview\":\"\u201CHouse
+        of Consignment\u201D is a new 10 episode, half-hour reality series featuring
+        Chicago entrepreneur and fashion maven, Corri McFadden, and her mission to
+        improve the way women shop. By working with high-end clients at her sleek,
+        Lincoln Park retail store, eDrop-Off, Corri\u2019s consignment business turns
+        luxury brand items into profit. What began as Corri\u2019s senior project
+        in fashion design school has turned her into a young, successful business
+        woman and owner of a booming multi-million dollar company. Watch as Corri
+        and her team of twenty-something fashionistas change the face of the consignment
+        world on a daily basis.\\r\\nThe show takes the cliche about \u201COne man\u2019s
+        trash being another man\u2019s treasure\u201D and turns the trash, in this
+        case Fendi bags and Jimmy Choos, into cash. Using her innate sense of style
+        and business savvy, Corri McFadden resells high-end fashion items that have
+        been rescued from her wealthy clients\u2019 overflowing closets. Billed as
+        \u201Cpart intervention, part fashion lesson\u201D, it\u2019s also part interactive
+        shopping experience, because viewers will be able to bid on certain items
+        seen the show throughout the season.\",\"seriesName\":\"House of Consignment\",\"slug\":\"house-of-consignment\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/253261-2.jpg\",\"firstAired\":\"2011-11-24\",\"id\":253261,\"network\":\"bTV\",\"seriesName\":\"House
+        Arrest\",\"slug\":\"house-arrest\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2009-10-1\",\"id\":253190,\"network\":null,\"overview\":\"House
+        Wreck Rescue has searched out the ordinary people who have dared to turn their
+        dream of developing a tumbledown barn or romantic ruin into reality. There
+        are over a million empty properties in Britain, just waiting to be transformed
+        into spectacular homes. In a property market that leaves no room for error,
+        trying to turn a wreck into a hot property is anything but easy. For nearly
+        three years, families, property developers and first time buyers risk their
+        relationships, businesses and a whole lot of money attempting to rescue their
+        wrecks. From trouble with builders to bankers, they\u2019ll be up against
+        it. Whether it\u2019s a dovecote, a windmill or even a fishing trawler, House
+        Wreck Rescue will see if they\u2019ve got what it takes. And they won\u2019t
+        be alone \u2013 our two property experts, Zilpah and Gary are on hand to offer
+        their advice and support a long the way. With imagination and drive, almost
+        any property can be transformed from a wreck into a real gem.\",\"seriesName\":\"House
+        Wreck Rescue\",\"slug\":\"house-wreck-rescue\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":null,\"id\":252016,\"network\":null,\"overview\":\"New
+        series. Documentary following British estate agents hoping to sell families
+        a dream life in south-west France, showing prospective buyers around properties
+        in an area renowned for its vineyards and chateaux.\",\"seriesName\":\"House
+        Hunt in France\",\"slug\":\"house-hunt-in-france\",\"status\":\"Continuing\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2011-6-6\",\"id\":251048,\"network\":\"HGTV\",\"overview\":\"In
+        this House Hunters spinoff series, HGTV gives lucky families the chance to
+        stay in an incredible vacation home for a week. In each half-hour episode,
+        we'll whisk away a family to a beautiful vacation destination to kick back,
+        relax and explore all of the area's activities. Once they arrive at their
+        destination, host Taniya Nayak takes the family to tour spectacular homes
+        chosen just for them. The question the family and viewers must answer: Which
+        home would they like to stay in for a week? It will be a tough decision, as
+        every property will offer incredible yet different features. \",\"seriesName\":\"House
+        Hunters on Vacation\",\"slug\":\"house-hunters-on-vacation\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/247909-6.jpg\",\"firstAired\":\"2012-1-8\",\"id\":247909,\"network\":\"Showtime\",\"overview\":\"Charming,
+        fast talking Marty Kaan and his crack team of management consultants know
+        how to play the corporate game better than anyone, by using every dirty trick
+        in the book to woo powerful CEOs and close huge deals. In the board rooms,
+        barrooms and bedrooms of the power elite, corruption is business as usual
+        and everyone's out for themselves first. Nothing is sacred in this scathing,
+        irreverent satire of corporate America today. Outrageous, subversive and wildly
+        funny, HOUSE OF LIES stars Academy Award\xAE nominee Don Cheadle and Kristen
+        Bell.\",\"seriesName\":\"House of Lies\",\"slug\":\"house-of-lies\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/219621-1.jpg\",\"firstAired\":\"2011-1-1\",\"id\":219621,\"network\":\"Nickelodeon\",\"overview\":\"The
+        hit series known around the world comes to US television. At an exclusive
+        boarding school in England a girl named Joy goes missing. And taking her place
+        is American named Nina. Patricia, who now has to share a room with Nina thinks
+        Nina has something to do with it. But, there are more secrets to be uncovered
+        in House of Anubis.\",\"seriesName\":\"House of Anubis\",\"slug\":\"house-of-anubis\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2010-10-5\",\"id\":211481,\"network\":\"Oxygen\",\"overview\":\"B
+        Lynn Group is one of the hottest image agencies in the entertainment business:
+        agents to the top fashion stylists, makeup artists and hairstylists around--with
+        Brandi Simpkins at the helm. The House of Glam docu-series features her and
+        her team.\\r\\n\\r\\nThese fashion stylists, makeup artists and hairstylists
+        to the stars specialize in cooking up original and unforgettable looks for
+        some of the biggest names in music and fashion--so they stand out in Hollywood
+        and beyond. And this show takes you through the chaotic days of trying to
+        please demanding clients, taking you behind the scenes of their magazine-glossy
+        world. But don't forget the drama! After all, this show is about more than
+        what to wear: The cast is not only comprised of colleagues, but also best
+        friends and fierce rivals. \",\"seriesName\":\"House Of Glam\",\"slug\":\"house-of-glam\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/183411-1.jpg\",\"firstAired\":\"2006-2-20\",\"id\":183411,\"network\":\"HGTV\",\"overview\":\"This
+        spinoff of the wildly popular HGTV House Hunters globe trots from Sao Paolo
+        to Prague. Home hunters and their real estate agents check out all sorts of
+        architectural styles and work through the idiosyncrasies of buying real estate
+        in other countries. In any language, home buying is not an emotional experience.\",\"seriesName\":\"House
+        Hunters International\",\"slug\":\"house-hunters-international\",\"status\":\"Continuing\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2010-2-22\",\"id\":165081,\"network\":\"BBC
+        One\",\"overview\":\"Laurence Llewelyn-Bowen visits three houses per county,
+        of all shapes and size, in the competition to find Northern Ireland's House
+        of the Year.\",\"seriesName\":\"House of the Year\",\"slug\":\"house-of-the-year\",\"status\":\"Ended\"},{\"aliases\":[\"Sarai-ya
+        Goy\u014D\",\"Sarai-ya Goyou\"],\"banner\":\"/banners/posters/156821-4.jpg\",\"firstAired\":\"2010-4-16\",\"id\":156821,\"network\":\"Fuji
+        TV\",\"overview\":\"Masterless samurai Akitsu Masanosuke is a skilled and
+        loyal swordsman, but his na\xEFve, diffident nature has time and again caused
+        him to be let go by the lords who have employed him. Hungry and desperate,
+        he becomes a bodyguard for Yaichi, the charismatic leader of a gang called
+        \\\"Five Leaves.\\\" Although disturbed by the gang's sinister activities,
+        Masa begins to suspect that Yaichi's motivations are not what they seem. And
+        despite his misgivings, the deeper he's drawn into the world of the Five Leaves,
+        the more he finds himself fascinated by these devious, mysterious outlaws.\",\"seriesName\":\"House
+        of Five Leaves\",\"slug\":\"house-of-five-leaves\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/153311-2.jpg\",\"firstAired\":\"2009-09-29\",\"id\":153311,\"network\":null,\"seriesName\":\"House
+        of Anubis (DE)\",\"slug\":\"house-of-anubis-2009\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/151451-1.jpg\",\"firstAired\":\"2006-10-2\",\"id\":151451,\"network\":\"E!\",\"overview\":\"Backstreet
+        Boy Nick Carter tries to reunite his family by living together in one house
+        with his four younger siblings, including pop star Aaron Carter, for the first
+        time in years. After years of separation and plenty of family trouble (including
+        their parents' acrimonious divorce, Nick's arrest\u2026 More for DUI, and
+        Aaron's lawsuit against his own mother), the five Carter kids try to reconnect
+        as a family while pursuing their own separate career and life goals.\",\"seriesName\":\"House
+        of Carters\",\"slug\":\"house-of-carters\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2006-10-12\",\"id\":124551,\"network\":\"ITV\",\"overview\":\"Bafta-winning
+        drama based on a true story, written by and starring Victoria Wood. Downtrodden
+        wife and mother Nella's life takes an unexpected turn for the better after
+        she joins the Women's Voluntary Service office in Barrow-in-Furness during
+        the Second World War. However, her new-found happiness is shattered when her
+        son Cliff leaves to join the troops - provoking a painful confrontation with
+        husband Will. David Threlfall and Stephanie Cole co-star.\",\"seriesName\":\"Housewife,
+        49\",\"slug\":\"housewife-49\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2003-1-1\",\"id\":124171,\"network\":null,\"overview\":\"Gregg
+        Kendall and Mandy Kraike are leaving London life behind to design and project-manage
+        the building of a smart and sophisticated houseboat.\",\"seriesName\":\"Houseboat\",\"slug\":\"houseboat\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":null,\"id\":122951,\"network\":null,\"overview\":\"Three
+        experts are challenged to find the perfect item to complement a home on budgets
+        of \xA31,000, \xA3300 and \xA380, before the owner decides which object to
+        keep. \",\"seriesName\":\"House Gift\",\"slug\":\"house-gift\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/images/missing/series.jpg\",\"firstAired\":\"2009-8-18\",\"id\":110461,\"network\":\"MTV\",\"overview\":\"This
+        show follows Jazmin Whitley, a 20-year-old aspiring fashion designer, as she
+        pursues her career and her fashion line, \\\"Li Cari,\\\" while also balancing
+        the typical life of a teenager.\",\"seriesName\":\"House of Jazmin\",\"slug\":\"house-of-jazmin\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/108331-1.jpg\",\"firstAired\":\"2009-8-5\",\"id\":108331,\"network\":\"DIY
+        Network\",\"overview\":\"HGTV and DIY Network build on the success of the
+        hit show Yard Crashers by taking this series inside. House Crashers is ambush
+        renovation at its best. Host and contractor Josh Temple stalks a big-box home
+        improvement store looking for unsuspecting weekend warriors, then follows
+        them home with a large crew of experts in tow. Watch as stunned homeowners
+        who journeyed into the store to fix a simple leaky faucet end up winning the
+        remodeling lottery with dramatic, eye-popping room transformations.\",\"seriesName\":\"House
+        Crashers\",\"slug\":\"house-crashers\",\"status\":\"Ended\"},{\"aliases\":[\"Het
+        Huis Anubis\"],\"banner\":\"/banners/posters/97051-2.jpg\",\"firstAired\":\"2006-9-26\",\"id\":97051,\"network\":\"Nickelodeon\",\"overview\":\"In
+        a building dating from 1900, currently serving as a boarding school, eight
+        young people live together under the leadership of the strict landlord, Victor.
+        When newcomer Nienke moves into the house, another resident, Joyce, suddenly
+        disappears. Joyce's best friend, Patricia doesn't trust Nienke and forces
+        her to spend a night in the attic.There, Nienke makes a bizarre discovery:
+        the recorded diary of a young girl, Sarah, who lived in the house, many years
+        before. Sarah's parents were archaeologists in Egypt who mysteriously died.
+        On the tapes, it is revealed the house has a secret history, a mystery that
+        nobody knows anything about. She decides to investigate, together with fellow
+        resident Fabian and her roommate, Amber. Meanwhile, Patricia searches for
+        answers about Joyce's disappearance, while other residents have their own
+        problems to deal with.\\r\\nWhile each resident has their own way of dealing
+        with school, friends, love and growing up, the teens bond together to search
+        for the treasure hidden within Het Huis Anubis (The House of Anubis) .\",\"seriesName\":\"The
+        House of Anubis (NL)\",\"slug\":\"house-of-anubis-nl\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/90651-2.jpg\",\"firstAired\":\"2008-3-19\",\"id\":90651,\"network\":\"LifeStyle\",\"overview\":\"The
+        series follows property owners who are having difficulty selling their home.
+        The show is hosted by property expert Andrew Winter, who is joined by landscaper
+        Charlie Albone, and interior designer Shaynna Blaze. The team initially assess
+        the property, and then proceed with a renovation to boost the property's appeal
+        and salability. The property is then put up for sale and the result is shown
+        at the end of each episode.\",\"seriesName\":\"Selling Houses Australia\",\"slug\":\"selling-houses-australia\",\"status\":\"Continuing\"},{\"aliases\":[],\"banner\":\"/banners/posters/85109-1.jpg\",\"firstAired\":\"2005-3-25\",\"id\":85109,\"network\":\"ABC
+        (US)\",\"overview\":\"This new retelling of the ever popular Laura Ingalls
+        Wilder books chronicles Charles Ingalls and his decision to uproot his family
+        and move from their Wisconsin home to a new plot of land in Kansas. Their
+        journey is full of danger and peril as they encounter rough terrain, wild
+        animals and complete isolation. For young Laura and Mary Ingalls this new
+        world is magical and full of adventure.\",\"seriesName\":\"Little House on
+        the Prairie (2005) \",\"slug\":\"little-house-on-the-prairie-2005\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/84959-1.jpg\",\"firstAired\":\"2009-1-15\",\"id\":84959,\"network\":\"VH1\",\"overview\":\"Sober
+        House is a continuation of Celebrity Rehab, in which celebrities with substance
+        addictions transition from a drug-rehabilitation center to a less structured,
+        drug-free, sober living home, which is housed in a mansion in the Hollywood
+        Hills. The facility, at which the recovering addicts stay for 30 days, is
+        run by House Manager Jennifer Gimenez and rehab tech Will Smith, a former
+        stuntman. Bob Forrest serves as the head counselor. Dr. Drew Pinsky provides
+        outpatient counseling to the recovering addicts during their time in the house.\",\"seriesName\":\"Sober
+        House\",\"slug\":\"sober-house\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/84228-2.jpg\",\"firstAired\":\"2008-12-22\",\"id\":84228,\"network\":\"BBC
+        Four\",\"overview\":\"A ghost story about a cursed house. The cursed house
+        - Geap Manor - weaves together three ghost stories set during Georgian times,
+        the 1920s and the present day.\",\"seriesName\":\"Crooked House\",\"slug\":\"crooked-house\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/84193-1.jpg\",\"firstAired\":\"1999-9-22\",\"id\":84193,\"network\":\"Channel
+        4\",\"overview\":\"The Bowlers, a thoroughly modern family of six, were selected
+        from over 400 families around the UK, to embark on a unique time travel journey
+        to 1900. For three months they swap the luxury of 1999 for a life of urban
+        Victorian domesticity.\",\"seriesName\":\"1900 House (UK)\",\"slug\":\"1900-house-uk\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/84079-1.jpg\",\"firstAired\":\"2008-12-9\",\"id\":84079,\"network\":\"Channel
+        4\",\"overview\":\"This new reality series takes the old Ramsay's Kitchen
+        Nightmares format and applies it the stately homes of England,\",\"seriesName\":\"Country
+        House Rescue\",\"slug\":\"country-house-rescue\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/82200-1.jpg\",\"firstAired\":\"1988-2-21\",\"id\":82200,\"network\":\"NBC\",\"overview\":\"Ian
+        Struan Dunross is chairman of Struan \\u0026 Co, the oldest and largest of
+        the British-East Asia trading companies. To the Chinese, that also makes him
+        \\\"Tai-Pan\\\" (\\\"supreme leader\\\") of the \\\"Noble House\\\". Unfortunately,
+        with his power, he inherits ancient promises, dark secrets and deep financial
+        problems on a small island full of people who want to see Struan's fall so
+        they can become the Noble House. Dunross' worst enemy is the vicious Quillan
+        Gornt, a lesser tai-pan, and he's doing everything in his power to bring the
+        Noble House to ruin. Drawn into the fight between Gornt and Dunross is an
+        upstart American billionaire who tries to gain a foothold on the Hong Kong
+        market and has made a deal to steal something that will give him power, even
+        over the Noble House. Unfortunately, that something has fallen into the hands
+        of a powerful Chinese overlord. \\\"Everybody was watching [and cheating on]
+        everybody.\\\" Who will succeed in the end?\",\"seriesName\":\"Noble House\",\"slug\":\"noble-house\",\"status\":\"Ended\"},{\"aliases\":[],\"banner\":\"/banners/posters/81249-1.jpg\",\"firstAired\":\"2008-7-16\",\"id\":81249,\"network\":\"MTV\",\"overview\":\"Run's
+        had his hands full with his lovely wife and family. Oh, and don't forget about
+        his comeback album. Roll with Rev Run and fam in this reality sitcom. Who's
+        house? Run's House!\",\"seriesName\":\"Run's House\",\"slug\":\"runs-house\",\"status\":\"Ended\"}]}"
     headers:
-      CF-RAY: [32e1fdbdfdae6581-SYD]
-      Cache-Control: ['private, max-age=600']
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:56:58 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=de72f78bc1892e63282bde99f594cb4c71486587417; expires=Thu,
-          08-Feb-18 20:56:57 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"apikey": "4D297D8CFDE0E105"}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
-    method: POST
-    uri: https://api.thetvdb.com/login
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwTByZKiMAAA0Ht/heW9uxCCSt8URIMQCBMEuVhsIpBAAJFlav593vv7tVqt302V
-        1evf1TqbjVd8Tgq7MP54C9ygAvawduVEhVtY8eCmGspPNhs0uxwKuzwJtnYX0WIBi+Q9ZLSCZVO4
-        bKLZKaWpCnvIlDny02fk6wIsmwlpuYhILiHtBJ74J266q8u3nuEOrio9zyDhdRBiKIVlrFzG+h6r
-        g3nwZI6FXXxipZoKJ3hmqW0tXGU7Wdjnx1FcFLLcNpIYoAxWnehFMl+k/Yvqzkw+fREeETIeFEeT
-        An2g1wbgt7tT8B7zUQOKlQjhhZy/8Tiaxb0epjZTci3nePY3XjBitHk1OHB2A9kc/AglW9u4Vm9j
-        eEc6Mz6TzO1WtchOTaoUCA8hyn0lvlGYgDFh4WvJMNU/7lw39ltr1QU328I6pteujRtn7EguoogB
-        c9g/sO/ZntdavcbNOHDshje9424lIhepNJmV79PwZppt15Hp+qC4fKJ3u9MZJvybCSKaMaOyCWKA
-        11///gMAAP//AwC4Tgcy1wEAAA==
-    headers:
-      CF-RAY: [32e1fdc6be6319d4-SYD]
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:56:58 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d710f6d03ba0867b4d608ddcc497b83b21486587418; expires=Thu,
-          08-Feb-18 20:56:58 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 21:57:55 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 aa0f45a042ef12e49743189a7dace623.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - h9yzyBesYkugah6nExQncatRJRSREOKTa81gum_3KY0LFg08vF7S_Q==
+      X-Amz-Cf-Pop:
+      - GIG51-C2
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODY2NzM4MTgsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDg2NTg3NDE4fQ.borKRp6UJRuRC3fG4cpnXZQI3Zjb9HwnYbCuLAU5pQ07bEmjCd0EIGmdOMzpCm7508gBw2z9TzV132XNeIkr2Ua5pz38hlFPyTvsiZBNNJ_lQax9IW4FnJ4pVYPipsQpwD49Mc0ZHTG-QwwLiYnuxqe9gDgpQyW1UXwQN1hoQXP7uT1AWaNc6OJKktJutaFmJvx5pOqCMT7Cckd40_0agW9bVlIc4wcmZhzeQlFvRynoOtDqCzQo6iMBdKrqboPwrTg2Nam4Lu8_QWUOUUqMsDpLbXPOoposPR63T5id3xLkWWlZVLLqrrTxK_lQjfNtq7FmQTp-m02NyQml5L4b4Q]
-      Connection: [keep-alive]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzM0NzQsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4Njc0fQ.gZO1DaMXesZ9tiVBZOA7S1hBq2NfBUSQ6wcZwDr3H2yGLrbhLMiUQVXW2shD89cCzJxs4Tjf0ap4dB8KwFRBpmcU-VEpyY9Z3tZf5Q9fAEnxjQXc6FVfR7LeXRLcupBy5AQpE23X3roJek6F--77l01Q_YZU8yjyr4QB7_namYS1MuZ9apCI98sMII_ojR7gdk75HwVCZZyOYoEuzVoRLS8I7NNWpnKDSwIPuwx9detMGJB37KRdeMgp2nDYDz28pl6nUe1EpWh2_wX8cxKDfybMszKu9u-883ohO5hP_yumAFS2g_nfaspuda00kQ4vp8EE517WfdgeyxPSnHO6eg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/series/73255
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA2RTXW/TQBB8z69Y+aUgJSZ2vtq8ASkFiVIEaYuEeNj4tvaS8511t3ZIq/53dHac
-        tvA6c7czszf3MACIFApGS3gYAABErKIlLCbpbDbsAE+OyX/BkqIlRB9t7Sk6UKgZPfloCT9bAA48
-        XMar+HDoCVtFLfDrcHmDxpALM3OHVcEZ6jet7ihfxL+rPHqh/ynYitJ0spgeCUGpg3h0bhSpHr5j
-        5+UtO+pujMfTUZKMknnPG5KdddtAfrj6Aa+uv7/+h+q0etDVRrgLP531YE7G0fPcK4clPkW+3Hsh
-        t3+Z2DbkGqZdGHVhQRFV5ICNWJCCoCQVlgBle5fJg72DdndDWN+ceCitF8hsWZHWbHJQQTOGj3Ve
-        wGesHRN4QecBfTtw41hrRiOwqQU8ugy9cAYrF8OFo9y6fT8focSGHGdbqIq954zRwK6wwB4UNZZV
-        MLMh5VkRlO3TxXBbsCYo2MOGCmzYOsjQwMY6RQ6sATTC3maMetiqdk2QwnET4pnWZlag1mRyChLe
-        6iZke76Qqr6/1xQyoYCVghwom4l1HnJuCOoKrIlhbXNqyR1L0boq0KhRxdmWFAhhGQT2tjb5cTT9
-        qciJH0JBJ1qDsrArUKgJ7yIguCUP3Nl0mBFgjmy8dL61zbYgtvVMHYSe+uJHGr1cVwqlbWIyPZ2n
-        k3kyW/Sfh51f4f7q7pZo+7xwgVgfGncsIQqbPCDrm1Fy/AJcqk3XVpHxNEmTadpT91ilLB15/nU8
-        np+eTmZnRw2l6EXLW+DdPlqCqbXufxgLfeuVz+LkP/i9rY2EcOnZZADwOHj8CwAA//8DAINwpblS
-        BAAA
+      string: '{"data":{"id":73255,"seriesId":"22374","seriesName":"House","aliases":["House
+        M.D."],"season":"8","poster":"posters/73255-24.jpg","banner":"graphical/73255-g7.jpg","fanart":"fanart/original/73255-11.jpg","status":"Ended","firstAired":"2004-11-16","network":"FOX","networkId":"1318","runtime":"45","language":"en","genre":["Drama","Suspense"],"overview":"Dr.
+        Gregory House is a maverick physician who is devoid of bedside manner. While
+        his behavior can border on antisocial, Dr. House thrives on the challenge
+        of solving the medical puzzles that other doctors give up on. Together with
+        his hand-picked team of young medical experts, he''ll do whatever it takes
+        in the race against the clock to solve the case.","lastUpdated":1575144873,"airsDayOfWeek":"","airsTime":"","rating":"TV-14","imdbId":"tt0412142","zap2itId":"EP00688359","added":"","addedBy":null,"siteRating":9.1,"siteRatingCount":34962,"slug":"house"}}'
     headers:
-      CF-RAY: [32e1fdc86fa46581-SYD]
-      Cache-Control: ['private, max-age=600']
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:56:59 GMT']
-      Last-Modified: ['Sat, 04 Feb 2017 19:22:37 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d94e29ff987a8c93eaa6f5a8be87dcb2f1486587418; expires=Thu,
-          08-Feb-18 20:56:58 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"apikey": "4D297D8CFDE0E105"}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
-    method: POST
-    uri: https://api.thetvdb.com/login
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwTB2bJjQAAA0Pf7Fam8u4WxzptBS0voJjTxkrI0Q1sykbJNzb/POX+/TqfzZ2J0
-        PP88nenu/i6cskWte48PKPgtnOEYyqUJFcheKTFd/Zvubk8vRos6m0fWQ/QPT/IiNsOhZ7Cb2nDY
-        empXfWXCGQ76nidVnSeAh920+VYj+lHzw7dsuQ6+EyyGoRpXfqlQkQF6BVPR68teULaao8FJs8Hc
-        Xi6fSunKUgK4TGDExaaWBCRGubnyvKjhWgrS90MqCjJXcz3jUW0zcP9jIaKFY6mRd4Nsy0C3HICK
-        iFnYI2ecbHzDBzPuSoBlnKw2UFVbzgqHPCkZ4tg+4o/oaM9I2SZn80h6q3HN+F58xrmETBEMtuqs
-        za3xAhx55Rt2C90WwKHJLUhxPKIluzxwb4aItgPJe5/tTfLBF5leaglEIwHsADvUFJ1wqxODLkk4
-        vhqFdXxJsjeZigvnmp/Sa7xCz8mva2f7nA7QnKqJ2qJX3R3rXka/9MVUuuUNuUwAVw2PghcZ569/
-        /wEAAP//AwCiw/ho1wEAAA==
-    headers:
-      CF-RAY: [32e1fdcd7a1f65cf-SYD]
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:56:59 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d30c3a742b93a766fe0de31de2f0642c01486587419; expires=Thu,
-          08-Feb-18 20:56:59 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '912'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 15:32:48 GMT
+      Last-Modified:
+      - Sat, 30 Nov 2019 20:14:33 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 ef0351f6e6a938444811465f38f5ed86.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - K1uC4yYv8SNEQ3kx9WBZnzVdKNJUG63DCOA6QI--6Q1j7MDzyXSTcg==
+      X-Amz-Cf-Pop:
+      - GIG51-C2
+      X-Cache:
+      - Hit from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Accept-Language: [en]
-      Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODY2NzM4MTksImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDg2NTg3NDE5fQ.WP2RR7UdNc6e2kFeKFobl9vybekwCnA-4sAkJl5c_6cJ54WF-Z1kVJPC8WQVUOaCw0028Pf4QXrY4bbVsdsfsPn7iZFSqDOV8Rnc8VrgOEDAOLaFFdV2ZRlOGnoEPLPzkAS6QP5PWwEF77E5ZbGV_eVmUUEzUt2G8_T6xoGxMVXLfPfk0l2_Ua4OC2FmE7GwgLgMQPTMcrIjvexvF-OoJbVbzYTvZHYPlCROeimValNkygWtPH5eHf4FTnVFkzFyI869V-wGUFjWW-0dn1wnp45MoC6JIsf0oXKUwIMGaKwjEN-9FOsX7W7iOpfjzwycTB9vC6jvrI-Z1FK8Pn1MTA]
-      Connection: [keep-alive]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzM0NzQsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4Njc0fQ.gZO1DaMXesZ9tiVBZOA7S1hBq2NfBUSQ6wcZwDr3H2yGLrbhLMiUQVXW2shD89cCzJxs4Tjf0ap4dB8KwFRBpmcU-VEpyY9Z3tZf5Q9fAEnxjQXc6FVfR7LeXRLcupBy5AQpE23X3roJek6F--77l01Q_YZU8yjyr4QB7_namYS1MuZ9apCI98sMII_ojR7gdk75HwVCZZyOYoEuzVoRLS8I7NNWpnKDSwIPuwx9detMGJB37KRdeMgp2nDYDz28pl6nUe1EpWh2_wX8cxKDfybMszKu9u-883ohO5hP_yumAFS2g_nfaspuda00kQ4vp8EE517WfdgeyxPSnHO6eg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
     method: GET
-    uri: https://api.thetvdb.com/series/73255/episodes/query?airedEpisode=2&airedSeason=1
+    uri: https://api.thetvdb.com/series/73255/episodes/query?airedSeason=1&airedEpisode=2
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3xSTW8aQQy98yue9sIFEB8harhFSaX20KpSVPVQ9eBlDOsyeLbjmaUo4r9Xu5AN
-        kaIe/d7z87NnngdA4UV3VqzwPACAYiPRUrHCbHSuPb0plf+2pWbvL0gdubkgA+DUooWjRMUKPzvF
-        2RgoqLTgc+KveV9yLFZYjHpKIruPtVhwr/T8Lf3EZEFfs7zFPz8WKyyXi9uedM1/HF3znh9f9LTn
-        YoXiGyWOKulY9IruPPft2FYwn05vxrPZeL54VUjLzGbTu7tlj3nSbaYt92d+bxprbwIUoeHYCB8u
-        zIU4XVla+l47Sl2S2WJ++2F6M19Me8G1wY+KFYTErLRleFrHYMaoPR05QgyWoqx3rDhIqkCKrOJY
-        k2yESs8oI4nCiTEZj/AYJ/gUsjFIHVLFSEx7VNmSZ6SArTSMSgw1RdZkILUDR5vgoSJr/Zh21nWW
-        5KB8sFFX7cShIsOXpxHKnM6KcBwaVLZVGieOMURU5H1ei1KSoNYGq2NouJM7oa0GE+vCGau7ytpm
-        6rKWtN61Se1PpsgIyhPc29W8ismnCo4TRwmREttl6aHBxPG45ISgXUv98lUQNi+AsCaIbnKUtrk7
-        2kN27nh1tO5B4rC/03npPR3xO1tCTa3hBqKwmhzb5PwTTgPg1+D0DwAA//8DAN3Hnf/BAwAA
+        H4sIAAAAAAAAA3RUwXIaORD9FZUuvgxkAEMSbgTvrlNZb1whXh9SOWhGDaMgpFm1BCEu/3ueZsBL
+        amuLy/Tr192vu9U8SWvcluX8Sa5N4Cjno0Jadfpw9B0fLllbyDbQvv9+LqRWUcn5lydpNIij8u3b
+        aSGVCaRXpNi7LvrCfn8j59PpZHYCf2sNe01/pV1FQc7HhaQTonYk5/JeRQrOxKMselmLHAXHuCyv
+        B6PRYDyBZ5OI4yqqAPlf5MLSd7HapioHfThaIrH0dROUg32vkhV/KJcYxidfGSc+N36nsrmqfYzi
+        FlyOSscX5I7qxvqDqX8AeiSnj8jwg6wl+RUTgKI6+r72PUGv+Hj1u7IWzcN9CAZQ5/xTHQK5msQH
+        1SJf9vo9hb2hAzp6bMgJJSKRUxsSVtXBM5NorToip2HBMZh6C9bBxEYoJ5Izmlw0a6MqS6IKCu1o
+        w5g0FeImDNFMQgrltIgNIbfaiSZxBDl6sTF7Eg0Stwq6IoPHB2gdimWDDMhHastdZKW0cHTgorO2
+        RgswxN2qEFWKPcMfr1g4s2niAA0HH0CxNtXGqWi84yysDWi4o2ujNs6z4U4cY6gXWrOmTmul6m1W
+        yv8kSBTe0VAs+KJeQ8piFjqP3fiA18KnpuFkTGdQUURcF9KeH5Pw6zNg0Lgwbp2CycHd0JZJY8X/
+        Dq1bSLh6mVPf9E4dxTfMEmhOuEYWwa3SUCDz5bhNQli+p1+fNOVneLF32M/5qLxOdR7UElTAtx8f
+        BqNyCi43/vAQLDDZX+RDi6vLVzCajGdvyuvxpMQz3Osbw3U+w8yDeXGAsP57aQCx5zZms79sVbG3
+        Kb6QJvnoLNrvhfcZ+NXryXg6fdUf+/Bbu8kaMX7i9yjeOX/R+e54/hPgxRrVzrpONQG/o7UP9H/4
+        SfnZYXa6yoVkjOUMv8k16tfeRazmExbqNvB9/nswynhs0Moixca/NNlDWtNpUp39aHRsYM+uyzN0
+        S/ktA5vMMsY443P618M3l8DSJwfieDQGbPjOY7NyXj5/ff4JAAD//wMAADCCkVUFAAA=
     headers:
-      CF-RAY: [32e1fdcf1e3065e7-SYD]
-      Cache-Control: ['private, max-age=600']
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:00 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d057dafe9f49f469d6d36065559cd426f1486587420; expires=Thu,
-          08-Feb-18 20:57:00 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"apikey": "4D297D8CFDE0E105"}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
-    method: POST
-    uri: https://api.thetvdb.com/login
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwTByXKiQAAA0Hu+wvKeFDsyNzbTjdKyhC0XClkbaEBAbJmaf5/3/n4cDsd17Mrh
-        +OdwLN9Wc//O8Q1bfrBDFmG4wMETcx1KsJviULeUr/Jt9SVQ8a01mZuRcGi3BbtVF0j6DrYj9gjt
-        S7PoCx0ukCjvLCqqLDozsB0pMmoO/dQ8MuCrcr/YomjCAa9b4qldc71F/GoR01hcsBRD+nyle9k5
-        qiJm4NeMZaMXVodS25lEyx1kNxTkJnWT0KqbC1CFJe8IDCFyRjELr9c2FhZBT2cNSlxjGAXWJNFS
-        okJN6QZ96mtzz1YK8IWXQ5zAe5vyeWbZE1GAYxDzwiMvlgVVH0xZWleqUJ2S39LjSptkz/pT1M4S
-        dvhUHiqanfJq2raWw+73CBJwD0gG5rp+gOssXqZ5SjBi9D5GkKsry7W3095xP3guOdNuPOOxLfOp
-        TWIQcMqk8jQVVpDiIk36R8uwJHj3Jzd6MM8Jgd3IcyYezVddfsoUXZZr4QeP+3yjU9pHEAyjpHHq
-        8ePffwAAAP//AwD8KAK+1wEAAA==
-    headers:
-      CF-RAY: [32e1fdd47b5865cf-SYD]
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:01 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d5e69f310d871a2e3e8734007285491db1486587420; expires=Thu,
-          08-Feb-18 20:57:00 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 21:03:17 GMT
+      Vary:
+      - Accept-Encoding,Accept-Language
+      Via:
+      - 1.1 af3ec872aa77de6760622a554164a644.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - W95TdIgRkvfHufyhQk-mhaRep16IbC-BylBtaVURHGIp_t2UK5EiQw==
+      X-Amz-Cf-Pop:
+      - GIG51-C2
+      X-Cache:
+      - Hit from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Accept-Language: [en]
-      Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODY2NzM4MjAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDg2NTg3NDIwfQ.1ddhVnitvYRAkhLOW3tJmEDsQHsdn_uw_zekPA95aHZEX7Dl4tPxxMPp5JQn7QV47h_QYVJghKHA4sckmIVINPo5aVLLjX4s4C_rBI62hDDdiB65J9WdA_xvISxSBrl1f9HS4wPmPURyE7Fr118m9HPDmEK3NRX74ACnE76ttx9xCxmZeR2eMmaug-5BF6iP3_7nfxa8cfpvvj2iQGoHYHbUmaHrggqHLr5KprpYiN0ClXNI2gfJQMv8zk2Tire2EMhRDqvsr8jYXHU29pA3x_4tH_id_Ylqj01mUyl8QWq0upNHzDcc0XoEwge-7xNKsLdSUqbrOxp_lWIHno6B2A]
-      Connection: [keep-alive]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzM0NzQsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4Njc0fQ.gZO1DaMXesZ9tiVBZOA7S1hBq2NfBUSQ6wcZwDr3H2yGLrbhLMiUQVXW2shD89cCzJxs4Tjf0ap4dB8KwFRBpmcU-VEpyY9Z3tZf5Q9fAEnxjQXc6FVfR7LeXRLcupBy5AQpE23X3roJek6F--77l01Q_YZU8yjyr4QB7_namYS1MuZ9apCI98sMII_ojR7gdk75HwVCZZyOYoEuzVoRLS8I7NNWpnKDSwIPuwx9detMGJB37KRdeMgp2nDYDz28pl6nUe1EpWh2_wX8cxKDfybMszKu9u-883ohO5hP_yumAFS2g_nfaspuda00kQ4vp8EE517WfdgeyxPSnHO6eg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/episodes/110995
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3xUTZPbNgy976/A6LKXtS1/J7453jabSdNk4u7sodMDJMImY4pUCdCqktn/3pEs
-        f8XTHvkeAD48EvhxB5AoFEwW8OMOACAxKlnAcJi+fTt9OCBoAqk1IXvXULfoh8dkAdPpeHZJ/VIa
-        9op+j0VGIVnAqCOpw7GgZAHJFxQKzkiddPzGBJZlU6GhR2k66Q2HvdH4yG8jsawFAycL+LPFAJKP
-        tSWClc91QNeFAiRLS//Aehez+oytcy8CnyjX1lcm/35mvmC08B5d5DP21WfGwR/aF3iBvpBTNbzH
-        72Qt/Vz6yeeaBZUkLf5XJ1yZQLn40HZNQgE+3/+K1vqj3lPEVWc/hV6VrIIRug7/DatALif4iKX1
-        1XW831PYG6oaCS+aHCAIkcMtgcU8eGaC0mJNAQwDSzD5jhxURjSgg+iMIidmYzCzBFlA40AZJmR6
-        gMfQhycfmQCdAtEEQliAjiyWQDxszZ5AG4YSAzlhQMcVBe7DSiM39Qh33GZmqMBRxQ/taWcUaGT4
-        tH6ALMohwtf3DM5stfSEQvABNFobc+NQjHfcCCuD31MbrgxunWfDrTgmpy60NpparRnmu0Yp/x0x
-        EHhHfVjyxX2a0IoG1byJ8QGFuGv6noGNol5GAt61KeXxa4PfHAFDTsC4TQymSW5NW0Wl6gvT2gcJ
-        9yefDk0XWMO3yAIlNgU3YBxwiYq4f/w/Ft024pZOw3w7bnQxHJe/gbqf9dqVKoNXMW+MXHnVZj59
-        fu4N0+nxLta+eg62YbRIuRgMqqrqy76f+2LQXToYTyfpfDrgWBQY6r6Wwp61sjyXCqWd8+F4NHuT
-        Tkbj9DgKe/VoOG+XUZKcwZs1pPb/uWnUXq00ltKCLlp7XE8ZexvlnDA+rR5L7mjUoSgP5uPRdDo4
-        LMT+t3J7MoCCIf7QCGxDbvt6Vze1p/M0nZ8XIy83QuHUxqUsE/gdbXyg/2e7dq9p0bHIllF0u1+G
-        V6hSdGVji74YJbpBJ2l6RTxRM1Pt7h2dXtsUKmtbTUTSWTpLx5OTD0boK4px28aJ/psbeOWja+rN
-        Z3cAr3ev/wIAAP//AwB625MPdAYAAA==
+        H4sIAAAAAAAAA3RUy3IbNxD8FRQuupA0HyJt80ZTSeRyFKtMKzqkcphdDLkwQWCDAcTQLv17GktS
+        oSqV2tP0NGZ6XvtDG0qk5z+0NXo+Gg3fv5/2NNnIZsUkwQN8ZX+80fPpdDI7gT+1VoLh3/Ku4qjn
+        457mE0I71nN9T4mjt+mge3pto6RFeQXHeDi87o9G/fEEnk1mSatEUfT8D71w/LdabXNVHn06OGa1
+        DHUTycO+p+zUL+SzwPgSKuvV1ybsqJirOqSkbsGVRCa9IHdcNy7sbf0d0CN7c0CE7+wc6z972kBR
+        ncIx9z1Dr/p89TM5h+Lh3kcLqHP+SvvIvmb1iVrEK97wxPHJ8h4VPTbsFanE7GnDylEdgwir1tEB
+        Ma0oSdHWW7D2NjWKvMreGvbJri1VjlUVCeUYK+g099RNHKCYjBDkjUoNIzbtVJMlgZyC2tgnVg0C
+        twRdScCTPbQO1LJBBMRj2kr3siKjPO+l11lbaxQY6m7VU1VOR0Y4XInydtOkPgqOIYLiXK6tp2SD
+        lyKsjSi4oxtLGx/ESidO0NQLrUVTp7WieluUyl8ZElXwPFALucjXMDn0wpS22xCxLXIqGk5Bd/oV
+        J7zrnrTnZVJhfQYsClfWr3O05XHXtGU2GPG/TesGEq9e+nQsekcH9Q29BFoCrhFFSUsGCrAmjvwm
+        41k5jdcrzWUNL+YO+7mn0RmT69KoJaiAbz8/9EfDKbjShP1DdMC6uJIeWhxduYLRZDx7N7weT4ZY
+        wydzY6UuZ1h4MC8OENZ/Lw0g5tymYvrsHE6ykuByeiFNytE5lH8Ufowgb95OxtPpm+OxD761m6IR
+        7Wf5iOSd85XOD4fzT0AWa2Q76zrlBPyB1yHy/+En5WeH3ZmqJNIpDWf4JtfIXwefMJovGKjfwPf1
+        9/6o4KlBKYucmvBS5BEyhk+d6uxHa1IDe3Y9PEO3XHYZ2GRWMMEZn8O/Hby7BJYhexDHozFgK3cB
+        k9Xz4fPzPwAAAP//AwCwrjxJHgUAAA==
     headers:
-      CF-RAY: [32e1fdd6099919d4-SYD]
-      Cache-Control: ['private, max-age=600']
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:01 GMT']
-      Last-Modified: ['Tue, 17 Jan 2012 12:43:50 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d9cbbecbb17d6f466395c6d5ce73d185a1486587421; expires=Thu,
-          08-Feb-18 20:57:01 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"apikey": "4D297D8CFDE0E105"}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
-    method: POST
-    uri: https://api.thetvdb.com/login
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAxTIu5KqMAAA0H6/wrHPjrxlOwSFIAYRQaRhBCJCIqIBDdy5/76zpzz/vmazef8g
-        uJ3/zOZ4dG+5XdR+7YbRBAVUQwbbg1KYUIWkS2LT1b/x6FLsGLXfrBe+dRbRtJN3DWTwTglsHvXh
-        zilel7Q0/04fL6fyejltFrB5cGRVIjpWErLgeA2+bXfsNagkU+iAJzZyU3+qjQNfjW2cp9d1lXfp
-        FlRqwMMqLiA1BzVmovp+7TQelOZdWKc7DHTUF5maT+7bAqLiFguo2bRMVc/pUbHnWSDptoZ1RSBv
-        i8EMAF0haVEtz5lIOKmr6KSHVt2OTBpIQTyl12MrvoLEB888ItuMRhKPKvBJmLUygyWlE0Khn3tQ
-        s5cwTmUrBKEU+TefvTYgGOWw6SiND6CdWs/Gt/s7Kx2rdTst4j2D/V7KzNtDrNEFdFsiy8xu5G4Z
-        DXxwyNETIsbCPAxJO7jFqboLxoIcjwng+4PRjAs48WlAUDTfk7EXNtj7cClKbD0TYj8eSJ0qK/yZ
-        f/3/BQAA//8DAEHFVYLXAQAA
-    headers:
-      CF-RAY: [32e1fddb0aa565b1-SYD]
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:02 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d23c527c769d023953025f7027c7e723c1486587421; expires=Thu,
-          08-Feb-18 20:57:01 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 21:03:18 GMT
+      Last-Modified:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Vary:
+      - Accept-Encoding,Accept-Language
+      Via:
+      - 1.1 d16dfa38c231b4b8f5df64d8f47f48d0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - x6e0BQYnsdoLGpBRKdI7g2-QkrwZeMagMtWPkDORcDEvgLhbJNVN1Q==
+      X-Amz-Cf-Pop:
+      - GIG51-C2
+      X-Cache:
+      - Hit from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODY2NzM4MjIsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDg2NTg3NDIyfQ.GJyt7I5XzSH-qeAbC9q6jHIrjGAYzrfBbpZK-g6QxSgVcIlCu6Vs26vrM7xQdCm1EZMe-9Ntc_6bzJvD-25Jc0I7GldZ6LHtNcPx_Q39G7e951kvDsI_--95kZcg8Y_2kxkigUW9SDinys3ukckL5t9VDVf-XO-qbUkK_lU3xUg-wXsDBCQ8llzNNSObLI7G8IVZ4DS-S3UOhOsrF-Qy4SjpllVR-nznLGehmv_dHDnJp7UxtsItP3_Cho2iNa-pKk44sGj4p8UuxuHkTL1UssSbSSknuJcWgm1A0kTTX-xPRAjy0IzxzuNI2CvzAP1FeLwx3UXG9_1VOVukiZ5Bew]
-      Connection: [keep-alive]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzM0NzQsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4Njc0fQ.gZO1DaMXesZ9tiVBZOA7S1hBq2NfBUSQ6wcZwDr3H2yGLrbhLMiUQVXW2shD89cCzJxs4Tjf0ap4dB8KwFRBpmcU-VEpyY9Z3tZf5Q9fAEnxjQXc6FVfR7LeXRLcupBy5AQpE23X3roJek6F--77l01Q_YZU8yjyr4QB7_namYS1MuZ9apCI98sMII_ojR7gdk75HwVCZZyOYoEuzVoRLS8I7NNWpnKDSwIPuwx9detMGJB37KRdeMgp2nDYDz28pl6nUe1EpWh2_wX8cxKDfybMszKu9u-883ohO5hP_yumAFS2g_nfaspuda00kQ4vp8EE517WfdgeyxPSnHO6eg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/search/series?name=Doctor+Who+2005
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA2xSXWvbQBB8968Y9NSCrbpp2ga/5QOalNJCauhDycPaWuk2Oe+Ju5WECIH8kObP
-        5ZcUyantQl4Obmdmb46Z+wmQFWSULfB7AgD34wlk5IUSpx0wDi/C2kLELxdwNJ9/zKavQQssHWN7
-        T7jmVpIYF/+RR+Lh5HXJC37zj5itSJVjtkBWRaqdrMm/+3xyMj+eVcfv89u62u3MSonJTiVyMdAH
-        u7P5h9nRpz1DBmRU70bK1oV4NyjOzs7xQ3lPDy3HVrgbwL1dSAIpyAsrlrJhfAuxQBnDBuYYtSdl
-        wxfyXsrIPToXYJFa9gnmYmgqB/IeoYQNctICqaY1QxROEpan1xdXP3NcMhwlEHzQCl6SDZoyCmuR
-        Rtk6bGpSCZrGVxy1jOQocoHb0ETlPqETc3CyyXGlyZiKYUnRi1bT0e/Br1aeYQHPj38iV6wcyfj5
-        8QmiFkBQ7rAKRT+F0Z1ohaAv05pjCkperN++x7R22C2RoDmWHfuWQWPkU9S+SfganOKyiTbdeq89
-        9Vwc1AnmmoSSYr6PJXEUTt9pw0MwBw19M2T+9oBoZM1Q6Ow8qIk2otW2YQ8T4Gby8BcAAP//AwCM
-        HsrDDgMAAA==
+        H4sIAAAAAAAAA4RSTW/bMAz9K4ROG2CnSfqZ3NpmGDoMG9AF3WHoQbFoW4ksGpKcLCgK9Idsf66/
+        ZJSdzd4h28kWyfdIPr4noWSQYv7tSUijpUfP/2JBWSAHX0uaw7JE6N4e7nGrvQ6oRCKOxRctDt5M
+        x+Pzt/FNm8j1gJV4TMRKWotOzMVJ9+dPavIhfi+vrsZn6fl0tK4LhuXa+XCtHXPOReRKT9PpBSc0
+        B9raRFgMO3IbLri5uYXPFjlNW3RbjTsO9hOC9iAt8IZoYakrhI/kFOSOKghcVRvJXPBeGqNzh3vY
+        8QbByS0azwWOmqJktAHKIUS4tAp8LTMEbVuG5fX94u7LaKAWlJKbgiFbgNE+RGzueADlW3hGVS2t
+        JuvbbiU3A19KXhjW1DiLe65r0ZF/J/cjuLMslVSRSe21LZI2NVhxZRACwevLD4cFsrwy4OvLTx6S
+        oxIs7mBFas84uWE8kD1Ea74AWdYn8O46lIAyK+EPCU85AmB1PfIG/pOskPXtXdJf25um4JRqUykv
+        lsZMTAQZGjaXuCUbtG24vXhOhq77pzsmk+nF5SSdHHHHLJ2lZwdzdKUDd9jGmL+MMRg8YlvpwJJN
+        a0e5DlB16nTLRrV9SS5AzhbKtak8ZGhwFXU5XCfab/nwG9DTs2gf6OAQqbZoQ+Mw6RSWwAzsgyh/
+        32lyClhrT4qfOZP0B046q/Gs+D3TbesIjUPx2GvMwug/B5odPdBseKB3VrGsz4/PvwAAAP//AwAT
+        ik7FHAQAAA==
     headers:
-      CF-RAY: [32e1fddca8050b08-SYD]
-      Cache-Control: ['private, max-age=600']
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:02 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d4cdfff84716df4a22b3d110ae52caf4d1486587422; expires=Thu,
-          08-Feb-18 20:57:02 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"apikey": "4D297D8CFDE0E105"}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
-    method: POST
-    uri: https://api.thetvdb.com/login
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwTByZKiMAAA0Ht/heXdLhoCytxiiBiWAIIoXChkExACom1gav593vv7tVqtX6wt
-        +vWf1bqYjftNz2qnNvzzQn5oTSbSn+QMEYW0wzVEhvpdzMajOMLaabDgaJFIFxvYjT2R7tGShtWn
-        jj8KnD9yRCbSqXN6ycv0chBIwzjVKpEGlUQ1spTet77DkXQYTZ+/BdvJbw1WcXA22HSGCb2rsdzC
-        +8g7ML6rUpxfJkOeHNCrewP7e7enBgw+bgtozDXBa4bti9vipvz1mWdn2tMTUj1n+RAOyH9V0BoV
-        Tfyd8iyddg7gDCrqx+xEZnaS1xcK8qJA2btpxqLJbwCK3SRzorzPoh9JzKXIuJjbD2RDUvtn/p7y
-        yM22vYas+vThDQom5W6iudnNIAhZJ/p+Bi2CeZGku/KChxRbuG1jFMklWtjbOvK4GkJldjUgTBje
-        XqB1kg3enNJjVNOx2w71EluHpyad93qfiPNDdHTAjyN0KmBbyLJh2qSLBolMS3TVhWdtqxQKRmeH
-        n/XXv/8AAAD//wMA/OasPNcBAAA=
-    headers:
-      CF-RAY: [32e1fde29dbc65cf-SYD]
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:03 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=daa9d13b4f4ca8ea49016cc7b437d96a21486587423; expires=Thu,
-          08-Feb-18 20:57:03 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 21:57:56 GMT
+      Vary:
+      - Accept-Encoding,Accept-Language
+      Via:
+      - 1.1 db8930385bcdd90dd32aced7ffdcaacd.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - MtGht3RozS4TjlXTU_3i2bwb5SPEEDjMrBbu6euFWjiYzEnhGJQhCA==
+      X-Amz-Cf-Pop:
+      - GIG51-C2
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODY2NzM4MjMsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDg2NTg3NDIzfQ.G8EY3FqKSxu0MOdbjE9ETUJosUA_Nh9Z5kAhqxm4qugf2ytKoCQ5TNXPb4BhmBNJATwPk4NZxD0Qjp7txM2-fvSoQMcDrQ0aGdodpVpCStgALq6D2vsdcas8O4xoA69wKm2oKm3Qne6CQYT6BPacoYsSj4CZP_cOYdncY132d3YJWK7wAop_iSUxusdYPc7nDCLiRwxjCTs6hKCyj8y4TVom2SScALIExe_a8fWEpaELEkkZCY5fCzouLHxZgpV6yPD40sEAbt4kO_-E-RaHYiNqm7pizZLFrD3UBGn_2yl2OG4xHqAOg4MLCLMAajazDAI5NfCXG0riM9NA0JmMVw]
-      Connection: [keep-alive]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzM0NzQsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4Njc0fQ.gZO1DaMXesZ9tiVBZOA7S1hBq2NfBUSQ6wcZwDr3H2yGLrbhLMiUQVXW2shD89cCzJxs4Tjf0ap4dB8KwFRBpmcU-VEpyY9Z3tZf5Q9fAEnxjQXc6FVfR7LeXRLcupBy5AQpE23X3roJek6F--77l01Q_YZU8yjyr4QB7_namYS1MuZ9apCI98sMII_ojR7gdk75HwVCZZyOYoEuzVoRLS8I7NNWpnKDSwIPuwx9detMGJB37KRdeMgp2nDYDz28pl6nUe1EpWh2_wX8cxKDfybMszKu9u-883ohO5hP_yumAFS2g_nfaspuda00kQ4vp8EE517WfdgeyxPSnHO6eg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/series/78804
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA2xTy27bSBC8+ysKPGUBSaElxZJ182M38WKTGLaSHBZ7aIstspNRDzHTlMAYAfIh
-        yc/lSwJSoiwle5yq6umunprHEyDJyCiZ4fEEABLJkhkm02k67m2ByEE4vqEVJzMk135hPuBD4fFs
-        mKYv/kh2MnJCkWMyw78tgCNtI90pj4gZ5gVje46447VEMc4OpK3s6fz/8pb9bzfJA6lyaIbNA5WF
-        LMg9bw318/Hp4GOZJ0fObhrDyWg8Oj/dE0ZWNVaSK68mWonui5YSol1I4Las8dVPR/3hWccr28aH
-        Tw15eXmFt8q/MNt+HRgqNdmudtxtKMlZAx9u8iJbs1oV+HAxtKKn4/1CWBfc/0sWJl6PN+LXHNbC
-        m6bL0wIhEaQgJ6yYy4rxjw8ZlsGvYAWjdKRseEnOyTJwjU3hYYHW7CKsCL7KC5Bz8Es0HkCaIZa0
-        YIiikIj5xd31zf0ArxgFRRCc1xxOojU1yyCsWWzLFn5VkorX2HYpaM2IBQXO8NFXQbmO2IgVKGQ1
-        wI1GY8qaS7JaNO+18x64enAM8/jx9VvgnJUDGf/4+h2i5kFQ3uDBZ3UPRp9Ec3jdoSWH6JWcWL3t
-        x7QosL9EvA4w37BbM6gNYQ+lqyL+9oXiVRWst529dFRzdhBuWFFFLCkMukd2FO1dmZG1STodT8+G
-        k+H0bNL9Jwnxmuq3yw/MbZruyaqQUZ0cCOa76ExnoxS3r/ehImsS27z2+/7tyw6WVfawTZ9ZOh6d
-        nZ8PO+ozlUOxLfnnbZpOXqSnk+m+VZbxUWpb4LJOZtDKue7XiPFd1/l8MP4NvvKVWjLDNJ2cAF9O
-        vvwEAAD//wMAiaB3MH8EAAA=
+        H4sIAAAAAAAAA2xTy07bQBT9lSuvWokEx7HJYwekRUhtQZCWRdXFTXxjDzgz1sw4kYuQ+JD25/iS
+        nnECZNGVZ8499zHnHj9GOXuOpo+RyqPpaDyO06PIiVXiLgFEw3Q4GUSv0DdeC8CZWXpj6a409CGJ
+        4+wjCFwpduKi6c+D8JTmpdDu7uhGNsopLzno/8d/hUbsjEaTQQJabZwXi9vu4I67CXtZ0r+vC8QX
+        rHUXLyzXpVpytWcUyWRPWbFm60HZHY6NVYXSb8RBHO+JzrNv8IDo3GivdKN0l66s86fKSlAjPLYX
+        D3vJCSJa/NbYB8BnZ+d0peUd20k3AmAb1OpEy2JcK9ZFw0W4i8a9EG0laHaab0T7xoYiM8trxvd2
+        qUQvhT6rpVfQBOqYjdiNki3y3xUk5Yg1YQOiaY5u9MXYnFbWrMmDVaOreLrgqlIrKy1tsThveSOV
+        A8GapiiRXZFZURgWxXJyNaO10l2F+enN7PK2f7BNKhlNqTK6oEo5H3JXsIjOXZe+NOuaNaZ2XbcS
+        zciVDBnp3jRWSwtelx3qb7nt06XGijkPlfIW4h91oYMnLiohb+jl+Y8VCCeWvbw8/8WQQJm0bGlh
+        8hZ5/IB8MnqP1nCOwcqVx9uVL0l4WdJbEUzZJ+q24/z3Gj9EWPYgG2XjNB1kY5gbJphxe7W6EwkL
+        v210zm20C8x3+z2Zphldfw07R0l4Byv60bu+AKDW+aKzhPdxOjyZTIK1f3OdKN/Bn67jeJTFg9E4
+        lMzzzmuvx7M2muqmqmBQ/CM3+9qTfnoInBv4LJomaTI5AV41oX3eSdeD/r1g3Ojp6R8AAAD//wMA
+        9ID/Pu4DAAA=
     headers:
-      CF-RAY: [32e1fde7ad626599-SYD]
-      Cache-Control: ['private, max-age=600']
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:04 GMT']
-      Last-Modified: ['Sun, 05 Feb 2017 05:34:27 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=dc85fc9aaf6031deee0ce08c89d6240811486587423; expires=Thu,
-          08-Feb-18 20:57:03 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"apikey": "4D297D8CFDE0E105"}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
-    method: POST
-    uri: https://api.thetvdb.com/login
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwTBy3KqMAAA0H2/wnFPBzCC3p0GkIA8AgSKGwYMSHgYilqEO/33nvP/Y7VaP3lb
-        3tf/VutyturidGUes0KyIMll6IHuwfYKkYLa4SuG1v6znK2uNA/Ma3TR01LZXRzgNPiB+q5FDWdB
-        /+5KnXYUogfq93Oe0CpPDBE1/O1qN9mNbhtXQ2KFPxFvx6mzbs5L3MSOh3WRGH0mFbp/FgaamEa4
-        vZAlWFIOdo7YDk/NGJ1IfqkAbGcgedJOdmeFpqHrSSGT9UhJixmUpf1W5+ZYJ8TvVVjpKusvb/qI
-        D+rGIo1tnhxlmV+LALH9TS3J49aZMsc/IP+6hZqvODpS7vyS6zWxT5Hm5rZZn9KYo7oPWIpfafMN
-        IAzeWaaMWzb++E/gjxeR51O29+f9FFlVLiIjLgV8JPSrDXQVZgIYyWY6GeLN5D+h3VWjkRxB2JJp
-        B3B3aXcgceEQXzsj8LEUpEFcEaFw+sC2sDxDAybDcZiwzkkhM1OoH5lyT57msmHRpNEze+JCpqXC
-        wGH98fsHAAD//wMA4Ne8odcBAAA=
-    headers:
-      CF-RAY: [32e1fde95a866569-SYD]
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:04 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d97d1aaa0f56815c2656b586630b154e81486587424; expires=Thu,
-          08-Feb-18 20:57:04 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 12:46:12 GMT
+      Last-Modified:
+      - Sun, 08 Dec 2019 22:29:18 GMT
+      Vary:
+      - Accept-Encoding,Accept-Language
+      Via:
+      - 1.1 91e4318d5ae7ae2c5a90aaf2b1916ef6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - RY7hB2Ss6pJ8GyPdpLQ4ygTq5pVwnzrKeG4DQhPVWbIpAuZon5Ct_g==
+      X-Amz-Cf-Pop:
+      - GIG51-C2
+      X-Cache:
+      - Hit from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Accept-Language: [en]
-      Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODY2NzM4MjQsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDg2NTg3NDI0fQ.IokrwlJgMu03VMOQE0UFm_1bEPL-pdWHFS5ZUzRzYo48M0kptDFrMT2u7445y41O182Ny6dYSNO1Si2ET6Yby4eeKx7yjBhWUPm7CfE7imZxdsVA73JUjKHGM6zyuz-CQKqdJ1OoJLdiMPAIPc5CDP6MEI6noZaEhUKGTDNaKHhGYVoIhmRiYQuYjq4CCRx__6r5irvPt4PrZ0oaw_9Py9wTJfa0IFVe-QBUdXkRE7C_-4rU3wGF0gHovSKlfrFWB4SkUw84QlZk84WNCpVclFRPQ1RYRVfU-bMmRKJQ2yCFCWpBpwQEoUb2iH-hs_6nWtHz3iTwDdLitQb2de6i4A]
-      Connection: [keep-alive]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzM0NzQsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4Njc0fQ.gZO1DaMXesZ9tiVBZOA7S1hBq2NfBUSQ6wcZwDr3H2yGLrbhLMiUQVXW2shD89cCzJxs4Tjf0ap4dB8KwFRBpmcU-VEpyY9Z3tZf5Q9fAEnxjQXc6FVfR7LeXRLcupBy5AQpE23X3roJek6F--77l01Q_YZU8yjyr4QB7_namYS1MuZ9apCI98sMII_ojR7gdk75HwVCZZyOYoEuzVoRLS8I7NNWpnKDSwIPuwx9detMGJB37KRdeMgp2nDYDz28pl6nUe1EpWh2_wX8cxKDfybMszKu9u-883ohO5hP_yumAFS2g_nfaspuda00kQ4vp8EE517WfdgeyxPSnHO6eg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
     method: GET
-    uri: https://api.thetvdb.com/series/78804/episodes/query?airedEpisode=3&airedSeason=2
+    uri: https://api.thetvdb.com/series/78804/episodes/query?airedSeason=2&airedEpisode=3
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3yQsWrDMBCGdz/FcbMDtuyaRlshhRZKh4Z26aREZ0dUkYwkuy0h715kGzuB0PH+
-        7+c7nU4JAGplvjxyOCUAAFgr5wNyyNNx1uJqNPQTR9NpPSWto35KEoBzTFGKIJDD59AYxQAodt7q
-        LtBrd9yRi9IqnZlyJB9b5a1ceHGNtyS8NciB3cqfN9F4V92vZyr7f5SyvyWkqS+OhBxwuz9Yq+GN
-        OqOswbk2/NJDXB5bLMuqVVau2HppqEiKjJVFPmdamKYTDc2/fWslLWsA0PbkekXfE5nA+ULpw3sr
-        RRhekpcVq1iR5ctBl4IXuxdBWcNhQ3XtfuFDaIIn1RxgPDT9AwAA//80UUFKBEEMvO8r6gE9sngR
-        9rzjRUXQ8bYewnS2O9iTXjpR8bDga3yYL5GexUMoKqFCVYL7qrFqwKipkMaAkZpnHNpB9+S8w/V2
-        e7PSUXkRth2mzLhrUoo4Kds67DVlbgxqDPNGmhipiiYbqoIchLkup8aZ1eSDYZdTD3i5fbSA7nsQ
-        dS5FEqtjzlJiYw0gjagxDk7moulfGUWVm11hymIg90azGzxzJ6w9OepxbUysnrGvs9cW8FSN160P
-        Mr/xF54X8RxAhk8upWM3+34q3PW1RBybsEb7/f65vOS8AV435z8AAAD//wMAEI70klEDAAA=
+        H4sIAAAAAAAAA3RUwXIaORD9lS6dBwdjAuO5YSBrZ4k3ZXB8SHIQo2ZGsZAoSWPCuly1X7Mftl+y
+        TzOQsmtrDxTq163u161+8yyMto9BFM9io32IojjPhJHHg+WfONjGmEzsPD9155dMKBmlKL4+C61E
+        cdEfDC8QLbVntWQZnBXF4I19M0O+96P88ojOdzo4xbfNds0eGTLBR0RuWRRiWdbOGbrjxmpkyzpy
+        k3QV3kG/P+r1h73BJTxVwyEuo/Ro4quY2Fg7e6Bl5L30ka5ZKgRdsf0ht9rScqtjDWAqvUPnTFfs
+        /SEBhre00uvEJxNzo4Ncc6xpaaTixGDeVIz4BxlqbavYskL2WLOnKVj7FvnomD7r8tHwobVqSwvm
+        0PoWTamtkjTzhz/5EcCtY0NTI/0jw7pziiY+1o0X3zFh9FpG13X1EfkDXcs9h+Tbex2586zc+kAP
+        NZpyTeDkdE/snzTvMaeFK2XE/Aqa8WbjD/RFGqZrXaGtdsAZLZxVzmY0t5WRVuGAqdX0zX+zMxm5
+        IMx63Jpzy1vNoaBVzfS718boKC1oJWf6AfdMEr8QvbQVU+UwqdBzlmQkSaXbYolqtkE/Iah74h7d
+        f/gjZJRo97SNjLwYdKSy1kZ5BjfwIqdUL2ItkfB0U2lrMYUzENIBFVC0jIHwIMlACnRObtMCK5g1
+        zVyaaEZ3LnCb9RNeig/dUqBOoD3Kp/9EttlhWLjvjKKN12xV+Oevv0WSh60aWXESzdu1bRfl1QPA
+        fknKcaopE50pQgHfTj8s+/l4geBQu/29NwBFp7v7HbSVtvz8/Xg4yIf5qI9leFIzHcokthQH85XM
+        YP1XTgCntdzFZHb6levgTBN/BZ2PkqoM2yP1LkV4N87z/vBdp+mzH7sqkWS0H25QvXW+IXp1QKr8
+        4vwyb6UdJhvUPLE7VgZ8xRvn+f/wI/+TQ2/V+ubYa+lsess7mZ4e0OpL7/NvwKGT7XrSYO9/ddhB
+        SvHxams/aAXBF2I07J+ga4YC8F0TF6OEBYjplH58lr8Gpq6x6UuY54B1+OTwrqLov3x/+RcAAP//
+        AwCd2z+yOAUAAA==
     headers:
-      CF-RAY: [32e1fdeaed546581-SYD]
-      Cache-Control: ['private, max-age=600']
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:04 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d51c1f11584b78596237c75e4a5cf21bc1486587424; expires=Thu,
-          08-Feb-18 20:57:04 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"apikey": "4D297D8CFDE0E105"}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
-    method: POST
-    uri: https://api.thetvdb.com/login
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwTBy3KqMAAA0H2/wnFPBzCC3p0GkIA8AgSKGwYMSHgYilqEO/33nvP/Y7VaP3lb
-        3tf/VutyturidGUes0KyIMll6IHuwfYKkYLa4SuG1v6znK2uNA/Ma3TR01LZXRzgNPiB+q5FDWdB
-        /+5KnXYUogfq93Oe0CpPDBE1/O1qN9mNbhtXQ2KFPxFvx6mzbs5L3MSOh3WRGH0mFbp/FgaamEa4
-        vZAlWFIOdo7YDk/NGJ1IfqkAbGcgedJOdmeFpqHrSSGT9UhJixmUpf1W5+ZYJ8TvVVjpKusvb/qI
-        D+rGIo1tnhxlmV+LALH9TS3J49aZMsc/IP+6hZqvODpS7vyS6zWxT5Hm5rZZn9KYo7oPWIpfafMN
-        IAzeWaaMWzb++E/gjxeR51O29+f9FFlVLiIjLgV8JPSrDXQVZgIYyWY6GeLN5D+h3VWjkRxB2JJp
-        B3B3aXcgceEQXzsj8LEUpEFcEaFw+sC2sDxDAybDcZiwzkkhM1OoH5lyT57msmHRpNEze+JCpqXC
-        wGH98fsHAAD//wMA4Ne8odcBAAA=
-    headers:
-      CF-RAY: [32e1fdec7bb46569-SYD]
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:04 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d97d1aaa0f56815c2656b586630b154e81486587424; expires=Thu,
-          08-Feb-18 20:57:04 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 21:03:19 GMT
+      Vary:
+      - Accept-Encoding,Accept-Language
+      Via:
+      - 1.1 1aa2bf2109b471b97d9f7ada4bca1cd4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - DovEWaoXkywOZHkwhXgMkT78Z8sj33fAIzat41qCcseIVkro5FiMZg==
+      X-Amz-Cf-Pop:
+      - GIG51-C2
+      X-Cache:
+      - Hit from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Accept-Language: [en]
-      Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODY2NzM4MjQsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDg2NTg3NDI0fQ.IokrwlJgMu03VMOQE0UFm_1bEPL-pdWHFS5ZUzRzYo48M0kptDFrMT2u7445y41O182Ny6dYSNO1Si2ET6Yby4eeKx7yjBhWUPm7CfE7imZxdsVA73JUjKHGM6zyuz-CQKqdJ1OoJLdiMPAIPc5CDP6MEI6noZaEhUKGTDNaKHhGYVoIhmRiYQuYjq4CCRx__6r5irvPt4PrZ0oaw_9Py9wTJfa0IFVe-QBUdXkRE7C_-4rU3wGF0gHovSKlfrFWB4SkUw84QlZk84WNCpVclFRPQ1RYRVfU-bMmRKJQ2yCFCWpBpwQEoUb2iH-hs_6nWtHz3iTwDdLitQb2de6i4A]
-      Connection: [keep-alive]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzM0NzQsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4Njc0fQ.gZO1DaMXesZ9tiVBZOA7S1hBq2NfBUSQ6wcZwDr3H2yGLrbhLMiUQVXW2shD89cCzJxs4Tjf0ap4dB8KwFRBpmcU-VEpyY9Z3tZf5Q9fAEnxjQXc6FVfR7LeXRLcupBy5AQpE23X3roJek6F--77l01Q_YZU8yjyr4QB7_namYS1MuZ9apCI98sMII_ojR7gdk75HwVCZZyOYoEuzVoRLS8I7NNWpnKDSwIPuwx9detMGJB37KRdeMgp2nDYDz28pl6nUe1EpWh2_wX8cxKDfybMszKu9u-883ohO5hP_yumAFS2g_nfaspuda00kQ4vp8EE517WfdgeyxPSnHO6eg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/episodes/302431
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3xUzW4iRxC++ylKcwbvMMYYc8PACm8cb2RwfMjm0EwX07XuqUbdNSCyspSnyYPl
-        SaIe/oag5DAa9fdVVddP1/fjCiDRSlQygB9XAAAJ6WQAN2nWvem0dogij3qGKjhOBpBdoo/jZACd
-        217/vslNVhScxueqXKCPMfck7nFVYjKAZJYb5yy8YMXkONkbLckHGcYw0SZL01477baz+wNfVBhk
-        JsqHZAC/1RhA8uzQwsgq/457Q4BkYimoBYqBmVUa+cR8cYbhCTG4BjipCmSENxUMcSFNaqS8s8QI
-        D+j99oS/OA1DL6byDVuLJcxpEWs/gg/I31VJDLOSxJzwIYtxvIWZ4EZ5gSkqfWKnqMSgh5Eq0Tfz
-        eapyYq1g7Ld/4HuzLoRfKH+3uE1q7Pd91zR5zMXFaSRfVIkBpmqDIfkXfdbTpt1ZsI0nwXPbuVts
-        4c2QGFcFPDd3a/Rrwk28+8nlSsjxAMa4XPot/KoswpQKA7vn0IInx9pxCyZcWMW6BRPlxcA3/43H
-        SnAAWZre1ccJY0kYBjA3CD95spZEMYaajN/coEdQHiGIV1wgFI64CG3HoAQU5K5ceTTIgdYIYfcg
-        2/D6+WtoQcy7TSxoLRXIArkhqz1yCxRrcFq3RQUhLg6empjRh2uYGwqgRLzKJYAYjAfkWDm4ZQ3M
-        kcXA2MW2t+DFBayj/kz5O253z6QFKsAGrY3/mGy1shj9ndWw9ISsw99//nUYolVcVKrA40Zfrlxz
-        B5pjQd6N7GMfauWdrvKY7sjp2vN59HmW9u+eDpcF4zav3kbqdH+Q15VWUq9up9vLetlN2jnIhl7r
-        MYW8Vpmjj15f6ote/6eC6LUeGbWSGuTK2oPsLIKzlZwcOr2jnFjkQ/W7qOHTXb+fdj/tpO76+6o4
-        FoWeMDzGDGuTy8IetjGb+143uzspXhguBf2xjmZe5MMDLp3H/2f39Z7TYqpyMazE1Gub3d6c4Vrj
-        WSdr9I20mIh20/SMmCIVRmpFzW4PDJV68XgWJJDgi4pPOrbgun8Bj1zFMUzv/grg4+rjHwAAAP//
-        AwDo6SZ+RwYAAA==
+        H4sIAAAAAAAAA3RT23IaORD9lS49Dw5gAuN5w0DWzhJvyuD4YbMPYtTMKNZIlKQxxaZctV+zH5Yv
+        ydEAKbu29mEK+nSr+/TlfBdKRimK70IrUVz2h6PLQSak9qxWLIOzohi+sW/nohi8H+dXJ3Sx08Ep
+        vmubDXtkyASfENmwKMSqrJ0zdM+t1ciWia32IU7TU3iH/f641x/1hlfwVC2HuIrSB1H8KaY21s4e
+        aBV5L32kG5YKQddsv8lGW1o1OtYAZtI7oy3TNXt/SIDhhtZ6k/hkYmF0kBuONa2MVJwYLNqKEf8o
+        Q61tFTtWyB5r9jQDa98hHx3TZ10+GT50Vm1pyRw637IttVWS5v7wNz8BuHNsaGakf2JY907R1Me6
+        9eKvTCj0WkZ37Ooj8ge6kXsOybf3OvLRs3abAz3WaMq1gZPTPbN/1rzHnJaulBHzK2jO260/0Bdp
+        mG50hba6AWe0dFY5m9HCVkZahT+YWk1f/Vc7l5ELwqwnnbmw3GgOBa1rpt+9NkZHaUErOdMH3DNJ
+        fCF6aSumymFSoecsyUiSStfsPNdsg35G0HHFPXr48EfIKNHuaRsZeTHoSGWtjfIMbuBFTqlelCEi
+        4fml0tZiChcgpAMqoGgZA2EhyUAKdE5u2wFrmDXNXZpoRvcucJf1EzbFh+NRoE6gPcqn30S23WFY
+        eO+Moq3XbFX48c+/WBQGVbWy4nT/b8+2O5RXC4D9komdd6otE50ZQgHfzT6s+vlkieBQu/2DNwC7
+        xCE+7CCtdOWD95PRMB/l4z6O4VnNdSiT2FIczFcyg/VfOQGc1XIXk2lbY6C7TXCmjb+CBuOkKsP2
+        RP2YIryb5Hl/9O6o6YtvuyqRZLQfblG9c74hen1AqvxycJV30g7TLWqe2Z0qA77mrfP8f/iJ/9mh
+        G7W5PfVaOpt2eS/T6gGtv/Q+/wYcOmk20xZ3/6vDI6QUn5529qNWEHwhxqP+GbphKCACuxwnLEBM
+        5/STi/w1MHOtjam/HLAOnxz2Kor+y8tPAAAA//8DANxX6YABBQAA
     headers:
-      CF-RAY: [32e1fdee0ebe19d4-SYD]
-      Cache-Control: ['private, max-age=600']
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:05 GMT']
-      Last-Modified: ['Sat, 07 May 2016 12:10:12 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=db74d913f6825d4625b9601ee9209288e1486587424; expires=Thu,
-          08-Feb-18 20:57:04 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"apikey": "4D297D8CFDE0E105"}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
-    method: POST
-    uri: https://api.thetvdb.com/login
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwTBSZKqMAAA0H2fwnJvlwyC9E4jQoghAgaQTRdD0ABxAAXh1797v/fvazabv+41
-        u81/ZnM2OtfMyjnhTkAnKLkcdvDmr3IANVg/4hA4xjcbnYbZG04qc0l2Z9mdsIor2kHR1LC6c198
-        GmYWTQFgB4UxplFRptF+Cav7x91dZPd0UdwdlErve1p49DcwfOPivq1cO/SPHmg3HJaDkPCqN1qr
-        y2QZUFfQV6DEsXg5eOAL8XJRhK1ie3uCdcYM4JwKpqifjZEFmAsmoeUG9YR4CiDxvplEJsT2Wuve
-        +dn6iue5q4+XSVjVh+T0YIa2X7SF6fvTGEh9+Kjz0HuRq2w1FFP7fIyvOrFV93DEqcI7mhdi0jka
-        u5ON1gM56of+QKYottcUoR3Mm42zfHsgbLpeAxvx5muzIDr0xiDYSlMlSnoKhrLMl7Sr5ZvDjoaq
-        Wwnr9eSxTUPTD9DzGder5KnZ0YRWlBEFH0RrDkBNzwVv0WRnTmHorcyLKkJoavkgKSBMm2TdL5wu
-        GeZf//8AAAD//wMA2jcvrdcBAAA=
-    headers:
-      CF-RAY: [32e1fdefa9a00b20-SYD]
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:05 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=dc9f3bbb0181f5ed7efe58f13a12b06151486587425; expires=Thu,
-          08-Feb-18 20:57:05 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 21:03:19 GMT
+      Last-Modified:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Vary:
+      - Accept-Encoding,Accept-Language
+      Via:
+      - 1.1 76ebb2b2a599c264ac624f33b5da568f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 0Wcyuh9-Eb2v4Xl3AwVdK9oL-Qv2R040DlwM_PyBsN07c0BVvXIj2A==
+      X-Amz-Cf-Pop:
+      - GIG51-C2
+      X-Cache:
+      - Hit from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Accept-Language: [en]
-      Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODY2NzM4MjUsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDg2NTg3NDI1fQ.z-QU_S9R9gNuGc6LvpvC6nMVfwm1M5v9rGsb22CUNmUtS3XXmtJMwi-mtNKWMGdBnqC8be9CJTde34xA9bSMime1K0AKvOOQ3COXFlzmbmmBhk7QYqrR3QQN5xQb1M47wZTpe96F-rdERRzyS1vVpkcVQtOh2GlUMUHYPXh7OH4NLPMa3isUcdmz7iKysTHK8wOP7LvLOzWXH8UKKDIclAJ0uQCVlsv6CAmui8EdO7IQySSB1zjmfUTSwffc0Usk2nJeP947GZev7ZpBaVERSKqqXk5Zq6HWzK5UeO3MLmrEwC4aYdirKzHbJd97r2idjWKKzriw13CValZ8v-JsZw]
-      Connection: [keep-alive]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzM0NzQsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4Njc0fQ.gZO1DaMXesZ9tiVBZOA7S1hBq2NfBUSQ6wcZwDr3H2yGLrbhLMiUQVXW2shD89cCzJxs4Tjf0ap4dB8KwFRBpmcU-VEpyY9Z3tZf5Q9fAEnxjQXc6FVfR7LeXRLcupBy5AQpE23X3roJek6F--77l01Q_YZU8yjyr4QB7_namYS1MuZ9apCI98sMII_ojR7gdk75HwVCZZyOYoEuzVoRLS8I7NNWpnKDSwIPuwx9detMGJB37KRdeMgp2nDYDz28pl6nUe1EpWh2_wX8cxKDfybMszKu9u-883ohO5hP_yumAFS2g_nfaspuda00kQ4vp8EE517WfdgeyxPSnHO6eg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/series/73255
+  response:
+    body:
+      string: '{"data":{"id":73255,"seriesId":"22374","seriesName":"House","aliases":["House
+        M.D."],"season":"8","poster":"posters/73255-24.jpg","banner":"graphical/73255-g7.jpg","fanart":"fanart/original/73255-11.jpg","status":"Ended","firstAired":"2004-11-16","network":"FOX","networkId":"1318","runtime":"45","language":"en","genre":["Drama","Suspense"],"overview":"Dr.
+        Gregory House is a maverick physician who is devoid of bedside manner. While
+        his behavior can border on antisocial, Dr. House thrives on the challenge
+        of solving the medical puzzles that other doctors give up on. Together with
+        his hand-picked team of young medical experts, he''ll do whatever it takes
+        in the race against the clock to solve the case.","lastUpdated":1575144873,"airsDayOfWeek":"","airsTime":"","rating":"TV-14","imdbId":"tt0412142","zap2itId":"EP00688359","added":"","addedBy":null,"siteRating":9.1,"siteRatingCount":34962,"slug":"house"}}'
+    headers:
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '912'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 13:58:45 GMT
+      Last-Modified:
+      - Sat, 30 Nov 2019 20:14:33 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 ecee0359d5c5ac41b0df518901cd63aa.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - SNVhLtZ4uDaRq5ZrlJ7Et2LqXmUKA2hLcclyviQZ9nI0KOKg7dylug==
+      X-Amz-Cf-Pop:
+      - GIG51-C2
+      X-Cache:
+      - Hit from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzM0NzQsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4Njc0fQ.gZO1DaMXesZ9tiVBZOA7S1hBq2NfBUSQ6wcZwDr3H2yGLrbhLMiUQVXW2shD89cCzJxs4Tjf0ap4dB8KwFRBpmcU-VEpyY9Z3tZf5Q9fAEnxjQXc6FVfR7LeXRLcupBy5AQpE23X3roJek6F--77l01Q_YZU8yjyr4QB7_namYS1MuZ9apCI98sMII_ojR7gdk75HwVCZZyOYoEuzVoRLS8I7NNWpnKDSwIPuwx9detMGJB37KRdeMgp2nDYDz28pl6nUe1EpWh2_wX8cxKDfybMszKu9u-883ohO5hP_yumAFS2g_nfaspuda00kQ4vp8EE517WfdgeyxPSnHO6eg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/series/73255/images/query?keyType=poster
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7zTzU6EMBAH8DtPMZnzulsKLR9vYEw8efNgumyXrbItocVINr67qVEghmQNgpce
-        /jPtTH5JLwEAHoQTmMNjAABw+TwBUB0wB8o4jzff0YvsHrpaYg5YG+tkg33Jtvs72fnKkB1VJe/F
-        edRvd0lEGbsJt891OTQ20pqqdcpo38pT8hYSQkZ14ZQu7a0+Gsz7DQFQvMpGlH4A39LNkBem1c6v
-        z7+y9/4td2rPey1U5Uc9FaI4yd3UcsHo2k+TLFzBhK5gEk2YhOkME3rNJGVJurxJ9E8mjMwwiX5h
-        ki1vEq9gwqf+TjzDJL5mkpEsWd6E/cnkAwAA//+82NENAyAIBNCNGkER2H+x/vSTFEI4NzAvcJ5G
-        JvLxaHc6eSIFE8Du3HmTQKQDcgsggMXRR2HCnTDR1ITWmjcxwOJYtDgdE0tN9qJ5EwfMCQUm2iDx
-        hGRvJcCY0ALMyZmak9/p/qiYqgEmhfnRqHinsmWdjfzeDVAhfnLzSGdSKiYHYYJosjLV2mgXWBjB
-        gngIhsWtxUIFFkSu0HzH32FVaamcgoojVBAtX4fSliRXUUGoXMAKhVczd1huymKkCBZ9xdL6Ykrr
-        Pi2BBK49+nnrsViBhRAsDogWniotXlBBFDmeb/0nfB12VHjlKlp7Hn4BAAD//8yaMQ7DMAwD97wi
-        T1BEWZYf06f070W3DgGUCqGQ3dPBpijSf1Lp8iwl05+G12rCeEGKJio4KljSrBYSlMtiTb6/lGBr
-        ZuVGjOUMLKMpi6tMIR0XqFDiBO+KsVHB4ikWF8burPPJl2XmVA6K4HZFtyUqmZEby4ViWQjh7dkD
-        Kg2hzMdNRzCgQJoW54qsIPNxMV2F0LdjNqltxcdhXqEyCFS6ZKXi+RE5FTdC/4H1ZCqZrkSIThB+
-        IkiL2FYGkKWqEt9zBCbHg1XFsu1wuTmjP8T926HddFOQdh9i6osxgBh59mknVMGS5tlHmIHxv+n+
-        +lBOoFT2ZfutD7d9f23vDwAAAP//AwDaZiutQSkAAA==
+      string: '{"data":[{"id":25664,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-1.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":6.2,"count":676},"thumbnail":"posters/73255-1_t.jpg"},{"id":25914,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-2.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":6.3,"count":468},"thumbnail":"posters/73255-2_t.jpg"},{"id":28578,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-3.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":6.4,"count":1326},"thumbnail":"posters/73255-3_t.jpg"},{"id":28579,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-4.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":7,"count":780},"thumbnail":"posters/73255-4_t.jpg"},{"id":29097,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-5.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":5.9,"count":416},"thumbnail":"posters/73255-5_t.jpg"},{"id":29098,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-6.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":5,"count":156},"thumbnail":"posters/73255-6_t.jpg"},{"id":29099,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-7.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":6,"count":546},"thumbnail":"posters/73255-7_t.jpg"},{"id":29100,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-8.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":5.8,"count":260},"thumbnail":"posters/73255-8_t.jpg"},{"id":29301,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-9.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":7,"count":234},"thumbnail":"posters/73255-9_t.jpg"},{"id":33710,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-10.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":5.8,"count":286},"thumbnail":"posters/73255-10_t.jpg"},{"id":196621,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-11.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":7.2,"count":546},"thumbnail":"posters/73255-11_t.jpg"},{"id":196631,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-12.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":4.8,"count":104},"thumbnail":"posters/73255-12_t.jpg"},{"id":196641,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-13.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":6.7,"count":650},"thumbnail":"posters/73255-13_t.jpg"},{"id":196681,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-14.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":3.3,"count":104},"thumbnail":"posters/73255-14_t.jpg"},{"id":196691,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-15.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":5.7,"count":234},"thumbnail":"posters/73255-15_t.jpg"},{"id":196751,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-16.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":6.4,"count":286},"thumbnail":"posters/73255-16_t.jpg"},{"id":198171,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-17.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":6.4,"count":416},"thumbnail":"posters/73255-17_t.jpg"},{"id":210511,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-19.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":5.2,"count":130},"thumbnail":"posters/73255-19_t.jpg"},{"id":210521,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-18.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":6.2,"count":416},"thumbnail":"posters/73255-18_t.jpg"},{"id":210531,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-20.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":4.8,"count":130},"thumbnail":"posters/73255-20_t.jpg"},{"id":210701,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-21.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":6.3,"count":312},"thumbnail":"posters/73255-21_t.jpg"},{"id":224011,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-23.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":6.1,"count":546},"thumbnail":"posters/73255-23_t.jpg"},{"id":230801,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-24.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":6.5,"count":1352},"thumbnail":"posters/73255-24_t.jpg"},{"id":387781,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-22.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":6.4,"count":260},"thumbnail":"posters/73255-22_t.jpg"},{"id":585961,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-25.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":6.3,"count":156},"thumbnail":"posters/73255-25_t.jpg"},{"id":585981,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-26.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":5.9,"count":338},"thumbnail":"posters/73255-26_t.jpg"},{"id":586041,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-27.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":6.3,"count":156},"thumbnail":"posters/73255-27_t.jpg"},{"id":586111,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-28.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":5.8,"count":156},"thumbnail":"posters/73255-28_t.jpg"},{"id":596031,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-29.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":6,"count":286},"thumbnail":"posters/73255-29_t.jpg"},{"id":763831,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-30.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":5.7,"count":78},"thumbnail":"posters/73255-30_t.jpg"},{"id":876204,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-37.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":5.9,"count":234},"thumbnail":"posters/73255-37_t.jpg"},{"id":876205,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-38.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":5.8,"count":130},"thumbnail":"posters/73255-38_t.jpg"},{"id":876640,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-39.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":5.8,"count":130},"thumbnail":"posters/73255-39_t.jpg"},{"id":880273,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-40.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":6,"count":156},"thumbnail":"posters/73255-40_t.jpg"},{"id":883255,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-41.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":5.9,"count":234},"thumbnail":"posters/73255-41_t.jpg"},{"id":964610,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-33.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":4,"count":156},"thumbnail":"posters/73255-33_t.jpg"},{"id":1042694,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-35.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":5.5,"count":52},"thumbnail":"posters/73255-35_t.jpg"},{"id":1184439,"keyType":"poster","subKey":"graphical","fileName":"posters/73255-42.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":0,"count":0},"thumbnail":"posters/73255-42_t.jpg"},{"id":1343589,"keyType":"poster","subKey":"graphical","fileName":"posters/5c78a1888d8e7.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":0,"count":0},"thumbnail":"posters/5c78a1888d8e7_t.jpg"},{"id":1362732,"keyType":"poster","subKey":"graphical","fileName":"posters/5ce09b0f2cf29.jpg","languageId":0,"language":"en","resolution":"680x1000","ratingsInfo":{"average":7,"count":52},"thumbnail":"posters/5ce09b0f2cf29_t.jpg"}]}'
     headers:
-      CF-RAY: [32e1fdf13f6a65b1-SYD]
-      Cache-Control: ['private, max-age=600']
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:05 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=df3a0911d445901320fe60404700d65901486587425; expires=Thu,
-          08-Feb-18 20:57:05 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"apikey": "4D297D8CFDE0E105"}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
-    method: POST
-    uri: https://api.thetvdb.com/login
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwTBSZKqMAAA0H2fwnJvlwyC9E4jQoghAgaQTRdD0ABxAAXh1797v/fvazabv+41
-        u81/ZnM2OtfMyjnhTkAnKLkcdvDmr3IANVg/4hA4xjcbnYbZG04qc0l2Z9mdsIor2kHR1LC6c198
-        GmYWTQFgB4UxplFRptF+Cav7x91dZPd0UdwdlErve1p49DcwfOPivq1cO/SPHmg3HJaDkPCqN1qr
-        y2QZUFfQV6DEsXg5eOAL8XJRhK1ie3uCdcYM4JwKpqifjZEFmAsmoeUG9YR4CiDxvplEJsT2Wuve
-        +dn6iue5q4+XSVjVh+T0YIa2X7SF6fvTGEh9+Kjz0HuRq2w1FFP7fIyvOrFV93DEqcI7mhdi0jka
-        u5ON1gM56of+QKYottcUoR3Mm42zfHsgbLpeAxvx5muzIDr0xiDYSlMlSnoKhrLMl7Sr5ZvDjoaq
-        Wwnr9eSxTUPTD9DzGder5KnZ0YRWlBEFH0RrDkBNzwVv0WRnTmHorcyLKkJoavkgKSBMm2TdL5wu
-        GeZf//8AAAD//wMA2jcvrdcBAAA=
-    headers:
-      CF-RAY: [32e1fdf2fcd50b08-SYD]
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:05 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d73b2154db2d6ec3519a1f7a610e225ae1486587425; expires=Thu,
-          08-Feb-18 20:57:05 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 01:40:18 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 8b1c1823a9db474c5721c440e560ca5e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - NpmxlqyzUGQm_oFQrv6pICl8duQKxYFTgrTlRYBIU9AWvXU-gy69RA==
+      X-Amz-Cf-Pop:
+      - GIG51-C2
+      X-Cache:
+      - Hit from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Accept-Language: [en]
-      Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODY2NzM4MjUsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDg2NTg3NDI1fQ.z-QU_S9R9gNuGc6LvpvC6nMVfwm1M5v9rGsb22CUNmUtS3XXmtJMwi-mtNKWMGdBnqC8be9CJTde34xA9bSMime1K0AKvOOQ3COXFlzmbmmBhk7QYqrR3QQN5xQb1M47wZTpe96F-rdERRzyS1vVpkcVQtOh2GlUMUHYPXh7OH4NLPMa3isUcdmz7iKysTHK8wOP7LvLOzWXH8UKKDIclAJ0uQCVlsv6CAmui8EdO7IQySSB1zjmfUTSwffc0Usk2nJeP947GZev7ZpBaVERSKqqXk5Zq6HWzK5UeO3MLmrEwC4aYdirKzHbJd97r2idjWKKzriw13CValZ8v-JsZw]
-      Connection: [keep-alive]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzM0NzQsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4Njc0fQ.gZO1DaMXesZ9tiVBZOA7S1hBq2NfBUSQ6wcZwDr3H2yGLrbhLMiUQVXW2shD89cCzJxs4Tjf0ap4dB8KwFRBpmcU-VEpyY9Z3tZf5Q9fAEnxjQXc6FVfR7LeXRLcupBy5AQpE23X3roJek6F--77l01Q_YZU8yjyr4QB7_namYS1MuZ9apCI98sMII_ojR7gdk75HwVCZZyOYoEuzVoRLS8I7NNWpnKDSwIPuwx9detMGJB37KRdeMgp2nDYDz28pl6nUe1EpWh2_wX8cxKDfybMszKu9u-883ohO5hP_yumAFS2g_nfaspuda00kQ4vp8EE517WfdgeyxPSnHO6eg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/series/73255/actors
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA6yWQW/bMAyF7/0VhM51J8lW7OhWZNmyNEOLtsMO60WJuUSDbQWUvSEo9t8He2va
-        bbHrBL74ID4ZxIfHRz2eAbDUlIZp+HIGAPDYfAGYTZkGGSZhfP505JEs+g91IQ6lUvtCYXJkGtgc
-        vUe422KxQmL7MrmsKb+lC7h1S6QSJhvj8VnhHZXXlCIxDWJ/anOzbi6aVenIv2m6ufi2XbO/JZdV
-        uXHUtKv+qaQp1u0yyYUIhAhkBCLUYqzl6PknmfHlp21qykPacKyjkDXSn+ctiJL+iBbWG5immPkS
-        bXGYUaOZVGm6O4VQcjKhUcBFIGMQUotEc9VF6D9tN6Fxf0Kzar2BhanI4mE87wnXjnYwc1Wbh3gn
-        ofEQHoqk5nEXoTDgUSBGjd+iWttJKOLHjFlR2K9I8NERWe9abHSZZXURJiZHeinq7aWID+IloWXc
-        10uNtpuU6E/qOjcE0+3WHyY0JbuCd44wNyfhEUMYSUodqv5hpF4ZtUj2x/MnjO/QFLBAVxhKD4Oa
-        mxw9fLaZP81HchBQQnP5CigZ8BEIoVWkQ94BKuE8GfUHdYMlEszNyi1bx22yIevh3lTLw4TCVkJN
-        M0NMGo+1CntO2m9tN6EjVv+VyeAGi7aNZn5Q/SiAq6osXj4N+gOKB4kipVXUN4oabTegIxb/dWa/
-        W1PPUNqy124x38EDu99YKhGLBwYzk2bY8giQnbSSgYJbqf7B/ZRMvwAAAP//rJexbsMgEIb3PMW9
-        QCVsMMZsVrtGqpSqVYcO5xgpljGVMB089N0rwtiAjZOZG45P3Hc/UVoZIaA1RsHLT6/GyG6bOmXh
-        /VvjOMx7nlM6A/BaRAkRcdUM87cuK0n5SggonkgJhEsiJGtS7ha04BkpICB4w6nTy42xO6J1F4Qj
-        zk7ZbEShmTus7bNP6U1Ma1mwrYgaX5tC1AhOtyN6vqDVi1HwOcScPcAr2jF3xEIj9+BpfDQkVzxp
-        IzFfSzgQISvhF+AKHpahpF45p6A1BjsdkZL/0g1nhLbHad6FiT1k9zNJyFZMtWSpDEkJr6sMc5+U
-        Rvi4mY1ODs+LP9ux1EIbD/E0XbHQv9oA5wDwdfj9AwAA//8DAJU7q4gEEAAA
+      string: '{"data":[{"id":63585230,"seriesId":73255,"name":"Hugh Laurie","role":"Gregory
+        House","sortOrder":1,"image":"actors/23839.jpg","imageAuthor":171,"imageAdded":"2011-11-24
+        13:42:07","lastUpdated":"2011-11-24 13:42:07"},{"id":63585227,"seriesId":73255,"name":"Lisa
+        Edelstein","role":"Lisa Cuddy","sortOrder":2,"image":"actors/23838.jpg","imageAuthor":171,"imageAdded":"2016-01-27
+        12:18:05","lastUpdated":"2016-01-27 12:18:05"},{"id":63585224,"seriesId":73255,"name":"Jesse
+        Spencer","role":"Robert Chase","sortOrder":3,"image":"actors/23837.jpg","imageAuthor":171,"imageAdded":"2011-11-24
+        13:19:26","lastUpdated":"2011-11-24 13:19:26"},{"id":63585233,"seriesId":73255,"name":"Jennifer
+        Morrison","role":"Allison Cameron","sortOrder":4,"image":"actors/23840.jpg","imageAuthor":171,"imageAdded":"2016-01-27
+        12:11:27","lastUpdated":"2016-01-27 12:11:27"},{"id":63585235,"seriesId":73255,"name":"Omar
+        Epps","role":"Eric Foreman","sortOrder":5,"image":"actors/23841.jpg","imageAuthor":171,"imageAdded":"2011-11-24
+        13:22:35","lastUpdated":"2011-11-24 13:22:35"},{"id":63585237,"seriesId":73255,"name":"Robert
+        Sean Leonard","role":"James Wilson","sortOrder":6,"image":"actors/23842.jpg","imageAuthor":171,"imageAdded":"2011-11-24
+        13:21:02","lastUpdated":"2011-11-24 13:21:02"},{"id":63585239,"seriesId":73255,"name":"Peter
+        Jacobson","role":"Chris Taub","sortOrder":7,"image":"actors/80086.jpg","imageAuthor":171,"imageAdded":"2016-01-27
+        12:07:53","lastUpdated":"2016-01-27 12:07:53"},{"id":63585241,"seriesId":73255,"name":"Kal
+        Penn","role":"Lawrence Kutner","sortOrder":8,"image":"actors/80087.jpg","imageAuthor":171,"imageAdded":"2016-01-27
+        12:15:54","lastUpdated":"2016-01-27 12:15:54"},{"id":63585243,"seriesId":73255,"name":"Olivia
+        Wilde","role":"Remy \"Thirteen\" Hadley","sortOrder":9,"image":"actors/80088.jpg","imageAuthor":171,"imageAdded":"2016-01-27
+        12:11:55","lastUpdated":"2016-01-27 12:11:55"},{"id":63585245,"seriesId":73255,"name":"Anne
+        Dudek","role":"Amber Volakis","sortOrder":10,"image":"actors/80089.jpg","imageAuthor":2545,"imageAdded":"2008-12-04
+        12:25:36","lastUpdated":"2008-12-04 12:25:36"},{"id":63585248,"seriesId":73255,"name":"Amber
+        Tamblyn","role":"Martha M. Masters","sortOrder":11,"image":"actors/283160.jpg","imageAuthor":171,"imageAdded":"2011-04-12
+        11:37:14","lastUpdated":"2011-04-12 11:37:14"},{"id":63585251,"seriesId":73255,"name":"Charlyne
+        Yi","role":"Chi Park","sortOrder":12,"image":"actors/289863.jpg","imageAuthor":171,"imageAdded":"2011-09-16
+        01:37:54","lastUpdated":"2011-09-16 01:37:54"},{"id":63585254,"seriesId":73255,"name":"Odette
+        Annable","role":"Jessica Adams","sortOrder":13,"image":"actors/289864.jpg","imageAuthor":171,"imageAdded":"2011-11-24
+        13:24:00","lastUpdated":"2011-11-24 13:24:00"},{"id":63585257,"seriesId":73255,"name":"Sela
+        Ward","role":"Stacy Warner","sortOrder":14,"image":"actors/306758.jpg","imageAuthor":171,"imageAdded":"2016-01-27
+        12:13:36","lastUpdated":"2016-01-27 12:13:36"}]}'
     headers:
-      CF-RAY: [32e1fdf48d2d6569-SYD]
-      Cache-Control: ['private, max-age=600']
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:06 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d804f5a85a6dbf6b646a612354e49a1d21486587426; expires=Thu,
-          08-Feb-18 20:57:06 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 21:57:57 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 ecee0359d5c5ac41b0df518901cd63aa.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - t7WsEQr4zT1rjhthbE4nIP7wq0umvdozCHlf2bMAhMoDUD5bDQqSZQ==
+      X-Amz-Cf-Pop:
+      - GIG51-C2
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/flexget/tests/cassettes/test_thetvdb.TestTVDBLookup.test_no_posters_actors
+++ b/flexget/tests/cassettes/test_thetvdb.TestTVDBLookup.test_no_posters_actors
@@ -2,275 +2,322 @@ interactions:
 - request:
     body: '{"apikey": "4D297D8CFDE0E105"}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
     method: POST
     uri: https://api.thetvdb.com/login
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAAwTBx5KbMAAA0Pt+hcd37wBainID4SJqwBbFlx06AiTIGmNDJv+e9/5+7Hb7eewr
-        vv+121er1ebngvrUupINix7FD8xDuUBYwf2URMiCn9VqDdVFp353FHwzlbzN/XK79IHZ0ONupCF7
-        D9WxHEqEH5jBNYvLOotPAu7Gt2c2kndrgGdiqQ4+ywMp9PhN4YubILrWV/StQlpcQKSfZZE8kzaj
-        rjGm4ZAvnoTaEkYi6h4OaWEpKe/D2vTX23YvKuIdkSjFoy4R1Ulk15na6X4mgj0ej90p0DWyimhd
-        NuYN5Q8MzGdtOIEJ3FnRwO29sFAf1AvvLhEXXmwGaGuMIdrYJhOV+rGRIELKV8MMTU9hsT3C30Jf
-        63rMJrNSRJon+HTLN4PKCpv7emnPTcsyWOeKT1WggZ+ose0JGLEJAZEI70S74LA1ePo12a6eND2S
-        Ru30mtV5kUH+ukeiZ7SHIINgCrWDP2Iu2N3md0Z6cP6IWf70z7POzW/wdbOWMoisCAsOHLgQnRTc
-        7D/+/QcAAP//AwBgFy3s1wEAAA==
+      string: '{"token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzI4NTEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4MDUxfQ.h86E_1r6vER9S4L79aoSLh26vp9eFBclUbhDETPrq6hPh5SE34ab6PGLcZCz04O1AYaIMbiE_3eNjpxoV2B5ipuGk8mrTiutfFC_X2kpo8YbPgGq_-hTr_6GrCpjSz7v_bzd1u5jKhP3SA3WvbU2rOiIItXOpeMoycbw9b83Q93XhHNYIYCmVMeSOKk1upm8XCWu6_GDb0uq5xVZzBA-mpsAqCN474kRt5zDCdVlfxqjZULybz3T6bXfxsowJIjR5eZwySAg4Y4Zv-CNoJ3Yu4Y-HP8jwVsRQoLbdSo9aAuWOYh7pqr7NrwUj653Y7EIDCH0LX45q61XZNh3Q3TC2A"}'
     headers:
-      CF-RAY: [32e1fdf87fba6581-SYD]
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:06 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=dff4dc1c6ca07fc828d643236fc2526911486587426; expires=Thu,
-          08-Feb-18 20:57:06 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '466'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 21:47:31 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 9561d4f7fd20a46f9a3b03c625437a57.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - T2z9wGLDgJaMz7ra1lvdhrh308NAvLf-qIcWnKpZ4uQXqYMc1t2dZw==
+      X-Amz-Cf-Pop:
+      - EZE51-C1
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Accept-Language: [en]
-      Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODY2NzM4MjYsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDg2NTg3NDI2fQ.d-UcAWxi9wnD3VSfSC_79icH3VAG51UuXhaiMBoYRlbvN2Chd9V1CjsLUh9d26x-ygkSTzZceUNEC12WoA2U7LX5MLphpZGU0KoEEjFQA8Uy1CyvzmNldr9QDufBLQD3Mt683TxvmRAl7HnjHVn0wmt3CzgBlVzmz5U7iOWBXCUUdwgmB8AY9czsRP0kfAAWmpDe61ibXIFTbzBi56mtkfvhGghma9fb6Oi7383rVgKKp3BWD93U2Unj1Kcn9hBnY4pKMAXgkC2o8Fwt7tv53bwZV1NBh-Qa93pR8-OoIn0KjzOjBY-Lq1abuOGtAnD_34TJvdQVJVI0L9ln0VF6Ig]
-      Connection: [keep-alive]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzI4NTEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4MDUxfQ.h86E_1r6vER9S4L79aoSLh26vp9eFBclUbhDETPrq6hPh5SE34ab6PGLcZCz04O1AYaIMbiE_3eNjpxoV2B5ipuGk8mrTiutfFC_X2kpo8YbPgGq_-hTr_6GrCpjSz7v_bzd1u5jKhP3SA3WvbU2rOiIItXOpeMoycbw9b83Q93XhHNYIYCmVMeSOKk1upm8XCWu6_GDb0uq5xVZzBA-mpsAqCN474kRt5zDCdVlfxqjZULybz3T6bXfxsowJIjR5eZwySAg4Y4Zv-CNoJ3Yu4Y-HP8jwVsRQoLbdSo9aAuWOYh7pqr7NrwUj653Y7EIDCH0LX45q61XZNh3Q3TC2A
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/search/series?name=Sex+House
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA1RSQW4bMQy8+xWDPduuYwRtkVuBFmgv7SG5FE0O9IreZSNLC5La9TbI3wvZTdwc
-        JAjD4WBIzdMCaAI5NTf4tQCAp9MNNBSFjK0WHpYv4I5SYm1u0HRKQy8txXfb95uP19erbv176JpX
-        5l7U/JMoh8rebq62q82H1dX2wpBaOTe/Yol9yvpYWy7EPLKOwlNFb/mIr7kYQwyEiXcwVmHDoDmU
-        lgN2M+56xo8kOS0v8CgE71n0XMFn6cQp4tZLkGwIPJD6gZOv8c2rPB/bWExGhmf8zOWu7BgDKwid
-        UnLsNR+qZrVh4vzSSAikjzByUUbeQ5mi+Azr82TLfzbOzrx6oRRgRTWXFCR1aEv0ory+1/tUz60c
-        MXAeIkN5UDZOXnkjqeRib/RhzsrZ54ENktpYTpKEA6kKB+QYWNHm5GyOSeqPgpQxFIckEPrTggOb
-        dIkD6OQLPY0nIcOhtD2Mj/U9ZDPZRV7Xpc+wnNPZzh9eos8Tj6x1YvI69oxJYkTKjh1jz2GJA4ca
-        ozijJeWAfVZkBcWYJw519ZFpZJTkElHl5voJlhN6smpjfYnKOQvf6cBvwvIfwclLDXXzJQUOzQl/
-        XgAPi+e/AAAA//8DAH7h1AMNAwAA
+      string: '{"data":[{"aliases":[],"banner":"/banners/images/missing/series.jpg","firstAired":"2012-7-12","id":260844,"network":"YouTube","overview":"Sex
+        House is a web series produced by The Onion, produced via their Onion Digital
+        Studios department. It is exclusive to YouTube per a grant from the website.
+        It is a dark satire of reality shows, their production and surrounding culture.\r\n\r\nSix
+        people representing various reality show stereotypes including a married older
+        contest winner are put in a house designed around having as much sex as possible.
+        They soon realize, however, that they will not be fed, medically cared for
+        or allowed to leave until every person has sex.","seriesName":"Sex House","slug":"sex-house","status":"Ended"}]}'
     headers:
-      CF-RAY: [32e1fdfa09cd65cf-SYD]
-      Cache-Control: ['private, max-age=600']
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:07 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d0a3db692b5b03cdf0550f66c339b78e41486587426; expires=Thu,
-          08-Feb-18 20:57:06 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"apikey": "4D297D8CFDE0E105"}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
-    method: POST
-    uri: https://api.thetvdb.com/login
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwTBSZKqMAAA0H2fwnJvl4oD/J0E0VASxSEMGwpCaBPCDAb41Xfv9/5/zWbzrsxo
-        Mf83m9PRescnwq7MerwmuEIMtrC4bwmAO5hVHgaW9k1HS9DzgV35cXk1/DWa7I3NSQtzkUFesns+
-        CHpMRAJgC3NtjNwkjVxzCXk5IONnjZ4/CjKgkjrf/Qh5AbvzYTj08d4BWkWEddNevU20SRWp0jFU
-        n63ddMNVRurI8OUo45fYpGkgGopFJ7bAcmNHyyv9YSxC+hYeYUw1t6/W013/M66ZHb6vwHfaCwyB
-        u9LbWJq0NcjqWMsiCRZJrPbYAmSDNnJoab3LtuZp75gyDJIPANw7I5yqN4yV1r4voxzXsacrMQxe
-        AVKuYcFUJ0QJbsBHjSBaa1E35P7hbaucH8xsfJaG4lg2k/kzGUKfNGLXJY2sRLMnx1zJM3kMdHgT
-        Asb0w40+vZzqSWKFLie4sOD0aPeTrHzP09/6cDGWC2HRs5dioCIuTn3hTp1eonLP+1VMm8iPP878
-        6/cPAAD//wMA8/w+b9cBAAA=
-    headers:
-      CF-RAY: [32e1fdfb88456581-SYD]
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:07 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d7cd2709ee2b05ed1f077d5d6aa31104f1486587427; expires=Thu,
-          08-Feb-18 20:57:07 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '736'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 21:47:31 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 449a33633af422ed0455ecaba4d77f39.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - qi-k9H6bgR7hauasUrY9sKAJMmdp4NRFMDGr4DjdXWiP9TCtCIcnpQ==
+      X-Amz-Cf-Pop:
+      - EZE51-C1
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Accept-Language: [en]
-      Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODY2NzM4MjcsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDg2NTg3NDI3fQ.uyIjnItHAxAub7QC9pclJP9UuMc9z8lf3tiNqHJ6zPVpkcqaDYwywbUl4ffZlreVltl5CJWbQ9mpBSD-_ehlXcii8F5UsXBWYvy2iM_hOCYQsLI_CW1BsbwFesDc1EqwndZ-db8uVJCc4N4wxseq6k5FG7QFw_ZdvCCjXHNVf8PVV3sMR0amVqbXB3bIZUZN3O_ni8Q_NdVrCv8aIN29atxmYAhM8jjAFkyToD3QJMiwmTdx_Ycrl6tdrwplr7cEm3mkwEZBIPllIbevjDufLGqzwV3e0zI-JIzSs7zwpYXXBhBxLD0-lJeHXfVC8NjlGunWztBoNo7ju1beraYbvQ]
-      Connection: [keep-alive]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzI4NTEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4MDUxfQ.h86E_1r6vER9S4L79aoSLh26vp9eFBclUbhDETPrq6hPh5SE34ab6PGLcZCz04O1AYaIMbiE_3eNjpxoV2B5ipuGk8mrTiutfFC_X2kpo8YbPgGq_-hTr_6GrCpjSz7v_bzd1u5jKhP3SA3WvbU2rOiIItXOpeMoycbw9b83Q93XhHNYIYCmVMeSOKk1upm8XCWu6_GDb0uq5xVZzBA-mpsAqCN474kRt5zDCdVlfxqjZULybz3T6bXfxsowJIjR5eZwySAg4Y4Zv-CNoJ3Yu4Y-HP8jwVsRQoLbdSo9aAuWOYh7pqr7NrwUj653Y7EIDCH0LX45q61XZNh3Q3TC2A
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/series/260844
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA2RTXW/TQBB8768Y+TkN+WgK5A1aJHihUluEEPCwyW3ihcudtbeX1EX8d3R2XBp4
-        sOSbXc/NrGd/nQGVI6NqiV9nAFCJq5aYXU5eXVyMeiSxCqePtONqieqOH/A+5sTVsUxeKHGqlvj6
-        /QitKATW0r1VampZk3/RU55vxz+abXXC/KHcWD1hRpYLW/UuOHYDvBFN9kaUu+bZZDo7n7w8n86G
-        emA7RP35nOkIndJrDia9k5cDtuWgBfnaHYHqKu7YtccyUN0yebG26s6Dybhn3QsfToYCSSAceIXe
-        GxqNLq/ZYdXivmbcBIlh9BfeC8FqFu0ruJatGHncWXYSExw3pLbjYGN8sELPD2ufk+wZFvEl5vu8
-        YjSsIGyVgmGjcVc4i4wkxsOHBEf6E4lMlBE30N4WUh0PaXSU0SuzooWCQ8qqMQcnYYt19paVx9/0
-        WyjPnTyg4dh4hnKjnDhY6duTSszphB/JWDla23CChLXPHSVhR6rCDtE7VqxjME6Gg5QEgZTRZIME
-        EOpuwI6TbAM7UKcLNe07ooRdXtdI/FDem5iSrDyPy9BbpBhDL+eRR6jjgfesxTFZsd3iIN4jRMOK
-        sWE3wo5dia1vsSZlh01URAV5Hw/syug9055R4uRR6NryE1IMqCkVGeMhXp6SfWocWZfd6cXk9Xy6
-        mC6G9SLRdE3tzeYzc5ff+zprctRWzxruj5l9ijGVST9HZOdWfdTNZvPp5eTV0248UjMTO90Dcu6f
-        VXqN6WK5mC8Xk5Oet221xPxiNp1Phg0V49vh/v/Bq5iDlcoZ8Pvs9x8AAAD//wMA1mtytmMEAAA=
+        H4sIAAAAAAAAA1RTXU8bMRD8Kys/JyEJpC15a6FSeSkSpKoq6MPmvLlzceyTP5IciP/e8V0iQEqk
+        2w+vZ8azL0pzYrV8UUar5fzT9MvFxUhFCUbiDTJKnaKfvBXE93KgHz5HQYGt4ShRLR/+li6O3qFj
+        hkrrY5IwHF+zc/13HbhtTMX2bLhnXE/+tTU6Nuw4JHQMH2c+mNq4t77ZsS8mThnXqe9Oiy4HTYjp
+        qwlSkM6ns/l4+nk8m6PiJO19eEL6j8+rvJa3XE9rcXmOTMgumZ7WApFlV2euSygOcS0uIHhQV34r
+        ukPmTkA5dQp0/U7Czsj+vSRkIjHtZU2DZNQGr3MlmtYdrRqhW2e8G72ld4YpNWLCUKFr8E5s6T5l
+        bXwkLS302IpLE7pJZbwcKpuj2QklT0dq1ErAvZDXJdoEvy0zC4xokpwOMmkOTxQ5QS7yGwoDF4qN
+        38fREcaALBUs7DTFHILPThtXU5VtykEmj+HRlf+9OeBi31rBqDZIBMrSt+NgIMaH+VTcID51LUQx
+        DhT6kUxbDhBKk7caHCrvksREe1McQwygbQZ6gKGmF1hLNLXDAe5xUcO7flCkba4ayH4o33BfNGsL
+        7hAdCDzo9HCeZYRBe8HbFcacCu0O91lLzieClhvRI8JzF5/ajiqA0LTxgfBDBod1kd4K4w2KfSyV
+        cV15BPgfiGKBMen9FNOvFvtV7DnFusCt19zdbn6LFGeumhyi5mKsUloNTiy25KKkWrps7UiZrV73
+        nk1pfj7DRhR/P3M7N+m0oaz1xxW4pNliuThfLqan6rdOLS/ml7MF1gi2uDteMX0fXkHTNORsRhE7
+        fRj3wqvX1/8AAAD//wMA7FGKACoEAAA=
     headers:
-      CF-RAY: [32e1fdfd29b0654b-SYD]
-      Cache-Control: ['private, max-age=600']
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:07 GMT']
-      Last-Modified: ['Fri, 29 Aug 2014 12:25:54 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d1f775197124fdd38419501f799a953541486587427; expires=Thu,
-          08-Feb-18 20:57:07 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"apikey": "4D297D8CFDE0E105"}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
-    method: POST
-    uri: https://api.thetvdb.com/login
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwTBSZKqMAAA0H2fwnJvl4oD/J0E0VASxSEMGwpCaBPCDAb41Xfv9/5/zWbzrsxo
-        Mf83m9PRescnwq7MerwmuEIMtrC4bwmAO5hVHgaW9k1HS9DzgV35cXk1/DWa7I3NSQtzkUFesns+
-        CHpMRAJgC3NtjNwkjVxzCXk5IONnjZ4/CjKgkjrf/Qh5AbvzYTj08d4BWkWEddNevU20SRWp0jFU
-        n63ddMNVRurI8OUo45fYpGkgGopFJ7bAcmNHyyv9YSxC+hYeYUw1t6/W013/M66ZHb6vwHfaCwyB
-        u9LbWJq0NcjqWMsiCRZJrPbYAmSDNnJoab3LtuZp75gyDJIPANw7I5yqN4yV1r4voxzXsacrMQxe
-        AVKuYcFUJ0QJbsBHjSBaa1E35P7hbaucH8xsfJaG4lg2k/kzGUKfNGLXJY2sRLMnx1zJM3kMdHgT
-        Asb0w40+vZzqSWKFLie4sOD0aPeTrHzP09/6cDGWC2HRs5dioCIuTn3hTp1eonLP+1VMm8iPP878
-        6/cPAAD//wMA8/w+b9cBAAA=
-    headers:
-      CF-RAY: [32e1fdfebc450b20-SYD]
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:07 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d15421ef2c421924c3f7d85a4ab7dec4a1486587427; expires=Thu,
-          08-Feb-18 20:57:07 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 21:03:22 GMT
+      Last-Modified:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Vary:
+      - Accept-Encoding,Accept-Language
+      Via:
+      - 1.1 90a8a98f54c295f099272d8c7711dc97.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - sgve9t89dIStBdFJWyJPOk_i8s7CJnS37wilXkeOBoEAxhb8iwAGeA==
+      X-Amz-Cf-Pop:
+      - EZE51-C1
+      X-Cache:
+      - Hit from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Accept-Language: [en]
-      Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODY2NzM4MjcsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDg2NTg3NDI3fQ.uyIjnItHAxAub7QC9pclJP9UuMc9z8lf3tiNqHJ6zPVpkcqaDYwywbUl4ffZlreVltl5CJWbQ9mpBSD-_ehlXcii8F5UsXBWYvy2iM_hOCYQsLI_CW1BsbwFesDc1EqwndZ-db8uVJCc4N4wxseq6k5FG7QFw_ZdvCCjXHNVf8PVV3sMR0amVqbXB3bIZUZN3O_ni8Q_NdVrCv8aIN29atxmYAhM8jjAFkyToD3QJMiwmTdx_Ycrl6tdrwplr7cEm3mkwEZBIPllIbevjDufLGqzwV3e0zI-JIzSs7zwpYXXBhBxLD0-lJeHXfVC8NjlGunWztBoNo7ju1beraYbvQ]
-      Connection: [keep-alive]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzI4NTEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4MDUxfQ.h86E_1r6vER9S4L79aoSLh26vp9eFBclUbhDETPrq6hPh5SE34ab6PGLcZCz04O1AYaIMbiE_3eNjpxoV2B5ipuGk8mrTiutfFC_X2kpo8YbPgGq_-hTr_6GrCpjSz7v_bzd1u5jKhP3SA3WvbU2rOiIItXOpeMoycbw9b83Q93XhHNYIYCmVMeSOKk1upm8XCWu6_GDb0uq5xVZzBA-mpsAqCN474kRt5zDCdVlfxqjZULybz3T6bXfxsowJIjR5eZwySAg4Y4Zv-CNoJ3Yu4Y-HP8jwVsRQoLbdSo9aAuWOYh7pqr7NrwUj653Y7EIDCH0LX45q61XZNh3Q3TC2A
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/series/260844
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA1RTXU8bMRD8Kys/JyEJpC15a6FSeSkSpKoq6MPmvLlzceyTP5IciP/e8V0iQEqk
+        2w+vZ8azL0pzYrV8UUar5fzT9MvFxUhFCUbiDTJKnaKfvBXE93KgHz5HQYGt4ShRLR/+li6O3qFj
+        hkrrY5IwHF+zc/13HbhtTMX2bLhnXE/+tTU6Nuw4JHQMH2c+mNq4t77ZsS8mThnXqe9Oiy4HTYjp
+        qwlSkM6ns/l4+nk8m6PiJO19eEL6j8+rvJa3XE9rcXmOTMgumZ7WApFlV2euSygOcS0uIHhQV34r
+        ukPmTkA5dQp0/U7Czsj+vSRkIjHtZU2DZNQGr3MlmtYdrRqhW2e8G72ld4YpNWLCUKFr8E5s6T5l
+        bXwkLS302IpLE7pJZbwcKpuj2QklT0dq1ErAvZDXJdoEvy0zC4xokpwOMmkOTxQ5QS7yGwoDF4qN
+        38fREcaALBUs7DTFHILPThtXU5VtykEmj+HRlf+9OeBi31rBqDZIBMrSt+NgIMaH+VTcID51LUQx
+        DhT6kUxbDhBKk7caHCrvksREe1McQwygbQZ6gKGmF1hLNLXDAe5xUcO7flCkba4ayH4o33BfNGsL
+        7hAdCDzo9HCeZYRBe8HbFcacCu0O91lLzieClhvRI8JzF5/ajiqA0LTxgfBDBod1kd4K4w2KfSyV
+        cV15BPgfiGKBMen9FNOvFvtV7DnFusCt19zdbn6LFGeumhyi5mKsUloNTiy25KKkWrps7UiZrV73
+        nk1pfj7DRhR/P3M7N+m0oaz1xxW4pNliuThfLqan6rdOLS/ml7MF1gi2uDteMX0fXkHTNORsRhE7
+        fRj3wqvX1/8AAAD//wMA7FGKACoEAAA=
+    headers:
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 21:03:22 GMT
+      Last-Modified:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Vary:
+      - Accept-Encoding,Accept-Language
+      Via:
+      - 1.1 5e2644fb49bed6d1558a80cc2424f54c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - t_ohOwSPoQDZb0gtyNsKKx-mo5e3SSSYmT7u7KcwiZ5-ZsDrOeTSDg==
+      X-Amz-Cf-Pop:
+      - EZE51-C1
+      X-Cache:
+      - Hit from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzI4NTEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4MDUxfQ.h86E_1r6vER9S4L79aoSLh26vp9eFBclUbhDETPrq6hPh5SE34ab6PGLcZCz04O1AYaIMbiE_3eNjpxoV2B5ipuGk8mrTiutfFC_X2kpo8YbPgGq_-hTr_6GrCpjSz7v_bzd1u5jKhP3SA3WvbU2rOiIItXOpeMoycbw9b83Q93XhHNYIYCmVMeSOKk1upm8XCWu6_GDb0uq5xVZzBA-mpsAqCN474kRt5zDCdVlfxqjZULybz3T6bXfxsowJIjR5eZwySAg4Y4Zv-CNoJ3Yu4Y-HP8jwVsRQoLbdSo9aAuWOYh7pqr7NrwUj653Y7EIDCH0LX45q61XZNh3Q3TC2A
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/series/260844/images/query?keyType=poster
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA6rmUlBQci0qyi9SslJQ8stXKEotLs0pKVZIyy9SqMwvLVIoLE0tqrRSyE0siM5O
-        rQypLEi1KsgvLkktUshOrQxLzClNtTIyM7AwMYlV4qoFAAAA//8DAG6HlThPAAAA
+      string: '{"Error":"No results for your query"}'
     headers:
-      CF-RAY: [32e1fe004c730b20-SYD]
-      Cache-Control: ['private, max-age=600']
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:08 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d15421ef2c421924c3f7d85a4ab7dec4a1486587427; expires=Thu,
-          08-Feb-18 20:57:07 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 404, message: Not Found}
-- request:
-    body: '{"apikey": "4D297D8CFDE0E105"}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
-    method: POST
-    uri: https://api.thetvdb.com/login
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwTBSZKqMAAA0H2fwnJPlyCg/h0ymSAJKCq46WKIDAEEokL41Xfv9/5/LRbL15OS
-        dvlvsSQcFomdlriE58sMRFQCBtqTkupABbQLrzrcfRMOa3LQSlyZK2xEEppd2a1yBpqagupZnpqp
-        JmZWZzpgoNnx+JY94pu1AtVzQkYuoSBfIwPID/+7fAMnPNyCpP3YXPRCBKVcZ9p9pVU/VoSo4Ozi
-        S6KY/ZS0Ga1f0zqdrya4vJWMTzPW03MmrQkr4QZZds/Ddt+FbSE7Qhh0924bFXBkgWIOzw3izkEg
-        gui5kHr7IJaz5DHQsy/ltrT69Ekz9PjtjB3G91oj7esEZb22M7RTpx82GoZkAYhid8Bx7TknqvfJ
-        bDWDucfRsD4eWS90KTFuQmNWIoveIvaN4BkkFT6qok3T+tPGvaDWoLOMopN9vj0DmnMe+BWixaRw
-        ZlNThUOnu1uG2cNNRi1yNmTQxo/qdFLpyx4nQ2Bf5VUgm58scjexfQw9ZF+s8yxg5bgu7n3hEks0
-        x+XX7x8AAAD//wMAiqkb29cBAAA=
-    headers:
-      CF-RAY: [32e1fe01ecb90b20-SYD]
-      Connection: [keep-alive]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:08 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=da08170be6b2b64c262d4703734d526ad1486587428; expires=Thu,
-          08-Feb-18 20:57:08 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '37'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 21:47:33 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 2948d9a27a84204b2bc36934485844b4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - p0Jbp7q21ScjR3HSCAzJ2elFq-y4NJHI3_i6JEycP3jZ1neGdqAd9g==
+      X-Amz-Cf-Pop:
+      - EZE51-C1
+      X-Cache:
+      - Error from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 404
+      message: Not Found
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Accept-Language: [en]
-      Authorization: [Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODY2NzM4MjgsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDg2NTg3NDI4fQ.iuIKXHWTbnvGy1PXNJ2gCsAZ0Aj_FYNk-K9aUb5Eqxbndkltx3czVEIUu5dyxzOCcSd23esiJ7NFGqyXnBpXnh4K-XTpZp8YhJwsT5Ero7NyKH-e-1PMJkPBTa4dbfrkSQ2gG20vqbmrqOuKwpOOZlAentRJ4ClGdN96x_swDD2FIJNaMrOalPKRkCqbzFmrEBOYr3LLsq-pceDW-mEj1sYu1OQDToTbjOL61Gkclvnaq-6lIpFDhp4Qy8SIkgyyTQjNkhx5ysGkE6JrpCM8sOsfMbwAYK7erAwv6Kp2iQ4PyerTGV40T4EvdYM7aGLXPNGUFSz-O5L3hZqhMeF1Ew]
-      Connection: [keep-alive]
-      User-Agent: [FlexGet/2.9.16.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1MzI4NTEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTI4MDUxfQ.h86E_1r6vER9S4L79aoSLh26vp9eFBclUbhDETPrq6hPh5SE34ab6PGLcZCz04O1AYaIMbiE_3eNjpxoV2B5ipuGk8mrTiutfFC_X2kpo8YbPgGq_-hTr_6GrCpjSz7v_bzd1u5jKhP3SA3WvbU2rOiIItXOpeMoycbw9b83Q93XhHNYIYCmVMeSOKk1upm8XCWu6_GDb0uq5xVZzBA-mpsAqCN474kRt5zDCdVlfxqjZULybz3T6bXfxsowJIjR5eZwySAg4Y4Zv-CNoJ3Yu4Y-HP8jwVsRQoLbdSo9aAuWOYh7pqr7NrwUj653Y7EIDCH0LX45q61XZNh3Q3TC2A
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/series/260844/actors
   response:
-    body: {string: "{\n  \"data\": null\n}"}
+    body:
+      string: '{"Error":"not found"}'
     headers:
-      CF-RAY: [32e1fe037b6c65cf-SYD]
-      Cache-Control: ['private, max-age=600']
-      Connection: [keep-alive]
-      Content-Length: ['18']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 08 Feb 2017 20:57:08 GMT']
-      Server: [cloudflare-nginx]
-      Set-Cookie: ['__cfduid=d5b602ec20cb6ce3142507ce3271ee1df1486587428; expires=Thu,
-          08-Feb-18 20:57:08 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      Vary: [Accept-Language]
-      X-Powered-By: [Thundar!]
-      X-Thetvdb-Api-Version: [2.1.2]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '21'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 09 Dec 2019 21:47:33 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 fccb6b9c4ebd61ac6c5fc94394de34f2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - DlBHby1kv4XQlOZCUF5oxyIf7P626frB2wJY9jPchtwe7LND3VUY9w==
+      X-Amz-Cf-Pop:
+      - EZE51-C1
+      X-Cache:
+      - Error from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 404
+      message: Not Found
 version: 1

--- a/flexget/tests/cassettes/test_tvdb_lookup_api.TestTVDBLanguages.test_series_lookup_with_language
+++ b/flexget/tests/cassettes/test_tvdb_lookup_api.TestTVDBLanguages.test_series_lookup_with_language
@@ -1,13 +1,19 @@
 interactions:
 - request:
-    body: !!python/unicode '{"apikey": "4D297D8CFDE0E105"}'
+    body: '{"apikey": "4D297D8CFDE0E105"}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [!!python/unicode FlexGet/2.4.1.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FlexGet/2.4.1.dev (www.flexget.com)
     method: POST
     uri: https://api.thetvdb.com/login
   response:
@@ -22,27 +28,45 @@ interactions:
         P+rGg5fHqETx3QPnMWqV0qtG81TZk+rnybVoUB8lsSz2vcymm7Ueu6/wcRem4PcMJhSrzQsBNmTF
         /uPffwAAAP//AwDq9zv21wEAAA==
     headers:
-      cf-ray: [2f4ae6b82b9508bd-FRA]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 20 Oct 2016 07:54:21 GMT']
-      server: [cloudflare-nginx]
-      set-cookie: ['__cfduid=dd3d3a056911a9388c81d5d23f38254911476950060; expires=Fri,
-          20-Oct-17 07:54:20 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      vary: [Accept-Language]
-      x-powered-by: [Thundar!]
-      x-thetvdb-api-version: [2.1.1]
-    status: {code: 200, message: OK}
+      cf-ray:
+      - 2f4ae6b82b9508bd-FRA
+      connection:
+      - keep-alive
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 20 Oct 2016 07:54:21 GMT
+      server:
+      - cloudflare-nginx
+      set-cookie:
+      - __cfduid=dd3d3a056911a9388c81d5d23f38254911476950060; expires=Fri, 20-Oct-17
+        07:54:20 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      vary:
+      - Accept-Language
+      x-powered-by:
+      - Thundar!
+      x-thetvdb-api-version:
+      - 2.1.1
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Accept-Language: [!!python/unicode nl]
-      Authorization: [!!python/unicode Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzcwMzY0NjEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc2OTUwMDYxfQ.TV2Crbw1bIm-uX4rHmcAQ4KbHWcQ0nAscf-KguozPze7KAz3T8KcewwoMeU8jDCl9wXWWHDiVf1dYCnoaoEoV1tWTmlkM-oRYDNfIJrhAxPWHSSWONWYj2zw4QjmfF644m5PyWelFkA5aSggt1uLbDMG0-pOoM0n4pzfo8i6RXhz7ai4GoPnX4FPpusQciFFGZwCqiTemfRkNQQcE1_mCRzMMpP0vxzxn-snF4Zm_RF-eKO4gKHxTdtVnLvAxHBwmfhvVdEmeYiT5JKU0CuYhMaLSF7uYnDhSjuN6jPvETfb9glMrYbaC4rrCovGOy5p3WUL1vVq7FvMaEl_MFosdg]
-      Connection: [keep-alive]
-      User-Agent: [!!python/unicode FlexGet/2.4.1.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - nl
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzcwMzY0NjEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc2OTUwMDYxfQ.TV2Crbw1bIm-uX4rHmcAQ4KbHWcQ0nAscf-KguozPze7KAz3T8KcewwoMeU8jDCl9wXWWHDiVf1dYCnoaoEoV1tWTmlkM-oRYDNfIJrhAxPWHSSWONWYj2zw4QjmfF644m5PyWelFkA5aSggt1uLbDMG0-pOoM0n4pzfo8i6RXhz7ai4GoPnX4FPpusQciFFGZwCqiTemfRkNQQcE1_mCRzMMpP0vxzxn-snF4Zm_RF-eKO4gKHxTdtVnLvAxHBwmfhvVdEmeYiT5JKU0CuYhMaLSF7uYnDhSjuN6jPvETfb9glMrYbaC4rrCovGOy5p3WUL1vVq7FvMaEl_MFosdg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.4.1.dev (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/search/series?name=Tegenlicht
   response:
@@ -62,28 +86,47 @@ interactions:
         UuIYQTbJ4KDe5NhejEkNdWV16iUW2XE9tMrPcXZtez/+DBPk9zzgv+f/osLZp/I3W/2Z1EUn0fb8
         +/r+QPT14fu/AAAA//8DACFnYIYLBQAA
     headers:
-      cache-control: ['private, max-age=600']
-      cf-ray: [2f4ae6bf5bc30893-FRA]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 20 Oct 2016 07:54:22 GMT']
-      server: [cloudflare-nginx]
-      set-cookie: ['__cfduid=de870999eb84d04d1dc875489b63ec3d91476950061; expires=Fri,
-          20-Oct-17 07:54:21 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      vary: [Accept-Language]
-      x-powered-by: [Thundar!]
-      x-thetvdb-api-version: [2.1.1]
-    status: {code: 200, message: OK}
+      cache-control:
+      - private, max-age=600
+      cf-ray:
+      - 2f4ae6bf5bc30893-FRA
+      connection:
+      - keep-alive
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 20 Oct 2016 07:54:22 GMT
+      server:
+      - cloudflare-nginx
+      set-cookie:
+      - __cfduid=de870999eb84d04d1dc875489b63ec3d91476950061; expires=Fri, 20-Oct-17
+        07:54:21 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      vary:
+      - Accept-Language
+      x-powered-by:
+      - Thundar!
+      x-thetvdb-api-version:
+      - 2.1.1
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Accept-Language: [!!python/unicode nl]
-      Authorization: [!!python/unicode Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzcwMzY0NjEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc2OTUwMDYxfQ.TV2Crbw1bIm-uX4rHmcAQ4KbHWcQ0nAscf-KguozPze7KAz3T8KcewwoMeU8jDCl9wXWWHDiVf1dYCnoaoEoV1tWTmlkM-oRYDNfIJrhAxPWHSSWONWYj2zw4QjmfF644m5PyWelFkA5aSggt1uLbDMG0-pOoM0n4pzfo8i6RXhz7ai4GoPnX4FPpusQciFFGZwCqiTemfRkNQQcE1_mCRzMMpP0vxzxn-snF4Zm_RF-eKO4gKHxTdtVnLvAxHBwmfhvVdEmeYiT5JKU0CuYhMaLSF7uYnDhSjuN6jPvETfb9glMrYbaC4rrCovGOy5p3WUL1vVq7FvMaEl_MFosdg]
-      Connection: [keep-alive]
-      User-Agent: [!!python/unicode FlexGet/2.4.1.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - nl
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzcwMzY0NjEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc2OTUwMDYxfQ.TV2Crbw1bIm-uX4rHmcAQ4KbHWcQ0nAscf-KguozPze7KAz3T8KcewwoMeU8jDCl9wXWWHDiVf1dYCnoaoEoV1tWTmlkM-oRYDNfIJrhAxPWHSSWONWYj2zw4QjmfF644m5PyWelFkA5aSggt1uLbDMG0-pOoM0n4pzfo8i6RXhz7ai4GoPnX4FPpusQciFFGZwCqiTemfRkNQQcE1_mCRzMMpP0vxzxn-snF4Zm_RF-eKO4gKHxTdtVnLvAxHBwmfhvVdEmeYiT5JKU0CuYhMaLSF7uYnDhSjuN6jPvETfb9glMrYbaC4rrCovGOy5p3WUL1vVq7FvMaEl_MFosdg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.4.1.dev (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/series/252712
   response:
@@ -106,29 +149,49 @@ interactions:
         HcbpdDSdjKZTmswX5WxRzq9qfnkuFjSbT2f3j6ejK4b3J/7H8f/hN75XKxb06oboy82X/wAAAP//
         AwCS+q/JVwYAAA==
     headers:
-      cache-control: ['private, max-age=600']
-      cf-ray: [2f4ae6c68b0c08bd-FRA]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 20 Oct 2016 07:54:23 GMT']
-      last-modified: ['Sat, 15 Oct 2016 12:29:33 GMT']
-      server: [cloudflare-nginx]
-      set-cookie: ['__cfduid=da05affedd1bb1efcc3a806a26ff674571476950063; expires=Fri,
-          20-Oct-17 07:54:23 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      vary: [Accept-Language]
-      x-powered-by: [Thundar!]
-      x-thetvdb-api-version: [2.1.1]
-    status: {code: 200, message: OK}
+      cache-control:
+      - private, max-age=600
+      cf-ray:
+      - 2f4ae6c68b0c08bd-FRA
+      connection:
+      - keep-alive
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 20 Oct 2016 07:54:23 GMT
+      last-modified:
+      - Sat, 15 Oct 2016 12:29:33 GMT
+      server:
+      - cloudflare-nginx
+      set-cookie:
+      - __cfduid=da05affedd1bb1efcc3a806a26ff674571476950063; expires=Fri, 20-Oct-17
+        07:54:23 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      vary:
+      - Accept-Language
+      x-powered-by:
+      - Thundar!
+      x-thetvdb-api-version:
+      - 2.1.1
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Accept-Language: [!!python/unicode en]
-      Authorization: [!!python/unicode Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzcwMzY0NjEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc2OTUwMDYxfQ.TV2Crbw1bIm-uX4rHmcAQ4KbHWcQ0nAscf-KguozPze7KAz3T8KcewwoMeU8jDCl9wXWWHDiVf1dYCnoaoEoV1tWTmlkM-oRYDNfIJrhAxPWHSSWONWYj2zw4QjmfF644m5PyWelFkA5aSggt1uLbDMG0-pOoM0n4pzfo8i6RXhz7ai4GoPnX4FPpusQciFFGZwCqiTemfRkNQQcE1_mCRzMMpP0vxzxn-snF4Zm_RF-eKO4gKHxTdtVnLvAxHBwmfhvVdEmeYiT5JKU0CuYhMaLSF7uYnDhSjuN6jPvETfb9glMrYbaC4rrCovGOy5p3WUL1vVq7FvMaEl_MFosdg]
-      Connection: [keep-alive]
-      User-Agent: [!!python/unicode FlexGet/2.4.1.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzcwMzY0NjEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc2OTUwMDYxfQ.TV2Crbw1bIm-uX4rHmcAQ4KbHWcQ0nAscf-KguozPze7KAz3T8KcewwoMeU8jDCl9wXWWHDiVf1dYCnoaoEoV1tWTmlkM-oRYDNfIJrhAxPWHSSWONWYj2zw4QjmfF644m5PyWelFkA5aSggt1uLbDMG0-pOoM0n4pzfo8i6RXhz7ai4GoPnX4FPpusQciFFGZwCqiTemfRkNQQcE1_mCRzMMpP0vxzxn-snF4Zm_RF-eKO4gKHxTdtVnLvAxHBwmfhvVdEmeYiT5JKU0CuYhMaLSF7uYnDhSjuN6jPvETfb9glMrYbaC4rrCovGOy5p3WUL1vVq7FvMaEl_MFosdg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.4.1.dev (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/series/252712/images/query?keyType=poster
   response:
@@ -137,17 +200,169 @@ interactions:
         H4sIAAAAAAAAAwTBMQqAMAwF0N1TfHoDCyJkd3USF3HoEJdWUtNmCOLdfe8dgLCoigZCWAXKzUpv
         uEThYorHWJ1wp3pk9s0rU5XWWZHZ91SMKU5xHuMZhu8HAAD//wMALKj4ak8AAAA=
     headers:
-      cache-control: ['private, max-age=600']
-      cf-ray: [2f4ae6cdcf3826c6-FRA]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 20 Oct 2016 07:54:24 GMT']
-      server: [cloudflare-nginx]
-      set-cookie: ['__cfduid=d42b3c7498a1fe2637d6d183e1b6037a51476950064; expires=Fri,
-          20-Oct-17 07:54:24 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      vary: [Accept-Language]
-      x-powered-by: [Thundar!]
-      x-thetvdb-api-version: [2.1.1]
-    status: {code: 404, message: Not Found}
+      cache-control:
+      - private, max-age=600
+      cf-ray:
+      - 2f4ae6cdcf3826c6-FRA
+      connection:
+      - keep-alive
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 20 Oct 2016 07:54:24 GMT
+      server:
+      - cloudflare-nginx
+      set-cookie:
+      - __cfduid=d42b3c7498a1fe2637d6d183e1b6037a51476950064; expires=Fri, 20-Oct-17
+        07:54:24 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      vary:
+      - Accept-Language
+      x-powered-by:
+      - Thundar!
+      x-thetvdb-api-version:
+      - 2.1.1
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzcwMzY0NjEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc2OTUwMDYxfQ.TV2Crbw1bIm-uX4rHmcAQ4KbHWcQ0nAscf-KguozPze7KAz3T8KcewwoMeU8jDCl9wXWWHDiVf1dYCnoaoEoV1tWTmlkM-oRYDNfIJrhAxPWHSSWONWYj2zw4QjmfF644m5PyWelFkA5aSggt1uLbDMG0-pOoM0n4pzfo8i6RXhz7ai4GoPnX4FPpusQciFFGZwCqiTemfRkNQQcE1_mCRzMMpP0vxzxn-snF4Zm_RF-eKO4gKHxTdtVnLvAxHBwmfhvVdEmeYiT5JKU0CuYhMaLSF7uYnDhSjuN6jPvETfb9glMrYbaC4rrCovGOy5p3WUL1vVq7FvMaEl_MFosdg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/series/252712
+  response:
+    body:
+      string: '{"Error":"Not authorized","authorizer":"cloudfront"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '52'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Tue, 10 Dec 2019 00:18:59 GMT
+      Server:
+      - CloudFront
+      Via:
+      - 1.1 8dde5b6e309f57468962360ed8be8907.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - g3R0NazCS2Hy6glJqZq6J-pLLSarU99vc437RXoMK8QYAiSTfcZzkg==
+      X-Amz-Cf-Pop:
+      - GRU1-C1
+      X-Cache:
+      - LambdaGeneratedResponse from cloudfront
+    status:
+      code: 401
+      message: ''
+- request:
+    body: '{"apikey": "4D297D8CFDE0E105"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: POST
+    uri: https://api.thetvdb.com/login
+  response:
+    body:
+      string: '{"token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1NDE5MzksImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTM3MTM5fQ.H_ACCcpOYNFsoWZylhIH-GfdBG0VjvqanoQYvc_S94A7PC1HMOdV7yxgMVpGUQd8zJ8QM6LgHiI9mA4DrHzhQvc0V-lw5eKNd9uP0C8esZji77IU3CsA3blKeSEkdefgWuepPB-hkpLWa8C-31mCcHPxKODsPDYn15o2CKXPRV5Xz2jPtbkuBUcKpsazHdJ2oBPTTABYGX-lskveLQvvOhilS8SKXcRCm0PGrzUV8_Lu1xm8H9JDUc4fyy574LEVjlXn0K6v1esZlq0X75BcM_KgX8jY2j4q5-VgjVA6SYP59hRPH4Yjanw7gxOBMm8lBKMxIcgzkjbF1N8ig3eCIg"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '466'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 10 Dec 2019 00:18:59 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 52f920f33acb1140004f09dd7ec8ef94.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - S-S7o9KO69vpiyrkJ-L7EawYZas0jUlfkJ4IO2ys8NgjD5e-NBwEkg==
+      X-Amz-Cf-Pop:
+      - GRU1-C1
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1NDE5MzksImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTM3MTM5fQ.H_ACCcpOYNFsoWZylhIH-GfdBG0VjvqanoQYvc_S94A7PC1HMOdV7yxgMVpGUQd8zJ8QM6LgHiI9mA4DrHzhQvc0V-lw5eKNd9uP0C8esZji77IU3CsA3blKeSEkdefgWuepPB-hkpLWa8C-31mCcHPxKODsPDYn15o2CKXPRV5Xz2jPtbkuBUcKpsazHdJ2oBPTTABYGX-lskveLQvvOhilS8SKXcRCm0PGrzUV8_Lu1xm8H9JDUc4fyy574LEVjlXn0K6v1esZlq0X75BcM_KgX8jY2j4q5-VgjVA6SYP59hRPH4Yjanw7gxOBMm8lBKMxIcgzkjbF1N8ig3eCIg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/series/252712
+  response:
+    body:
+      string: '{"data":{"id":252712,"seriesId":"","seriesName":"VPRO Backlight","aliases":[],"season":"17","poster":"","banner":"graphical/252712-g2.jpg","fanart":"fanart/original/252712-1.jpg","status":"Continuing","firstAired":"2002-09-08","network":"VPRO","networkId":"432","runtime":"50","language":"en","genre":["Documentary"],"overview":null,"lastUpdated":0,"airsDayOfWeek":"Sunday","airsTime":"9:00
+        PM","rating":null,"imdbId":"tt0913290","zap2itId":"","added":"2011-10-11 05:23:25","addedBy":null,"siteRating":8.8,"siteRatingCount":180,"slug":"backlight"}}'
+    headers:
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '548'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 10 Dec 2019 00:46:24 GMT
+      Last-Modified:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 b87b6be4a9421126859b29704feaec64.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 26UPsw6i5Du_aJy_69tmeg-DBiPdvHAGXj4t68SX5UJyXrsftEsZAQ==
+      X-Amz-Cf-Pop:
+      - GRU50-C1
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/flexget/tests/cassettes/test_tvdb_lookup_api.TestTVDBSeriesActorsLookupAPI.test_tvdb_series_lookup_with_actors
+++ b/flexget/tests/cassettes/test_tvdb_lookup_api.TestTVDBSeriesActorsLookupAPI.test_tvdb_series_lookup_with_actors
@@ -1,13 +1,19 @@
 interactions:
 - request:
-    body: !!python/unicode '{"apikey": "4D297D8CFDE0E105"}'
+    body: '{"apikey": "4D297D8CFDE0E105"}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [!!python/unicode FlexGet/2.3.33.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FlexGet/2.3.33.dev (www.flexget.com)
     method: POST
     uri: https://api.thetvdb.com/login
   response:
@@ -22,26 +28,43 @@ interactions:
         GnjtuKBVrFmcG3rRlQpMqTd7vu+wo1SQQL9mslEg/zXGwKw9oTgKbzP83KiW25XAAkvrxPSTMNUg
         ern++vcfAAD//wMAFd0nLdcBAAA=
     headers:
-      cf-ray: [2e97c837bbc126fc-FRA]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 28 Sep 2016 14:11:00 GMT']
-      server: [cloudflare-nginx]
-      set-cookie: ['__cfduid=d18b07f414a3c3f2d6984c483bb7cb4341475071860; expires=Thu,
-          28-Sep-17 14:11:00 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      vary: [Accept-Language]
-      x-powered-by: [Thundar!]
-      x-thetvdb-api-version: [2.1.1]
-    status: {code: 200, message: OK}
+      cf-ray:
+      - 2e97c837bbc126fc-FRA
+      connection:
+      - keep-alive
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2016 14:11:00 GMT
+      server:
+      - cloudflare-nginx
+      set-cookie:
+      - __cfduid=d18b07f414a3c3f2d6984c483bb7cb4341475071860; expires=Thu, 28-Sep-17
+        14:11:00 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      vary:
+      - Accept-Language
+      x-powered-by:
+      - Thundar!
+      x-thetvdb-api-version:
+      - 2.1.1
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [!!python/unicode Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTgyNjAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcxODYwfQ.qhwXATjie5g97wC6r8KGdtDWMXXbVSEjK2awMhSC6mzw9_NCltAbVSLWSdiPzMa0mC8vgHz-4Iz3wzeHtWlT1MbeEYl6_mxgFrPy-r_OnGYG8b1mBRw4j-0t0pqkeUq5ZRXMRiUg0x1s9e5a3YmfzvtZy_qyoEpgG4zNYQaqiSF3zOSMVeNjvA_Cz036yu1hpaMOymYx_7IeSo4gKi1BsmqvuvW7XJgRW7Ho4S0nLB_SiHYl7xAScZtZnAnvIDCEdVjR-sTKszlNO0nAKw3wmjQFAk0v_PwPRRNxB4diUFTa9GdSRptX0HlP1dB1rHVuZjEbMk1xUKEo3_uYxCGiFg]
-      Connection: [keep-alive]
-      User-Agent: [!!python/unicode FlexGet/2.3.33.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTgyNjAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcxODYwfQ.qhwXATjie5g97wC6r8KGdtDWMXXbVSEjK2awMhSC6mzw9_NCltAbVSLWSdiPzMa0mC8vgHz-4Iz3wzeHtWlT1MbeEYl6_mxgFrPy-r_OnGYG8b1mBRw4j-0t0pqkeUq5ZRXMRiUg0x1s9e5a3YmfzvtZy_qyoEpgG4zNYQaqiSF3zOSMVeNjvA_Cz036yu1hpaMOymYx_7IeSo4gKi1BsmqvuvW7XJgRW7Ho4S0nLB_SiHYl7xAScZtZnAnvIDCEdVjR-sTKszlNO0nAKw3wmjQFAk0v_PwPRRNxB4diUFTa9GdSRptX0HlP1dB1rHVuZjEbMk1xUKEo3_uYxCGiFg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.3.33.dev (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/search/series?name=The+X-Files
   response:
@@ -73,27 +96,45 @@ interactions:
         Mm6yxCr/FAzXSfeSGLUL6I2lQ4UTu5wpCDfkc6OsL/DhGF4TooEdnfIV+veU8AzQ/U3jWuxWAF+r
         n18AAAD//wMAaGwvS4ELAAA=
     headers:
-      cache-control: ['private, max-age=600']
-      cf-ray: [2e97c83dbe1e274a-FRA]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 28 Sep 2016 14:11:01 GMT']
-      server: [cloudflare-nginx]
-      set-cookie: ['__cfduid=da619cfb62142d2756c17991ba077844d1475071861; expires=Thu,
-          28-Sep-17 14:11:01 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      vary: [Accept-Language]
-      x-powered-by: [Thundar!]
-      x-thetvdb-api-version: [2.1.1]
-    status: {code: 200, message: OK}
+      cache-control:
+      - private, max-age=600
+      cf-ray:
+      - 2e97c83dbe1e274a-FRA
+      connection:
+      - keep-alive
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2016 14:11:01 GMT
+      server:
+      - cloudflare-nginx
+      set-cookie:
+      - __cfduid=da619cfb62142d2756c17991ba077844d1475071861; expires=Thu, 28-Sep-17
+        14:11:01 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      vary:
+      - Accept-Language
+      x-powered-by:
+      - Thundar!
+      x-thetvdb-api-version:
+      - 2.1.1
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [!!python/unicode Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTgyNjAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcxODYwfQ.qhwXATjie5g97wC6r8KGdtDWMXXbVSEjK2awMhSC6mzw9_NCltAbVSLWSdiPzMa0mC8vgHz-4Iz3wzeHtWlT1MbeEYl6_mxgFrPy-r_OnGYG8b1mBRw4j-0t0pqkeUq5ZRXMRiUg0x1s9e5a3YmfzvtZy_qyoEpgG4zNYQaqiSF3zOSMVeNjvA_Cz036yu1hpaMOymYx_7IeSo4gKi1BsmqvuvW7XJgRW7Ho4S0nLB_SiHYl7xAScZtZnAnvIDCEdVjR-sTKszlNO0nAKw3wmjQFAk0v_PwPRRNxB4diUFTa9GdSRptX0HlP1dB1rHVuZjEbMk1xUKEo3_uYxCGiFg]
-      Connection: [keep-alive]
-      User-Agent: [!!python/unicode FlexGet/2.3.33.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTgyNjAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcxODYwfQ.qhwXATjie5g97wC6r8KGdtDWMXXbVSEjK2awMhSC6mzw9_NCltAbVSLWSdiPzMa0mC8vgHz-4Iz3wzeHtWlT1MbeEYl6_mxgFrPy-r_OnGYG8b1mBRw4j-0t0pqkeUq5ZRXMRiUg0x1s9e5a3YmfzvtZy_qyoEpgG4zNYQaqiSF3zOSMVeNjvA_Cz036yu1hpaMOymYx_7IeSo4gKi1BsmqvuvW7XJgRW7Ho4S0nLB_SiHYl7xAScZtZnAnvIDCEdVjR-sTKszlNO0nAKw3wmjQFAk0v_PwPRRNxB4diUFTa9GdSRptX0HlP1dB1rHVuZjEbMk1xUKEo3_uYxCGiFg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.3.33.dev (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/series/77398
   response:
@@ -112,28 +153,47 @@ interactions:
         M1+mxWyEpSk3u8jGmBf5vDhZjNQdtYcSd+SbD3men+aL44cQU1nyk6gPwOs+W0I7a8e3JpE/jsqL
         /8Bz12nMljic53vAn70/fwEAAP//AwBBRUjpdwQAAA==
     headers:
-      cache-control: ['private, max-age=600']
-      cf-ray: [2e97c8415fc32720-FRA]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 28 Sep 2016 14:11:02 GMT']
-      last-modified: ['Tue, 27 Sep 2016 21:50:44 GMT']
-      server: [cloudflare-nginx]
-      set-cookie: ['__cfduid=def0f7b109b4f6f0d2276ee8a01237e791475071861; expires=Thu,
-          28-Sep-17 14:11:01 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      vary: [Accept-Language]
-      x-powered-by: [Thundar!]
-      x-thetvdb-api-version: [2.1.1]
-    status: {code: 200, message: OK}
+      cache-control:
+      - private, max-age=600
+      cf-ray:
+      - 2e97c8415fc32720-FRA
+      connection:
+      - keep-alive
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2016 14:11:02 GMT
+      last-modified:
+      - Tue, 27 Sep 2016 21:50:44 GMT
+      server:
+      - cloudflare-nginx
+      set-cookie:
+      - __cfduid=def0f7b109b4f6f0d2276ee8a01237e791475071861; expires=Thu, 28-Sep-17
+        14:11:01 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      vary:
+      - Accept-Language
+      x-powered-by:
+      - Thundar!
+      x-thetvdb-api-version:
+      - 2.1.1
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [!!python/unicode Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTgyNjAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcxODYwfQ.qhwXATjie5g97wC6r8KGdtDWMXXbVSEjK2awMhSC6mzw9_NCltAbVSLWSdiPzMa0mC8vgHz-4Iz3wzeHtWlT1MbeEYl6_mxgFrPy-r_OnGYG8b1mBRw4j-0t0pqkeUq5ZRXMRiUg0x1s9e5a3YmfzvtZy_qyoEpgG4zNYQaqiSF3zOSMVeNjvA_Cz036yu1hpaMOymYx_7IeSo4gKi1BsmqvuvW7XJgRW7Ho4S0nLB_SiHYl7xAScZtZnAnvIDCEdVjR-sTKszlNO0nAKw3wmjQFAk0v_PwPRRNxB4diUFTa9GdSRptX0HlP1dB1rHVuZjEbMk1xUKEo3_uYxCGiFg]
-      Connection: [keep-alive]
-      User-Agent: [!!python/unicode FlexGet/2.3.33.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTgyNjAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcxODYwfQ.qhwXATjie5g97wC6r8KGdtDWMXXbVSEjK2awMhSC6mzw9_NCltAbVSLWSdiPzMa0mC8vgHz-4Iz3wzeHtWlT1MbeEYl6_mxgFrPy-r_OnGYG8b1mBRw4j-0t0pqkeUq5ZRXMRiUg0x1s9e5a3YmfzvtZy_qyoEpgG4zNYQaqiSF3zOSMVeNjvA_Cz036yu1hpaMOymYx_7IeSo4gKi1BsmqvuvW7XJgRW7Ho4S0nLB_SiHYl7xAScZtZnAnvIDCEdVjR-sTKszlNO0nAKw3wmjQFAk0v_PwPRRNxB4diUFTa9GdSRptX0HlP1dB1rHVuZjEbMk1xUKEo3_uYxCGiFg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.3.33.dev (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/series/77398/images/query?keyType=poster
   response:
@@ -152,27 +212,45 @@ interactions:
         Ff7oYiajS1SLpuXoQgRr7KGJv0W7yagbs4cexM2VyxnLCsmFHHuLZsTSi5vDom2mvZXJ5/IvAAAA
         //+i0qC2EfVbLvDmOFKBS1bRgtxu4VJQiOWqBQAAAP//AwCjblZo+hcAAA==
     headers:
-      cache-control: ['private, max-age=600']
-      cf-ray: [2e97c847badc15bf-FRA]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 28 Sep 2016 14:11:03 GMT']
-      server: [cloudflare-nginx]
-      set-cookie: ['__cfduid=d294f74944dbe59bb0b5456940473cc721475071862; expires=Thu,
-          28-Sep-17 14:11:02 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      vary: [Accept-Language]
-      x-powered-by: [Thundar!]
-      x-thetvdb-api-version: [2.1.1]
-    status: {code: 200, message: OK}
+      cache-control:
+      - private, max-age=600
+      cf-ray:
+      - 2e97c847badc15bf-FRA
+      connection:
+      - keep-alive
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2016 14:11:03 GMT
+      server:
+      - cloudflare-nginx
+      set-cookie:
+      - __cfduid=d294f74944dbe59bb0b5456940473cc721475071862; expires=Thu, 28-Sep-17
+        14:11:02 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      vary:
+      - Accept-Language
+      x-powered-by:
+      - Thundar!
+      x-thetvdb-api-version:
+      - 2.1.1
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [!!python/unicode Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTgyNjAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcxODYwfQ.qhwXATjie5g97wC6r8KGdtDWMXXbVSEjK2awMhSC6mzw9_NCltAbVSLWSdiPzMa0mC8vgHz-4Iz3wzeHtWlT1MbeEYl6_mxgFrPy-r_OnGYG8b1mBRw4j-0t0pqkeUq5ZRXMRiUg0x1s9e5a3YmfzvtZy_qyoEpgG4zNYQaqiSF3zOSMVeNjvA_Cz036yu1hpaMOymYx_7IeSo4gKi1BsmqvuvW7XJgRW7Ho4S0nLB_SiHYl7xAScZtZnAnvIDCEdVjR-sTKszlNO0nAKw3wmjQFAk0v_PwPRRNxB4diUFTa9GdSRptX0HlP1dB1rHVuZjEbMk1xUKEo3_uYxCGiFg]
-      Connection: [keep-alive]
-      User-Agent: [!!python/unicode FlexGet/2.3.33.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTgyNjAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcxODYwfQ.qhwXATjie5g97wC6r8KGdtDWMXXbVSEjK2awMhSC6mzw9_NCltAbVSLWSdiPzMa0mC8vgHz-4Iz3wzeHtWlT1MbeEYl6_mxgFrPy-r_OnGYG8b1mBRw4j-0t0pqkeUq5ZRXMRiUg0x1s9e5a3YmfzvtZy_qyoEpgG4zNYQaqiSF3zOSMVeNjvA_Cz036yu1hpaMOymYx_7IeSo4gKi1BsmqvuvW7XJgRW7Ho4S0nLB_SiHYl7xAScZtZnAnvIDCEdVjR-sTKszlNO0nAKw3wmjQFAk0v_PwPRRNxB4diUFTa9GdSRptX0HlP1dB1rHVuZjEbMk1xUKEo3_uYxCGiFg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.3.33.dev (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/series/77398/actors
   response:
@@ -196,17 +274,174 @@ interactions:
         dG0g/oSHvTUy+L94TsRXF9GETUnSXhqvrybCXRET0kfob2yHUMDJsZaVVQhLk2fYQLSRVpUS5uZJ
         Wlv9ULKA/1gmdMQioEl9dr32xxXA96vffwAAAP//AwDzsD0f6hAAAA==
     headers:
-      cache-control: ['private, max-age=600']
-      cf-ray: [2e97c84e496d088d-FRA]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 28 Sep 2016 14:11:04 GMT']
-      server: [cloudflare-nginx]
-      set-cookie: ['__cfduid=d294f26423a096c8eb142d19a44dc2f4d1475071864; expires=Thu,
-          28-Sep-17 14:11:04 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      vary: [Accept-Language]
-      x-powered-by: [Thundar!]
-      x-thetvdb-api-version: [2.1.1]
-    status: {code: 200, message: OK}
+      cache-control:
+      - private, max-age=600
+      cf-ray:
+      - 2e97c84e496d088d-FRA
+      connection:
+      - keep-alive
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2016 14:11:04 GMT
+      server:
+      - cloudflare-nginx
+      set-cookie:
+      - __cfduid=d294f26423a096c8eb142d19a44dc2f4d1475071864; expires=Thu, 28-Sep-17
+        14:11:04 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      vary:
+      - Accept-Language
+      x-powered-by:
+      - Thundar!
+      x-thetvdb-api-version:
+      - 2.1.1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTgyNjAsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcxODYwfQ.qhwXATjie5g97wC6r8KGdtDWMXXbVSEjK2awMhSC6mzw9_NCltAbVSLWSdiPzMa0mC8vgHz-4Iz3wzeHtWlT1MbeEYl6_mxgFrPy-r_OnGYG8b1mBRw4j-0t0pqkeUq5ZRXMRiUg0x1s9e5a3YmfzvtZy_qyoEpgG4zNYQaqiSF3zOSMVeNjvA_Cz036yu1hpaMOymYx_7IeSo4gKi1BsmqvuvW7XJgRW7Ho4S0nLB_SiHYl7xAScZtZnAnvIDCEdVjR-sTKszlNO0nAKw3wmjQFAk0v_PwPRRNxB4diUFTa9GdSRptX0HlP1dB1rHVuZjEbMk1xUKEo3_uYxCGiFg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/series/77398
+  response:
+    body:
+      string: '{"Error":"Not authorized","authorizer":"cloudfront"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '52'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Tue, 10 Dec 2019 00:18:57 GMT
+      Server:
+      - CloudFront
+      Via:
+      - 1.1 b97800dba63a54d15f1e69f88e3a1a3e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - tMgqqgpcpMoqwe4VcDtu8BM3T7kOgccGixg13R69ZlbcqzQJHJ5-gg==
+      X-Amz-Cf-Pop:
+      - GRU1-C1
+      X-Cache:
+      - LambdaGeneratedResponse from cloudfront
+    status:
+      code: 401
+      message: ''
+- request:
+    body: '{"apikey": "4D297D8CFDE0E105"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: POST
+    uri: https://api.thetvdb.com/login
+  response:
+    body:
+      string: '{"token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1NDE5MzgsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTM3MTM4fQ.QPDpSGF7TiOAHovnUoAIgmdTwQFTqQmWSqPATxGykxLRhvA4V0UIr3_ntSvTX-2spkXjX5fmnQPz3QdzNukT3PtbDOwGxEmSWG91i3ed1JLsr1ac7TlhQYsWPFuD6h9p6ed4JTD0-OfdBbmuLX-sGjn2vQIyIGiqk-WrON-ZyB7fG8mdeysDQcOFLaph75izecYM2RfGUgeJY4TfY0t2EVDXsA8HvQ2J-3NbmXzXTLLcIrM3BY2dtciFv0IGciTAspWTFhUG25XTpMQO8Fohsey6h0QDlXsdq388ERzW83_sEH7hwuJBPXnpdtdKFLCbuUG5cNNLVpQz7to7STv5ug"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '466'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 10 Dec 2019 00:18:58 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 b97800dba63a54d15f1e69f88e3a1a3e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 4RZRyVfhCPr62l6ykqQ1JUYTwTnYrCEGhCnx8jRjbqpCP5QM0WUhSg==
+      X-Amz-Cf-Pop:
+      - GRU1-C1
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1NDE5MzgsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTM3MTM4fQ.QPDpSGF7TiOAHovnUoAIgmdTwQFTqQmWSqPATxGykxLRhvA4V0UIr3_ntSvTX-2spkXjX5fmnQPz3QdzNukT3PtbDOwGxEmSWG91i3ed1JLsr1ac7TlhQYsWPFuD6h9p6ed4JTD0-OfdBbmuLX-sGjn2vQIyIGiqk-WrON-ZyB7fG8mdeysDQcOFLaph75izecYM2RfGUgeJY4TfY0t2EVDXsA8HvQ2J-3NbmXzXTLLcIrM3BY2dtciFv0IGciTAspWTFhUG25XTpMQO8Fohsey6h0QDlXsdq388ERzW83_sEH7hwuJBPXnpdtdKFLCbuUG5cNNLVpQz7to7STv5ug
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/series/77398
+  response:
+    body:
+      string: '{"data":{"id":77398,"seriesId":"61","seriesName":"The X-Files","aliases":["The
+        X Files","The X-Files (2016)"],"season":"11","poster":"posters/77398-2.jpg","banner":"graphical/61-g.jpg","fanart":"fanart/original/77398-4.jpg","status":"Ended","firstAired":"1993-09-10","network":"FOX","networkId":"1318","runtime":"45","language":"en","genre":["Science
+        Fiction","Suspense"],"overview":"`The truth is out there,'' and FBI agents
+        Scully and Mulder seek it in this sci-fi phenomenon about their quest to explain
+        the seemingly unexplainable. Their strange cases include UFO sightings, alien
+        abductions and just about anything else paranormal. ","lastUpdated":1574810128,"airsDayOfWeek":"Wednesday","airsTime":"8:00
+        PM","rating":"TV-14","imdbId":"tt0106179","zap2itId":"EP00080955","added":"","addedBy":null,"siteRating":8.9,"siteRatingCount":8113,"slug":"the-x-files"}}'
+    headers:
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '862'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 10 Dec 2019 00:46:21 GMT
+      Last-Modified:
+      - Tue, 26 Nov 2019 23:15:28 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 fb8b139e9fbca049551cc54f2dd63574.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - eG9ZKJ2Uma9yvYgj5IjoYLvWLQhcek0tqH9daNODTy4FBcgKVp7K7A==
+      X-Amz-Cf-Pop:
+      - GRU50-C1
+      X-Cache:
+      - Hit from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/flexget/tests/cassettes/test_tvdb_lookup_api.TestTVDBSeriesLookupAPI.test_tvdb_series_lookup
+++ b/flexget/tests/cassettes/test_tvdb_lookup_api.TestTVDBSeriesLookupAPI.test_tvdb_series_lookup
@@ -1,13 +1,19 @@
 interactions:
 - request:
-    body: !!python/unicode '{"apikey": "4D297D8CFDE0E105"}'
+    body: '{"apikey": "4D297D8CFDE0E105"}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [!!python/unicode FlexGet/2.3.33.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FlexGet/2.3.33.dev (www.flexget.com)
     method: POST
     uri: https://api.thetvdb.com/login
   response:
@@ -22,26 +28,43 @@ interactions:
         UALxopVcnuMZT+d4ctyB7Z8uG/tYKOd6uNnm3udS0NvKJU5W54aJIFnh7bQ/3ZW4KGf8sqI9q7in
         TH78+P0DAAD//wMAT1srT9cBAAA=
     headers:
-      cf-ray: [2e97c77e4a8e08a5-FRA]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 28 Sep 2016 14:10:31 GMT']
-      server: [cloudflare-nginx]
-      set-cookie: ['__cfduid=d81976e8d37c7d4397c29738861f3e6ff1475071830; expires=Thu,
-          28-Sep-17 14:10:30 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      vary: [Accept-Language]
-      x-powered-by: [Thundar!]
-      x-thetvdb-api-version: [2.1.1]
-    status: {code: 200, message: OK}
+      cf-ray:
+      - 2e97c77e4a8e08a5-FRA
+      connection:
+      - keep-alive
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2016 14:10:31 GMT
+      server:
+      - cloudflare-nginx
+      set-cookie:
+      - __cfduid=d81976e8d37c7d4397c29738861f3e6ff1475071830; expires=Thu, 28-Sep-17
+        14:10:30 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      vary:
+      - Accept-Language
+      x-powered-by:
+      - Thundar!
+      x-thetvdb-api-version:
+      - 2.1.1
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [!!python/unicode Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTgyMzEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcxODMxfQ.aV7J17NrbJfMnpO3PMg7IbscYNmLa310tKFFr2F1OiYE7Lqo799roA2gSRj-unmHnoOBbSrBKw9Z-J4V6a9LIvHE965gVsxpL9D_MiS5Vsx9gpMYYHWAY6Drtna3R48VplCv96orFPL7Dcz-Qefa45zVL9qpEQRrmttGvcw5xCJNrlC7bZhpeR-n3fzm8hkqF_C0OrW8WTX5YmjlVFqscdyQT5YZBlFaRuHCdYH0CTVN0yQNhJBxTEZvq5Ixw4ZnLN3NDek__D9bvJi5ggetes8bsTUp4oXU4bWe7itkpKROzogDYoRFAbcwTKex7DQ_K-zXUwxUNg3Wij1VQhPd3g]
-      Connection: [keep-alive]
-      User-Agent: [!!python/unicode FlexGet/2.3.33.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTgyMzEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcxODMxfQ.aV7J17NrbJfMnpO3PMg7IbscYNmLa310tKFFr2F1OiYE7Lqo799roA2gSRj-unmHnoOBbSrBKw9Z-J4V6a9LIvHE965gVsxpL9D_MiS5Vsx9gpMYYHWAY6Drtna3R48VplCv96orFPL7Dcz-Qefa45zVL9qpEQRrmttGvcw5xCJNrlC7bZhpeR-n3fzm8hkqF_C0OrW8WTX5YmjlVFqscdyQT5YZBlFaRuHCdYH0CTVN0yQNhJBxTEZvq5Ixw4ZnLN3NDek__D9bvJi5ggetes8bsTUp4oXU4bWe7itkpKROzogDYoRFAbcwTKex7DQ_K-zXUwxUNg3Wij1VQhPd3g
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.3.33.dev (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/search/series?name=The+X-Files
   response:
@@ -73,27 +96,45 @@ interactions:
         4KEjrfJPOeg01O8SkdoFTKGjfoKdshll54Y3qvXPF3jDCi8LYoAL2pnk/fRvtODDr4z9gGbrvHXs
         k2J3D+DPe3//AwAA//8DAGhsL0uBCwAA
     headers:
-      cache-control: ['private, max-age=600']
-      cf-ray: [2e97c78569620f81-FRA]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 28 Sep 2016 14:10:32 GMT']
-      server: [cloudflare-nginx]
-      set-cookie: ['__cfduid=d39793ba91cd08425e62b4f6fa31b03441475071831; expires=Thu,
-          28-Sep-17 14:10:31 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      vary: [Accept-Language]
-      x-powered-by: [Thundar!]
-      x-thetvdb-api-version: [2.1.1]
-    status: {code: 200, message: OK}
+      cache-control:
+      - private, max-age=600
+      cf-ray:
+      - 2e97c78569620f81-FRA
+      connection:
+      - keep-alive
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2016 14:10:32 GMT
+      server:
+      - cloudflare-nginx
+      set-cookie:
+      - __cfduid=d39793ba91cd08425e62b4f6fa31b03441475071831; expires=Thu, 28-Sep-17
+        14:10:31 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      vary:
+      - Accept-Language
+      x-powered-by:
+      - Thundar!
+      x-thetvdb-api-version:
+      - 2.1.1
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [!!python/unicode Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTgyMzEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcxODMxfQ.aV7J17NrbJfMnpO3PMg7IbscYNmLa310tKFFr2F1OiYE7Lqo799roA2gSRj-unmHnoOBbSrBKw9Z-J4V6a9LIvHE965gVsxpL9D_MiS5Vsx9gpMYYHWAY6Drtna3R48VplCv96orFPL7Dcz-Qefa45zVL9qpEQRrmttGvcw5xCJNrlC7bZhpeR-n3fzm8hkqF_C0OrW8WTX5YmjlVFqscdyQT5YZBlFaRuHCdYH0CTVN0yQNhJBxTEZvq5Ixw4ZnLN3NDek__D9bvJi5ggetes8bsTUp4oXU4bWe7itkpKROzogDYoRFAbcwTKex7DQ_K-zXUwxUNg3Wij1VQhPd3g]
-      Connection: [keep-alive]
-      User-Agent: [!!python/unicode FlexGet/2.3.33.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTgyMzEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcxODMxfQ.aV7J17NrbJfMnpO3PMg7IbscYNmLa310tKFFr2F1OiYE7Lqo799roA2gSRj-unmHnoOBbSrBKw9Z-J4V6a9LIvHE965gVsxpL9D_MiS5Vsx9gpMYYHWAY6Drtna3R48VplCv96orFPL7Dcz-Qefa45zVL9qpEQRrmttGvcw5xCJNrlC7bZhpeR-n3fzm8hkqF_C0OrW8WTX5YmjlVFqscdyQT5YZBlFaRuHCdYH0CTVN0yQNhJBxTEZvq5Ixw4ZnLN3NDek__D9bvJi5ggetes8bsTUp4oXU4bWe7itkpKROzogDYoRFAbcwTKex7DQ_K-zXUwxUNg3Wij1VQhPd3g
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.3.33.dev (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/series/77398
   response:
@@ -112,28 +153,47 @@ interactions:
         M1+mxWyEpSk3u8jGmBf5vDhZjNQdtYcSd+SbD3men+aL44cQU1nyk6gPwOs+W0I7a8e3JpE/jsqL
         /8Bz12nMljic53vAn70/fwEAAP//AwBBRUjpdwQAAA==
     headers:
-      cache-control: ['private, max-age=600']
-      cf-ray: [2e97c7892edc274a-FRA]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 28 Sep 2016 14:10:32 GMT']
-      last-modified: ['Tue, 27 Sep 2016 21:50:44 GMT']
-      server: [cloudflare-nginx]
-      set-cookie: ['__cfduid=d44ca21046d9f1ed258bc18e4f807432a1475071832; expires=Thu,
-          28-Sep-17 14:10:32 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      vary: [Accept-Language]
-      x-powered-by: [Thundar!]
-      x-thetvdb-api-version: [2.1.1]
-    status: {code: 200, message: OK}
+      cache-control:
+      - private, max-age=600
+      cf-ray:
+      - 2e97c7892edc274a-FRA
+      connection:
+      - keep-alive
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2016 14:10:32 GMT
+      last-modified:
+      - Tue, 27 Sep 2016 21:50:44 GMT
+      server:
+      - cloudflare-nginx
+      set-cookie:
+      - __cfduid=d44ca21046d9f1ed258bc18e4f807432a1475071832; expires=Thu, 28-Sep-17
+        14:10:32 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      vary:
+      - Accept-Language
+      x-powered-by:
+      - Thundar!
+      x-thetvdb-api-version:
+      - 2.1.1
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [!!python/unicode Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTgyMzEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcxODMxfQ.aV7J17NrbJfMnpO3PMg7IbscYNmLa310tKFFr2F1OiYE7Lqo799roA2gSRj-unmHnoOBbSrBKw9Z-J4V6a9LIvHE965gVsxpL9D_MiS5Vsx9gpMYYHWAY6Drtna3R48VplCv96orFPL7Dcz-Qefa45zVL9qpEQRrmttGvcw5xCJNrlC7bZhpeR-n3fzm8hkqF_C0OrW8WTX5YmjlVFqscdyQT5YZBlFaRuHCdYH0CTVN0yQNhJBxTEZvq5Ixw4ZnLN3NDek__D9bvJi5ggetes8bsTUp4oXU4bWe7itkpKROzogDYoRFAbcwTKex7DQ_K-zXUwxUNg3Wij1VQhPd3g]
-      Connection: [keep-alive]
-      User-Agent: [!!python/unicode FlexGet/2.3.33.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTgyMzEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcxODMxfQ.aV7J17NrbJfMnpO3PMg7IbscYNmLa310tKFFr2F1OiYE7Lqo799roA2gSRj-unmHnoOBbSrBKw9Z-J4V6a9LIvHE965gVsxpL9D_MiS5Vsx9gpMYYHWAY6Drtna3R48VplCv96orFPL7Dcz-Qefa45zVL9qpEQRrmttGvcw5xCJNrlC7bZhpeR-n3fzm8hkqF_C0OrW8WTX5YmjlVFqscdyQT5YZBlFaRuHCdYH0CTVN0yQNhJBxTEZvq5Ixw4ZnLN3NDek__D9bvJi5ggetes8bsTUp4oXU4bWe7itkpKROzogDYoRFAbcwTKex7DQ_K-zXUwxUNg3Wij1VQhPd3g
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.3.33.dev (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/series/77398/images/query?keyType=poster
   response:
@@ -152,17 +212,174 @@ interactions:
         k+dF4ZptdYlQJVutJlLhV5c0rS6uiNZ9dVGVEzu08iO6TquuZ4e+hlvJ5RvLgeailR7RRCx9uBWW
         mFs0KyPeIn5zsTo+GK7LWsbe8ng+Px6fXwAAAP//AwCjblZo+hcAAA==
     headers:
-      cache-control: ['private, max-age=600']
-      cf-ray: [2e97c78d2e1e0f81-FRA]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 28 Sep 2016 14:10:33 GMT']
-      server: [cloudflare-nginx]
-      set-cookie: ['__cfduid=d93416373f01100d6a3547b95f7dd61f61475071833; expires=Thu,
-          28-Sep-17 14:10:33 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      vary: [Accept-Language]
-      x-powered-by: [Thundar!]
-      x-thetvdb-api-version: [2.1.1]
-    status: {code: 200, message: OK}
+      cache-control:
+      - private, max-age=600
+      cf-ray:
+      - 2e97c78d2e1e0f81-FRA
+      connection:
+      - keep-alive
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2016 14:10:33 GMT
+      server:
+      - cloudflare-nginx
+      set-cookie:
+      - __cfduid=d93416373f01100d6a3547b95f7dd61f61475071833; expires=Thu, 28-Sep-17
+        14:10:33 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      vary:
+      - Accept-Language
+      x-powered-by:
+      - Thundar!
+      x-thetvdb-api-version:
+      - 2.1.1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTgyMzEsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcxODMxfQ.aV7J17NrbJfMnpO3PMg7IbscYNmLa310tKFFr2F1OiYE7Lqo799roA2gSRj-unmHnoOBbSrBKw9Z-J4V6a9LIvHE965gVsxpL9D_MiS5Vsx9gpMYYHWAY6Drtna3R48VplCv96orFPL7Dcz-Qefa45zVL9qpEQRrmttGvcw5xCJNrlC7bZhpeR-n3fzm8hkqF_C0OrW8WTX5YmjlVFqscdyQT5YZBlFaRuHCdYH0CTVN0yQNhJBxTEZvq5Ixw4ZnLN3NDek__D9bvJi5ggetes8bsTUp4oXU4bWe7itkpKROzogDYoRFAbcwTKex7DQ_K-zXUwxUNg3Wij1VQhPd3g
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/series/77398
+  response:
+    body:
+      string: '{"Error":"Not authorized","authorizer":"cloudfront"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '52'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Tue, 10 Dec 2019 00:18:55 GMT
+      Server:
+      - CloudFront
+      Via:
+      - 1.1 e5af57927ce133b9d537596c7798d3ff.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - H-1UF_voBoFfKORu_vOoptQZH_EKaCqKhfmeXIf4XAzqeaKlkXplbg==
+      X-Amz-Cf-Pop:
+      - GRU1-C1
+      X-Cache:
+      - LambdaGeneratedResponse from cloudfront
+    status:
+      code: 401
+      message: ''
+- request:
+    body: '{"apikey": "4D297D8CFDE0E105"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: POST
+    uri: https://api.thetvdb.com/login
+  response:
+    body:
+      string: '{"token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1NDE5MzYsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTM3MTM2fQ.E8GUTfixfecwPwVsElrqdCot1Ru2O0Er49opO4f2r2wxaRl_qBX1o2KUw1TP1Q8sdnQsGR-FGnrfObaUEtnvTFWDTDo-8jgITt3UnDbGGqUjR51f59wDpYv9xJXxiywJnEhdBw9plLrt6BrCQObuMxCBcxI5Zmr_d1h1zuXrEqIqQV7_uISc9u5O55W555sEUCFLoboZdxZVl5IpVvqI0dZOMgoTWoye9dhw5JxUtY1jsHbAspZTog47VAS81leX5n22Z9zTcgyqDZnn_hVxm3wbu85VOThyB03eXwTy-NjDBZvd6F1AKoo02S4L0A7VH0yi1jXpxMkjBNPgP3Ahbg"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '466'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 10 Dec 2019 00:18:56 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 31154529f9ff5fc95f3438c30cfb64f0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - ZV4WqPRQx_8jowrkdeUeZUKyv1KEmyqoCM0NaGRTeRxyS_p3LTI7Cw==
+      X-Amz-Cf-Pop:
+      - GRU1-C1
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1NDE5MzYsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTM3MTM2fQ.E8GUTfixfecwPwVsElrqdCot1Ru2O0Er49opO4f2r2wxaRl_qBX1o2KUw1TP1Q8sdnQsGR-FGnrfObaUEtnvTFWDTDo-8jgITt3UnDbGGqUjR51f59wDpYv9xJXxiywJnEhdBw9plLrt6BrCQObuMxCBcxI5Zmr_d1h1zuXrEqIqQV7_uISc9u5O55W555sEUCFLoboZdxZVl5IpVvqI0dZOMgoTWoye9dhw5JxUtY1jsHbAspZTog47VAS81leX5n22Z9zTcgyqDZnn_hVxm3wbu85VOThyB03eXwTy-NjDBZvd6F1AKoo02S4L0A7VH0yi1jXpxMkjBNPgP3Ahbg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/series/77398
+  response:
+    body:
+      string: '{"data":{"id":77398,"seriesId":"61","seriesName":"The X-Files","aliases":["The
+        X Files","The X-Files (2016)"],"season":"11","poster":"posters/77398-2.jpg","banner":"graphical/61-g.jpg","fanart":"fanart/original/77398-4.jpg","status":"Ended","firstAired":"1993-09-10","network":"FOX","networkId":"1318","runtime":"45","language":"en","genre":["Science
+        Fiction","Suspense"],"overview":"`The truth is out there,'' and FBI agents
+        Scully and Mulder seek it in this sci-fi phenomenon about their quest to explain
+        the seemingly unexplainable. Their strange cases include UFO sightings, alien
+        abductions and just about anything else paranormal. ","lastUpdated":1574810128,"airsDayOfWeek":"Wednesday","airsTime":"8:00
+        PM","rating":"TV-14","imdbId":"tt0106179","zap2itId":"EP00080955","added":"","addedBy":null,"siteRating":8.9,"siteRatingCount":8113,"slug":"the-x-files"}}'
+    headers:
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '862'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 10 Dec 2019 00:46:21 GMT
+      Last-Modified:
+      - Tue, 26 Nov 2019 23:15:28 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 37a135c363e9512a2b27aa63bc837339.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 5-3s65bQF1VSL1ZRRm6Zn9aGSlB0vc67nfk6gPVXv3nGXioEBzXqbQ==
+      X-Amz-Cf-Pop:
+      - GRU50-C1
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/flexget/tests/cassettes/test_tvdb_lookup_api.TestTVDBSeriesLookupAPI.test_tvdb_series_lookup_by_id
+++ b/flexget/tests/cassettes/test_tvdb_lookup_api.TestTVDBSeriesLookupAPI.test_tvdb_series_lookup_by_id
@@ -1,13 +1,19 @@
 interactions:
 - request:
-    body: !!python/unicode '{"apikey": "4D297D8CFDE0E105"}'
+    body: '{"apikey": "4D297D8CFDE0E105"}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['30']
-      Content-Type: [application/json]
-      User-Agent: [!!python/unicode FlexGet/2.3.33.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FlexGet/2.3.33.dev (www.flexget.com)
     method: POST
     uri: https://api.thetvdb.com/login
   response:
@@ -22,26 +28,43 @@ interactions:
         hPTj6cevlcYOGHJG4TyWD1EYf2iwP2r7yQaSL3eqVtix6TQHfBxcLnUJoCoRJSDO9GXzOHM4vQm0
         ztt+/fsPAAD//wMA1wOBZdcBAAA=
     headers:
-      cf-ray: [2e97df477d7e0f7b-FRA]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 28 Sep 2016 14:26:45 GMT']
-      server: [cloudflare-nginx]
-      set-cookie: ['__cfduid=d3625b44633773953c25f1191daaa9cab1475072805; expires=Thu,
-          28-Sep-17 14:26:45 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      vary: [Accept-Language]
-      x-powered-by: [Thundar!]
-      x-thetvdb-api-version: [2.1.1]
-    status: {code: 200, message: OK}
+      cf-ray:
+      - 2e97df477d7e0f7b-FRA
+      connection:
+      - keep-alive
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2016 14:26:45 GMT
+      server:
+      - cloudflare-nginx
+      set-cookie:
+      - __cfduid=d3625b44633773953c25f1191daaa9cab1475072805; expires=Thu, 28-Sep-17
+        14:26:45 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      vary:
+      - Accept-Language
+      x-powered-by:
+      - Thundar!
+      x-thetvdb-api-version:
+      - 2.1.1
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [!!python/unicode Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTkyMDUsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcyODA1fQ.S64Z8gViex-aHw4SzJhhPEylERjVLBm3e7ugOXDorr-taCOyK1Az6zoslqFhcwE1WBznSvfsPyjA-i8BkqA71F42Lvi-wVHQkLTU01jdV7D_1URzjisc5lOWbzpzbvJgKEDZkUduVt_6RXeEcGrDPovg3fBTsU3drOWakeUh4sZ3fHnpdHR5NEQB0ObXDJmbRO9QP18eUCoEy3DFJGVmgLHUZH9DVbqW-68h7jEl5ksHX2mwJq6FwiJkRMnD7Qez9tBZ1IbPaOouKYRk9lMTeINu4Luip54uYUT2GB2wM16R7nABhMXFNl8JGsP0bPO1UAO5615xUrM3JcN0ClTBnQ]
-      Connection: [keep-alive]
-      User-Agent: [!!python/unicode FlexGet/2.3.33.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTkyMDUsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcyODA1fQ.S64Z8gViex-aHw4SzJhhPEylERjVLBm3e7ugOXDorr-taCOyK1Az6zoslqFhcwE1WBznSvfsPyjA-i8BkqA71F42Lvi-wVHQkLTU01jdV7D_1URzjisc5lOWbzpzbvJgKEDZkUduVt_6RXeEcGrDPovg3fBTsU3drOWakeUh4sZ3fHnpdHR5NEQB0ObXDJmbRO9QP18eUCoEy3DFJGVmgLHUZH9DVbqW-68h7jEl5ksHX2mwJq6FwiJkRMnD7Qez9tBZ1IbPaOouKYRk9lMTeINu4Luip54uYUT2GB2wM16R7nABhMXFNl8JGsP0bPO1UAO5615xUrM3JcN0ClTBnQ
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.3.33.dev (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/series/77398
   response:
@@ -60,28 +83,47 @@ interactions:
         M1+mxWyEpSk3u8jGmBf5vDhZjNQdtYcSd+SbD3men+aL44cQU1nyk6gPwOs+W0I7a8e3JpE/jsqL
         /8Bz12nMljic53vAn70/fwEAAP//AwBBRUjpdwQAAA==
     headers:
-      cache-control: ['private, max-age=600']
-      cf-ray: [2e97df4e2b5b08a5-FRA]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 28 Sep 2016 14:26:46 GMT']
-      last-modified: ['Tue, 27 Sep 2016 21:50:44 GMT']
-      server: [cloudflare-nginx]
-      set-cookie: ['__cfduid=d19213b88dfa36896bdd91c846966fa471475072806; expires=Thu,
-          28-Sep-17 14:26:46 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      vary: [Accept-Language]
-      x-powered-by: [Thundar!]
-      x-thetvdb-api-version: [2.1.1]
-    status: {code: 200, message: OK}
+      cache-control:
+      - private, max-age=600
+      cf-ray:
+      - 2e97df4e2b5b08a5-FRA
+      connection:
+      - keep-alive
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2016 14:26:46 GMT
+      last-modified:
+      - Tue, 27 Sep 2016 21:50:44 GMT
+      server:
+      - cloudflare-nginx
+      set-cookie:
+      - __cfduid=d19213b88dfa36896bdd91c846966fa471475072806; expires=Thu, 28-Sep-17
+        14:26:46 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      vary:
+      - Accept-Language
+      x-powered-by:
+      - Thundar!
+      x-thetvdb-api-version:
+      - 2.1.1
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [!!python/unicode Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTkyMDUsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcyODA1fQ.S64Z8gViex-aHw4SzJhhPEylERjVLBm3e7ugOXDorr-taCOyK1Az6zoslqFhcwE1WBznSvfsPyjA-i8BkqA71F42Lvi-wVHQkLTU01jdV7D_1URzjisc5lOWbzpzbvJgKEDZkUduVt_6RXeEcGrDPovg3fBTsU3drOWakeUh4sZ3fHnpdHR5NEQB0ObXDJmbRO9QP18eUCoEy3DFJGVmgLHUZH9DVbqW-68h7jEl5ksHX2mwJq6FwiJkRMnD7Qez9tBZ1IbPaOouKYRk9lMTeINu4Luip54uYUT2GB2wM16R7nABhMXFNl8JGsP0bPO1UAO5615xUrM3JcN0ClTBnQ]
-      Connection: [keep-alive]
-      User-Agent: [!!python/unicode FlexGet/2.3.33.dev (www.flexget.com)]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTkyMDUsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcyODA1fQ.S64Z8gViex-aHw4SzJhhPEylERjVLBm3e7ugOXDorr-taCOyK1Az6zoslqFhcwE1WBznSvfsPyjA-i8BkqA71F42Lvi-wVHQkLTU01jdV7D_1URzjisc5lOWbzpzbvJgKEDZkUduVt_6RXeEcGrDPovg3fBTsU3drOWakeUh4sZ3fHnpdHR5NEQB0ObXDJmbRO9QP18eUCoEy3DFJGVmgLHUZH9DVbqW-68h7jEl5ksHX2mwJq6FwiJkRMnD7Qez9tBZ1IbPaOouKYRk9lMTeINu4Luip54uYUT2GB2wM16R7nABhMXFNl8JGsP0bPO1UAO5615xUrM3JcN0ClTBnQ
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/2.3.33.dev (www.flexget.com)
     method: GET
     uri: https://api.thetvdb.com/series/77398/images/query?keyType=poster
   response:
@@ -99,17 +141,174 @@ interactions:
         NIwQupHqlk4528JCMBf4n7F4ikXH0vcwegAAAP//olawUL/lYoAlUMgqWpDbLVwKCrFctQAAAAD/
         /wMAo25WaPoXAAA=
     headers:
-      cache-control: ['private, max-age=600']
-      cf-ray: [2e97df549c6326f6-FRA]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 28 Sep 2016 14:26:47 GMT']
-      server: [cloudflare-nginx]
-      set-cookie: ['__cfduid=db67a5dc9bcddd62a16abfa002328f15a1475072807; expires=Thu,
-          28-Sep-17 14:26:47 GMT; path=/; domain=.thetvdb.com; HttpOnly']
-      vary: [Accept-Language]
-      x-powered-by: [Thundar!]
-      x-thetvdb-api-version: [2.1.1]
-    status: {code: 200, message: OK}
+      cache-control:
+      - private, max-age=600
+      cf-ray:
+      - 2e97df549c6326f6-FRA
+      connection:
+      - keep-alive
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2016 14:26:47 GMT
+      server:
+      - cloudflare-nginx
+      set-cookie:
+      - __cfduid=db67a5dc9bcddd62a16abfa002328f15a1475072807; expires=Thu, 28-Sep-17
+        14:26:47 GMT; path=/; domain=.thetvdb.com; HttpOnly
+      vary:
+      - Accept-Language
+      x-powered-by:
+      - Thundar!
+      x-thetvdb-api-version:
+      - 2.1.1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzUxNTkyMDUsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNDc1MDcyODA1fQ.S64Z8gViex-aHw4SzJhhPEylERjVLBm3e7ugOXDorr-taCOyK1Az6zoslqFhcwE1WBznSvfsPyjA-i8BkqA71F42Lvi-wVHQkLTU01jdV7D_1URzjisc5lOWbzpzbvJgKEDZkUduVt_6RXeEcGrDPovg3fBTsU3drOWakeUh4sZ3fHnpdHR5NEQB0ObXDJmbRO9QP18eUCoEy3DFJGVmgLHUZH9DVbqW-68h7jEl5ksHX2mwJq6FwiJkRMnD7Qez9tBZ1IbPaOouKYRk9lMTeINu4Luip54uYUT2GB2wM16R7nABhMXFNl8JGsP0bPO1UAO5615xUrM3JcN0ClTBnQ
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/series/77398
+  response:
+    body:
+      string: '{"Error":"Not authorized","authorizer":"cloudfront"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '52'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Tue, 10 Dec 2019 00:18:56 GMT
+      Server:
+      - CloudFront
+      Via:
+      - 1.1 9bfe9025214153b614d35b5ab1f95b66.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 8JvSeI9SaO9qyDHErymxVVipeJMDw9z_XtuqJdOaSwdMoZxfQ-ao7A==
+      X-Amz-Cf-Pop:
+      - GRU1-C1
+      X-Cache:
+      - LambdaGeneratedResponse from cloudfront
+    status:
+      code: 401
+      message: ''
+- request:
+    body: '{"apikey": "4D297D8CFDE0E105"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: POST
+    uri: https://api.thetvdb.com/login
+  response:
+    body:
+      string: '{"token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1NDE5MzcsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTM3MTM3fQ.ANrjHa1OiaXh33ooYV_r0mD4MCw478qmjf-YUJYflOnFe8LpTU9D1v_g39eJw6grPtmGpgREpYwJzb5FAd0UkJ0WpFGcc_uIWJX5HQR5MSDJwUFjPBklTAe742lSMPpeyxgLa_sE3P4T_kdA4xp8g-xaQEWEFkqhzZi_TlplGvtyVguJc9K0aFFOono-9tFQuCxSbbYic2dUPd8jrYjrdzSECnwib2HD-h_Lr8O1K5gUv7klWImt_KnpiX3Vf-Lqpe36wjskThWygrgC4fvDsVuUZtyq38_7vRI6135wzx1PCNrZkt54KLM8SwuWiP3LaPwNruLcXlGJPdn2ehQ14w"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '466'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 10 Dec 2019 00:18:57 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 5f26efcc09f40c81ef0f61d4bcb1f2c8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - kubegHlzOK5oAO03VgpvLaEE56rO4rYdyrTQUpC68FUaubjbK14XpQ==
+      X-Amz-Cf-Pop:
+      - GRU1-C1
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzY1NDE5MzcsImlkIjoiRmxleEdldCIsIm9yaWdfaWF0IjoxNTc1OTM3MTM3fQ.ANrjHa1OiaXh33ooYV_r0mD4MCw478qmjf-YUJYflOnFe8LpTU9D1v_g39eJw6grPtmGpgREpYwJzb5FAd0UkJ0WpFGcc_uIWJX5HQR5MSDJwUFjPBklTAe742lSMPpeyxgLa_sE3P4T_kdA4xp8g-xaQEWEFkqhzZi_TlplGvtyVguJc9K0aFFOono-9tFQuCxSbbYic2dUPd8jrYjrdzSECnwib2HD-h_Lr8O1K5gUv7klWImt_KnpiX3Vf-Lqpe36wjskThWygrgC4fvDsVuUZtyq38_7vRI6135wzx1PCNrZkt54KLM8SwuWiP3LaPwNruLcXlGJPdn2ehQ14w
+      Connection:
+      - keep-alive
+      User-Agent:
+      - FlexGet/3.0.12 (www.flexget.com)
+    method: GET
+    uri: https://api.thetvdb.com/series/77398
+  response:
+    body:
+      string: '{"data":{"id":77398,"seriesId":"61","seriesName":"The X-Files","aliases":["The
+        X Files","The X-Files (2016)"],"season":"11","poster":"posters/77398-2.jpg","banner":"graphical/61-g.jpg","fanart":"fanart/original/77398-4.jpg","status":"Ended","firstAired":"1993-09-10","network":"FOX","networkId":"1318","runtime":"45","language":"en","genre":["Science
+        Fiction","Suspense"],"overview":"`The truth is out there,'' and FBI agents
+        Scully and Mulder seek it in this sci-fi phenomenon about their quest to explain
+        the seemingly unexplainable. Their strange cases include UFO sightings, alien
+        abductions and just about anything else paranormal. ","lastUpdated":1574810128,"airsDayOfWeek":"Wednesday","airsTime":"8:00
+        PM","rating":"TV-14","imdbId":"tt0106179","zap2itId":"EP00080955","added":"","addedBy":null,"siteRating":8.9,"siteRatingCount":8113,"slug":"the-x-files"}}'
+    headers:
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '862'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 10 Dec 2019 00:46:21 GMT
+      Last-Modified:
+      - Tue, 26 Nov 2019 23:15:28 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 ac4e6581409ee543d30418bc80eff8a8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - TQedbRLDvFq-EWsm28n77GjECoc1_TBcdcFdVEObAHQCa7Yuk32cBQ==
+      X-Amz-Cf-Pop:
+      - GRU50-C1
+      X-Cache:
+      - Hit from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/flexget/tests/test_thetvdb.py
+++ b/flexget/tests/test_thetvdb.py
@@ -86,30 +86,28 @@ class TestTVDBLookup:
         assert entry['tvdb_air_time'] == ''
         assert entry['tvdb_airs_day_of_week'] == ''
         assert re.match(
-            'http://thetvdb.com/banners/graphical/73255-g[0-9]+.jpg', entry['tvdb_banner']
+            'https://artworks.thetvdb.com/banners/graphical/73255-g[0-9]+.jpg', entry['tvdb_banner']
         )
-        assert 'http://thetvdb.com/banners/posters/73255-1.jpg' in entry['tvdb_posters']
+        assert 'https://artworks.thetvdb.com/banners/posters/73255-1.jpg' in entry['tvdb_posters']
         assert entry['tvdb_content_rating'] == 'TV-14'
         assert entry['tvdb_episode'] == 2
         assert entry['tvdb_first_air_date'] == datetime(2004, 11, 16, 0, 0)
-        assert entry['tvdb_network'] == 'FOX (US)'
-        assert entry['tvdb_genres'] == ['Drama', 'Mystery']
+        assert entry['tvdb_network'] == 'FOX'
+        assert entry['tvdb_genres'] == ['Drama', 'Suspense']
         assert 'Jesse Spencer' in entry['tvdb_actors']
         assert (
             entry['tvdb_overview']
-            == 'Go deeper into the medical mysteries of House, TV\'s most compelling '
-            'drama. Hugh Laurie stars as the brilliant but sarcastic Dr. Gregory'
-            ' House, a maverick physician who is devoid of bedside manner. While'
-            ' his behavior can border on antisocial, Dr. House thrives on the'
-            ' challenge of solving the medical puzzles that other doctors give up on.'
-            ' Together with his hand-picked team of young medical experts, he\'ll'
-            ' do whatever it takes in the race against the clock to solve the case.'
+            == 'Dr. Gregory House is a maverick physician who is devoid of bedside manner. '
+            'While his behavior can border on antisocial, Dr. House thrives on the challenge '
+            'of solving the medical puzzles that other doctors give up on. Together with his '
+            'hand-picked team of young medical experts, he\'ll do whatever it takes in the '
+            'race against the clock to solve the case.'
         )
 
         assert entry['tvdb_ep_air_date'] == datetime(2004, 11, 23, 0, 0)
         assert entry['tvdb_ep_directors'] == 'Peter O\'Fallon'
         assert entry['tvdb_ep_id'] == 'S01E02'
-        assert entry['tvdb_ep_image'] == 'http://thetvdb.com/banners/episodes/73255/110995.jpg'
+        assert entry['tvdb_ep_image'] == 'https://artworks.thetvdb.com/banners/episodes/73255/110995.jpg'
         assert entry['tvdb_ep_name'] == 'Paternity'
         assert (
             entry['tvdb_ep_overview']

--- a/flexget/tests/test_thetvdb.py
+++ b/flexget/tests/test_thetvdb.py
@@ -86,9 +86,9 @@ class TestTVDBLookup:
         assert entry['tvdb_air_time'] == ''
         assert entry['tvdb_airs_day_of_week'] == ''
         assert re.match(
-            'https://artworks.thetvdb.com/banners/graphical/73255-g[0-9]+.jpg', entry['tvdb_banner']
+            'http://thetvdb.com/banners/graphical/73255-g[0-9]+.jpg', entry['tvdb_banner']
         )
-        assert 'https://artworks.thetvdb.com/banners/posters/73255-1.jpg' in entry['tvdb_posters']
+        assert 'http://thetvdb.com/banners/posters/73255-1.jpg' in entry['tvdb_posters']
         assert entry['tvdb_content_rating'] == 'TV-14'
         assert entry['tvdb_episode'] == 2
         assert entry['tvdb_first_air_date'] == datetime(2004, 11, 16, 0, 0)
@@ -107,7 +107,7 @@ class TestTVDBLookup:
         assert entry['tvdb_ep_air_date'] == datetime(2004, 11, 23, 0, 0)
         assert entry['tvdb_ep_directors'] == 'Peter O\'Fallon'
         assert entry['tvdb_ep_id'] == 'S01E02'
-        assert entry['tvdb_ep_image'] == 'https://artworks.thetvdb.com/banners/episodes/73255/110995.jpg'
+        assert entry['tvdb_ep_image'] == 'http://thetvdb.com/banners/episodes/73255/110995.jpg'
         assert entry['tvdb_ep_name'] == 'Paternity'
         assert (
             entry['tvdb_ep_overview']


### PR DESCRIPTION
### Motivation for changes:
TheTVDB returns posters in a random order and Flexget caps the list to 5 entries. I like to use the main poster (curated to be used by the site) on my notifications and given the aforementioned actions, it's not always on the list, and when it is there is no way to determine which entry t is.
### Detailed changes:
- ~~[unrelated] Changed URL for the posters CDN to the new one post TheTVDB's v3 migration. There are currently 301 redirects in place at the old URL but they did recommend changing it wherever possible.~~
- Request the main poster path from the `/series/{id}` endpoint and start the list with it
- Append up to 5 posters to the list (not 4 just in case the main one is not defined)
- Trim the list down to 5 entries

### Addressed issues:
- Fixes *my OCD*.

