### PR TITLE
Implement Gotify notification plugin

### DIFF
--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -10,17 +10,12 @@ from flexget.plugin import PluginWarning
 from flexget.utils.requests import Session as RequestSession, TimedLimiter
 from requests.exceptions import RequestException
 from http import HTTPStatus
+from urllib.parse import urljoin
 
 plugin_name = 'gotify'
 log = logging.getLogger(plugin_name)
 
 requests = RequestSession(max_retries=3)
-
-gotify_url_pattern = {
-    'type': 'string',
-    'pattern': r'^http(s?)\:\/\/.*\/message$',
-    'error_pattern': 'Gotify URL must begin with http(s) and end with `/message`',
-}
 
 class GotifyNotifier(object):
     """
@@ -38,7 +33,7 @@ class GotifyNotifier(object):
     schema = {
         'type': 'object',
         'properties': {
-            'url': gotify_url_pattern,
+            'url': {'format': 'url'},
             'token': {'type': 'string'},
             'priority': {'type': 'integer', 'default': 4},  
         },  
@@ -53,7 +48,9 @@ class GotifyNotifier(object):
         """
         Send a Gotify notification
         """
-        url = config['url']
+        base_url = config['url']
+        api_endpoint = '/message'
+        url = urljoin(base_url, api_endpoint)
         params = {'token': config['token']}
         
         priority = config['priority']

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 from flexget import plugin
 from flexget.event import event
 from flexget.plugin import PluginWarning
-from flexget.utils.requests import Session as RequestSession, TimedLimiter
+from flexget.utils.requests import Session as RequestSession
 
 plugin_name = 'gotify'
 

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -1,6 +1,3 @@
-from __future__ import unicode_literals, division, absolute_import
-from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
-
 import logging
 import base64
 import datetime

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -37,7 +37,7 @@ class GotifyNotifier(object):
     schema = {
         'type': 'object',
         'properties': {
-            'url': one_or_more(gotify_url_pattern),
+            'url': gotify_url_pattern,
             'token': {'type': 'string'},
             'priority': {'type': 'integer', 'default': 4},  
         },  
@@ -48,28 +48,21 @@ class GotifyNotifier(object):
         'additionalProperties': False,
     }
 
-
     def notify(self, title, message, config):
         """
         Send a Gotify notification
         """
-        priority = config.get('priority')      
-        token = config.get('token')
-        url = f"{config.get('url') + '?token=' + token}"
-        self.send_push(token, title, message, priority, url)
-
-    def send_push(self, token, title, body, priority, url=None, destination=None, destination_type=None):
-
+        url = config['url']
+        params = {'token': config['token']}
+        
+        if config['priority']:
+          priority = config['priority']
+        
         requests = RequestSession(max_retries=3)
-        notification = {'title': title, 'message': body, 'priority': priority}
-        if url:
-            notification['url'] = url
-        if destination:
-            notification[destination_type] = destination
-
+        notification = {'title': title, 'message': message, 'priority': priority}
         # Make the request
         try:
-            response = requests.post(url, headers=headers, json=notification)
+            response = requests.post(url, params=params, json=notification)
         except RequestException as e:
             if e.response is not None:
                 if e.response.status_code == 401 or e.response.status_code == 403:

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -89,10 +89,7 @@ class GotifyNotifier(object):
                     message = 'Invalid Gotify access token'
                 elif e.response.status_code == 404:
                     url_format = 'https://push.example.com/message'
-                    message = f"{
-                        'Invalid Gotify URL, please verify that the URL matches the format: %s'
-                        % url_format
-                    }"
+                    message = f"{Invalid Gotify URL, please verify that the URL matches the format: {url_format}"
                 else:
                   message = e.response.json()['error']['message']
             else:

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -67,9 +67,6 @@ class GotifyNotifier(object):
             if e.response is not None:
                 if e.response.status_code == 401 or e.response.status_code == 403:
                     message = 'Invalid Gotify access token'
-                elif e.response.status_code == 404:
-                    url_format = 'https://push.example.com/message'
-                    message = f"Invalid Gotify URL, please verify that the URL matches the format: {url_format}"
                 else:
                   message = e.response.json()['error']['message']
             else:

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -56,8 +56,7 @@ class GotifyNotifier(object):
         url = config['url']
         params = {'token': config['token']}
         
-        if config['priority']:
-          priority = config['priority']
+        priority = config['priority']
         
         notification = {'title': title, 'message': message, 'priority': priority}
         # Make the request

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -64,7 +64,7 @@ class GotifyNotifier(object):
             response = requests.post(url, params=params, json=notification)
         except RequestException as e:
             if e.response is not None:
-                if e.response.code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
+                if e.response.status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
                     message = 'Invalid Gotify access token'
                 else:
                   message = e.response.json()['error']['message']

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -31,21 +31,27 @@ class GotifyNotifier(object):
     Configuration parameters are also supported from entries (eg. through set).
     """
     schema = {
-          'type': 'object',
-          'properties': {
-                'oneOf': [
-                    {'url': {'type': 'string', 'format': 'url'}},
-                    {'token': {'type': 'string'}},
-                    {'priority': {'type': 'integer', 'default': 4}},
-                ],  
-            },
-          'required': [
-              'token',
-              'url',
-          ],
-        'error_oneOf': 'One (and only one) of `url` or `priority` are allowed.',
+        'type': 'object',
+        'properties': {
+            'url': {'type': 'string', 'format': 'url'},
+            'token': {'type': 'string'},
+            'priority': {'type': 'integer', 'default': 4},  
+        },  
+        'required': [
+            'token',
+            'url',
+        ],
+        'anyOf': [
+         {
+             'oneOf': [{'required': ['url']}],
+             'oneOf': [{'required': ['token']}],
+             'oneOf': [{'required': ['priority']}],
+             },
+        ],
+        'error_oneOf': 'One (and only one) of `url`, `token` or `priority` are allowed.',
         'additionalProperties': False,
-      }
+    }
+
 
     def notify(self, title, message, config):
         """

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -67,7 +67,7 @@ class GotifyNotifier(object):
         requests = RequestSession(max_retries=3)
         notification = {'title': title, 'message': body, 'priority': priority}
         if url:
-            notification['url'] = url + '?token=' + token
+            notification['url'] = url
         if destination:
             notification[destination_type] = destination
 

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -1,0 +1,94 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+import logging
+import base64
+import datetime
+
+from flexget import plugin
+from flexget.event import event
+from flexget.config_schema import one_or_more
+from flexget.plugin import PluginWarning
+from flexget.utils.requests import Session as RequestSession, TimedLimiter
+from requests.exceptions import RequestException
+
+plugin_name = 'gotify'
+log = logging.getLogger(plugin_name)
+
+requests = RequestSession(max_retries=3)
+
+class GotifyNotifier(object):
+    """
+    Example::
+
+    notify:
+      entries:
+        via:
+          - gotify:
+              url: <GOTIFY_SERVER_URL>
+              token: <GOTIFY_TOKEN>
+              priority: <PRIORITY>
+    Configuration parameters are also supported from entries (eg. through set).
+    """
+    schema = {
+          'type': 'object',
+          'properties': {
+                'oneOf': [
+                    {'url': {'type': 'string', 'format': 'url'}},
+                    {'token': {'type': 'string'}},
+                    {'priority': {'type': 'integer', 'default': 4}},
+                ],  
+            },
+          'required': [
+              'token',
+              'url',
+          ],
+        'error_oneOf': 'One (and only one) of `url` or `priority` are allowed.',
+        'additionalProperties': False,
+      }
+
+    def notify(self, title, message, config):
+        """
+        Send a Gotify notification
+        """
+        priority = config.get('priority')      
+        token = config.get('token')
+        url = config.get('url') + '?token=' + token
+        self.send_push(token, title, message, priority, url)
+
+    def send_push(self, token, title, body, priority, url=None, destination=None, destination_type=None):
+
+        requests = RequestSession(max_retries=3)
+        notification = {'title': title, 'message': body, 'priority': priority}
+        if url:
+            notification['url'] = url + '?token=' + token
+        if destination:
+            notification[destination_type] = destination
+
+        # Make the request
+        headers = {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'User-Agent': 'Flexget',
+        }
+        try:
+            response = requests.post(url, headers=headers, json=notification)
+        except RequestException as e:
+            if e.response is not None:
+                if e.response.status_code == 401 or e.response.status_code == 403:
+                    message = 'Invalid Gotify access token'
+                elif e.response.status_code == 404:
+                    url_format = 'https://push.example.com/message'
+                    message = (
+                        'Invalid Gotify URL, please verify that the URL matches the format: %s'
+                        % url_format
+                    )
+                else:
+                  message = e.response.json()['error']['message']
+            else:
+                message = str(e)
+            raise PluginWarning(message)
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(GotifyNotifier, plugin_name, api_ver=2, interfaces=['notifiers'])

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -9,6 +9,7 @@ from flexget.config_schema import one_or_more
 from flexget.plugin import PluginWarning
 from flexget.utils.requests import Session as RequestSession, TimedLimiter
 from requests.exceptions import RequestException
+from http import HTTPStatus
 
 plugin_name = 'gotify'
 log = logging.getLogger(plugin_name)
@@ -64,7 +65,7 @@ class GotifyNotifier(object):
             response = requests.post(url, params=params, json=notification)
         except RequestException as e:
             if e.response is not None:
-                if e.response.status_code == 401 or e.response.status_code == 403:
+                if e.response.code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
                     message = 'Invalid Gotify access token'
                 else:
                   message = e.response.json()['error']['message']

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -58,7 +58,6 @@ class GotifyNotifier(object):
         if config['priority']:
           priority = config['priority']
         
-        requests = RequestSession(max_retries=3)
         notification = {'title': title, 'message': message, 'priority': priority}
         # Make the request
         try:

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -89,7 +89,7 @@ class GotifyNotifier(object):
                     message = 'Invalid Gotify access token'
                 elif e.response.status_code == 404:
                     url_format = 'https://push.example.com/message'
-                    message = f"{Invalid Gotify URL, please verify that the URL matches the format: {url_format}"
+                    message = f"Invalid Gotify URL, please verify that the URL matches the format: {url_format}"
                 else:
                   message = e.response.json()['error']['message']
             else:

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -76,11 +76,6 @@ class GotifyNotifier(object):
             notification[destination_type] = destination
 
         # Make the request
-        headers = {
-            'Content-Type': 'application/json',
-            'Accept': 'application/json',
-            'User-Agent': 'Flexget',
-        }
         try:
             response = requests.post(url, headers=headers, json=notification)
         except RequestException as e:

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -6,7 +6,6 @@ from urllib.parse import urljoin
 
 from flexget import plugin
 from flexget.event import event
-from flexget.config_schema import one_or_more
 from flexget.plugin import PluginWarning
 from flexget.utils.requests import Session as RequestSession, TimedLimiter
 

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -63,7 +63,7 @@ class GotifyNotifier(object):
         """
         priority = config.get('priority')      
         token = config.get('token')
