### PR TITLE
Don't make tray icon wait for daemon start

### DIFF
--- a/flexget/__init__.py
+++ b/flexget/__init__.py
@@ -1,19 +1,12 @@
 #!/usr/bin/python
 import os
 import sys
-import threading
-
-from loguru import logger
 
 # __version__ import need to be first in order to avoid circular import within logger
 from ._version import __version__  # noqa
 from flexget import log
 from flexget.event import event
-from flexget.tray_icon import tray_icon
 from flexget.manager import Manager
-
-logger = logger.bind(name='main')
-daemon_or_shutdown = threading.Event()
 
 
 def main(args=None):
@@ -46,11 +39,7 @@ def main(args=None):
                     os.path.join(manager.config_base, manager.options.profile),
                 )
             else:
-                m = threading.Thread(target=manager.start, daemon=True)
-                m.start()
-                if tray_icon and daemon_or_shutdown.wait(timeout=60) and manager.is_daemon:
-                    tray_icon.run()
-                m.join()
+                manager.start()
         except (IOError, ValueError) as e:
             if _is_debug():
                 import traceback
@@ -75,11 +64,3 @@ def _is_debug():
         arg in ['debug', '--debug', '--loglevel=trace', '--loglevel=debug']
         for arg in [a.lower() for a in sys.argv]
     )
-
-
-@event('manager.daemon.started')
-@event('manager.shutdown')
-def tray_icon_hook(manager):
-    """The daemon.started event is hooked in order to make sure that we trigger the tray icon only in daemon mode.
-    In addition, the shutdown event is hooked so we won't wait for the daemon to start on non daemon commands"""
-    daemon_or_shutdown.set()

--- a/flexget/__init__.py
+++ b/flexget/__init__.py
@@ -1,11 +1,14 @@
 #!/usr/bin/python
 import os
 import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__name__)
 
 # __version__ import need to be first in order to avoid circular import within logger
 from ._version import __version__  # noqa
-from flexget import log
-from flexget.manager import Manager
+from flexget import log  # noqa
+from flexget.manager import Manager  # noqa
 
 
 def main(args=None):

--- a/flexget/__init__.py
+++ b/flexget/__init__.py
@@ -79,7 +79,7 @@ def _is_debug():
 
 @event('manager.daemon.started')
 @event('manager.shutdown')
-def try_icon_hook(manager):
+def tray_icon_hook(manager):
     """The daemon.started event is hooked in order to make sure that we trigger the tray icon only in daemon mode.
     In addition, the shutdown event is hooked so we won't wait for the daemon to start on non daemon commands"""
     daemon_or_shutdown.set()

--- a/flexget/__init__.py
+++ b/flexget/__init__.py
@@ -5,7 +5,6 @@ import sys
 # __version__ import need to be first in order to avoid circular import within logger
 from ._version import __version__  # noqa
 from flexget import log
-from flexget.event import event
 from flexget.manager import Manager
 
 

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -169,9 +169,6 @@ class Manager:
         self._add_tray_icon_items()
 
     def _add_tray_icon_items(self):
-        if not tray_icon:
-            return
-
         tray_icon.add_menu_item(text='Shutdown', action=self.shutdown, index=2)
         tray_icon.add_menu_item(text='Reload Config', action=self.load_config, index=3)
         tray_icon.add_menu_separator(index=4)
@@ -485,17 +482,13 @@ class Manager:
                 self.ipc_server.start()
                 self.task_queue.wait()
                 fire_event('manager.daemon.completed', self)
-                if tray_icon:
-                    tray_icon.stop()
+                tray_icon.stop()
 
-            if tray_icon:
-                # Tray icon must be run in the main thread.
-                m = threading.Thread(target=run_daemon)
-                m.start()
-                tray_icon.run()
-                m.join()
-            else:
-                run_daemon()
+            # Tray icon must be run in the main thread.
+            m = threading.Thread(target=run_daemon)
+            m.start()
+            tray_icon.run()
+            m.join()
 
         elif options.action in ['stop', 'reload-config', 'status']:
             if not self.is_daemon:

