### PR TITLE
[fix] Prevent accidental downloading of magnet links

### DIFF
--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -409,8 +409,8 @@ class PluginTransmission(TransmissionBase):
                             filedump = base64.b64encode(f.read()).decode('utf-8')
                         torrent_info = self.client.add_torrent(filedump, 30, **options['add'])
                     else:
-                        # we need to set paused to false so the magnetization begins immediately
-                        options['add']['paused'] = False
+                        if options['post'].get('magnetization_timeout', 0) > 0:
+                            options['add']['paused'] = False
                         torrent_info = self.client.add_torrent(
                             entry['url'], timeout=30, **options['add']
                         )


### PR DESCRIPTION
### Motivation for changes:

To prevent accidental downloading of magnet links which are added as paused.

### Detailed changes:

On high speed connections setting paused to `False` might cause the magnet file to be downloaded event though `add_paused` was defined. This issue is noticeable especially when transmissionrpc times out.

Changing the paused status (Flexget#462) is meant to address an issue with handling `content_filename` with magnet links but there is no need to change the status if `magnetization_timeout` is zero.

Original issue:
https://web.archive.org/web/20150515004451/http://flexget.com/ticket/2911

### Config usage:

If content renaming or selective downloading is used with magnet links, and `add_paused` is `true`, then `magnetization_timeout` must be also set to a value greater than zero.

```yaml
transmission:
  add_paused: true
  magnetization_timeout: 5
```

#### To Do:

- [ ] Someone who adds paused magnets with content renaming or selective downloading could test this