-        url = config.get('url') + '?token=' + token
+        url = f"{config.get('url') + '?token=' + token}"
         self.send_push(token, title, message, priority, url)
 
     def send_push(self, token, title, body, priority, url=None, destination=None, destination_type=None):
@@ -89,10 +89,10 @@ class GotifyNotifier(object):
                     message = 'Invalid Gotify access token'
                 elif e.response.status_code == 404:
                     url_format = 'https://push.example.com/message'
-                    message = (
+                    message = f"{
                         'Invalid Gotify URL, please verify that the URL matches the format: %s'
                         % url_format
-                    )
+                    }"
                 else:
                   message = e.response.json()['error']['message']
             else:

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -1,16 +1,15 @@
 import logging
-import base64
-import datetime
-import re
+
+from http import HTTPStatus
+from requests.exceptions import RequestException
+from urllib.parse import urljoin
 
 from flexget import plugin
 from flexget.event import event
 from flexget.config_schema import one_or_more
 from flexget.plugin import PluginWarning
 from flexget.utils.requests import Session as RequestSession, TimedLimiter
-from requests.exceptions import RequestException
-from http import HTTPStatus
-from urllib.parse import urljoin
+
 
 plugin_name = 'gotify'
 log = logging.getLogger(plugin_name)

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -4,6 +4,7 @@ from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 import logging
 import base64
 import datetime
