### PR TITLE
[fix] Removed pillow and pystray as dependencies

### DIFF
--- a/flexget/tray_icon.py
+++ b/flexget/tray_icon.py
@@ -17,7 +17,7 @@ try:
 
     _import_success = True
 except Exception as e:
-    logger.debug('Could not import pystray: {}', e)
+    logger.debug('Could not load tray icon: {}', e)
     _import_success = False
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -30,4 +30,3 @@ pyparsing>=2.0.3
 zxcvbn-python
 progressbar==2.5
 more-itertools
-Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,6 @@ jsonschema==2.6.0         # via -r requirements.in, flask-restplus
 loguru==0.4.1             # via -r requirements.in
 markupsafe==1.1.1         # via jinja2
 more-itertools==7.2.0     # via -r requirements.in, cheroot, cherrypy, jaraco.functools
-pillow==7.0.0             # via -r requirements.in
 plumbum==1.6.3            # via rpyc
 portend==2.6              # via cherrypy
 progressbar==2.5          # via -r requirements.in
@@ -55,7 +54,6 @@ webencodings==0.5.1       # via html5lib
 werkzeug==0.15.6          # via flask
 zc.lockfile==2.0          # via cherrypy
 zxcvbn-python==4.4.15     # via -r requirements.in
-pystray==0.15.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
### Motivation for changes:
Pillow needs compilation which hurts Flexget's compatibility.

### Detailed changes:
- Removed `pillow` and `pystray` from deps. If someone wants to run the tray icon, they can install them manually.

### Addressed issues:
- Fixes #2651

