### PR TITLE
Update proposed by BH Math to workaround API output size limit when u…

### DIFF
--- a/flexget/plugins/input/betaseries_list.py
+++ b/flexget/plugins/input/betaseries_list.py
@@ -157,6 +157,10 @@ def query_member_id(api_key, user_token, login_name):
 
 
 def query_series(api_key, user_token, member_name=None):
+    return query_series_status(api_key, user_token, member_name, 'active') + query_series_status(api_key, user_token, member_name, 'current')
+
+def query_series_status(api_key, user_token, member_name=None, status='active'):
+
     """
     Get the list of series followed by the authenticated user
 
@@ -170,7 +174,7 @@ def query_series(api_key, user_token, member_name=None):
     if member_name:
         member_id = query_member_id(api_key, user_token, member_name)
         if member_id:
-            params = {'id': member_id}
+            params = {'id': member_id, 'status': status, 'limit': '199'}
         else:
             logger.error('member {!r} not found', member_name)
             return []


### PR DESCRIPTION
### Motivation for changes:
- Workaround proposed by BH Math who saw a message on the Betaseries forum about my previous PR. Before the change the user was limited to a total of 199 series (archived or active) . With this patch we slit the request by series statut to be able to get 199 active series.

### Detailed changes:
- Split request in 2 parts 

### Addressed issues:
N/A

### Implemented feature requests:
N/A

### Config usage if relevant (new plugin or updated schema):
N/A

### Log and/or tests output (preferably both):
Working debug with the patch:

```
2020-03-22 08:55:23 DEBUG    input_cache   series-XTHOR-HDTV cache name: betaseries_list_700d71ace2d4360cc43a12638f7b8b2c (has:
)
2020-03-22 08:55:23 DEBUG    utils.requests series-XTHOR-HDTV POSTing URL https://api.betaseries.com/members/auth with args () a
nd kwargs {'data': None, 'params': {'login': 'x', 'password': 'x'}, 'headers': {'Accept': 'application/json', 'X-BetaSer
ies-Version': '2.1', 'X-BetaSeries-Key': 'x'}, 'timeout': 30}
2020-03-22 08:55:23 DEBUG    utils.requests series-XTHOR-HDTV GETing URL https://api.betaseries.com/members/search with args ()
and kwargs {'params': {'login': 'Mirgolth'}, 'headers': {'Accept': 'application/json', 'X-BetaSeries-Version': '2.1', 'X-BetaSeries-Key': 'x', 'X-B
etaSeries-Token': '34980a6f8b48'}, 'allow_redirects': True, 'timeout': 30}
2020-03-22 08:55:23 DEBUG    utils.requests series-XTHOR-HDTV GETing URL https://api.betaseries.com/shows/member with args () an
d kwargs {'params': {'id': 93218, 'status': 'active', 'limit': '199'}, 'headers': {'Accept': 'application/json', 'X-BetaSeries-Version': '2.1', 'X-BetaSeries-
Key': 'aafc9b2fdff4', 'X-BetaSeries-Token': '34980a6f8b48'}, 'allow_redirects': True, 'timeout': 30}
2020-03-22 08:55:24 DEBUG    utils.requests series-XTHOR-HDTV GETing URL https://api.betaseries.com/members/search with args ()
and kwargs {'params': {'login': 'Mirgolth'}, 'headers': {'Accept': 'application/json', 'X-BetaSeries-Version': '2.1', 'X-BetaSeries-Key': 'x', 'X-B
etaSeries-Token': '34980a6f8b48'}, 'allow_redirects': True, 'timeout': 30}
2020-03-22 08:55:24 DEBUG    utils.requests series-XTHOR-HDTV GETing URL https://api.betaseries.com/shows/member with args () an
d kwargs {'params': {'id': 93218, 'status': 'current', 'limit': '199'}, 'headers': {'Accept': 'application/json', 'X-BetaSeries-Version': '2.1', 'X-BetaSeries
-Key': 'x', 'X-BetaSeries-Token': '34980a6f8b48'}, 'allow_redirects': True, 'timeout': 30}
2020-03-22 08:55:26 VERBOSE  betaseries_list series-XTHOR-HDTV series: Extant, Magnum P.I., Why Women Kill, Da Vinci's Demons, Ascen
sion, The Dark Crystal: Age of Resistance, Lovecraft Country, Swamp Thing (2019), Dr. Pimple Popper, The Umbrella Academy, Chilling Adventures of Sabrina, Bat
woman, The Walking Dead, Gypsy, The Lord of the Rings, The Terror, Counterpart, Dracula (2020), The Outsider (2020), Too Old to Die Young, American Horror Sto
ry, Hannibal, Tom Clancy's Jack Ryan, Marvel's Agents of S.H.I.E.L.D., Seven Worlds, One Planet, The Walking Dead: World Beyond, The Witcher, Star Trek: Disco
very, Stumptown, Single Parents, Black Lightning, Maniac (2018), War of the Worlds (2019), Devs, The Mist, Homecoming, The Morning Show, Creepshow, Gotham, Hu
nters (2020), Good Girls, Le bureau des légendes, Chance, The Man in the High Castle, Maniac Cop, Blue Planet II, The Leftovers, The I-Land, Black Mirror, Los
t in Space (2018), Watchmen, Miracle Workers (2019), Better Call Saul, Instinct (2018), The First, For All Mankind, CALLS, Locke & Key, Krypton, Doom Patrol,
Marvel's Cloak & Dagger, Here and Now (2018), The Rookie, Homeland, All Rise, Marvel's Spider-Man, Vixen, Pennyworth, DC's Legends of Tomorrow, The Marvelous
Mrs. Maisel, Philip K. Dick's Electric Dreams, American Gods, The OA, Marvel's Runaways, 3%, In the Dark (2019), SMILF, Emergence, His Dark Materials, Raising
 Dion, The Mandalorian, Star Trek: Picard, Stranger Things, Legacies, Impulse, Suits, Russian Doll, True Detective, Fuller House, Sense8, Good Omens, Marvel's
 The Falcon and the Winter Soldier, Servant, Nancy Drew (2019), Titans (2018), The Good Doctor, The Boys, Planet Earth II, Supergirl, The Twilight Zone (2019)
, Penn & Teller: Fool Us, Mom, Snowpiercer, The Flash (2014), The Red Line, Continuum, Into the Night, Mayans M.C., Siren (2018), Avenue 5, See, Manifest, The
 War of the Worlds, The Gifted, DARK, Legion, Criminal: United Kingdom, Castle Rock, Arrow, This Is Us, Missions, The Handmaid's Tale, The Rain
2020-03-22 08:55:26 DEBUG    input_cache   series-XTHOR-HDTV storing entries to cache betaseries_list_700d71ace2d4360cc43a12638f
7b8b2c

```

#### To Do:
Hopefully none :)
