### PR TITLE
[Add] pending list batch operation and deletion endpoint

### DIFF
--- a/flexget/components/managed_lists/lists/pending_list/api.py
+++ b/flexget/components/managed_lists/lists/pending_list/api.py
@@ -74,7 +74,12 @@ class ObjectsContainer:
         'type': 'object',
         'properties': {
             'operation': {'type': 'string', 'enum': ['approve', 'reject', 'remove']},
-            'ids': {'type': 'array', 'items': {'type': 'integer'}},
+            'ids': {
+                'type': 'array',
+                'items': {'type': 'integer'},
+                'uniqueItems': True,
+                'minItems': 1,
+            },
         },
         'required': ['operation', 'ids'],
         'additionalProperties': False,
@@ -99,7 +104,7 @@ pending_list_operation_schema = api.schema_model(
     'pending_list.operation_schema', ObjectsContainer.operation_object
 )
 pending_list_batch_schema = api.schema_model(
-    'pending_List.batch_object', ObjectsContainer.batch_object
+    'pending_list.batch_object', ObjectsContainer.batch_object
 )
 
 list_parser = api.parser()
@@ -294,7 +299,7 @@ class PendingListEntriesBatchAPI(APIResource):
         try:
             entries = db.get_entries_by_list_id(list_id, entry_ids=entry_ids, session=session)
         except NoResultFound:
-            raise NotFoundError('could not find entries in list %d' % list_id)
+            raise NotFoundError(f'could not find entries in list {list_id}')
 
         response = None
         if operation == 'remove':

--- a/flexget/components/managed_lists/lists/pending_list/api.py
+++ b/flexget/components/managed_lists/lists/pending_list/api.py
@@ -285,7 +285,7 @@ class PendingListEntriesBatchAPI(APIResource):
     @api.response(201, model=pending_lists_entries_return_schema)
     @api.response(204)
     @api.validate(model=pending_list_batch_schema)
-    @api.doc(description='Approve, rejct, or remove multiple entries')
+    @api.doc(description='Approve, reject, or remove multiple entries')
     def post(self, list_id, session=None):
         """Perform operations on multiple entries"""
         data = request.json

--- a/flexget/components/managed_lists/lists/pending_list/db.py
+++ b/flexget/components/managed_lists/lists/pending_list/db.py
@@ -114,6 +114,7 @@ def get_entries_by_list_id(
     descending=False,
     approved=False,
     filter=None,
+    entry_ids=None,
     session=None,
 ):
     log.debug('querying entries from pending list with id %d', list_id)
