### PR TITLE
[change]: Allow trakt lookup api without title

### DIFF
--- a/flexget/components/managed_lists/lists/movie_list/api.py
+++ b/flexget/components/managed_lists/lists/movie_list/api.py
@@ -59,7 +59,7 @@ class ObjectsContainer:
             'added_on': {'type': 'string'},
             'year': {'type': ['integer', 'null']},
             'list_id': {'type': 'integer'},
-            'movie_list_ids': {'type': 'array', 'items': return_movie_list_id_object},
+            'movies_list_ids': {'type': 'array', 'items': return_movie_list_id_object},
         },
     }
 

--- a/flexget/components/managed_lists/lists/movie_list/api.py
+++ b/flexget/components/managed_lists/lists/movie_list/api.py
@@ -59,7 +59,7 @@ class ObjectsContainer:
             'added_on': {'type': 'string'},
             'year': {'type': ['integer', 'null']},
             'list_id': {'type': 'integer'},
-            'movies_list_ids': {'type': 'array', 'items': return_movie_list_id_object},
+            'movie_list_ids': {'type': 'array', 'items': return_movie_list_id_object},
         },
     }
 

--- a/flexget/components/trakt/api_trakt.py
+++ b/flexget/components/trakt/api_trakt.py
@@ -224,9 +224,12 @@ class ApiTrakt:
         if movie and not movie.expired:
             return movie
         # Parse the movie for better results
-        title_parser = plugin.get('parsing', 'api_trakt').parse_movie(title)
-        y = year or title_parser.year
-        parsed_title = title_parser.name
+        parsed_title = None
+        y = year
+        if title:
+            title_parser = plugin.get('parsing', 'api_trakt').parse_movie(title)
+            y = year or title_parser.year
+            parsed_title = title_parser.name
         try:
             trakt_movie = db.get_trakt_data(
                 'movie', title=parsed_title, year=y, trakt_ids=trakt_movie_ids

--- a/flexget/tests/api_tests/test_trakt_lookup_api.py
+++ b/flexget/tests/api_tests/test_trakt_lookup_api.py
@@ -15,7 +15,7 @@ class TestTraktSeriesLookupAPI:
         rsp = api_client.get('/trakt/series/')
         assert rsp.status_code == 404, 'Response code is %s' % rsp.status_code
 
-        rsp = api_client.get('/trakt/series/the x-files/')
+        rsp = api_client.get('/trakt/series/?title=the x-files')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
         data = json.loads(rsp.get_data(as_text=True))
@@ -49,7 +49,7 @@ class TestTraktSeriesLookupAPI:
             'year': 1990,
         }
 
-        rsp = api_client.get('/trakt/series/the flash/?year=1990')
+        rsp = api_client.get('/trakt/series/?title=the flash&year=1990')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
         data = json.loads(rsp.get_data(as_text=True))
@@ -62,7 +62,7 @@ class TestTraktSeriesLookupAPI:
     def test_trakt_series_lookup_with_trakt_slug_id_param(self, api_client, schema_match):
         values = {'id': 75481, 'title': 'The Flash', 'tvdb_id': 272094, 'year': 1967}
 
-        rsp = api_client.get('/trakt/series/the flash/?trakt_slug=the-flash-1967')
+        rsp = api_client.get('/trakt/series/?title=the flash&trakt_slug=the-flash-1967')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
         data = json.loads(rsp.get_data(as_text=True))
@@ -84,7 +84,7 @@ class TestTraktSeriesLookupAPI:
             'year': 2014,
         }
 
-        rsp = api_client.get('/trakt/series/the flash/?tmdb_id=60735')
+        rsp = api_client.get('/trakt/series/?title=the flash&tmdb_id=60735')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
         data = json.loads(rsp.get_data(as_text=True))
@@ -105,7 +105,7 @@ class TestTraktSeriesLookupAPI:
             'year': 2014,
         }
 
-        rsp = api_client.get('/trakt/series/the flash/?imdb_id=tt3107288')
+        rsp = api_client.get('/trakt/series/?title=the flash&imdb_id=tt3107288')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
         data = json.loads(rsp.get_data(as_text=True))
@@ -123,7 +123,7 @@ class TestTraktSeriesLookupAPI:
             'year': 2014,
         }
 
-        rsp = api_client.get('/trakt/series/the flash/?tvdb_id=279121')
+        rsp = api_client.get('/trakt/series/?title=the flash&tvdb_id=279121')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
         data = json.loads(rsp.get_data(as_text=True))
@@ -144,7 +144,7 @@ class TestTraktSeriesLookupAPI:
             'year': 2014,
         }
 
-        rsp = api_client.get('/trakt/series/the flash/?tvrage_id=36939')
+        rsp = api_client.get('/trakt/series/?title=the flash&tvrage_id=36939')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
         data = json.loads(rsp.get_data(as_text=True))
@@ -157,7 +157,7 @@ class TestTraktSeriesLookupAPI:
     def test_trakt_series_lookup_with_trakt_id_param(self, api_client, schema_match):
         values = {'id': 75481, 'title': 'The Flash', 'year': 1967}
 
