### PR TITLE
fix login for filelist search plugin

### DIFF
--- a/flexget/components/sites/sites/filelist.py
+++ b/flexget/components/sites/sites/filelist.py
@@ -141,12 +141,25 @@ class SearchFileList:
 
         url = BASE_URL + 'takelogin.php'
         try:
+            # get validator token
+            response = requests.get(BASE_URL + 'login.php')
+            soup = get_soup(response.content)
+            
+            login_validator = soup.find("input", {"name": "validator"})
+            
+            if not login_validator:
+                raise plugin.PluginError(
+                    'FileList.ro could not get login validator'
+                )
+            logger.debug('Login Validator: {}'.format(login_validator.get('value')))
             logger.debug('Attempting to retrieve FileList.ro cookie')
+            
             response = requests.post(
                 url,
                 data={
                     'username': username,
                     'password': password,
+                    'validator': login_validator.get('value'),
                     'login': 'Log in',
                     'unlock': '1',
                 },
@@ -179,7 +192,7 @@ class SearchFileList:
         """
             Search for entries on FileList.ro
         """
-        entries = set()
+        entries = list()
 
         params = {
             'cat': CATEGORIES[config['category']],
@@ -257,7 +270,7 @@ class SearchFileList:
                 if genres:
                     e['torrent_genres'] = genres
 
-                entries.add(e)
+                entries.append(e)
 
         return entries
 


### PR DESCRIPTION
### Motivation for changes:
Recently filelist changed the login procedure on the site, making the plugin unusable. 

### Detailed changes:
- fetched the "validator" key that is expected for a successful login from the login page
- search method now returns a list instead of a set, this way the order_by defined in config is kept

### Addressed issues:
- no issue filled yet, however it was posted on the [forum](https://discuss.flexget.com/t/filelist-ro-search-plugin-broken/5024).
