### PR TITLE
Move v2 to root

### DIFF
--- a/flexget/_version.py
+++ b/flexget/_version.py
@@ -7,4 +7,4 @@ The version should always be set to the <next release version>.dev
 The jenkins release job will automatically strip the .dev for release,
 and update the version again for continued development.
 """
-__version__ = '3.0.32.dev'
+__version__ = '3.1.0.dev'

--- a/flexget/plugins/daemon/web_server.py
+++ b/flexget/plugins/daemon/web_server.py
@@ -25,7 +25,10 @@ web_config_schema = {
                 'ssl_private_key': {'type': 'string'},
                 'web_ui': {'type': 'boolean'},
                 'base_url': {'type': 'string'},
-                'run_v2': {'type': 'boolean'},
+                'run_v2': {
+                    'type': 'boolean',
+                    'deprecated': 'v2 is registered by default if web_ui: true so `run_v2` is now redundant. To run v1 alongside, use the `run_v1`.',
+                },
                 'run_v1': {'type': 'boolean'},
             },
             'additionalProperties': False,
@@ -101,9 +104,6 @@ def register_web_server(manager):
 
     # Register WebUI
     if web_server_config.get('web_ui'):
-        if web_server_config.get('run_v2'):
-            logger.warning('Run V2 is deprecated and can be removed from the config')
-
         if web_server_config.get('run_v1'):
             logger.info('Registering WebUI v1')
             register_web_ui_v1(manager)

--- a/flexget/plugins/daemon/web_server.py
+++ b/flexget/plugins/daemon/web_server.py
@@ -51,6 +51,7 @@ def prepare_config(config):
     config.setdefault('web_ui', True)
     config.setdefault('base_url', '')
     config.setdefault('run_v2', False)
+    config.setdefault('run_v1', False)
     if config['base_url']:
         if not config['base_url'].startswith('/'):
             config['base_url'] = '/' + config['base_url']
@@ -100,11 +101,14 @@ def register_web_server(manager):
     # Register WebUI
     if web_server_config.get('web_ui'):
         if web_server_config.get('run_v2'):
-            logger.info('Registering WebUI v2')
-            register_web_ui_v2(web_server_config)
+            logger.warning('Run V2 is deprecated and can be removed from the config')
 
-        logger.info('Registering WebUI v1')
-        register_web_ui_v1(manager)
+        if web_server_config.get('run_v1'):
+            logger.info('Registering WebUI v1')
+            register_web_ui_v1(manager)
+
+        logger.info('Registering WebUI v2')
+        register_web_ui_v2(web_server_config)
 
     web_server = setup_server(web_server_config)
 

--- a/flexget/plugins/daemon/web_server.py
+++ b/flexget/plugins/daemon/web_server.py
@@ -26,6 +26,7 @@ web_config_schema = {
                 'web_ui': {'type': 'boolean'},
                 'base_url': {'type': 'string'},
                 'run_v2': {'type': 'boolean'},
+                'run_v1': {'type': 'boolean'},
             },
             'additionalProperties': False,
             'dependencies': {

--- a/flexget/ui/v1/__init__.py
+++ b/flexget/ui/v1/__init__.py
@@ -1,7 +1,7 @@
 import fnmatch
 import os
 
-from flask import Flask, send_from_directory
+from flask import Flask, redirect, request, send_from_directory
 from flask_compress import Compress
 from loguru import logger
 
@@ -20,7 +20,7 @@ bower_components = os.path.join(ui_base, 'bower_components')
 
 webui_app = Flask(__name__)
 Compress(webui_app)
-webui_app.url_path = '/'
+webui_app.url_path = '/v1/'
 
 
 @webui_app.route('/<path:path>')
@@ -38,6 +38,12 @@ def serve_app(path):
         return send_from_directory(ui_base, 'load.failure.html')
 
     return send_from_directory(app_base, path)
+
+
+@webui_app.route('/api/')
+@webui_app.route('/api/<path:path>')
+def api_redirect(path='/'):
+    return redirect(request.full_path.replace('/v1', '', 1), 302)
 
 
 @webui_app.route('/')

--- a/flexget/ui/v2/__init__.py
+++ b/flexget/ui/v2/__init__.py
@@ -17,7 +17,7 @@ ui_assets = os.path.join(ui_dist, 'assets')
 
 webui_app = Flask(__name__, template_folder=ui_dist)
 Compress(webui_app)
-webui_app.url_path = '/v2/'
+webui_app.url_path = '/'
 
 
 @webui_app.route('/assets/<path:path>')


### PR DESCRIPTION
### Motivation for changes:
Instead of getting rid of webuv1 right away (#2556), I'd like to move webui_v1 to `/v1/` and v2 to `/`

### Detailed changes:
- Move `/` -> `v1`
- Redirect `/v1/api` -> `/api`
- Move `/v2` -> `/`
### Config usage if relevant (new plugin or updated schema):
```yaml
web_server:
   run_v1: yes
```

