### PR TITLE
Api schema

### DIFF
--- a/flexget/api/__init__.py
+++ b/flexget/api/__init__.py
@@ -5,6 +5,7 @@ from .core import (  # noqa
     database,
     format_checker,
     plugins,
+    schema,
     server,
     tasks,
     user,

--- a/flexget/api/core/schema.py
+++ b/flexget/api/core/schema.py
@@ -28,7 +28,6 @@ def rewrite_ref(identifier, base_url):
 def rewrite_refs(schema, base_url):
     """
     Make sure any $refs in the schema point properly back to this endpoint.
-
     """
     if isinstance(schema, dict):
         if '$ref' in schema:
@@ -44,10 +43,11 @@ class SchemaAllAPI(APIResource):
     @api.response(200, model=schema_api_list)
     def get(self, session=None):
         """ List all schema definitions """
-        schemas = {}
+        schemas = []
         for path in schema_paths:
-            schemas[path] = rewrite_refs(resolve_ref(path), request.base_url)
-            schemas[path]['id'] = rewrite_ref(path, request.base_url)
+            schema = rewrite_refs(resolve_ref(path), request.base_url)
+            schema['id'] = rewrite_ref(path, request.base_url)
+            schemas.append(schema)
         return jsonify({'schemas': schemas})
 
 

--- a/flexget/api/core/schema.py
+++ b/flexget/api/core/schema.py
@@ -1,0 +1,41 @@
+from flask import jsonify, request
+from jsonschema import RefResolutionError
+
+from flexget.api import APIResource, api
+from flexget.api.app import NotFoundError
+from flexget.config_schema import resolve_ref, schema_paths
+
+schema_api = api.namespace('schema', description='Config and plugin schemas')
+
+schema_api_list = api.schema_model(
+    'schema.list',
+    {'type': 'object', 'properties': {'schemas': {'type': 'array', 'items': {'type': 'object'}}}},
+)
+
+
+@schema_api.route('/')
+class SchemaAllAPI(APIResource):
+    @api.response(200, model=schema_api_list)
+    def get(self, session=None):
+        """ List all schema definitions """
+        schemas = {}
+        for path in schema_paths:
+            schemas[path] = resolve_ref(path)
+
+        return jsonify({'schemas': schemas})
+
+
+@schema_api.route('/<path:path>/')
+@api.doc(params={'path': 'Path of schema'})
+@api.response(NotFoundError)
+class SchemaAPI(APIResource):
+    @api.response(200, model=schema_api_list)
+    def get(self, path, session=None):
+        """ Get schema definition """
+        path = f'/schema/{path}'
+        if request.query_string:
+            path += '?' + request.query_string.decode('ascii')
+        try:
+            return jsonify(resolve_ref(path))
+        except RefResolutionError:
+            raise NotFoundError('invalid schema path')

--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -287,6 +287,8 @@ class PluginInfo(dict):
         self.debug = debug
         self.category = category
         self.phase_handlers = {}
+        self.schema = {}
+        self.schema_id = None
 
         self.plugin_class = plugin_class
         self.instance = None
@@ -319,9 +321,8 @@ class PluginInfo(dict):
             self.schema = {}
 
         if self.schema is not None:
-            location = '/schema/plugin/%s' % self.name
-            self.schema['id'] = location
-            config_schema.register_schema(location, self.schema)
+            self.schema_id = f'/schema/plugin/{self.name}'
+            config_schema.register_schema(self.schema_id, self.schema)
 
         self.build_phase_handlers()
 
@@ -603,7 +604,7 @@ def plugin_schemas(**kwargs):
     """Create a dict schema that matches plugins specified by `kwargs`"""
     return {
         'type': 'object',
-        'properties': dict((p.name, {'$ref': p.schema['id']}) for p in get_plugins(**kwargs)),
+        'properties': {p.name: {'$ref': p.schema_id} for p in get_plugins(**kwargs)},
         'additionalProperties': False,
         'error_additionalProperties': '{{message}} Only known plugin names are valid keys.',
         'patternProperties': {'^_': {'title': 'Disabled Plugin'}},


### PR DESCRIPTION
### Motivation for changes:
Add an api endpoint to get config schemas, for use by the web editor.

### Detailed changes:
- Schemas are available under /api/schema/
- All `$ref`s are rewritten to the actual uri that the referenced schema is available from
- `id` fields are added to each schema with their uri
