### PR TITLE
[add] from_transmission: Add 'transmission_errorString'

### DIFF
--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -220,6 +220,7 @@ class PluginTransmissionInput(TransmissionBase):
                 'date_added',
                 'date_done',
                 'date_started',
+                'errorString',
                 'priority',
                 'progress',
                 'secondsDownloading',


### PR DESCRIPTION
### Motivation for changes:
Currently there is no way to differentiate between a tracker error due to temporary downtime, vs permanent deletion of the torrent, making it difficult to automate cleanup tasks.

### Detailed changes:
- Adds [`errorString`](https://github.com/transmission/transmission/blob/master/extras/rpc-spec.txt#L195) to the whitelist of Transmission RPC fields to be populated on entries.
