### PR TITLE
imdb_watchlist:  return empty list when nothing's found

### DIFF
--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -130,7 +130,7 @@ class ImdbWatchlist:
             total_item_count = len(json_vars['list']['items'])
         if not total_item_count:
             logger.verbose('No movies were found in imdb list: {}', config['list'])
-            return
+            return []
         imdb_ids = []
         for item in json_vars['list']['items']:
             if is_valid_imdb_title_id(item.get('const')):


### PR DESCRIPTION
### Motivation for changes:
When there's no match in the watchlist (specially when you're filtering by, let's say, 'mini series')
utils/cached_input.py throws an error because it tries to iterate a NoneType
### Detailed changes:
just a replacing a plain return with return []


### Log and/or tests output (preferably both):
The error:
```
2020-01-31 21:47:44 VERBOSE  imdb_watchlist import-imdb No movies were found in imdb list: watchlist
2020-01-31 21:47:44 DEBUG    input_cache   import-imdb storing entries to cache imdb_watchlist_7e30027a73709633227b63e7a3a7fc01 
2020-01-31 21:47:44 CRITICAL task          import-imdb BUG: Unhandled error in plugin imdb_watchlist: 'NoneType' object is not iterable
Traceback (most recent call last):
<snip>
  File "/opt/venv/flexget/lib/python3.7/site-packages/flexget/utils/cached_input.py", line 204, in __init__
    self.iterable = iter(iterable)
    │                    └ None
    └ <flexget.utils.cached_input.IterableCache object at 0xb20fc710>
```
Becomes:
```
2020-01-31 21:49:09 VERBOSE  imdb_watchlist import-imdbl No movies were found in imdb list: watchlist
2020-01-31 21:49:09 DEBUG    input_cache   import-imdb-to storing entries to cache imdb_watchlist_7e30027a73709633227b63e7a3a7fc01 
2020-01-31 21:49:09 DEBUG    input_cache   import-imdbl Storing cache imdb_watchlist_7e30027a73709633227b63e7a3a7fc01 to database.
2020-01-31 21:49:09 DEBUG    backlog       import-imdb 0 entries purged from backlog
2020-01-31 21:49:09 WARNING  details       import-imdb Task didn't produce any entries. This is likely due to a mis-configured or non-functional input.
2020-01-31 21:49:09 DEBUG    urlrewriter   import-imdb Checking 0 entries
```