### PR TITLE
Add task id to the execute api streaming events and fix loglevel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ pip-selfcheck.json
 cached_resources/
 pyvenv.cfg
 .pytest_cache
+pip-wheel-metadata
+flexget/ui/v1/app

--- a/flexget/api/app.py
+++ b/flexget/api/app.py
@@ -20,7 +20,7 @@ from flexget.webserver import User
 
 from . import __path__
 
-__version__ = '1.7.0'
+__version__ = '1.7.1'
 
 logger = logger.bind(name='api')
 


### PR DESCRIPTION
### Motivation for changes:
- /api/tasks/execute was erroring if you passed a loglevel because of the casing
- add task_id to the events. This is just going to make my life easier in webui
