### PR TITLE
[fix] Reorder audio qualities based on bitrates

### DIFF
--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -147,19 +147,18 @@ _codecs = [
     QualityComponent('codec', 40, 'h265', '[hx].?265|hevc'),
     QualityComponent('codec', 50, '10bit', '10.?bit|hi10p'),
 ]
-channels = r'(?:(?:[^\w+]?[1-7][\W_]?(?:0|1|ch)))'
+_channels = r'(?:[^\w+]?[1-7][\W_]?(?:0|1|ch))'
+_dtshdma = r'[\W_]?hd(?:[\W_]?ma)?%s?' % _channels
 _audios = [
     QualityComponent('audio', 10, 'mp3'),
-    # TODO: No idea what order these should go in or if we need different regexps
-    QualityComponent('audio', 20, 'aac', 'aac%s?' % channels),
-    QualityComponent('audio', 30, 'dd5.1', 'dd%s' % channels),
-    QualityComponent('audio', 40, 'ac3', 'ac3%s?' % channels),
-    QualityComponent('audio', 45, 'dd+5.1', 'dd[p+]%s' % channels),
-    QualityComponent('audio', 50, 'flac', 'flac%s?' % channels),
-    # The DTSs are a bit backwards, but the more specific one needs to be parsed first
-    QualityComponent('audio', 60, 'dtshd', r'dts[\W_]?hd(?:[\W_]?ma)?%s?' % channels),
-    QualityComponent('audio', 70, 'dts'),
-    QualityComponent('audio', 80, 'truehd', 'truehd%s?' % channels),
+    QualityComponent('audio', 20, 'aac', 'aac%s?' % _channels),
+    QualityComponent('audio', 30, 'ac3', 'ac3%s?' % _channels),
+    QualityComponent('audio', 35, 'dd5.1', 'dd%s' % _channels),
+    QualityComponent('audio', 40, 'dts', r'dts(?!%s)' % _dtshdma),
+    QualityComponent('audio', 50, 'dd+5.1', 'dd[p+]%s' % _channels),
+    QualityComponent('audio', 60, 'flac', 'flac%s?' % _channels),
+    QualityComponent('audio', 70, 'truehd', 'truehd%s?' % _channels),
+    QualityComponent('audio', 80, 'dtshd', r'dts%s' % _dtshdma),
 ]
 
 _UNKNOWNS = {


### PR DESCRIPTION
### Motivation for changes:

The order of audio qualities was incorrect.

### Detailed changes:
 
Though sound quality is mostly subjective, audio qualities are now
ordered based on maximum supported bitrate. Even though FLAC, Dolby
TrueHD and DTS-HD MA are all lossless audio codecs the current order
takes into account the fact that FLAC is not standard audio codec for
video containers and that Dolby TrueHD and DTS-HD MA both contain a
core bitstream that is compatible with older players. DTS codecs are
placed above equivalent Dolby codecs because those are usually the
recommended choice between the two.

### Addressed issues:

- Fixes TODOs in code

### Log and/or tests output (preferably both):

```
1314 passed, 28 skipped, 4 xfailed, 5 xpassed, 59 warnings in 397.51s (0:06:37)
```