### PR TITLE
[add] rutracker.org topic pages urlrewrite

### DIFF
--- a/flexget/components/sites/sites/site_rutracker.py
+++ b/flexget/components/sites/sites/site_rutracker.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+from loguru import logger
+from requests.exceptions import RequestException
+
+from flexget import plugin
+from flexget.components.sites.urlrewriting import UrlRewritingError
+from flexget.event import event
+
+from urllib.parse import urlparse, parse_qs, urlencode
+
+
+logger = logger.bind(name='rutracker')
+
+
+class SiteRutracker:
+    schema = {'type': 'boolean'}
+
+    base_url = 'https://api.t-ru.org'
+
+    # urlrewriter API
+    def url_rewritable(self, task, entry):
+        url = entry['url']
+        return url.startswith('https://rutracker.org/forum/viewtopic.php?t=')
+
+    @plugin.internet(logger)
+    def url_rewrite(self, task, entry):
+        """
+            Gets torrent information for topic from rutracker api
+        """
+
+        url = entry['url']
+        logger.info('rewriting download url: {}', url)
+
+        topic_id = parse_qs(urlparse(url).query)['t'][0]
+
+        api_url = f"{self.base_url}/v1/get_tor_topic_data"
+        api_params = {
+            'by': 'topic_id',
+            'val': topic_id,
+        }
+        try:
+            topic_request = task.requests.get(api_url, params=api_params)
+        except RequestException as e:
+            raise UrlRewritingError(f'rutracker request failed: {e}')
+
+        topic = topic_request.json()['result'][topic_id]
+
+        magnet = {
+            'xt': f"urn:btih:{topic['info_hash']}",
+            'tr': [f'http://bt{i}.t-ru.org/ann?magnet' for i in ['', '2', '3', '4']],
+            'dn': topic['topic_title']
+        }
+        magnet_qs = urlencode(magnet, doseq=True, safe=':')
+        magnet_uri = f"magnet:?{magnet_qs}"
+        entry['url'] = magnet_uri
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(SiteRutracker, 'rutracker', interfaces=['urlrewriter'], api_ver=2)

--- a/flexget/tests/test_urlrewriting.py
+++ b/flexget/tests/test_urlrewriting.py
@@ -1,3 +1,5 @@
+import pytest
+
 from flexget.plugin import get_plugin_by_name
 
 
@@ -18,6 +20,7 @@ class TestURLRewriters:
               - {title: 'tbp torrent bad subdomain', url: 'https://torrent.thepiratebay.org/8492471/Test.avi'}
               - {title: 'nyaa', url: 'https://www.nyaa.si/view/15'}
               - {title: 'cinemageddon download', url: 'http://cinemageddon.net/details.php?id=1234'}
+              - {title: 'rutracker_topic', url: 'https://rutracker.org/forum/viewtopic.php?t=2455223'}
     """
 
     def get_urlrewriter(self, name):
@@ -66,6 +69,19 @@ class TestURLRewriters:
         assert (
             entry['url']
             == 'http://cinemageddon.net/download.php?id=1234&name=cinemageddon%20download.torrent'
+        )
+
+    @pytest.mark.online
+    def test_rutracker(self, execute_task):
+        task = execute_task('test')
+        entry = task.find_entry(title='rutracker_topic')
+        urlrewriter = self.get_urlrewriter('rutracker')
+        assert urlrewriter.url_rewritable(task, entry)
+        urlrewriter.url_rewrite(task, entry)
+        assert (
+            entry['url']
+            ==
+            'magnet:?xt=urn:btih:38527C88CFE76411EF0C20FDF36B84DFE2C2D210&tr=http:%2F%2Fbt.t-ru.org%2Fann%3Fmagnet&tr=http:%2F%2Fbt2.t-ru.org%2Fann%3Fmagnet&tr=http:%2F%2Fbt3.t-ru.org%2Fann%3Fmagnet&tr=http:%2F%2Fbt4.t-ru.org%2Fann%3Fmagnet&dn=%D0%9F%D0%A0%D0%AB%D0%96%D0%9A%D0%98+%D0%9D%D0%90+%D0%9B%D0%AB%D0%96%D0%90%D0%A5+%D0%A1+%D0%A2%D0%A0%D0%90%D0%9C%D0%9F%D0%9B%D0%98%D0%9D%D0%90.+%D0%A1%D0%B5%D0%B7%D0%BE%D0%BD+2008-2009.+%D0%92%D0%A1%D0%95+%D0%A1%D0%9E%D0%A0%D0%95%D0%92%D0%9D%D0%9E%D0%92%D0%90%D0%9D%D0%98%D0%AF.+%D0%A1+%D1%80%D0%B0%D0%B7%D0%BD%D1%8B%D1%85+%D0%BA%D0%B0%D0%BD%D0%B0%D0%BB%D0%BE%D0%B2.%5B%D0%A1%D0%B5%D0%B7%D0%BE%D0%BD+2008-2009%2C+%D1%80%D0%B0%D0%B7%D0%BD%D0%BE%D0%B3%D0%BE+%D0%BA%D0%B0%D1%87%D0%B5%D1%81%D1%82%D0%B2%D0%B0.%5D'
         )
 
 


### PR DESCRIPTION
### Motivation for changes:
Get magnet url from rutracker.org topics.

### Detailed changes:
- get torrent hash from topic id: uses https://api.t-ru.org to get topic data
- use it to reconstruct a magnet link

### Config usage if relevant (new plugin or updated schema):
rutracker.org has an atom feed: http://feed.rutracker.cc/atom/f/0.atom 

### Log and/or tests output (preferably both):
I added a test in `tests/test_urlrewriting.py`. Not sure it's the best way to do it (and it requires online access: don't know if we want to mock the network call nor how to do it.

#### To Do:

- [ ] maybe deprecate the old `rutracker_auth` plugin: I'm not sure it's that useful since torrents are public there, and my plugin creates magnet link without needing to really download `.torrent` files from rutracker.org.
- [ ] maybe rename the file from `site_rutracker.py` to `rutracker.py` if the old plugin is removed, or merge both?

