### PR TITLE
[Fix]: Properly parse timestamp in log api

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ pylint
 coverage==4.4.1
 flake8
 vcrpy~=1.11.1  # requests 2.16.3 doesn't work with vcrpy <1.11.1
-virtualenv==15.1.0
+virtualenv==15.2.0
 boto3
 wheel==0.31.0
 pytest~=5.1.2

--- a/flexget/api/core/server.py
+++ b/flexget/api/core/server.py
@@ -19,6 +19,7 @@ from pyparsing import (
     Group,
     Keyword,
     OneOrMore,
+    Optional,
     ParseException,
     Suppress,
     White,
@@ -507,6 +508,7 @@ class LogParser:
             + time_cmpnt
             + ':'
             + time_cmpnt
+            + Optional(':' + time_cmpnt)
         )
         word = Word(printables)
 


### PR DESCRIPTION
### Motivation for changes:
The old version didn't have seconds so it was messing up the Log Parser. Also pre-commit was complaining about the version of virtualenv so I upped it. 