-        rsp = api_client.get('/trakt/series/the flash/?trakt_id=75481')
+        rsp = api_client.get('/trakt/series/?title=the flash&trakt_id=75481')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
         data = json.loads(rsp.get_data(as_text=True))
@@ -168,7 +168,7 @@ class TestTraktSeriesLookupAPI:
             assert data.get(field) == value
 
     def test_trakt_series_lookup_with_actors_param(self, api_client, schema_match):
-        rsp = api_client.get('/trakt/series/the x-files/?include_actors=true')
+        rsp = api_client.get('/trakt/series/?title=the x-files&include_actors=true')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
         data = json.loads(rsp.get_data(as_text=True))
@@ -179,7 +179,7 @@ class TestTraktSeriesLookupAPI:
         assert len(data['actors']) > 0
 
     def test_trakt_series_lookup_with_translations_param(self, api_client, schema_match):
-        rsp = api_client.get('/trakt/series/game of thrones/?include_translations=true')
+        rsp = api_client.get('/trakt/series/?title=game of thrones&include_translations=true')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
         data = json.loads(rsp.get_data(as_text=True))
@@ -189,7 +189,7 @@ class TestTraktSeriesLookupAPI:
         assert 'translations' in data
 
     def test_trakt_series_lookup_error(self, api_client, schema_match):
-        rsp = api_client.get('/trakt/series/sdfgsdfgsdfgsdfgsdfg/')
+        rsp = api_client.get('/trakt/series/?title=sdfgsdfgsdfgsdfgsdfg')
         assert rsp.status_code == 404, 'Response code is %s' % rsp.status_code
 
         data = json.loads(rsp.get_data(as_text=True))
@@ -206,7 +206,7 @@ class TestTraktMovieLookupAPI:
         rsp = api_client.get('/trakt/movies/')
         assert rsp.status_code == 404, 'Response code is %s' % rsp.status_code
 
-        rsp = api_client.get('/trakt/movies/the matrix/')
+        rsp = api_client.get('/trakt/movies/?title=the matrix')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
         data = json.loads(rsp.get_data(as_text=True))
@@ -224,7 +224,7 @@ class TestTraktMovieLookupAPI:
             assert data.get(field) == value
 
     def test_trakt_movies_lookup_year_param(self, api_client, schema_match):
-        rsp = api_client.get('/trakt/movies/the matrix/?year=2003')
+        rsp = api_client.get('/trakt/movies/?title=the matrix&year=2003')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
         data = json.loads(rsp.get_data(as_text=True))
@@ -242,7 +242,7 @@ class TestTraktMovieLookupAPI:
             assert data.get(field) == value
 
     def test_trakt_movies_lookup_slug_param(self, api_client, schema_match):
-        rsp = api_client.get('/trakt/movies/the matrix/?trakt_slug=the-matrix-reloaded-2003')
+        rsp = api_client.get('/trakt/movies/?title=the matrix&trakt_slug=the-matrix-reloaded-2003')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
         data = json.loads(rsp.get_data(as_text=True))
@@ -260,7 +260,7 @@ class TestTraktMovieLookupAPI:
             assert data.get(field) == value
 
     def test_trakt_movies_lookup_actors_params(self, api_client, schema_match):
-        rsp = api_client.get('/trakt/movies/the matrix/?include_actors=true')
+        rsp = api_client.get('/trakt/movies/?title=the matrix&include_actors=true')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
         data = json.loads(rsp.get_data(as_text=True))
@@ -281,7 +281,7 @@ class TestTraktMovieLookupAPI:
         assert len(data['actors']) > 0
 
     def test_trakt_movies_lookup_translations_params(self, api_client, schema_match):
-        rsp = api_client.get('/trakt/movies/the matrix/?include_translations=true')
+        rsp = api_client.get('/trakt/movies/?title=the matrix&include_translations=true')
         assert rsp.status_code == 200, 'Response code is %s' % rsp.status_code
 
         data = json.loads(rsp.get_data(as_text=True))
@@ -302,7 +302,7 @@ class TestTraktMovieLookupAPI:
         assert len(data['translations']) > 0
 
     def test_trakt_movies_lookup_error(self, api_client, schema_match):
-        rsp = api_client.get('/trakt/movies/sdfgsdfgsdfgsdfgsdfg/')
+        rsp = api_client.get('/trakt/movies/?title=sdfgsdfgsdfgsdfgsdfg')
         assert rsp.status_code == 404, 'Response code is %s' % rsp.status_code
 
         data = json.loads(rsp.get_data(as_text=True))


### PR DESCRIPTION
### Motivation for changes:
You really don't need a trakt  title for lookup so making it a query parameter just seemed more consistent

### Detailed changes:
- add `GET /trakt/movies` and `GET /trakt/series`
- redirect `GET /trakt/movies/{title}  => /trakt/movies?title={title}`
- redirect `GET /trakt/series/{title}  => /trakt/series?title={title}`

