### PR TITLE
[fix] Series plugin doesn't pick the entry with best quality

### DIFF
--- a/flexget/components/series/series.py
+++ b/flexget/components/series/series.py
@@ -733,8 +733,10 @@ class FilterSeries(FilterSeriesBase):
                     entry.reject('entity has already been downloaded')
                 continue
 
-            best = entries[0]
             logger.debug('continuing w. entities: {}', [e['title'] for e in entries])
+            # sort qualities from best to worst
+            entries.sort(key=lambda e: (e['quality']), reverse=True)
+            best = entries[0]
             logger.debug('best entity is: `{}`', best['title'])
 
             # episode tracking. used only with season and sequence based series
@@ -774,7 +776,7 @@ class FilterSeries(FilterSeriesBase):
                     continue
 
             # Just pick the best ep if we get here
-            reason = reason or 'choosing first acceptable match'
+            reason = reason or 'choosing best acceptable match'
             best.accept(reason)
 
             # need to reject all other episode/season packs for an accepted season during the task,

--- a/flexget/tests/test_series.py
+++ b/flexget/tests/test_series.py
@@ -124,6 +124,16 @@ class TestQuality:
             series:
             - my 720p show:
                 quality: '<720p'
+
+          best_quality_is_chosen:
+            mock:
+              - {title: 'Some.Series.S01E01.720p.HDTV.DD+5.1.x264-FlexGet'}
+              - {title: 'Some.Series.S01E01.1080p.WEB.TrueHD.x264-FlexGet'}
+              - {title: 'Some.Series.S01E01.1080p.WEB.AAC5.1.x264-FlexGet'}
+            series:
+              - Some Series:
+                  target: ac3+
+
     """
 
     def test_exact_quality(self, execute_task):
@@ -184,6 +194,14 @@ class TestQuality:
             'accepted', title='my 720p show S01E01'
         ), 'quality in title should not have been parsed'
         assert len(task.accepted) == 1, 'should not have accepted 720p entry'
+
+    def test_best_quality_is_chosen(self, execute_task):
+        """Series plugin: choose by target quality"""
+        task = execute_task('best_quality_is_chosen')
+        assert task.find_entry(
+            'accepted', title='Some.Series.S01E01.1080p.WEB.TrueHD.x264-FlexGet'
+        ), 'truehd should have been accepted'
+        assert len(task.accepted) == 1, 'should have accepted only one'
 
 
 class TestDatabase:


### PR DESCRIPTION
### Motivation for changes:

Documentation and code both tell that series plugin will get the best quality in either given timeframe or within series entries but it doesn't actually do that. Series plugin assumes the first entry is the best quality entry.

### Detailed changes:

Order series entries by quality from best to worst. 

### Log and/or tests output (preferably both):

```
    @pytest.mark.parametrize('reverse', [False, True])
    def test_input_order_preserved(self, manager, execute_task, reverse):
        """If multiple versions of an episode are acceptable, make sure the first one is accepted."""
        entries = [
            Entry(title='Some Show S01E01 720p proper', url='http://a'),
            Entry(title='Some Show S01E01 1080p', url='http://b'),
        ]
        if reverse:
            entries.reverse()
        task = execute_task('test_input_order_preserved', options={'inject': entries})
>       assert task.accepted[0] == entries[0], 'first entry should have been accepted'
E       AssertionError: first entry should have been accepted
E       assert <Entry(title=...ate=accepted)> == <Entry(title=...te=undecided)>
E         -<Entry(title=Some Show S01E01 1080p,state=accepted)>
E         +<Entry(title=Some Show S01E01 720p proper,state=undecided)>
E         Full diff:
E         - <Entry(title=Some Show S01E01 1080p,state=accepted)>
E         ?                               ^^^         ^ ^^^^
E         + <Entry(title=Some Show S01E01 720p proper,state=undecided)>
E         ?                               ^^  +++++++       ^^^^ ^^

2 failed, 1314 passed, 28 skipped, 4 xfailed, 5 xpassed, 59 warnings in 383.88s (0:06:23)
```
#### To Do:

- [ ] Decide what to do with failing unit tests seen above