### PR TITLE
Correcting TMDB api preventing "imdb_id" parsing

### DIFF
--- a/flexget/components/tmdb/api.py
+++ b/flexget/components/tmdb/api.py
@@ -94,7 +94,7 @@ return_schema = api.schema_model('tmdb_search_schema', ObjectsContainer.movie_ob
 tmdb_parser = api.parser()
 tmdb_parser.add_argument('title', help='Movie title')
 tmdb_parser.add_argument('tmdb_id', help='TMDB ID')
-tmdb_parser.add_argument('tmdb_id', help='TMDB ID')
+tmdb_parser.add_argument('imdb_id', help='IMDB ID')
 tmdb_parser.add_argument('language', help='ISO 639-1 language code')
 tmdb_parser.add_argument('year', type=int, help='Movie year')
 tmdb_parser.add_argument('only_cached', type=int, help='Return only cached results')


### PR DESCRIPTION
### Motivation for changes:
"imdb_id" is already an optional parameter for lookup in TMDB API but is not included in the parser and so is never passed to the function.
Seems to be a copy-paste error with "tmdb_id" showing twice.

### Detailed changes:
- add "imdbID" in the parser for TMDB API
- remove duplicate "tmdbID" in the parser for TMDB API

### Addressed issues:
- "imdbID" from an API call is never parsed and not usable by function

#### To Do:
- [ ] Add unit testing

