### PR TITLE
Dockerfile: multi-stage building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,51 @@
-FROM alpine
-MAINTAINER Rémi Alvergnat <toilal.dev@gmail.com>
+FROM python:3-alpine
+ENV PYTHONUNBUFFERED 1
 
-RUN apk add --update python3 ca-certificates nodejs build-base python3-dev libffi-dev openssl-dev unzip && \
+RUN apk add --no-cache --upgrade \
+        ca-certificates \
+        nodejs \
+        build-base \
+        libffi-dev \
+        openssl-dev \
+        unzip && \
     rm -rf /var/cache/apk/*
 
-ADD . /opt/flexget
-WORKDIR /opt/flexget
+WORKDIR /wheels
 
-RUN pip3 install -e . && \
-    pip3 install transmissionrpc && \
-    pip3 install deluge-client && \
-    pip3 install cloudscraper
+COPY . /flexget
 
-WORKDIR /opt/flexget/flexget/ui/v2
+RUN pip install -U pip && \
+    pip wheel -e /flexget && \
+    pip wheel transmissionrpc && \
+    pip wheel deluge-client && \
+    pip wheel cloudscraper
+
+WORKDIR /flexget-ui-v2
 RUN wget https://github.com/Flexget/webui/releases/latest/download/dist.zip && \
     unzip dist.zip && \
     rm dist.zip
-WORKDIR /opt/flexget
+
+FROM python:3-alpine
+ENV PYTHONUNBUFFERED 1
+
+RUN apk add --no-cache --upgrade \
+        ca-certificates \
+        nodejs && \
+    rm -rf /var/cache/apk/*
+
+COPY --from=0 /wheels /wheels
+
+RUN pip install -U pip && \
+    pip install --no-cache-dir \
+                --no-index \
+                -f /wheels \
+                FlexGet \
+                transmissionrpc \
+                deluge-client \
+                cloudscraper && \
+    rm -rf /wheels
+
+COPY --from=0 /flexget-ui-v2 /usr/local/lib/python3.8/site-packages/flexget/ui/v2/
 
 RUN mkdir /root/.flexget
 VOLUME /root/.flexget


### PR DESCRIPTION
### Motivation for changes:

Current Docker image contains build deps and is unnecessary big.

### Detailed changes:

- Use multi-stage building to separate build from install. The resulting image is ~300MB instead of ~800MB.
- Use official python image (based on alpine) instead of installing python on an alpine image