### PR TITLE
Serienjunkies urlrewriter: Added seasonpack fallback. Added hosters

### DIFF
--- a/flexget/components/sites/sites/serienjunkies.py
+++ b/flexget/components/sites/sites/serienjunkies.py
@@ -147,7 +147,7 @@ class UrlRewriteSerienjunkies:
         series_url = entry['url']
         search_title = re.sub(r'\[.*\] ', '', entry['title'])
 
-        download_urls = self.parse_downloads(series_url, search_title, self.config['season_pack_fallback'])
+        download_urls = self.parse_downloads(series_url, search_title, self.config.get('season_pack_fallback', False))
         if not download_urls:
             entry.reject('No Episode found')
         else:
@@ -218,7 +218,7 @@ class UrlRewriteSerienjunkies:
             # filter language
             if not self.check_language(episode_lang):
                 logger.warning(
-                    'languages not matching: {} <> {}', self.config['language'], episode_lang
+                    'languages not matching: {} <> {}', self.config.get('language'), episode_lang
                 )
                 do_exit = True
 
@@ -238,7 +238,7 @@ class UrlRewriteSerienjunkies:
 
                 url = link['href']
                 next_sibling = str(link.next_sibling).strip(" |")
-                match = SerienjunkiesMatch.factory(url, next_sibling, self.config['hoster'])
+                match = SerienjunkiesMatch.factory(url, next_sibling, self.config.get('hoster', 'all'))
 
                 if match.found:
                     if best_hoster_match is None:
@@ -295,19 +295,24 @@ class UrlRewriteSerienjunkies:
 
         language_list = re.split(r'[,&]', languages)
 
+        configured_language = self.config.get('language')
+
+        if configured_language is None:
+            return True
+
         try:
-            if self.config['language'] == 'german':
+            if configured_language == 'german':
                 if regex_is_german.search(language_list[0]):
                     return True
-            elif self.config['language'] == 'foreign':
+            elif configured_language == 'foreign':
                 if (regex_is_foreign.search(language_list[0]) and len(language_list) == 1) or (
                         len(language_list) > 1 and not regex_is_subtitle.search(language_list[1])
                 ):
                     return True
-            elif self.config['language'] == 'subtitle':
+            elif configured_language == 'subtitle':
                 if len(language_list) > 1 and regex_is_subtitle.search(language_list[1]):
                     return True
-            elif self.config['language'] == 'dual':
+            elif configured_language == 'dual':
                 if len(language_list) > 1 and not regex_is_subtitle.search(language_list[1]):
                     return True
         except (KeyError, re.error):

--- a/flexget/plugins/clients/pyload.py
+++ b/flexget/plugins/clients/pyload.py
@@ -157,18 +157,19 @@ class PluginPyLoad:
             urls = []
 
             # check for preferred hoster
-            for name in hoster:
-                if name in parsed:
-                    urls.extend(parsed[name])
-                    if not config.get('multiple_hoster', self.DEFAULT_MULTIPLE_HOSTER):
-                        break
+            if hoster != "all":
+                for name in hoster:
+                    if name in parsed:
+                        urls.extend(parsed[name])
+                        if not config.get('multiple_hoster', self.DEFAULT_MULTIPLE_HOSTER):
+                            break
 
             # no preferred hoster and not preferred hoster only - add all recognized plugins
             if not urls and not config.get(
                 'preferred_hoster_only', self.DEFAULT_PREFERRED_HOSTER_ONLY
             ):
                 for name, purls in parsed.items():
-                    if name != 'BasePlugin':
+                    if name != 'BasePlugin' and name != 'DefaultPlugin':
                         urls.extend(purls)
 
             if task.options.test:


### PR DESCRIPTION
Signed-off-by: Stefan Bischoff <stefan.bischoff@9plus.de>

Serienjunkies.org changed their hosters and often, the way they update series: As share-online went down, they had to provide some alternatives. Previously, the uploaders where encouaged to only use share-online, uploaded an cz (cant even remember what it stands for). Now they may use every hoster they want. In the past, every episode got its own link. Now they often generate crypted folders and update them, as new episodes are broadcasted. There is a new fallback to handle that case. I also changed the config of the hoster configuration. This can now be a list. The best (=first) match is used then.