### PR TITLE
[fix] convert to timezone aware datetime for execution time in the api

### DIFF
--- a/flexget/components/status/db.py
+++ b/flexget/components/status/db.py
@@ -48,7 +48,7 @@ class StatusTask(Base):
             select([func.max(TaskExecution.start)])
             .where(TaskExecution.task_id == cls.id)
             .correlate(StatusTask.__table__)
-            .label('last_execuftion_time')
+            .label('last_execution_time')
         )
 
     def to_dict(self):

--- a/flexget/components/status/db.py
+++ b/flexget/components/status/db.py
@@ -48,11 +48,15 @@ class StatusTask(Base):
             select([func.max(TaskExecution.start)])
             .where(TaskExecution.task_id == cls.id)
             .correlate(StatusTask.__table__)
-            .label('last_execution_time')
+            .label('last_execuftion_time')
         )
 
     def to_dict(self):
-        return {'id': self.id, 'name': self.name, 'last_execution_time': self.last_execution_time}
+        return {
+            'id': self.id,
+            'name': self.name,
+            'last_execution_time': self.last_execution_time.astimezone(),
+        }
 
 
 class TaskExecution(Base):
@@ -90,8 +94,8 @@ class TaskExecution(Base):
         return {
             'id': self.id,
             'task_id': self.task_id,
-            'start': self.start,
-            'end': self.end,
+            'start': self.start.astimezone(),
+            'end': self.end.astimezone(),
             'succeeded': self.succeeded,
             'produced': self.produced,
             'accepted': self.accepted,

--- a/flexget/components/status/db.py
+++ b/flexget/components/status/db.py
@@ -55,7 +55,8 @@ class StatusTask(Base):
         return {
             'id': self.id,
             'name': self.name,
-            'last_execution_time': self.last_execution_time.astimezone(),
+            'last_execution_time': self.last_execution_time
+            and self.last_execution_time.astimezone(),
         }
 
 
@@ -94,8 +95,8 @@ class TaskExecution(Base):
         return {
             'id': self.id,
             'task_id': self.task_id,
-            'start': self.start.astimezone(),
-            'end': self.end.astimezone(),
+            'start': self.start and self.start.astimezone(),
+            'end': self.end and self.end.astimezone(),
             'succeeded': self.succeeded,
             'produced': self.produced,
             'accepted': self.accepted,


### PR DESCRIPTION
### Motivation for changes:
Since we store the the datetimes without timezones, when they are json encoded in the api, it is assumed that they are in UTC (which they aren't). This adds the system local timezone before json encoding,  so that it will properly offset the time 
