### PR TITLE
[Anilist] Evaluate if the english title is provided

### DIFF
--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -134,6 +134,7 @@ class AniList(object):
                             entry['alternate_name'] = anime.get('synonyms', [])
                             if (
                                 anime['title'].get('english')
+                                and anime['title'].get('english') != anime['title']['romaji']
                                 and anime['title'].get('english') not in entry['alternate_name']
                             ):
                                 entry['alternate_name'].insert(0, anime['title']['english'])

--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -131,9 +131,12 @@ class AniList(object):
                             entry['al_format'] = anime['format']
                             entry['al_release_status'] = anime['status'].capitalize()
                             entry['al_list_status'] = list_status['status'].capitalize()
-                            entry['alternate_name'] = [anime['title']['english']] + anime[
-                                'synonyms'
-                            ]
+                            entry['alternate_name'] = anime.get('synonyms', [])
+                            if (
+                                anime['title'].get('english')
+                                and anime['title'].get('english') not in entry['alternate_name']
+                            ):
+                                entry['alternate_name'].insert(0, anime['title']['english'])
                             entry['url'] = anime['siteUrl']
                             entry['al_idMal'] = anime['idMal']
                             entry['al_episodes'] = anime['episodes']


### PR DESCRIPTION
### Motivation for changes:
Found out some entries in Anilist don't have a proper English title (there are a number of valid reasons), which causes a `None` entry to be added to the alternate_name list
### Detailed changes:
- Evaluate if the English title is provided and not already in the alternate_name \ synonym \ a.k.a. list provided before inserting it on first position.
