### PR TITLE
Switch to using Enum to track Entry state

### DIFF
--- a/flexget/entry.py
+++ b/flexget/entry.py
@@ -33,8 +33,17 @@ class EntryState(Enum):
     def log_markup(self) -> str:
         return f'<{self.color}>{self.value.upper()}</>'
 
+    # __str__, __eq__, and __hash__ are make these states almost interchangeable with the old plain string states
     def __str__(self):
         return self.value
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return self.value == other
+        return super().__eq__(other)
+
+    def __hash__(self):
+        return hash(self.value)
 
 
 class EntryUnicodeError(Exception):

--- a/flexget/entry.py
+++ b/flexget/entry.py
@@ -33,6 +33,9 @@ class EntryState(Enum):
     def log_markup(self) -> str:
         return f'<{self.color}>{self.value.upper()}</>'
 
+    def __str__(self):
+        return self.value
+
 
 class EntryUnicodeError(Exception):
     """This exception is thrown when trying to set non-unicode compatible field value to entry."""
@@ -62,7 +65,7 @@ class Entry(LazyDict, Serializer):
     def __init__(self, *args, **kwargs):
         super().__init__()
         self.traces = []
-        self._state = 'undecided'
+        self._state = EntryState.UNDECIDED
         self._hooks = {'accept': [], 'reject': [], 'fail': [], 'complete': []}
         self.task = None
         self.lazy_lookups = []
@@ -154,7 +157,7 @@ class Entry(LazyDict, Serializer):
         if self.rejected:
             logger.debug('tried to accept rejected {!r}', self)
         elif not self.accepted:
-            self._state = 'accepted'
+            self._state = EntryState.ACCEPTED
             self.trace(reason, operation='accept')
             # Run entry on_accept hooks
             self.run_hooks('accept', reason=reason, **kwargs)
@@ -167,7 +170,7 @@ class Entry(LazyDict, Serializer):
             self.trace('Tried to reject immortal %s' % reason_str)
             return
         if not self.rejected:
-            self._state = 'rejected'
+            self._state = EntryState.REJECTED
             self.trace(reason, operation='reject')
             # Run entry on_reject hooks
             self.run_hooks('reject', reason=reason, **kwargs)
@@ -175,7 +178,7 @@ class Entry(LazyDict, Serializer):
     def fail(self, reason: Optional[str] = None, **kwargs):
         logger.debug("Marking entry '{}' as failed", self['title'])
         if not self.failed:
-            self._state = 'failed'
+            self._state = EntryState.FAILED
             self.trace(reason, operation='fail')
             logger.error('Failed {} ({})', self['title'], reason)
             # Run entry on_fail hooks
@@ -186,24 +189,24 @@ class Entry(LazyDict, Serializer):
         self.run_hooks('complete', **kwargs)
 
     @property
-    def state(self) -> str:
+    def state(self) -> EntryState:
         return self._state
 
     @property
     def accepted(self) -> bool:
-        return self._state == 'accepted'
+        return self._state == EntryState.ACCEPTED
 
     @property
     def rejected(self) -> bool:
-        return self._state == 'rejected'
+        return self._state == EntryState.REJECTED
 
     @property
     def failed(self) -> bool:
-        return self._state == 'failed'
+        return self._state == EntryState.FAILED
 
     @property
     def undecided(self) -> bool:
-        return self._state == 'undecided'
+        return self._state == EntryState.UNDECIDED
 
     def __setitem__(self, key, value):
         # Enforce unicode compatibility.

--- a/flexget/plugins/operate/digest.py
+++ b/flexget/plugins/operate/digest.py
@@ -7,7 +7,7 @@ from sqlalchemy import Column, DateTime, Integer, Unicode, select
 from flexget import db_schema, plugin
 from flexget.config_schema import one_or_more
 from flexget.db_schema import versioned_base
-from flexget.entry import Entry
+from flexget.entry import Entry, EntryState
 from flexget.event import event
 from flexget.manager import Session
 from flexget.utils import json, serialization
@@ -96,10 +96,11 @@ class OutputDigest:
         config = self.prepare_config(config)
         with Session() as session:
             for entry in task.all_entries:
-                if entry.state not in config['state']:
+                state = str(entry.state)
+                if state not in config['state']:
                     continue
                 entry['digest_task'] = task.name
-                entry['digest_state'] = entry.state
+                entry['digest_state'] = state
                 session.add(DigestEntry(list=config['list'], entry=entry))
 
 
@@ -142,7 +143,7 @@ class FromDigest:
                 if config.get('restore_state') and entry.get('digest_state'):
                     # Not sure this is the best way, but we don't want hooks running on this task
                     # (like backlog hooking entry.fail)
-                    entry._state = entry['digest_state']
+                    entry._state = EntryState(entry['digest_state'])
                 entries.append(entry)
                 # If expire is 'True', we remove it after it is output once.
                 if config.get('expire', True) is True:

--- a/flexget/tests/test_digest.py
+++ b/flexget/tests/test_digest.py
@@ -91,5 +91,5 @@ class TestDigest:
         task = execute_task('emit state')
         for entry in task.all_entries:
             assert (
-                entry.state == entry['title']
+                str(entry.state) == entry['title']
             ), 'Should have been emitted in same state as when digested'


### PR DESCRIPTION
### Motivation for changes:
While adding some type hints, I realized there was already an `EntryState` enum, and thought maybe we should start actually using it to store entry state.

There was some hacky stuff in digest plugin regarding entry state, I didn't even try to fix that in this pull, just updated it to still work.