### PR TITLE
Rate-Limit only for GET-Requests

### DIFF
--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -235,7 +235,8 @@ class Session(requests.Session):
             )
 
         # Run domain limiters for this url
-        limit_domains(url, self.domain_limiters)
+        if method == 'GET':
+            limit_domains(url, self.domain_limiters)
 
         kwargs.setdefault('timeout', self.timeout)
         raise_status = kwargs.pop('raise_status', True)


### PR DESCRIPTION
Limit only for get requests so cloudflare challenge gets answered timely (#2614)

### Motivation for changes:
Long timeout seems to reset the cloudflare challenge

### Detailed changes:
- Rate limiting only for get-requests so cloudflare gets the answer directly after the challenge