### PR TITLE
Fix tvdb firstaired

### DIFF
--- a/flexget/components/thetvdb/api_tvdb.py
+++ b/flexget/components/thetvdb/api_tvdb.py
@@ -478,7 +478,7 @@ def find_series_id(name, language=None):
         if s['firstAired']:
             try:
                 s['firstAired'] = datetime.strptime(s['firstAired'], "%Y-%m-%d")
-            except:
+            except ValueError:
                 logger.debug('Invalid firstAired date "{}" when parsing series {} ', s['firstAired'], s['seriesName'])
                 s['firstAired'] = datetime(1970, 1, 1)
         else:

--- a/flexget/components/thetvdb/api_tvdb.py
+++ b/flexget/components/thetvdb/api_tvdb.py
@@ -476,7 +476,11 @@ def find_series_id(name, language=None):
     # Cleanup results for sorting
     for s in series:
         if s['firstAired']:
-            s['firstAired'] = datetime.strptime(s['firstAired'], "%Y-%m-%d")
+            try:
+                s['firstAired'] = datetime.strptime(s['firstAired'], "%Y-%m-%d")
+            except:
+                logger.debug('Invalid firstAired date "{}" when parsing series {} ', s['firstAired'], s['seriesName'])
+                s['firstAired'] = datetime(1970, 1, 1)
         else:
             s['firstAired'] = datetime(1970, 1, 1)
 

--- a/flexget/components/thetvdb/api_tvdb.py
+++ b/flexget/components/thetvdb/api_tvdb.py
@@ -479,7 +479,7 @@ def find_series_id(name, language=None):
             try:
                 s['firstAired'] = datetime.strptime(s['firstAired'], "%Y-%m-%d")
             except ValueError:
-                logger.debug('Invalid firstAired date "{}" when parsing series {} ', s['firstAired'], s['seriesName'])
+                logger.warning('Invalid firstAired date "{}" when parsing series {} ', s['firstAired'], s['seriesName'])
                 s['firstAired'] = datetime(1970, 1, 1)
         else:
             s['firstAired'] = datetime(1970, 1, 1)


### PR DESCRIPTION
### Motivation for changes:
Sometimes TVDB returns invalid firstAired dates causing

```2019-12-31 03:38:11 ERROR    lazy_lookup   SOME_TASK      Unhandled error in lazy lookup plugin: time data '5-8-6' does not match format '%Y-%m-%d'
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/flexget/utils/lazy_dict.py", line 36, in __getitem__
    func(self.store)
  File "/usr/local/lib/python3.7/dist-packages/flexget/components/thetvdb/thetvdb_lookup.py", line 123, in lazy_series_lookup
    return self.series_lookup(entry, language, self.series_map)
  File "/usr/local/lib/python3.7/dist-packages/flexget/utils/database.py", line 30, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/flexget/components/thetvdb/thetvdb_lookup.py", line 113, in series_lookup
    session=session,
  File "/usr/local/lib/python3.7/dist-packages/flexget/utils/database.py", line 27, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/flexget/components/thetvdb/api_tvdb.py", line 580, in lookup_series
    tvdb_id = find_series_id(name, language=language)
  File "/usr/local/lib/python3.7/dist-packages/flexget/components/thetvdb/api_tvdb.py", line 479, in find_series_id
    s['firstAired'] = datetime.strptime(s['firstAired'], "%Y-%m-%d")
  File "/usr/lib/python3.7/_strptime.py", line 577, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/usr/lib/python3.7/_strptime.py", line 359, in _strptime
    (data_string, format))
ValueError: time data '5-8-6' does not match format '%Y-%m-%d'```