+import re
 
 from flexget import plugin
 from flexget.event import event
@@ -16,6 +17,12 @@ plugin_name = 'gotify'
 log = logging.getLogger(plugin_name)
 
 requests = RequestSession(max_retries=3)
+
+gotify_url_pattern = {
+    'type': 'string',
+    'pattern': r'^http(s?)\:\/\/.*\/message$',
+    'error_pattern': 'Gotify URL must begin with http(s) and end with `/message`',
+}
 
 class GotifyNotifier(object):
     """
@@ -33,7 +40,7 @@ class GotifyNotifier(object):
     schema = {
         'type': 'object',
         'properties': {
-            'url': {'type': 'string', 'format': 'url'},
+            'url': one_or_more(gotify_url_pattern),
             'token': {'type': 'string'},
             'priority': {'type': 'integer', 'default': 4},  
         },  

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -45,7 +45,6 @@ class GotifyNotifier(object):
             'token',
             'url',
         ],
-        'error_oneOf': 'One (and only one) of `url`, `token` or `priority` are allowed.',
         'additionalProperties': False,
     }
 

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -1,5 +1,3 @@
-import logging
-
 from http import HTTPStatus
 from requests.exceptions import RequestException
 from urllib.parse import urljoin
@@ -9,9 +7,7 @@ from flexget.event import event
 from flexget.plugin import PluginWarning
 from flexget.utils.requests import Session as RequestSession, TimedLimiter
 
-
 plugin_name = 'gotify'
-log = logging.getLogger(plugin_name)
 
 requests = RequestSession(max_retries=3)
 

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -45,13 +45,6 @@ class GotifyNotifier(object):
             'token',
             'url',
         ],
-        'anyOf': [
-         {
-             'oneOf': [{'required': ['url']}],
-             'oneOf': [{'required': ['token']}],
-             'oneOf': [{'required': ['priority']}],
-             },
-        ],
         'error_oneOf': 'One (and only one) of `url`, `token` or `priority` are allowed.',
         'additionalProperties': False,
     }


### PR DESCRIPTION
### Motivation for changes:
Currently using a hack script to forward flexget emails to [Gotify](https://github.com/gotify/server) instance. We should have more FOSS notification options :smile: 

### Detailed changes:
Based off of Pushbullet plugin. Gotify publishes messages via https://push.example.com/message?token=GOTIFY_TOKEN, and messages take the following format:

```
{ "title": "Some title", "message": "some message", "priority": 4 }
```
The `priority` field is optional (we use a default of 4, since the Android client mainly looks at priorities between 0 and 7, though this can be any integer.

### Config usage if relevant (new plugin or updated schema):

```
    notify:
      task:
        always_send: yes
        title: "Flexget {{task.name}} summary"
        via:
          - gotify:
              url: https://push.example.com/message
              token: TOKEN
              priority: 4

```
### Log and/or tests output (preferably both):
**Failed config validation (duplicate priority declared):**

```
$ flexget --loglevel debug check
2019-12-16 00:39 DEBUG    manager                       Figuring out config load paths
2019-12-16 00:39 DEBUG    manager                       Found config: /home/code/.config/flexget/config.yml
2019-12-16 00:39 DEBUG    manager                       Config file /home/code/.config/flexget/config.yml selected
2019-12-16 00:39 DEBUG    manager                       sys.defaultencoding: utf-8
2019-12-16 00:39 DEBUG    manager                       sys.getfilesystemencoding: utf-8
2019-12-16 00:39 DEBUG    manager                       flexget detected io encoding: utf-8
2019-12-16 00:39 DEBUG    manager                       os.path.supports_unicode_filenames: False
2019-12-16 00:39 DEBUG    plugin                        Trying to load plugins from: ['/home/code/.config/flexget/plugins', '/home/code/.local/lib/python3.6/site-packages/flexget/plugins']
2019-12-16 00:39 DEBUG    plugin                        Plugin `memusage` requires plugin `ext lib `guppy`` to load.
2019-12-16 00:39 DEBUG    plugin                        Trying to load components from: ['/home/code/.config/flexget/components', '/home/code/.local/lib/python3.6/site-packages/flexget/components']
2019-12-16 00:39 DEBUG    plugin                        Plugins took 0.94 seconds to load. 295 plugins in registry.
2019-12-16 00:39 DEBUG    manager                       Connecting to: sqlite:////home/code/.config/flexget/db-config.sqlite
2019-12-16 00:39 WARNING  check                         Trying to set value for `priority` in line 23, but it is already defined in line 22!
2019-12-16 00:39 VERBOSE  check                         Pre-checked 23 configuration lines
2019-12-16 00:39 DEBUG    manager                       config_name: config
2019-12-16 00:39 DEBUG    manager                       config_base: /home/code/.config/flexget
2019-12-16 00:39 DEBUG    manager                       New config data loaded.
2019-12-16 00:39 DEBUG    schema                        current flexget version already exist in db 2.20.6.dev
2019-12-16 00:39 DEBUG    parsing                       setting default movie parser to internal. (options: {'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x7eff41686198>, 'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x7eff416861d0>})
2019-12-16 00:39 DEBUG    parsing                       setting default series parser to internal. (options: {'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x7eff41686198>, 'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x7eff416861d0>})
2019-12-16 00:39 VERBOSE  check                         Checking config file `/home/code/.config/flexget/config.yml`
2019-12-16 00:39 VERBOSE  check                         Config passed check.
2019-12-16 00:39 DEBUG    util.simple_persistence                 Flushing simple persistence for task None to db.
2019-12-16 00:39 DEBUG    manager                       Shutting down
2019-12-16 00:39 DEBUG    manager                       Removed /home/code/.config/flexget/.config-lock
```

**Successful config validation:**

```
$ flexget --loglevel debug check
2019-12-16 00:41 DEBUG    manager                       Figuring out config load paths
2019-12-16 00:41 DEBUG    manager                       Found config: /home/code/.config/flexget/config.yml
2019-12-16 00:41 DEBUG    manager                       Config file /home/code/.config/flexget/config.yml selected
2019-12-16 00:41 DEBUG    manager                       sys.defaultencoding: utf-8
2019-12-16 00:41 DEBUG    manager                       sys.getfilesystemencoding: utf-8
2019-12-16 00:41 DEBUG    manager                       flexget detected io encoding: utf-8
2019-12-16 00:41 DEBUG    manager                       os.path.supports_unicode_filenames: False
2019-12-16 00:41 DEBUG    plugin                        Trying to load plugins from: ['/home/code/.config/flexget/plugins', '/home/code/.local/lib/python3.6/site-packages/flexget/plugins']
2019-12-16 00:41 DEBUG    plugin                        Plugin `memusage` requires plugin `ext lib `guppy`` to load.
2019-12-16 00:41 DEBUG    plugin                        Trying to load components from: ['/home/code/.config/flexget/components', '/home/code/.local/lib/python3.6/site-packages/flexget/components']
2019-12-16 00:41 DEBUG    plugin                        Plugins took 0.96 seconds to load. 295 plugins in registry.
2019-12-16 00:41 DEBUG    manager                       Connecting to: sqlite:////home/code/.config/flexget/db-config.sqlite
2019-12-16 00:41 VERBOSE  check                         Pre-checked 23 configuration lines
2019-12-16 00:41 DEBUG    manager                       config_name: config
2019-12-16 00:41 DEBUG    manager                       config_base: /home/code/.config/flexget
2019-12-16 00:41 DEBUG    manager                       New config data loaded.
2019-12-16 00:41 DEBUG    schema                        current flexget version already exist in db 2.20.6.dev
2019-12-16 00:41 DEBUG    parsing                       setting default movie parser to internal. (options: {'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x7feb6610b1d0>, 'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x7feb6610b208>})
2019-12-16 00:41 DEBUG    parsing                       setting default series parser to internal. (options: {'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x7feb6610b1d0>, 'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x7feb6610b208>})
2019-12-16 00:41 VERBOSE  check                         Checking config file `/home/code/.config/flexget/config.yml`
2019-12-16 00:41 VERBOSE  check                         Config passed check.
2019-12-16 00:41 DEBUG    util.simple_persistence                 Flushing simple persistence for task None to db.
2019-12-16 00:41 DEBUG    manager                       Shutting down
2019-12-16 00:41 DEBUG    manager                       Removed /home/code/.config/flexget/.config-lock
```

**Sending Notification:**

```
flexget --loglevel debug execute
2019-12-16 00:45 DEBUG    manager                       Figuring out config load paths
2019-12-16 00:45 DEBUG    manager                       Found config: /home/code/.config/flexget/config.yml
2019-12-16 00:45 DEBUG    manager                       Config file /home/code/.config/flexget/config.yml selected
2019-12-16 00:45 DEBUG    manager                       sys.defaultencoding: utf-8
2019-12-16 00:45 DEBUG    manager                       sys.getfilesystemencoding: utf-8
2019-12-16 00:45 DEBUG    manager                       flexget detected io encoding: utf-8
2019-12-16 00:45 DEBUG    manager                       os.path.supports_unicode_filenames: False
2019-12-16 00:45 DEBUG    plugin                        Trying to load plugins from: ['/home/code/.config/flexget/plugins', '/home/code/.local/lib/python3.6/site-packages/flexget/plugins']
2019-12-16 00:45 DEBUG    plugin                        Plugin `memusage` requires plugin `ext lib `guppy`` to load.
2019-12-16 00:45 DEBUG    plugin                        Trying to load components from: ['/home/code/.config/flexget/components', '/home/code/.local/lib/python3.6/site-packages/flexget/components']
2019-12-16 00:45 DEBUG    plugin                        Plugins took 0.90 seconds to load. 295 plugins in registry.
2019-12-16 00:45 DEBUG    manager                       Connecting to: sqlite:////home/code/.config/flexget/db-config.sqlite
2019-12-16 00:45 DEBUG    manager                       config_name: config
2019-12-16 00:45 DEBUG    manager                       config_base: /home/code/.config/flexget
2019-12-16 00:45 DEBUG    manager                       New config data loaded.
2019-12-16 00:45 DEBUG    schema                        current flexget version already exist in db 2.20.6.dev
2019-12-16 00:45 DEBUG    parsing                       setting default movie parser to internal. (options: {'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x7f8215db1198>, 'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x7f8215db11d0>})
2019-12-16 00:45 DEBUG    parsing                       setting default series parser to internal. (options: {'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x7f8215db1198>, 'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x7f8215db11d0>})
2019-12-16 00:45 DEBUG    cron_env                      Encoding utf-8 stored
2019-12-16 00:45 DEBUG    util.simple_persistence                 setting key terminal_encoding value 'utf-8'
2019-12-16 00:45 DEBUG    task_queue                    task queue shutdown requested
2019-12-16 00:45 INFO     ipc.rpyc                      server started on [127.0.0.1]:40903
2019-12-16 00:45 DEBUG    task          fake-task task  executing fake-task task
2019-12-16 00:45 VERBOSE  filesystem    fake-task task  Starting to scan folders.
2019-12-16 00:45 VERBOSE  filesystem    fake-task task  Scanning folder /opt/flexget. Recursion is set to True.
2019-12-16 00:45 DEBUG    filesystem    fake-task task  Scanning /opt/flexget
2019-12-16 00:45 DEBUG    filesystem    fake-task task  Checking if /opt/flexget/test1.txt qualifies to be added as an entry.
2019-12-16 00:45 DEBUG    filesystem    fake-task task  Checking if /opt/flexget/test3.txt qualifies to be added as an entry.
2019-12-16 00:45 DEBUG    filesystem    fake-task task  Checking if /opt/flexget/test2.txt qualifies to be added as an entry.
2019-12-16 00:45 DEBUG    backlog.db    fake-task task  0 entries purged from backlog
2019-12-16 00:45 VERBOSE  details       fake-task task  Produced 3 entries.
2019-12-16 00:45 DEBUG    flexget.components.seen.seen fake-task task  Rejecting 'file:///opt/flexget/test1.txt' 'test1' because of seen 'file:///opt/flexget/test1.txt'
2019-12-16 00:45 VERBOSE  task          fake-task task  REJECTED: `test1` by seen plugin because entry with url `file:///opt/flexget/test1.txt` is already marked seen in the task fake-task task at 2019-12-15 00:56
2019-12-16 00:45 DEBUG    flexget.components.seen.seen fake-task task  Rejecting 'file:///opt/flexget/test3.txt' 'test3' because of seen 'file:///opt/flexget/test3.txt'
2019-12-16 00:45 VERBOSE  task          fake-task task  REJECTED: `test3` by seen plugin because entry with url `file:///opt/flexget/test3.txt` is already marked seen in the task fake-task task at 2019-12-15 00:56
2019-12-16 00:45 DEBUG    flexget.components.seen.seen fake-task task  Rejecting 'file:///opt/flexget/test2.txt' 'test2' because of seen 'file:///opt/flexget/test2.txt'
2019-12-16 00:45 VERBOSE  task          fake-task task  REJECTED: `test2` by seen plugin because entry with url `file:///opt/flexget/test2.txt` is already marked seen in the task fake-task task at 2019-12-15 00:56
2019-12-16 00:45 DEBUG    urlrewriter   fake-task task  Checking 0 entries
2019-12-16 00:45 VERBOSE  details       fake-task task  Summary - Accepted: 0 (Rejected: 3 Undecided: 0 Failed: 0)
2019-12-16 00:45 DEBUG    notify        fake-task task  Sending a notification to `gotify`
2019-12-16 00:45 DEBUG    utils.requests fake-task task  POSTing URL https://push.example.com/message?token=TOKEN with args () and kwargs {'data': None, 'json': {'title': 'Flexget fake-task task summary', 'message': ' Task did not produce any entries.\n', 'priority': 1, 'url': 'https://push.example.com/message?token=TOKEN'}, 'headers': {'Content-Type': 'application/json', 'Accept': 'application/json', 'User-Agent': 'Flexget'}, 'timeout': 30}
2019-12-16 00:45 VERBOSE  notify        fake-task task  Successfully sent a notification to `gotify`
2019-12-16 00:45 DEBUG    util.simple_persistence fake-task task  Flushing simple persistence for task fake-task task to db.
2019-12-16 00:45 DEBUG    task_queue                    task queue shut down
2019-12-16 00:45 INFO     ipc.rpyc                      listener closed
2019-12-16 00:45 INFO     ipc.rpyc                      server has terminated
2019-12-16 00:45 DEBUG    util.simple_persistence                 Flushing simple persistence for task None to db.
2019-12-16 00:45 DEBUG    manager                       Shutting down
2019-12-16 00:45 DEBUG    manager                       Removed /home/code/.config/flexget/.config-lock
```

#### To Do:
 - [x] Update docs: https://github.com/Flexget/wiki/pull/7
 - [x] Testing - what to test beyond test suite here? Successfully tested with test flexget instance, now testing with production instance
 - [x] Correct usage of `oneOf`
 - [x] Fix percent encoding in paths with spaces in message body - use `safe` filter in template

