### PR TITLE
[add] AniList: Option to filter by custom lists

### DIFF
--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -61,9 +61,7 @@ class AniList(object):
                     'format': one_or_more(
                         {'type': 'string', 'enum': ANIME_FORMAT}, unique_items=True
                     ),
-                    'list': one_or_more(
-                        {'type': 'string'},
-                    ),
+                    'list': one_or_more({'type': 'string'}),
                 },
                 'required': ['username'],
                 'additionalProperties': False,
@@ -91,6 +89,7 @@ class AniList(object):
 
         if not isinstance(selected_list_name, list):
             selected_list_name = [selected_list_name]
+        selected_list_name = [i.lower() for i in selected_list_name]
 
         logger.debug('Selected List Status: {}', selected_list_status)
         logger.debug('Selected Release Status: {}', selected_release_status)
@@ -124,7 +123,10 @@ class AniList(object):
                 list_response = list_response.json()['data']
                 logger.debug('JSON output: {}', list_response)
                 for list_status in list_response['collection']['statuses']:
-                    if selected_list_name and list_status['name'] not in selected_list_name:
+                    if (
+                        selected_list_name
+                        and list_status['name'].lower() not in selected_list_name
+                    ):
                         continue
                     for anime in list_status['list']:
                         anime = anime['anime']
@@ -142,7 +144,7 @@ class AniList(object):
                             entry['al_title'] = anime['title']
                             entry['al_format'] = anime['format']
                             entry['al_release_status'] = anime['status'].capitalize()
-                            entry['al_list'] = list_status['name'].capitalize()
+                            entry['al_list'] = list_status['name']
                             entry['al_list_status'] = (
                                 list_status['status'].capitalize()
                                 if list_status.get('status')

--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -26,7 +26,7 @@ class AniList(object):
 
     Syntax:
     anilist:
-      username: <value>
+      username: <string>
       status:
         - <current|planning|completed|dropped|paused|repeating>
         - <current|planning|completed|dropped|paused|repeating>
@@ -38,6 +38,10 @@ class AniList(object):
       format:
         - <all|tv|tv_short|movie|special|ova|ona>
         - <tv|tv_short|movie|special|ova|ona>
+        ...
+      list:
+        - <string>
+        - <string>
         ...
     """
 
@@ -57,6 +61,9 @@ class AniList(object):
                     'format': one_or_more(
                         {'type': 'string', 'enum': ANIME_FORMAT}, unique_items=True
                     ),
+                    'list': one_or_more(
+                        {'type': 'string'},
+                    ),
                 },
                 'required': ['username'],
                 'additionalProperties': False,
@@ -68,11 +75,10 @@ class AniList(object):
     def on_task_input(self, task, config):
         if isinstance(config, str):
             config = {'username': config}
-        selected_list_status = config['status'] if 'status' in config else ['current', 'planning']
-        selected_release_status = (
-            config['release_status'] if 'release_status' in config else ['all']
-        )
-        selected_formats = config['format'] if 'format' in config else ['all']
+        selected_list_status = config.get('status', ['current', 'planning'])
+        selected_release_status = config.get('release_status', ['all'])
+        selected_formats = config.get('format', ['all'])
+        selected_list_name = config.get('list', [])
 
         if not isinstance(selected_list_status, list):
             selected_list_status = [selected_list_status]
@@ -82,6 +88,9 @@ class AniList(object):
 
         if not isinstance(selected_formats, list):
             selected_formats = [selected_formats]
+
+        if not isinstance(selected_list_name, list):
+            selected_list_name = [selected_list_name]
 
         logger.debug('Selected List Status: {}', selected_list_status)
         logger.debug('Selected Release Status: {}', selected_release_status)
@@ -99,7 +108,8 @@ class AniList(object):
                 f'query ($user: String){{ collection: MediaListCollection(userName: $user, '
                 f'type: ANIME, perChunk: 500, chunk: {req_chunk}, status_in: '
                 f'[{", ".join([s.upper() for s in selected_list_status])}]) {{ hasNextChunk, '
-                f'statuses: lists{{ status, list: entries{{ anime: media{{ {req_fields} }}}}}}}}}}'
+                f'statuses: lists{{ status, name, list: entries{{ anime: media{{ {req_fields}'
+                f' }}}}}}}}}}'
             )
 
             try:
@@ -114,6 +124,8 @@ class AniList(object):
                 list_response = list_response.json()['data']
                 logger.debug('JSON output: {}', list_response)
                 for list_status in list_response['collection']['statuses']:
+                    if selected_list_name and list_status['name'] not in selected_list_name:
+                        continue
                     for anime in list_status['list']:
                         anime = anime['anime']
                         has_selected_release_status = (
@@ -130,7 +142,12 @@ class AniList(object):
                             entry['al_title'] = anime['title']
                             entry['al_format'] = anime['format']
                             entry['al_release_status'] = anime['status'].capitalize()
-                            entry['al_list_status'] = list_status['status'].capitalize()
+                            entry['al_list'] = list_status['name'].capitalize()
+                            entry['al_list_status'] = (
+                                list_status['status'].capitalize()
+                                if list_status.get('status')
+                                else ''
+                            )
                             entry['alternate_name'] = anime.get('synonyms', [])
                             if (
                                 anime['title'].get('english')


### PR DESCRIPTION
Same as #2627 but based on the latest version to avoid merging conflicts.
### Motivation for changes:
Started getting a crash after creating custom lists on AniList
### Detailed changes:
- ~~Skip custom lists since their entries are duplicates of status lists~~
- Added optional plugin parameter to filter AniList custom lists.
### Addressed issues:
- Fixes #2626 .
### Config usage if relevant (new plugin or updated schema):
```diff
anilist:
  user: UserName
  status:
    - <current|planning|completed|dropped|paused|repeating>
    - <current|planning|completed|dropped|paused|repeating>
        ...
  release_status:
    - <all|finished|releasing|not_yet_released|cancelled>
    - <finished|releasing|not_yet_released|cancelled>
        ...
  format:
    - <all|tv|tv_short|movie|special|ova|ona>
    - <tv|tv_short|movie|special|ova|ona
        ...
+ list:
+   - List Name
+   - Other List Name
```
### To-do:
- [x] Add an optional `list` setting to filter by custom list name instead of skipping them 