--- a/flexget/tray_icon.py
+++ b/flexget/tray_icon.py
@@ -12,11 +12,12 @@ from flexget import __version__
 logger = logger.bind(name='tray_icon')
 
 try:
+    # If we are running outside of a graphical environment, these imports will fail
     from pystray import Icon, Menu, MenuItem
 
     _import_success = True
 except Exception as e:
-    logger.warning('Could not import pystray: {}', e)
+    logger.debug('Could not import pystray: {}', e)
     _import_success = False
 
 

--- a/flexget/tray_icon.py
+++ b/flexget/tray_icon.py
@@ -1,6 +1,6 @@
 import logging
 import webbrowser
-from functools import partial
+from functools import partial, wraps
 from pathlib import Path
 from typing import List, Optional
 
@@ -21,7 +21,16 @@ except Exception as e:
     _import_success = False
 
 
-tray_icon = None
+def check_if_tray_is_active(f):
+    @wraps(f)
+    def wrapped(self, *args, **kwargs):
+        if not self.active:
+            return
+        return f(self, *args, **kwargs)
+
+    return wrapped
+
+
 image_path = ROOT_DIR / 'resources' / 'flexget.png'
 
 
@@ -32,14 +41,16 @@ class TrayIcon:
         logging.getLogger('PIL.Image').setLevel(logging.INFO)
 
         self.path_to_image: Path = path_to_image
-        self.icon: Optional[Icon] = None
-        self._menu: Optional[Menu] = None
-        self.menu_items: List[MenuItem] = []
+        self.icon: Optional['Icon'] = None
+        self._menu: Optional['Menu'] = None
+        self.menu_items: List['MenuItem'] = []
 
+        self.active: bool = _import_success
         self.running: bool = False
 
         self.add_core_menu_items()
 
+    @check_if_tray_is_active
     def add_menu_item(
         self,
         text: str = None,
@@ -60,6 +71,7 @@ class TrayIcon:
         else:
             self.menu_items.append(menu_item)
 
+    @check_if_tray_is_active
     def add_menu_separator(self, index: int = None):
         self.add_menu_item(menu_item=Menu.SEPARATOR, index=index)
 
@@ -77,6 +89,7 @@ class TrayIcon:
             self._menu = Menu(*self.menu_items)
         return self._menu
 
+    @check_if_tray_is_active
     def run(self):
         """Run the tray icon. Must be run from the main thread and is blocking"""
         try:
@@ -88,6 +101,7 @@ class TrayIcon:
             logger.warning('Could not run tray icon: {}', e)
             self.running = False
 
+    @check_if_tray_is_active
     def stop(self):
         if not self.running:
             return
@@ -97,5 +111,4 @@ class TrayIcon:
         self.running = False
 
 
-if _import_success:
-    tray_icon = TrayIcon()
+tray_icon = TrayIcon()

--- a/flexget/tray_icon.py
+++ b/flexget/tray_icon.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from loguru import logger
 from PIL import Image
 
-from flexget import __version__
+from flexget import ROOT_DIR, __version__
 
 logger = logger.bind(name='tray_icon')
 
@@ -22,10 +22,11 @@ except Exception as e:
 
 
 tray_icon = None
+image_path = ROOT_DIR / 'resources' / 'flexget.png'
 
 
 class TrayIcon:
-    def __init__(self, path_to_image: Path = Path('flexget') / 'resources' / 'flexget.png'):
+    def __init__(self, path_to_image: Path = image_path):
         # Silence PIL noisy logging
         logging.getLogger('PIL.PngImagePlugin').setLevel(logging.INFO)
         logging.getLogger('PIL.Image').setLevel(logging.INFO)


### PR DESCRIPTION
### Motivation for changes:

Making Tray icon wait for daemon to start can needlessly cause Flexget to hang until timeout is met on non daemon command. hooking manager.shutdown will make the first event trigger the tray icon check.