@@ -122,6 +123,8 @@ def get_entries_by_list_id(
         query = query.filter(func.lower(PendingListEntry.title).contains(filter.lower()))
     if approved:
         query = query.filter(PendingListEntry.approved is approved)
+    if entry_ids:
+        query = query.filter(PendingListEntry.id.in_(entry_ids))
     if descending:
         query = query.order_by(getattr(PendingListEntry, order_by).desc())
     else:

--- a/flexget/components/tmdb/tmdb_lookup.py
+++ b/flexget/components/tmdb/tmdb_lookup.py
@@ -36,7 +36,7 @@ class PluginTmdbLookup:
         'tmdb_votes': 'votes',
         # Just grab the top 5 posters
         'tmdb_posters': lambda movie: [poster.url('original') for poster in movie.posters[:5]],
-        'tmdb_backdrops': lambda movie: [poster.url('original') for poster in movie.backdrops[:5]],
+        'tmdb_backdrops': lambda movie: [backdrop.url('original') for backdrop in movie.backdrops[:5]],
         'tmdb_runtime': 'runtime',
         'tmdb_tagline': 'tagline',
         'tmdb_budget': 'budget',

--- a/flexget/tests/api_tests/test_pending_list_api.py
+++ b/flexget/tests/api_tests/test_pending_list_api.py
@@ -175,7 +175,7 @@ class TestPendingListAPI:
 
         # Add 3 entries to list
         for i in range(3):
-            payload = {'title': 'title %d' % i, 'original_url': 'http://%dtest.com' % i}
+            payload = {'title': f'title {i}', 'original_url': f'http://{i}test.com'}
             rsp = api_client.json_post('/pending_list/1/entries/', data=json.dumps(payload))
             assert rsp.status_code == 201
 
@@ -241,7 +241,7 @@ class TestPendingListAPI:
 
         errors = schema_match(OC.pending_lists_entries_return_object, data)
         assert not errors
-        assert len(data) == 0
+        assert not data
 
     def test_pending_list_entry(self, api_client, schema_match):
         payload = {'name': 'test_list'}

--- a/flexget/tests/api_tests/test_pending_list_api.py
+++ b/flexget/tests/api_tests/test_pending_list_api.py
@@ -190,8 +190,7 @@ class TestPendingListAPI:
         assert not errors
         assert len(data) == 3
 
-        for item in data:
-            assert item.get('approved')
+        assert all((item['approved'] for item in data))
 
         # get entries is correct
         rsp = api_client.get('/pending_list/1/entries/')

--- a/flexget/tests/api_tests/test_pending_list_api.py
+++ b/flexget/tests/api_tests/test_pending_list_api.py
@@ -167,6 +167,82 @@ class TestPendingListAPI:
         errors = schema_match(OC.pending_list_entry_base_object, data)
         assert not errors
 
+    def test_pending_list_entries_batch(self, api_client, schema_match):
+        payload = {'name': 'test_list'}
+
+        # Create list
+        api_client.json_post('/pending_list/', data=json.dumps(payload))
+
+        # Add 3 entries to list
+        for i in range(3):
+            payload = {'title': 'title %d' % i, 'original_url': 'http://%dtest.com' % i}
+            rsp = api_client.json_post('/pending_list/1/entries/', data=json.dumps(payload))
+            assert rsp.status_code == 201
+
+        payload = {'operation': 'approve', 'ids': [1, 2, 3]}
+
+        # Approve several entries
+        rsp = api_client.json_post('/pending_list/1/entries/batch/', data=json.dumps(payload))
+        assert rsp.status_code == 201
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(OC.pending_lists_entries_return_object, data)
+        assert not errors
+        assert len(data) == 3
+
+        for item in data:
+            assert item.get('approved')
+
+        # get entries is correct
+        rsp = api_client.get('/pending_list/1/entries/')
+        assert rsp.status_code == 200
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(OC.pending_lists_entries_return_object, data)
+        assert not errors
+        assert len(data) == 3
+
+        for item in data:
+            assert item.get('approved')
+
+        payload['operation'] = 'reject'
+
+        # reject several entries
+        rsp = api_client.json_post('pending_list/1/entries/batch', data=json.dumps(payload))
+        assert rsp.status_code == 201
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(OC.pending_lists_entries_return_object, data)
+        assert not errors
+        assert len(data) == 3
+
+        for item in data:
+            assert not item.get('approved')
+
+        rsp = api_client.get('/pending_list/1/entries/')
+        assert rsp.status_code == 200
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(OC.pending_lists_entries_return_object, data)
+        assert not errors
+        assert len(data) == 3
+
+        for item in data:
+            assert not item.get('approved')
+
+        payload['operation'] = 'remove'
+
+        rsp = api_client.json_post('pending_list/1/entries/batch', data=json.dumps(payload))
+        assert rsp.status_code == 204
+
+        rsp = api_client.get('/pending_list/1/entries/')
+        assert rsp.status_code == 200
+        data = json.loads(rsp.get_data(as_text=True))
+
+        errors = schema_match(OC.pending_lists_entries_return_object, data)
+        assert not errors
+        assert len(data) == 0
+
     def test_pending_list_entry(self, api_client, schema_match):
         payload = {'name': 'test_list'}
 

--- a/flexget/tests/conftest.py
+++ b/flexget/tests/conftest.py
@@ -380,6 +380,12 @@ class APIClient:
 
         return self.client.delete(*args, **kwargs)
 
+    def json_delete(self, *args, **kwargs):
+        self._append_header('Content-Type', 'application/json', kwargs)
+        if kwargs.get('auth', True):
+            self._append_header('Authorization', 'Token %s' % self.api_key, kwargs)
+        return self.client.delete(*args, **kwargs)
+
     def head(self, *args, **kwargs):
         if kwargs.get('auth', True):
             self._append_header('Authorization', 'Token %s' % self.api_key, kwargs)


### PR DESCRIPTION
### Motivation for changes:
I'm adding some bulk operation features to webui (Flexget/webui#54) so this seemed better than making a lot of requests. Eventually I want to just make graphQL or gRPC endpoints for webui to use and these batch operations will be cleaner but that's a later activity. 

### Detailed changes:
- Add new endpoint `PUT /pending_list/{list_id}/entries/batch` for bulk approving, rejecting pending list entries
- Add new endpoint `DELETE /pending_list/{list_id}/entries/batch` for bulk removing removing pending list entries
