### PR TITLE
Add manual release github actions

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,0 +1,17 @@
+# Creating a Release
+
+Currently flexget is built nightly at 15:00 UTC as long as there are changes on the development branch.
+
+If you have write access to this repo, you can also trigger a manual release in slack or using the github api directly to create a deployment.
+
+To trigger a manual release in slack:
+
+1. Go to the #development channel
+2. Run the folllowing slash command (it will ask you to auth with github to link to your slack account if you haven't already)
+```
+/github deploy Flexget/Flexget
+```
+3. When the Popup comes up, change the `Branch or tag to deploy` to be the develop branch. Leave everything else as is.
+4. Press `Create`
+
+You should be able to navigate to the [Main Workflow](https://github.com/Flexget/Flexget/actions?query=workflow%3A%22Main+Workflow%22+event%deployment) tab in actions and see your workflow run there as well as seeing it on the [Deployments Page](https://github.com/Flexget/Flexget/deployments?environment=production#activity-log)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,7 @@ on:
   pull_request:
     branches:
     - "*"
-  schedule:
-  - cron:  '00 15 * * *'
+  deployment: {}
 
 jobs:
   tests:
@@ -51,7 +50,7 @@ jobs:
         pytest -n auto
   release:
     name: Build and release to PyPI
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'deployment'
     needs: tests
     runs-on: ubuntu-18.04
     env:
@@ -80,9 +79,25 @@ jobs:
     - name: Install dev dependencies
       run: |
         pip --cache-dir pip_cache install -r dev-requirements.txt
+    - name: Set Deployment Status Pending
+      uses: deliverybot/deployment-status@v1
+      with:
+        state: pending
+        token: ${{ github.token }}
     - name: Run release script
       env:
         TWINE_USERNAME: "__token__"
         TWINE_PASSWORD: ${{ secrets.pypi_token }}
       run: |
         ./release.sh
+    - name: Set Deployment Status Success
+      uses: deliverybot/deployment-status@v1
+      with:
+        state: success
+        token: ${{ github.token }}
+    - name: Set Deployment Status Failure
+      if: failure() || cancelled()
+      uses: deliverybot/deployment-status@v1
+      with:
+        state: failure
+        token: ${{ github.token }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,20 @@
+name: Nightly Cron
+
+on:
+  schedule:
+    - cron: 0 15 * * *
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/github-script@0.3.0
+        name: Create Deployment
+        with:
+          github-token: ${{ secrets.flexgetbot_pat }}
+          script: |
+            await github.repos.createDeployment({
+              ...context.repo,
+              ref: context.ref.slice(11),
+            });


### PR DESCRIPTION
### Motivation for changes:
I added this to webui when we were switching over to github actions so i figured I'd  add it over in main repo as well. Basically this gives the ability to kick off a github deployment (which is super easy to do in slack) as a way to do a manual release if necessary. 

