### PR TITLE
Refactor SFTP plugins to be more maintainable

### DIFF
--- a/flexget/components/ftp/sftp.py
+++ b/flexget/components/ftp/sftp.py
@@ -278,8 +278,8 @@ class SftpUpload:
         'required': ['host', 'username'],
     }
 
-    @classmethod
-    def prepare_config(cls, config: dict) -> dict:
+    @staticmethod
+    def prepare_config(config: dict) -> dict:
         """
         Sets defaults for the provided configuration
         """

--- a/flexget/components/ftp/sftp.py
+++ b/flexget/components/ftp/sftp.py
@@ -1,17 +1,25 @@
-import os
 from collections import namedtuple
 from itertools import groupby
+from pathlib import Path
+from typing import List, Optional
 from urllib.parse import unquote, urlparse
 
 from loguru import logger
 
 from flexget import plugin
-from flexget.config_schema import one_or_more
-from flexget.event import event
-from flexget.utils.template import RenderError, render_from_entry
 from flexget.components.ftp.sftp_client import SftpClient, SftpError
+from flexget.config_schema import one_or_more
+from flexget.entry import Entry
+from flexget.event import event
+from flexget.task import Task
+from flexget.utils.template import RenderError, render_from_entry
 
 logger = logger.bind(name='sftp')
+
+# Constants
+DEFAULT_SFTP_PORT: int = 22
+DEFAULT_CONNECT_TRIES: int = 3
+DEFAULT_SOCKET_TIMEOUT_SEC: int = 15
 
 
 SftpConfig = namedtuple(
@@ -25,17 +33,19 @@ class SftpList:
 
     Configuration:
 
-    host:                 Host to connect to
-    port:                 Port the remote SSH server is listening on. Defaults to port 22.
-    username:             Username to log in as
+    host:                 Host to connect to.
+    port:                 Port the remote SSH server is listening on (default 22).
+    username:             Username to log in as.
     password:             The password to use. Optional if a private key is provided.
-    private_key:          Path to the private key (if any) to log into the SSH server
-    private_key_pass:     Password for the private key (if needed)
-    recursive:            Indicates whether the listing should be recursive
+    private_key:          Path to the private key (if any) to log into the SSH server.
+    private_key_pass:     Password for the private key (if needed).
+    recursive:            Indicates whether the listing should be recursive.
     get_size:             Indicates whetern to calculate the size of the remote file/directory.
                           WARNING: This can be very slow when computing the size of directories!
     files_only:           Indicates wheter to omit diredtories from the results.
-    dirs:                 List of directories to download
+    dirs:                 List of directories to download.
+    socket_timeout_sec:   Socket timeout in seconds (default 15 seconds).
+    connection_tries:     Number of times to attempt to connect before failing (default 3).
 
     Example:
 
@@ -57,24 +67,25 @@ class SftpList:
             'host': {'type': 'string'},
             'username': {'type': 'string'},
             'password': {'type': 'string'},
-            'port': {'type': 'integer', 'default': 22},
+            'port': {'type': 'integer', 'default': DEFAULT_SFTP_PORT},
             'files_only': {'type': 'boolean', 'default': True},
             'recursive': {'type': 'boolean', 'default': False},
             'get_size': {'type': 'boolean', 'default': True},
             'private_key': {'type': 'string'},
             'private_key_pass': {'type': 'string'},
             'dirs': one_or_more({'type': 'string'}),
+            'socket_timeout_sec': {'type': 'integer', 'default': DEFAULT_SOCKET_TIMEOUT_SEC},
+            'connection_tries': {'type': 'integer', 'default': DEFAULT_CONNECT_TRIES},
         },
         'additionProperties': False,
         'required': ['host', 'username'],
     }
 
-    @classmethod
-    def prepare_config(cls, config):
+    @staticmethod
+    def prepare_config(config: dict) -> dict:
         """
         Sets defaults for the provided configuration
         """
-        config.setdefault('port', 22)
         config.setdefault('password', None)
         config.setdefault('private_key', None)
         config.setdefault('private_key_pass', None)
@@ -83,25 +94,29 @@ class SftpList:
         return config
 
     @classmethod
-    def on_task_input(cls, task, config):
+    def on_task_input(cls, task: Task, config: dict) -> List[Entry]:
         """
         Input task handler
         """
 
         config = cls.prepare_config(config)
 
-        files_only = config['files_only']
-        recursive = config['recursive']
-        get_size = config['get_size']
+        files_only: bool = config['files_only']
+        recursive: bool = config['recursive']
+        get_size: bool = config['get_size']
+        socket_timeout_sec: int = config['socket_timeout_sec']
+        connection_tries: int = config['connection_tries']
+        directories: List[str] = []
 
-        directories = config['dirs']
-        if not isinstance(directories, list):
-            directories = [directories]
+        if isinstance(config['dirs'], list):
+            directories.extend(config['dirs'])
+        else:
+            directories.append(config['dirs'])
 
-        sftp_config = task_config_to_sftp_config(config)
-        sftp = sftp_connect(sftp_config)
+        sftp_config: SftpConfig = task_config_to_sftp_config(config)
+        sftp: SftpClient = sftp_connect(sftp_config, socket_timeout_sec, connection_tries)
 
-        entries = sftp.list_directories(directories, recursive, get_size, files_only)
+        entries: List[Entry] = sftp.list_directories(directories, recursive, get_size, files_only)
         sftp.close()
 
         return entries
@@ -114,11 +129,13 @@ class SftpDownload:
 
     Configuration:
 
-    to:                 Destination path; supports Jinja2 templating on the input entry. Fields such
-                        as series_name must be populated prior to input into this plugin using
-                        metainfo_series or similar.
-    recursive:          Indicates wether to download directory contents recursively.
-    delete_origin:      Indicates wether to delete the remote files(s) once they've been downloaded.
+    to:                  Destination path; supports Jinja2 templating on the input entry. Fields such
+                         as series_name must be populated prior to input into this plugin using
+                         metainfo_series or similar.
+    recursive:           Indicates whether to download directory contents recursively.
+    delete_origin:       Indicates whether to delete the remote files(s) once they've been downloaded.
+    socket_timeout_sec:  Socket timeout in seconds
+    connection_tries:    Number of times to attempt to connect before failing (default 3).
 
     Example:
 
@@ -133,49 +150,52 @@ class SftpDownload:
             'to': {'type': 'string', 'format': 'path'},
             'recursive': {'type': 'boolean', 'default': True},
             'delete_origin': {'type': 'boolean', 'default': False},
+            'socket_timeout_sec': {'type': 'integer', 'default': DEFAULT_SOCKET_TIMEOUT_SEC},
+            'connection_tries': {'type': 'integer', 'default': DEFAULT_CONNECT_TRIES},
         },
         'required': ['to'],
         'additionalProperties': False,
     }
 
     @classmethod
-    def download_entry(cls, entry, config, sftp):
+    def download_entry(cls, entry: Entry, config: dict, sftp: SftpClient) -> None:
         """
         Downloads the file(s) described in entry
         """
-        path = unquote(urlparse(entry['url']).path) or '.'
-        delete_origin = config['delete_origin']
-        recursive = config['recursive']
-        to = config['to']
+        path: str = unquote(urlparse(entry['url']).path) or '.'
+        delete_origin: bool = config['delete_origin']
+        recursive: bool = config['recursive']
+        to: str = config['to']
 
         try:
             sftp.download(path, to, recursive, delete_origin)
         except SftpError as e:
-            logger.error(e)
-            entry.fail(e)
+            entry.fail(e)  # type: ignore
 
     @classmethod
-    def on_task_output(cls, task, config):
+    def on_task_output(cls, task: Task, config: dict) -> None:
         """Register this as an output plugin"""
 
     @classmethod
-    def on_task_download(cls, task, config):
+    def on_task_download(cls, task: Task, config: dict) -> None:
         """
         Task handler for sftp_download plugin
         """
+
+        socket_timeout_sec: int = config['socket_timeout_sec']
+        connection_tries: int = config['connection_tries']
 
         # Download entries by host so we can reuse the connection
         for sftp_config, entries in groupby(task.accepted, cls._get_sftp_config):
             if not sftp_config:
                 continue
 
-            error_message = None
-            sftp = None
+            error_message: Optional[str] = None
+            sftp: Optional[SftpClient] = None
             try:
-                sftp = sftp_connect(sftp_config)
+                sftp = sftp_connect(sftp_config, socket_timeout_sec, connection_tries)
             except Exception as e:
-                error_message = 'Failed to connect to %s (%s)' % (sftp_config.host, e)
-                logger.error(error_message)
+                error_message = f'Failed to connect to {sftp_config.host} ({e})'
 
             for entry in entries:
                 if sftp:
@@ -186,28 +206,27 @@ class SftpDownload:
                 sftp.close()
 
     @classmethod
-    def _get_sftp_config(cls, entry):
+    def _get_sftp_config(cls, entry: Entry):
         """
         Parses a url and returns a hashable config, source path, and destination path
         """
         # parse url
         parsed = urlparse(entry['url'])
-        host = parsed.hostname
-        username = parsed.username or None
-        password = parsed.password or None
-        port = parsed.port or 22
+        host: str = parsed.hostname
+        username: str = parsed.username
+        password: str = parsed.password
+        port: int = parsed.port or DEFAULT_SFTP_PORT
 
         # get private key info if it exists
-        private_key = entry.get('private_key')
-        private_key_pass = entry.get('private_key_pass')
+        private_key: str = entry.get('private_key')
+        private_key_pass: str = entry.get('private_key_pass')
+
+        config: Optional[SftpConfig] = None
 
         if parsed.scheme == 'sftp':
-            config = SftpConfig(
-                host, port, username, password, private_key, private_key_pass
-            )
+            config = SftpConfig(host, port, username, password, private_key, private_key_pass)
         else:
-            logger.warning('Scheme does not match SFTP: {}', entry['url'])
-            config = None
+            logger.warning(f'Scheme does not match SFTP: {entry["url"]}',)
 
         return config
 
@@ -226,8 +245,10 @@ class SftpUpload:
     to:                   Path to upload the file to; supports Jinja2 templating on the input entry. Fields such
                           as series_name must be populated prior to input into this plugin using
                           metainfo_series or similar.
-    delete_origin:        Indicates wheter to delete the original file after a successful
+    delete_origin:        Indicates whether to delete the original file after a successful
                           upload.
+    socket_timeout_sec:   Socket timeout in seconds
+    connection_tries:     Number of times to attempt to connect before failing (default 3).
 
     Example:
 
@@ -245,18 +266,20 @@ class SftpUpload:
             'host': {'type': 'string'},
             'username': {'type': 'string'},
             'password': {'type': 'string'},
-            'port': {'type': 'integer', 'default': 22},
+            'port': {'type': 'integer', 'default': DEFAULT_SFTP_PORT},
             'private_key': {'type': 'string'},
             'private_key_pass': {'type': 'string'},
             'to': {'type': 'string'},
             'delete_origin': {'type': 'boolean', 'default': False},
+            'socket_timeout_sec': {'type': 'integer', 'default': DEFAULT_SOCKET_TIMEOUT_SEC},
+            'connection_tries': {'type': 'integer', 'default': DEFAULT_CONNECT_TRIES},
         },
         'additionProperties': False,
         'required': ['host', 'username'],
     }
 
     @classmethod
-    def prepare_config(cls, config):
+    def prepare_config(cls, config: dict) -> dict:
         """
         Sets defaults for the provided configuration
         """
@@ -268,77 +291,84 @@ class SftpUpload:
         return config
 
     @classmethod
-    def handle_entry(cls, entry, sftp, config):
+    def handle_entry(cls, entry: Entry, sftp: SftpClient, config: dict):
 
-        to = config['to']
-        location = entry['location']
+        to: str = config['to']
+        location: str = entry['location']
 
         if to:
             try:
                 to = render_from_entry(to, entry)
             except RenderError as e:
-                logger.error('Could not render path: {}', to)
-                entry.fail(e)
+                logger.error(f'Could not render path: {to}')
+                entry.fail(e)  # type: ignore
                 return
 
         try:
             sftp.upload_file(location, to)
         except SftpError as e:
-            entry.fail(e)
+            entry.fail(e)  # type: ignore
             raise e
 
         if config['delete_origin']:
             try:
-                os.remove(location)
+                Path(location).unlink()
             except Exception as e:
-                logger.error('Failed to delete file {} ({})', location, e)
+                logger.warning(f'Failed to delete file {location} ({e})')  # type: ignore
 
     @classmethod
-    def on_task_output(cls, task, config):
+    def on_task_output(cls, task: Task, config: dict) -> None:
         """Uploads accepted entries to the specified SFTP server."""
 
         config = cls.prepare_config(config)
 
-        sftp_config = task_config_to_sftp_config(config)
-        sftp = sftp_connect(sftp_config)
+        socket_timeout_sec: int = config['socket_timeout_sec']
+        connection_tries: int = config['connection_tries']
+
+        sftp_config: SftpConfig = task_config_to_sftp_config(config)
+        sftp = sftp_connect(sftp_config, socket_timeout_sec, connection_tries)
 
         for entry in task.accepted:
             if sftp:
-                logger.debug('Uploading file: {}', entry['location'])
+                logger.debug(f'Uploading file: {entry["location"]}')
                 cls.handle_entry(entry, sftp, config)
             else:
-                logger.debug('SFTP connection failed; failing entry: {}', entry['title'])
-                entry.fail('SFTP connection failed; failing entry: %s' % entry['title'])
+                entry.fail('SFTP connection failed.')
 
 
-def task_config_to_sftp_config(config):
+def task_config_to_sftp_config(config: dict) -> SftpConfig:
     """
     Creates an SFTP connection from a Flexget config object
     """
-    host = config['host']
-    port = config['port']
-    username = config['username']
-    password = config['password']
-    private_key = config['private_key']
-    private_key_pass = config['private_key_pass']
+    host: int = config['host']
+    port: int = config['port']
+    username: str = config['username']
+    password: str = config['password']
+    private_key: str = config['private_key']
+    private_key_pass: str = config['private_key_pass']
 
     return SftpConfig(host, port, username, password, private_key, private_key_pass)
 
 
-def sftp_connect(sftp_config):
-    return SftpClient(
-        logger=logger,
+def sftp_connect(
+    sftp_config: SftpConfig, socket_timeout_sec: int, connection_tries: int
+) -> SftpClient:
+    sftp_client: SftpClient = SftpClient(
         host=sftp_config.host,
         username=sftp_config.username,
         private_key=sftp_config.private_key,
         password=sftp_config.password,
         port=sftp_config.port,
         private_key_pass=sftp_config.private_key_pass,
+        connection_tries=connection_tries,
     )
+    sftp_client.set_socket_timeout(socket_timeout_sec)
+
+    return sftp_client
 
 
 @event('plugin.register')
-def register_plugin():
+def register_plugin() -> None:
     plugin.register(SftpList, 'sftp_list', api_ver=2)
     plugin.register(SftpDownload, 'sftp_download', api_ver=2)
     plugin.register(SftpUpload, 'sftp_upload', api_ver=2)

--- a/flexget/components/ftp/sftp.py
+++ b/flexget/components/ftp/sftp.py
@@ -168,7 +168,7 @@ class SftpDownload:
         to: str = config['to']
 
         try:
-            sftp.download(path, to, recursive, delete_origin)
+            sftp.download_file(path, to, recursive, delete_origin)
         except SftpError as e:
             entry.fail(e)  # type: ignore
 

--- a/flexget/components/ftp/sftp.py
+++ b/flexget/components/ftp/sftp.py
@@ -304,11 +304,11 @@ class SftpUpload:
 
         for entry in task.accepted:
             if sftp:
-                logger.debug('Uploading file: {}', entry)
+                logger.debug('Uploading file: {}', entry['location'])
                 cls.handle_entry(entry, sftp, config)
             else:
-                logger.debug('SFTP connection failed; failing entry: {}', entry)
-                entry.fail('SFTP connection failed; failing entry: %s' % entry)
+                logger.debug('SFTP connection failed; failing entry: {}', entry['title'])
+                entry.fail('SFTP connection failed; failing entry: %s' % entry['title'])
 
 
 def task_config_to_sftp_config(config):

--- a/flexget/components/ftp/sftp.py
+++ b/flexget/components/ftp/sftp.py
@@ -1,130 +1,22 @@
-import logging
 import os
-import posixpath
-import time
 from collections import namedtuple
-from functools import partial
 from itertools import groupby
-from urllib.parse import quote, unquote, urljoin, urlparse
+from urllib.parse import unquote, urlparse
 
 from loguru import logger
 
 from flexget import plugin
 from flexget.config_schema import one_or_more
-from flexget.entry import Entry
 from flexget.event import event
 from flexget.utils.template import RenderError, render_from_entry
+from flexget.components.ftp.sftp_client import SftpClient, SftpError
 
 logger = logger.bind(name='sftp')
 
-ConnectionConfig = namedtuple(
-    'ConnectionConfig', ['host', 'port', 'username', 'password', 'private_key', 'private_key_pass']
+
+SftpConfig = namedtuple(
+    'SftpConfig', ['host', 'port', 'username', 'password', 'private_key', 'private_key_pass']
 )
-
-# retry configuration constants
-CONNECT_TRIES = 3
-RETRY_INTERVAL = 15
-RETRY_STEP = 5
-SOCKET_TIMEOUT = 15
-
-# make separate path instances for local vs remote path styles
-localpath = os.path
-remotepath = posixpath  # pysftp uses POSIX style paths
-
-try:
-    import pysftp
-
-    logging.getLogger("paramiko").setLevel(logging.ERROR)
-except ImportError:
-    pysftp = None
-
-
-def sftp_connect(conf):
-    """
-    Helper function to connect to an sftp server
-    """
-    sftp = None
-    tries = CONNECT_TRIES
-    retry_interval = RETRY_INTERVAL
-
-    while not sftp:
-        try:
-            sftp = pysftp.Connection(
-                host=conf.host,
-                username=conf.username,
-                private_key=conf.private_key,
-                password=conf.password,
-                port=conf.port,
-                private_key_pass=conf.private_key_pass,
-            )
-            sftp.timeout = SOCKET_TIMEOUT
-            logger.verbose('Connected to {}', conf.host)
-        except Exception as e:
-            if not tries:
-                raise e
-            else:
-                logger.debug('Caught exception: {}', e)
-                logger.warning(
-                    'Failed to connect to {}; waiting {} seconds before retrying.',
-                    conf.host,
-                    retry_interval,
-                )
-                time.sleep(retry_interval)
-                tries -= 1
-                retry_interval += RETRY_STEP
-
-    return sftp
-
-
-def sftp_from_config(config):
-    """
-    Creates an SFTP connection from a Flexget config object
-    """
-    host = config['host']
-    port = config['port']
-    username = config['username']
-    password = config['password']
-    private_key = config['private_key']
-    private_key_pass = config['private_key_pass']
-
-    conn_conf = ConnectionConfig(host, port, username, password, private_key, private_key_pass)
-
-    try:
-        sftp = sftp_connect(conn_conf)
-    except Exception as e:
-        raise plugin.PluginError('Failed to connect to %s (%s)' % (host, e))
-
-    return sftp
-
-
-def sftp_prefix(config):
-    """
-    Generate SFTP URL prefix
-    """
-    login_str = ''
-    port_str = ''
-
-    if config['username'] and config['password']:
-        login_str = '%s:%s@' % (config['username'], config['password'])
-    elif config['username']:
-        login_str = '%s@' % config['username']
-
-    if config['port'] and config['port'] != 22:
-        port_str = ':%d' % config['port']
-
-    return 'sftp://%s%s%s/' % (login_str, config['host'], port_str)
-
-
-def dependency_check():
-    """
-    Check if pysftp module is present
-    """
-    if not pysftp:
-        raise plugin.DependencyError(
-            issued_by='sftp',
-            missing='pysftp',
-            message='sftp plugin requires the pysftp Python module.',
-        )
 
 
 class SftpList:
@@ -177,7 +69,8 @@ class SftpList:
         'required': ['host', 'username'],
     }
 
-    def prepare_config(self, config):
+    @classmethod
+    def prepare_config(cls, config):
         """
         Sets defaults for the provided configuration
         """
@@ -189,96 +82,26 @@ class SftpList:
 
         return config
 
-    def on_task_input(self, task, config):
+    @classmethod
+    def on_task_input(cls, task, config):
         """
         Input task handler
         """
 
-        dependency_check()
-
-        config = self.prepare_config(config)
+        config = cls.prepare_config(config)
 
         files_only = config['files_only']
         recursive = config['recursive']
         get_size = config['get_size']
-        private_key = config['private_key']
-        private_key_pass = config['private_key_pass']
-        dirs = config['dirs']
-        if not isinstance(dirs, list):
-            dirs = [dirs]
 
-        logger.debug('Connecting to {}', config['host'])
+        directories = config['dirs']
+        if not isinstance(directories, list):
+            directories = [directories]
 
-        sftp = sftp_from_config(config)
-        url_prefix = sftp_prefix(config)
+        sftp_config = task_config_to_sftp_config(config)
+        sftp = sftp_connect(sftp_config)
 
-        entries = []
-
-        def file_size(path):
-            """
-            Helper function to get the size of a node
-            """
-            return sftp.lstat(path).st_size
-
-        def dir_size(path):
-            """
-            Walk a directory to get its size
-            """
-            sizes = []
-
-            def node_size(f):
-                sizes.append(file_size(f))
-
-            sftp.walktree(path, node_size, node_size, node_size, True)
-            size = sum(sizes)
-
-            return size
-
-        def handle_node(path, size_handler, is_dir):
-            """
-            Generic helper function for handling a remote file system node
-            """
-            if is_dir and files_only:
-                return
-
-            url = urljoin(url_prefix, quote(sftp.normalize(path)))
-            title = remotepath.basename(path)
-
-            entry = Entry(title, url)
-
-            if get_size:
-                try:
-                    size = size_handler(path)
-                except Exception as e:
-                    logger.error('Failed to get size for {} ({})', path, e)
-                    size = -1
-                entry['content_size'] = size
-
-            if private_key:
-                entry['private_key'] = private_key
-                if private_key_pass:
-                    entry['private_key_pass'] = private_key_pass
-
-            entries.append(entry)
-
-        # create helper functions to handle files and directories
-        handle_file = partial(handle_node, size_handler=file_size, is_dir=False)
-        handle_dir = partial(handle_node, size_handler=dir_size, is_dir=True)
-
-        def handle_unknown(path):
-            """
-            Skip unknown files
-            """
-            logger.warning('Skipping unknown file: {}', path)
-
-        # the business end
-        for dir in dirs:
-            try:
-                sftp.walktree(dir, handle_file, handle_dir, handle_unknown, recursive)
-            except IOError as e:
-                logger.error('Failed to open {} ({})', dir, e)
-                continue
-
+        entries = sftp.list_directories(directories, recursive, get_size, files_only)
         sftp.close()
 
         return entries
@@ -315,7 +138,55 @@ class SftpDownload:
         'additionalProperties': False,
     }
 
-    def get_sftp_config(self, entry):
+    @classmethod
+    def download_entry(cls, entry, config, sftp):
+        """
+        Downloads the file(s) described in entry
+        """
+        path = unquote(urlparse(entry['url']).path) or '.'
+        delete_origin = config['delete_origin']
+        recursive = config['recursive']
+        to = config['to']
+
+        try:
+            sftp.download(path, to, recursive, delete_origin)
+        except SftpError as e:
+            logger.error(e)
+            entry.fail(e)
+
+    @classmethod
+    def on_task_output(cls, task, config):
+        """Register this as an output plugin"""
+
+    @classmethod
+    def on_task_download(cls, task, config):
+        """
+        Task handler for sftp_download plugin
+        """
+
+        # Download entries by host so we can reuse the connection
+        for sftp_config, entries in groupby(task.accepted, cls._get_sftp_config):
+            if not sftp_config:
+                continue
+
+            error_message = None
+            sftp = None
+            try:
+                sftp = sftp_connect(sftp_config)
+            except Exception as e:
+                error_message = 'Failed to connect to %s (%s)' % (sftp_config.host, e)
+                logger.error(error_message)
+
+            for entry in entries:
+                if sftp:
+                    cls.download_entry(entry, config, sftp)
+                else:
+                    entry.fail(error_message)
+            if sftp:
+                sftp.close()
+
+    @classmethod
+    def _get_sftp_config(cls, entry):
         """
         Parses a url and returns a hashable config, source path, and destination path
         """
@@ -331,7 +202,7 @@ class SftpDownload:
         private_key_pass = entry.get('private_key_pass')
 
         if parsed.scheme == 'sftp':
-            config = ConnectionConfig(
+            config = SftpConfig(
                 host, port, username, password, private_key, private_key_pass
             )
         else:
@@ -339,154 +210,6 @@ class SftpDownload:
             config = None
 
         return config
-
-    def download_file(self, path, dest, sftp, delete_origin):
-        """
-        Download a file from path to dest
-        """
-        dir_name = remotepath.dirname(path)
-        dest_relpath = localpath.join(
-            *remotepath.split(path)
-        )  # convert remote path style to local style
-        destination = localpath.join(dest, dest_relpath)
-        dest_dir = localpath.dirname(destination)
-
-        if localpath.exists(destination):
-            logger.verbose('Destination file already exists. Skipping {}', path)
-            return
-
-        if not localpath.exists(dest_dir):
-            os.makedirs(dest_dir)
-
-        logger.verbose('Downloading file {} to {}', path, destination)
-
-        try:
-            sftp.get(path, destination)
-        except Exception as e:
-            logger.error('Failed to download {} ({})', path, e)
-            if localpath.exists(destination):
-                logger.debug('Removing partially downloaded file {}', destination)
-                os.remove(destination)
-            raise e
-
-        if delete_origin:
-            logger.debug('Deleting remote file {}', path)
-            try:
-                sftp.remove(path)
-            except Exception as e:
-                logger.error('Failed to delete file {} ({})', path, e)
-                return
-
-            self.remove_dir(sftp, dir_name)
-
-    def handle_dir(self, path):
-        """
-        Dummy directory handler. Does nothing.
-        """
-        pass
-
-    def handle_unknown(self, path):
-        """
-        Dummy unknown file handler. Warns about unknown files.
-        """
-        logger.warning('Skipping unknown file {}', path)
-
-    def remove_dir(self, sftp, path):
-        """
-        Remove a directory if it's empty
-        """
-        if sftp.exists(path) and not sftp.listdir(path):
-            logger.debug('Attempting to delete directory {}', path)
-            try:
-                sftp.rmdir(path)
-            except Exception as e:
-                logger.error('Failed to delete directory {} ({})', path, e)
-
-    def download_entry(self, entry, config, sftp):
-        """
-        Downloads the file(s) described in entry
-        """
-
-        path = unquote(urlparse(entry['url']).path) or '.'
-        delete_origin = config['delete_origin']
-        recursive = config['recursive']
-
-        to = config['to']
-        if to:
-            try:
-                to = render_from_entry(to, entry)
-            except RenderError as e:
-                logger.error('Could not render path: {}', to)
-                entry.fail(e)
-                return
-
-        if not sftp.lexists(path):
-            logger.error('Remote path does not exist: {}', path)
-            return
-
-        if sftp.isfile(path):
-            source_file = remotepath.basename(path)
-            source_dir = remotepath.dirname(path)
-            try:
-                sftp.cwd(source_dir)
-                self.download_file(source_file, to, sftp, delete_origin)
-            except Exception as e:
-                error = 'Failed to download file %s (%s)' % (path, e)
-                logger.error(error)
-                entry.fail(error)
-        elif sftp.isdir(path):
-            base_path = remotepath.normpath(remotepath.join(path, '..'))
-            dir_name = remotepath.basename(path)
-            handle_file = partial(
-                self.download_file, dest=to, sftp=sftp, delete_origin=delete_origin
-            )
-
-            try:
-                sftp.cwd(base_path)
-                sftp.walktree(
-                    dir_name, handle_file, self.handle_dir, self.handle_unknown, recursive
-                )
-            except Exception as e:
-                error = 'Failed to download directory %s (%s)' % (path, e)
-                logger.error(error)
-                entry.fail(error)
-
-                return
-
-            if delete_origin:
-                self.remove_dir(sftp, path)
-        else:
-            logger.warning('Skipping unknown file {}', path)
-
-    def on_task_output(self, task, config):
-        """Register this as an output plugin"""
-
-    def on_task_download(self, task, config):
-        """
-        Task handler for sftp_download plugin
-        """
-        dependency_check()
-
-        # Download entries by host so we can reuse the connection
-        for sftp_config, entries in groupby(task.accepted, self.get_sftp_config):
-            if not sftp_config:
-                continue
-
-            error_message = None
-            sftp = None
-            try:
-                sftp = sftp_connect(sftp_config)
-            except Exception as e:
-                error_message = 'Failed to connect to %s (%s)' % (sftp_config.host, e)
-                logger.error(error_message)
-
-            for entry in entries:
-                if sftp:
-                    self.download_entry(entry, config, sftp)
-                else:
-                    entry.fail(error_message)
-            if sftp:
-                sftp.close()
 
 
 class SftpUpload:
@@ -532,7 +255,8 @@ class SftpUpload:
         'required': ['host', 'username'],
     }
 
-    def prepare_config(self, config):
+    @classmethod
+    def prepare_config(cls, config):
         """
         Sets defaults for the provided configuration
         """
@@ -543,12 +267,12 @@ class SftpUpload:
 
         return config
 
-    def handle_entry(self, entry, sftp, config, url_prefix):
-
-        location = entry['location']
-        filename = localpath.basename(location)
+    @classmethod
+    def handle_entry(cls, entry, sftp, config):
 
         to = config['to']
+        location = entry['location']
+
         if to:
             try:
                 to = render_from_entry(to, entry)
@@ -557,37 +281,11 @@ class SftpUpload:
                 entry.fail(e)
                 return
 
-        destination = remotepath.join(to, filename)
-        destination_url = urljoin(url_prefix, destination)
-
-        if not os.path.exists(location):
-            logger.warning('File no longer exists: {}', location)
-            return
-
-        if not sftp.lexists(to):
-            try:
-                sftp.makedirs(to)
-            except Exception as e:
-                logger.error('Failed to create remote directory {} ({})', to, e)
-                entry.fail(e)
-                return
-
-        if not sftp.isdir(to):
-            logger.error('Not a directory: {}', to)
-            entry.fail('Not a directory: %s' % to)
-            return
-
         try:
-            sftp.put(localpath=location, remotepath=destination)
-            logger.verbose('Successfully uploaded {} to {}', location, destination_url)
-        except IOError as e:
-            logger.error('Remote directory does not exist: {} ({})', to)
-            entry.fail('Remote directory does not exist: %s (%s)' % to)
-            return
-        except Exception as e:
-            logger.error('Failed to upload {} ({})', location, e)
-            entry.fail('Failed to upload %s (%s)' % (location, e))
-            return
+            sftp.upload_file(location, to)
+        except SftpError as e:
+            entry.fail(e)
+            raise e
 
         if config['delete_origin']:
             try:
@@ -595,21 +293,48 @@ class SftpUpload:
             except Exception as e:
                 logger.error('Failed to delete file {} ({})', location, e)
 
-    def on_task_output(self, task, config):
+    @classmethod
+    def on_task_output(cls, task, config):
         """Uploads accepted entries to the specified SFTP server."""
 
-        config = self.prepare_config(config)
+        config = cls.prepare_config(config)
 
-        sftp = sftp_from_config(config)
-        url_prefix = sftp_prefix(config)
+        sftp_config = task_config_to_sftp_config(config)
+        sftp = sftp_connect(sftp_config)
 
         for entry in task.accepted:
             if sftp:
                 logger.debug('Uploading file: {}', entry)
-                self.handle_entry(entry, sftp, config, url_prefix)
+                cls.handle_entry(entry, sftp, config)
             else:
                 logger.debug('SFTP connection failed; failing entry: {}', entry)
                 entry.fail('SFTP connection failed; failing entry: %s' % entry)
+
+
+def task_config_to_sftp_config(config):
+    """
+    Creates an SFTP connection from a Flexget config object
+    """
+    host = config['host']
+    port = config['port']
+    username = config['username']
+    password = config['password']
+    private_key = config['private_key']
+    private_key_pass = config['private_key_pass']
+
+    return SftpConfig(host, port, username, password, private_key, private_key_pass)
+
+
+def sftp_connect(sftp_config):
+    return SftpClient(
+        logger=logger,
+        host=sftp_config.host,
+        username=sftp_config.username,
+        private_key=sftp_config.private_key,
+        password=sftp_config.password,
+        port=sftp_config.port,
+        private_key_pass=sftp_config.private_key_pass,
+    )
 
 
 @event('plugin.register')

--- a/flexget/components/ftp/sftp_client.py
+++ b/flexget/components/ftp/sftp_client.py
@@ -79,7 +79,7 @@ class SftpClient:
 
         return entries
 
-    def download(self, path: str, to: str, recursive: bool, delete_origin: bool) -> None:
+    def download_file(self, path: str, to: str, recursive: bool, delete_origin: bool) -> None:
         """
         Downloads the specified path
         """

--- a/flexget/components/ftp/sftp_client.py
+++ b/flexget/components/ftp/sftp_client.py
@@ -44,7 +44,7 @@ class SftpClient:
 
         self.prefix = self._get_prefix()
         self._sftp = self._connect()
-        self._handler_builder: HandlerBuilder = HandlerBuilder(self._sftp, self._logger, self.prefix)
+        self._handler_builder = HandlerBuilder(self._sftp, self._logger, self.prefix)
 
     def list_directories(self, directories, recursive, get_size, files_only):
 
@@ -284,12 +284,12 @@ class HandlerBuilder:
     :param url_prefix: SFTP URL prefix
     """
 
-    def __init__(self, sftp, logger: logging.Logger, url_prefix):
+    def __init__(self, sftp, logger, url_prefix):
         self._sftp = sftp
         self._logger = logger
         self._prefix = url_prefix
 
-    def get_file_handler(self, get_size, entry_accumulator: list):
+    def get_file_handler(self, get_size, entry_accumulator):
         """
         Builds a file node handler suitable for use with pysftp.Connection.walktree
 
@@ -298,7 +298,7 @@ class HandlerBuilder:
         """
         return partial(Handlers.handle_file, self._sftp, self._logger, self._prefix, get_size, entry_accumulator)
 
-    def get_dir_handler(self, get_size, files_only, entry_accumulator: list):
+    def get_dir_handler(self, get_size, files_only, entry_accumulator):
         """
         Builds a file node handler suitable for use with pysftp.Connection.walktree
 
@@ -324,7 +324,7 @@ class HandlerBuilder:
 
 class Handlers:
     @classmethod
-    def handle_file(cls, sftp, logger: logging.Logger, prefix, get_size, entry_accumulator, path):
+    def handle_file(cls, sftp, logger, prefix, get_size, entry_accumulator, path):
         """
         File node handler. Adds a file entry to entry_accumulator.
 
@@ -340,7 +340,7 @@ class Handlers:
         entry_accumulator.append(entry)
 
     @classmethod
-    def handle_directory(cls, sftp, logger: logging.Logger, prefix, get_size, files_only, entry_accumulator, path):
+    def handle_directory(cls, sftp, logger, prefix, get_size, files_only, entry_accumulator, path):
         """
         Directory node handler. Adds a directory entry to entry_accumulator.
 
@@ -360,7 +360,7 @@ class Handlers:
         entry_accumulator.append(entry)
 
     @staticmethod
-    def handle_unknown(logger: logging.Logger, path):
+    def handle_unknown(logger, path):
         """
         Handler for unknown nodes; logs a warning.
 
@@ -370,7 +370,7 @@ class Handlers:
         logger.warning('Skipping unknown file: {}', path)
 
     @staticmethod
-    def null_node_handler(logger: logging.Logger, path):
+    def null_node_handler(logger, path):
         """
         Generic noop node handler
 

--- a/flexget/components/ftp/sftp_client.py
+++ b/flexget/components/ftp/sftp_client.py
@@ -1,3 +1,4 @@
+from typing import Callable, List, Optional
 import logging
 import os
 import posixpath
@@ -9,10 +10,10 @@ from flexget import plugin
 from flexget.entry import Entry
 
 # retry configuration constants
-CONNECT_TRIES = 3
-RETRY_INTERVAL = 15
-RETRY_STEP = 5
-SOCKET_TIMEOUT = 15
+CONNECT_TRIES: int = 3
+RETRY_INTERVAL: int = 15
+RETRY_STEP: int = 5
+SOCKET_TIMEOUT: int = 15
 
 try:
     import pysftp
@@ -25,7 +26,8 @@ remote_path = posixpath  # pysftp uses POSIX style paths
 
 
 class SftpClient:
-    def __init__(self, logger, host, port, username, password=None, private_key=None, private_key_pass=None):
+    def __init__(self, logger: logging.Logger, host: str, port: int, username: str, password: Optional[str] = None,
+                 private_key: Optional[str] = None, private_key_pass: Optional[str] = None):
 
         if not pysftp:
             raise plugin.DependencyError(
@@ -34,25 +36,25 @@ class SftpClient:
                 message='sftp client requires the pysftp Python module.',
             )
 
-        self._logger = logger
-        self.host = host
-        self.port = port
-        self.username = username
-        self.password = password
-        self.private_key = private_key
-        self.private_key_pass = private_key_pass
+        self._logger: logging.Logger = logger
+        self.host: str = host
+        self.port: int = port
+        self.username: str = username
+        self.password: Optional[str] = password
+        self.private_key: Optional[str] = private_key
+        self.private_key_pass: Optional[str] = private_key_pass
 
-        self.prefix = self._get_prefix()
-        self._sftp = self._connect()
-        self._handler_builder = HandlerBuilder(self._sftp, self._logger, self.prefix)
+        self.prefix: str = self._get_prefix()
+        self._sftp: 'pysftp.Connection' = self._connect()
+        self._handler_builder: HandlerBuilder = HandlerBuilder(self._sftp, self._logger, self.prefix)
 
-    def list_directories(self, directories, recursive, get_size, files_only):
+    def list_directories(self, directories: List, recursive: bool, get_size: bool, files_only: bool) -> List:
 
-        entries = []
+        entries: List = []
 
-        dir_handler = self._handler_builder.get_dir_handler(get_size, files_only, entries)
-        file_handler = self._handler_builder.get_file_handler(get_size, entries)
-        unknown_handler = self._handler_builder.get_unknown_handler()
+        dir_handler: Callable[[str], None] = self._handler_builder.get_dir_handler(get_size, files_only, entries)
+        file_handler: Callable[[str], None] = self._handler_builder.get_file_handler(get_size, entries)
+        unknown_handler: Callable[[str], None] = self._handler_builder.get_unknown_handler()
 
         for directory in directories:
             try:
@@ -63,29 +65,29 @@ class SftpClient:
 
         return entries
 
-    def download(self, path, to, recursive, delete_origin):
+    def download(self, path: str, to: str, recursive: bool, delete_origin: bool) -> None:
         """
         Downloads the specified path
         """
 
-        dir_handler = self._handler_builder.get_null_handler()
-        unknown_handler = self._handler_builder.get_unknown_handler()
+        dir_handler: Callable[[str], None] = self._handler_builder.get_null_handler()
+        unknown_handler: Callable[[str], None] = self._handler_builder.get_unknown_handler()
 
         if not self.path_exists(path):
             raise SftpError('Remote path does not exist: {}', path)
 
         if self.is_file(path):
-            source_file = remote_path.basename(path)
-            source_dir = remote_path.dirname(path)
+            source_file: str = remote_path.basename(path)
+            source_dir: str = remote_path.dirname(path)
             try:
                 self._sftp.cwd(source_dir)
                 self._download_file(source_file, to, delete_origin)
             except Exception as e:
                 raise SftpError('Failed to download file %s (%s)' % (path, e))
         elif self.is_dir(path):
-            base_path = remote_path.normpath(remote_path.join(path, '..'))
-            dir_name = remote_path.basename(path)
-            handle_file = partial(self._download_file, to, delete_origin)
+            base_path: str = remote_path.normpath(remote_path.join(path, '..'))
+            dir_name: str = remote_path.basename(path)
+            handle_file: Callable[[str], None] = partial(self._download_file, to, delete_origin)
 
             try:
                 self._sftp.cwd(base_path)
@@ -98,11 +100,11 @@ class SftpClient:
         else:
             self._logger.warning('Skipping unknown file {}', path)
 
-    def upload_file(self, source, to):
+    def upload_file(self, source: str, to: str) -> None:
 
-        filename = local_path.basename(source)
-        destination = remote_path.join(to, filename)
-        destination_url = urljoin(self.prefix, destination)
+        filename: str = local_path.basename(source)
+        destination: str = remote_path.join(to, filename)
+        destination_url: str = urljoin(self.prefix, destination)
 
         if not os.path.exists(source):
             self._logger.warning('File no longer exists: {}', source)
@@ -124,7 +126,7 @@ class SftpClient:
         except Exception as e:
             raise SftpError('Failed to upload {} ({})', source, e)
 
-    def remove_dir(self, path):
+    def remove_dir(self, path: str) -> None:
         """
         Remove a directory if it's empty
         """
@@ -135,7 +137,7 @@ class SftpClient:
             except Exception as e:
                 self._logger.error('Failed to delete directory {} ({})', path, e)
 
-    def remove_file(self, path):
+    def remove_file(self, path: str) -> None:
         self._logger.debug('Deleting remote file {}', path)
         try:
             self._sftp.remove(path)
@@ -143,13 +145,13 @@ class SftpClient:
             self._logger.error('Failed to delete file {} ({})', path, e)
             return
 
-    def is_file(self, path):
+    def is_file(self, path: str) -> bool:
         return self._sftp.isfile(path)
 
-    def is_dir(self, path):
+    def is_dir(self, path: str) -> bool:
         return self._sftp.isdir(path)
 
-    def path_exists(self, path):
+    def path_exists(self, path: str) -> bool:
         """
         Check of a path exists
 
@@ -158,7 +160,7 @@ class SftpClient:
         """
         return self._sftp.lexists(path)
 
-    def make_dirs(self, path):
+    def make_dirs(self, path: str) -> None:
         """
         Build directories
 
@@ -166,17 +168,17 @@ class SftpClient:
         """
         self._sftp.makedirs(path)
 
-    def _connect(self):
+    def _connect(self) -> 'pysftp.Connection':
         """
         Connect to an sftp server
         """
 
-        tries = CONNECT_TRIES
-        retry_interval = RETRY_INTERVAL
+        tries: int = CONNECT_TRIES
+        retry_interval: int = RETRY_INTERVAL
 
         self._logger.debug('Connecting to {}', self.host)
 
-        sftp = None
+        sftp: 'Optional[pysftp.Connection]' = None
 
         while not sftp:
             try:
@@ -188,8 +190,7 @@ class SftpClient:
                     port=self.port,
                     private_key_pass=self.private_key_pass,
                 )
-                timeout = SOCKET_TIMEOUT
-                sftp.timeout = timeout
+                sftp.timeout = SOCKET_TIMEOUT
                 self._logger.verbose('Connected to {}', self.host)
             except Exception as e:
                 if not tries:
@@ -207,20 +208,20 @@ class SftpClient:
 
         return sftp
 
-    def close(self):
+    def close(self) -> None:
         """
         Close the sftp connection
         """
         self._sftp.close()
 
-    def _put_file(self, source, destination):
+    def _put_file(self, source: str, destination: str) -> None:
         return self._sftp.put(source, destination)
 
-    def _download_file(self, source, destination, delete_origin):
+    def _download_file(self, source: str, destination: str, delete_origin: bool) -> None:
 
-        dir_name = remote_path.dirname(source)
-        destination_path = self._build_destination_path(source, destination)
-        destination_dir = local_path.dirname(destination)
+        dir_name: str = remote_path.dirname(source)
+        destination_path: str = self._get_destination_path(source, destination)
+        destination_dir: str = local_path.dirname(destination)
 
         if local_path.exists(destination_path):
             self._logger.verbose('Skipping {} because destination file {} already exists. ', source, destination)
@@ -244,12 +245,12 @@ class SftpClient:
             self.remove_file(source)
             self.remove_dir(dir_name)
 
-    def _get_prefix(self):
+    def _get_prefix(self) -> str:
         """
         Generate SFTP URL prefix
         """
 
-        def get_login_string():
+        def get_login_string() -> str:
             if self.username and self.password:
                 return '%s:%s@' % (self.username, self.password)
             elif self.username:
@@ -257,7 +258,7 @@ class SftpClient:
             else:
                 return ''
 
-        def get_port_string():
+        def get_port_string() -> str:
             if self.port and self.port != 22:
                 return ':%d' % self.port
             else:
@@ -265,8 +266,8 @@ class SftpClient:
 
         return 'sftp://%s%s%s/' % (get_login_string(), self.host, get_port_string())
 
-    @classmethod
-    def _build_destination_path(cls, path, destination):
+    @staticmethod
+    def _get_destination_path(path: str, destination: str) -> str:
         relative_path = local_path.join(*remote_path.split(path))  # convert remote path style to local style
         return local_path.join(destination, relative_path)
 
@@ -284,12 +285,12 @@ class HandlerBuilder:
     :param url_prefix: SFTP URL prefix
     """
 
-    def __init__(self, sftp, logger, url_prefix):
+    def __init__(self, sftp: 'pysftp.Connection', logger: logging.Logger, url_prefix: str):
         self._sftp = sftp
         self._logger = logger
         self._prefix = url_prefix
 
-    def get_file_handler(self, get_size, entry_accumulator):
+    def get_file_handler(self, get_size: bool, entry_accumulator: list) -> Callable[[str], None]:
         """
         Builds a file node handler suitable for use with pysftp.Connection.walktree
 
@@ -298,7 +299,7 @@ class HandlerBuilder:
         """
         return partial(Handlers.handle_file, self._sftp, self._logger, self._prefix, get_size, entry_accumulator)
 
-    def get_dir_handler(self, get_size, files_only, entry_accumulator):
+    def get_dir_handler(self, get_size: bool, files_only: bool, entry_accumulator: list) -> Callable[[str], None]:
         """
         Builds a file node handler suitable for use with pysftp.Connection.walktree
 
@@ -309,13 +310,13 @@ class HandlerBuilder:
         return partial(Handlers.handle_directory, self._sftp, self._logger, self._prefix, get_size, files_only,
                        entry_accumulator)
 
-    def get_unknown_handler(self):
+    def get_unknown_handler(self) -> Callable[[str], None]:
         """
         Builds an unknown node handler suitable for use with pysftp.Connection.walktree
         """
         return partial(Handlers.handle_unknown, self._logger)
 
-    def get_null_handler(self):
+    def get_null_handler(self) -> Callable[[str], None]:
         """
         Builds a noop node handler suitable for use with pysftp.Connection.walktree
         """
@@ -324,7 +325,8 @@ class HandlerBuilder:
 
 class Handlers:
     @classmethod
-    def handle_file(cls, sftp, logger, prefix, get_size, entry_accumulator, path):
+    def handle_file(cls, sftp: 'pysftp.Connection', logger: logging.Logger, prefix,get_size,
+                    entry_accumulator, path):
         """
         File node handler. Adds a file entry to entry_accumulator.
 
@@ -340,7 +342,8 @@ class Handlers:
         entry_accumulator.append(entry)
 
     @classmethod
-    def handle_directory(cls, sftp, logger, prefix, get_size, files_only, entry_accumulator, path):
+    def handle_directory(cls, sftp: 'pysftp.Connection', logger: logging.Logger, prefix: str, get_size: bool,
+                         files_only: bool, entry_accumulator: List, path: str):
         """
         Directory node handler. Adds a directory entry to entry_accumulator.
 
@@ -355,12 +358,12 @@ class Handlers:
         if files_only:
             return
 
-        dir_size = partial(cls._dir_size, sftp)
-        entry = cls._get_entry(sftp, logger, prefix, dir_size, get_size, path)
+        dir_size: Callable[[str], int] = partial(cls._dir_size, sftp)
+        entry: Entry = cls._get_entry(sftp, logger, prefix, dir_size, get_size, path)
         entry_accumulator.append(entry)
 
     @staticmethod
-    def handle_unknown(logger, path):
+    def handle_unknown(logger: logging.Logger, path: str):
         """
         Handler for unknown nodes; logs a warning.
 
@@ -370,7 +373,7 @@ class Handlers:
         logger.warning('Skipping unknown file: {}', path)
 
     @staticmethod
-    def null_node_handler(logger, path):
+    def null_node_handler(logger: logging.Logger, path: str):
         """
         Generic noop node handler
 
@@ -381,7 +384,8 @@ class Handlers:
         logger.debug('null handler called  for {}', path)
 
     @staticmethod
-    def _get_entry(sftp, logger, prefix, size_handler, get_size, path):
+    def _get_entry(sftp: 'pysftp.Connection', logger: logging.Logger, prefix: str,
+                   size_handler: Callable[[str], int], get_size, path: str) -> Entry:
 
         url = urljoin(prefix, quote(sftp.normalize(path)))
         title = remote_path.basename(path)
@@ -399,8 +403,8 @@ class Handlers:
         return entry
 
     @classmethod
-    def _dir_size(cls, sftp, path):
-        sizes = []
+    def _dir_size(cls, sftp: 'pysftp.Connection', path: str) -> int:
+        sizes: List = []
 
         size_accumulator = partial(cls._accumulate_file_size, sftp, sizes)
         sftp.walktree(path, size_accumulator, size_accumulator, size_accumulator, True)
@@ -408,11 +412,11 @@ class Handlers:
         return sum(sizes)
 
     @classmethod
-    def _accumulate_file_size(cls, sftp, size_accumulator, path):
+    def _accumulate_file_size(cls, sftp: 'pysftp.Connection', size_accumulator: List, path: str):
         size_accumulator.append(cls._file_size(sftp, path))
 
     @staticmethod
-    def _file_size(sftp, path):
+    def _file_size(sftp: 'pysftp.Connection', path: str) -> int:
         """
         Helper function to get the size of a file node
         """

--- a/flexget/components/ftp/sftp_client.py
+++ b/flexget/components/ftp/sftp_client.py
@@ -11,8 +11,8 @@ from flexget import plugin
 from flexget.entry import Entry
 
 # retry configuration constants
-RETRY_INTERVAL: int = 15
-RETRY_STEP: int = 5
+RETRY_INTERVAL_SEC: int = 15
+RETRY_STEP_SEC: int = 5
 
 try:
     import pysftp
@@ -189,7 +189,7 @@ class SftpClient:
         """
 
         tries: int = connection_tries
-        retry_interval: int = RETRY_INTERVAL
+        retry_interval: int = RETRY_INTERVAL_SEC
 
         logger.debug('Connecting to {}', self.host)
 
@@ -216,7 +216,7 @@ class SftpClient:
                         f'Failed to connect to {self.host}; waiting {retry_interval} seconds before retrying.'
                     )  # type: ignore
                     time.sleep(retry_interval)
-                    retry_interval += RETRY_STEP
+                    retry_interval += RETRY_STEP_SEC
 
         return sftp
 

--- a/flexget/components/ftp/sftp_client.py
+++ b/flexget/components/ftp/sftp_client.py
@@ -214,7 +214,7 @@ class SftpClient:
                     logger.debug(f'Caught exception: {e}')
                     logger.warning(
                         f'Failed to connect to {self.host}; waiting {retry_interval} seconds before retrying.'
-                    )  # type: ignore
+                    )
                     time.sleep(retry_interval)
                     retry_interval += RETRY_STEP_SEC
 
@@ -414,7 +414,7 @@ class Handlers:
         :param logger: a logger object
         :param path: path to handle
         """
-        logger.warning('Skipping unknown file: {}', path)  # type: ignore
+        logger.warning('Skipping unknown file: {}', path)
 
     @staticmethod
     def null_node_handler(path: str) -> None:
@@ -445,7 +445,7 @@ class Handlers:
             try:
                 size = size_handler(path)
             except Exception as e:
-                logger.error('Failed to get size for {} ({})', path, e)
+                logger.warning('Failed to get size for {} ({})', path, e)
                 size = -1
             entry['content_size'] = size
 

--- a/flexget/components/ftp/sftp_client.py
+++ b/flexget/components/ftp/sftp_client.py
@@ -16,7 +16,6 @@ SOCKET_TIMEOUT = 15
 
 try:
     import pysftp
-
     logging.getLogger("paramiko").setLevel(logging.ERROR)
 except ImportError:
     pysftp = None
@@ -25,9 +24,16 @@ local_path = os.path
 remote_path = posixpath  # pysftp uses POSIX style paths
 
 
-# noinspection PyUnresolvedReferences
 class SftpClient:
     def __init__(self, logger, host, port, username, password=None, private_key=None, private_key_pass=None):
+
+        if not pysftp:
+            raise plugin.DependencyError(
+                issued_by='sftp_client',
+                missing='pysftp',
+                message='sftp client requires the pysftp Python module.',
+            )
+
         self._logger = logger
         self.host = host
         self.port = port
@@ -37,19 +43,9 @@ class SftpClient:
         self.private_key_pass = private_key_pass
 
         self.prefix = self._get_prefix()
-        self._sftp = None
+        self._sftp = self._connect()
+        self._handler_builder: HandlerBuilder = HandlerBuilder(self._sftp, self._logger, self.prefix)
 
-        if pysftp:
-            self.connect()
-        else:
-            raise plugin.DependencyError(
-                issued_by='sftp_client',
-                missing='pysftp',
-                message='sftp client requires the pysftp Python module.',
-            )
-
-        self._handler_builder = HandlerBuilder(self._sftp, self._logger, self.prefix)
-        
     def list_directories(self, directories, recursive, get_size, files_only):
 
         entries = []
@@ -62,7 +58,7 @@ class SftpClient:
             try:
                 self._sftp.walktree(directory, file_handler, dir_handler, unknown_handler, recursive)
             except IOError as e:
-                self._logger.error('Failed to open {} ({})', dir, e)
+                self._logger.error('Failed to open {} ({})', directory, e)
                 continue
 
         return entries
@@ -101,7 +97,7 @@ class SftpClient:
                 self.remove_dir(path)
         else:
             self._logger.warning('Skipping unknown file {}', path)
-            
+
     def upload_file(self, source, to):
 
         filename = local_path.basename(source)
@@ -154,22 +150,37 @@ class SftpClient:
         return self._sftp.isdir(path)
 
     def path_exists(self, path):
+        """
+        Check of a path exists
+
+        :param path: Path to check
+        :return: boolean indicating if the path exists
+        """
         return self._sftp.lexists(path)
 
     def make_dirs(self, path):
-        return self._sftp.makedirs(path)
+        """
+        Build directories
 
-    def connect(self):
+        :param path: path to build
+        """
+        self._sftp.makedirs(path)
+
+    def _connect(self):
+        """
+        Connect to an sftp server
+        """
+
         tries = CONNECT_TRIES
         retry_interval = RETRY_INTERVAL
 
-        self._sftp = None
-
         self._logger.debug('Connecting to {}', self.host)
 
-        while not self._sftp:
+        sftp = None
+
+        while not sftp:
             try:
-                self._sftp = pysftp.Connection(
+                sftp = pysftp.Connection(
                     host=self.host,
                     username=self.username,
                     private_key=self.private_key,
@@ -178,7 +189,7 @@ class SftpClient:
                     private_key_pass=self.private_key_pass,
                 )
                 timeout = SOCKET_TIMEOUT
-                self._sftp.timeout = timeout
+                sftp.timeout = timeout
                 self._logger.verbose('Connected to {}', self.host)
             except Exception as e:
                 if not tries:
@@ -194,23 +205,24 @@ class SftpClient:
                     tries -= 1
                     retry_interval += RETRY_STEP
 
+        return sftp
+
     def close(self):
+        """
+        Close the sftp connection
+        """
         self._sftp.close()
 
     def _put_file(self, source, destination):
         return self._sftp.put(source, destination)
 
     def _download_file(self, source, destination, delete_origin):
-        """
-        Download a file from source to destination
-        """
 
         dir_name = remote_path.dirname(source)
-
-        destination = self._build_destination_path(source, destination)
+        destination_path = self._build_destination_path(source, destination)
         destination_dir = local_path.dirname(destination)
 
-        if local_path.exists(destination):
+        if local_path.exists(destination_path):
             self._logger.verbose('Skipping {} because destination file {} already exists. ', source, destination)
             return
 
@@ -220,12 +232,12 @@ class SftpClient:
         self._logger.verbose('Downloading file {} to {}', source, destination)
 
         try:
-            self._sftp.get(source, destination)
+            self._sftp.get(source, destination_path)
         except Exception as e:
             self._logger.error('Failed to download {} ({})', source, e)
-            if local_path.exists(destination):
-                self._logger.debug('Removing partially downloaded file {}', destination)
-                os.remove(destination)
+            if local_path.exists(destination_path):
+                self._logger.debug('Removing partially downloaded file {}', destination_path)
+                os.remove(destination_path)
             raise e
 
         if delete_origin:
@@ -236,18 +248,22 @@ class SftpClient:
         """
         Generate SFTP URL prefix
         """
-        login_str = ''
-        port_str = ''
 
-        if self.username and self.password:
-            login_str = '%s:%s@' % (self.username, self.password)
-        elif self.username:
-            login_str = '%s@' % self.username
+        def get_login_string():
+            if self.username and self.password:
+                return '%s:%s@' % (self.username, self.password)
+            elif self.username:
+                return '%s@' % self.username
+            else:
+                return ''
 
-        if self.port and self.port != 22:
-            port_str = ':%d' % self.port
+        def get_port_string():
+            if self.port and self.port != 22:
+                return ':%d' % self.port
+            else:
+                return ''
 
-        return 'sftp://%s%s%s/' % (login_str, self.host, port_str)
+        return 'sftp://%s%s%s/' % (get_login_string(), self.host, get_port_string())
 
     @classmethod
     def _build_destination_path(cls, path, destination):
@@ -261,45 +277,111 @@ class SftpError(Exception):
 
 class HandlerBuilder:
     """
-    Helper class for building PySftp single-argument node handlers.
+    Class for building pysftp.Connection.walktree node handlers.
+
+    :param sftp: A Connection object
+    :param logger: a logger object
+    :param url_prefix: SFTP URL prefix
     """
-    def __init__(self, sftp, logger, url_prefix):
+
+    def __init__(self, sftp, logger: logging.Logger, url_prefix):
         self._sftp = sftp
         self._logger = logger
         self._prefix = url_prefix
 
-    def get_file_handler(self, get_size, accumulator):
-        return partial(Handlers.handle_file, self._sftp, self._logger, self._prefix, get_size, accumulator)
+    def get_file_handler(self, get_size, entry_accumulator: list):
+        """
+        Builds a file node handler suitable for use with pysftp.Connection.walktree
 
-    def get_dir_handler(self, get_size, files_only, accumulator):
+        :param get_size: boolean indicating whether to compute the for each file
+        :param entry_accumulator: list to add entries to
+        """
+        return partial(Handlers.handle_file, self._sftp, self._logger, self._prefix, get_size, entry_accumulator)
+
+    def get_dir_handler(self, get_size, files_only, entry_accumulator: list):
+        """
+        Builds a file node handler suitable for use with pysftp.Connection.walktree
+
+        :param get_size: boolean indicating whether to compute the for each file
+        :param files_only: Boolean indicating whether to skip directories
+        :param entry_accumulator: list to add entries to
+        """
         return partial(Handlers.handle_directory, self._sftp, self._logger, self._prefix, get_size, files_only,
-                       accumulator)
+                       entry_accumulator)
 
     def get_unknown_handler(self):
+        """
+        Builds an unknown node handler suitable for use with pysftp.Connection.walktree
+        """
         return partial(Handlers.handle_unknown, self._logger)
 
     def get_null_handler(self):
+        """
+        Builds a noop node handler suitable for use with pysftp.Connection.walktree
+        """
         return partial(Handlers.null_node_handler, self._logger)
 
 
 class Handlers:
     @classmethod
-    def handle_file(cls, sftp, logger, prefix, get_size, accumulator, path):
-        size_handler = partial(cls.file_size, sftp)
-        entry = cls.get_entry(sftp, logger, prefix, size_handler, get_size, path)
-        accumulator.append(entry)
+    def handle_file(cls, sftp, logger: logging.Logger, prefix, get_size, entry_accumulator, path):
+        """
+        File node handler. Adds a file entry to entry_accumulator.
+
+        :param sftp: A pysftp.Connection object
+        :param logger: a logger object
+        :param prefix: SFTP URL prefix
+        :param get_size: boolean indicating whether to compute the size of each file
+        :param entry_accumulator: a list in which to store entries
+        :param path: path to handle
+        """
+        size_handler = partial(cls._file_size, sftp)
+        entry = cls._get_entry(sftp, logger, prefix, size_handler, get_size, path)
+        entry_accumulator.append(entry)
 
     @classmethod
-    def handle_directory(cls, sftp, logger, prefix, get_size, files_only, accumulator, path):
+    def handle_directory(cls, sftp, logger: logging.Logger, prefix, get_size, files_only, entry_accumulator, path):
+        """
+        Directory node handler. Adds a directory entry to entry_accumulator.
+
+        :param sftp: A pysftp.Connection object
+        :param logger: a logger object
+        :param prefix: SFTP URL prefix
+        :param get_size: boolean indicating whether to compute the size of each directory
+        :param files_only: Boolean indicating whether to skip directories
+        :param entry_accumulator: a list in which to store entries
+        :param path: path to handle
+        """
         if files_only:
             return
 
-        dir_size = partial(cls.dir_size, sftp)
-        entry = cls.get_entry(sftp, logger, prefix, dir_size, get_size, path)
-        accumulator.append(entry)
+        dir_size = partial(cls._dir_size, sftp)
+        entry = cls._get_entry(sftp, logger, prefix, dir_size, get_size, path)
+        entry_accumulator.append(entry)
 
     @staticmethod
-    def get_entry(sftp, logger, prefix, size_handler, get_size, path):
+    def handle_unknown(logger: logging.Logger, path):
+        """
+        Handler for unknown nodes; logs a warning.
+
+        :param logger: a logger object
+        :param path: path to handle
+        """
+        logger.warning('Skipping unknown file: {}', path)
+
+    @staticmethod
+    def null_node_handler(logger: logging.Logger, path):
+        """
+        Generic noop node handler
+
+        :param logger: a logger object
+        :param path: path to handle
+        :return:
+        """
+        logger.debug('null handler called  for {}', path)
+
+    @staticmethod
+    def _get_entry(sftp, logger, prefix, size_handler, get_size, path):
 
         url = urljoin(prefix, quote(sftp.normalize(path)))
         title = remote_path.basename(path)
@@ -317,32 +399,21 @@ class Handlers:
         return entry
 
     @classmethod
-    def dir_size(cls, sftp, path):
+    def _dir_size(cls, sftp, path):
         sizes = []
 
-        size_accumulator = partial(cls.accumulate_file_size, sftp, sizes)
+        size_accumulator = partial(cls._accumulate_file_size, sftp, sizes)
         sftp.walktree(path, size_accumulator, size_accumulator, size_accumulator, True)
 
         return sum(sizes)
 
     @classmethod
-    def accumulate_file_size(cls, sftp, accumulator, path):
-        accumulator.append(cls.file_size(sftp, path))
+    def _accumulate_file_size(cls, sftp, size_accumulator, path):
+        size_accumulator.append(cls._file_size(sftp, path))
 
     @staticmethod
-    def file_size(sftp, path):
+    def _file_size(sftp, path):
         """
         Helper function to get the size of a file node
         """
         return sftp.lstat(path).st_size
-
-    @staticmethod
-    def null_node_handler(logger, path):
-        logger.trace('null handler called  for {}', path)
-
-    @staticmethod
-    def handle_unknown(logger, path):
-        """
-        Skip unknown files
-        """
-        logger.warning('Skipping unknown file: {}', path)

--- a/flexget/components/ftp/sftp_client.py
+++ b/flexget/components/ftp/sftp_client.py
@@ -1,0 +1,348 @@
+import logging
+import os
+import posixpath
+import time
+from functools import partial
+from urllib.parse import quote, urljoin
+
+from flexget import plugin
+from flexget.entry import Entry
+
+# retry configuration constants
+CONNECT_TRIES = 3
+RETRY_INTERVAL = 15
+RETRY_STEP = 5
+SOCKET_TIMEOUT = 15
+
+try:
+    import pysftp
+
+    logging.getLogger("paramiko").setLevel(logging.ERROR)
+except ImportError:
+    pysftp = None
+
+local_path = os.path
+remote_path = posixpath  # pysftp uses POSIX style paths
+
+
+# noinspection PyUnresolvedReferences
+class SftpClient:
+    def __init__(self, logger, host, port, username, password=None, private_key=None, private_key_pass=None):
+        self._logger = logger
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.private_key = private_key
+        self.private_key_pass = private_key_pass
+
+        self.prefix = self._get_prefix()
+        self._sftp = None
+
+        if pysftp:
+            self.connect()
+        else:
+            raise plugin.DependencyError(
+                issued_by='sftp_client',
+                missing='pysftp',
+                message='sftp client requires the pysftp Python module.',
+            )
+
+        self._handler_builder = HandlerBuilder(self._sftp, self._logger, self.prefix)
+        
+    def list_directories(self, directories, recursive, get_size, files_only):
+
+        entries = []
+
+        dir_handler = self._handler_builder.get_dir_handler(get_size, files_only, entries)
+        file_handler = self._handler_builder.get_file_handler(get_size, entries)
+        unknown_handler = self._handler_builder.get_unknown_handler()
+
+        for directory in directories:
+            try:
+                self._sftp.walktree(directory, file_handler, dir_handler, unknown_handler, recursive)
+            except IOError as e:
+                self._logger.error('Failed to open {} ({})', dir, e)
+                continue
+
+        return entries
+
+    def download(self, path, to, recursive, delete_origin):
+        """
+        Downloads the specified path
+        """
+
+        dir_handler = self._handler_builder.get_null_handler()
+        unknown_handler = self._handler_builder.get_unknown_handler()
+
+        if not self.path_exists(path):
+            raise SftpError('Remote path does not exist: {}', path)
+
+        if self.is_file(path):
+            source_file = remote_path.basename(path)
+            source_dir = remote_path.dirname(path)
+            try:
+                self._sftp.cwd(source_dir)
+                self._download_file(source_file, to, delete_origin)
+            except Exception as e:
+                raise SftpError('Failed to download file %s (%s)' % (path, e))
+        elif self.is_dir(path):
+            base_path = remote_path.normpath(remote_path.join(path, '..'))
+            dir_name = remote_path.basename(path)
+            handle_file = partial(self._download_file, to, delete_origin)
+
+            try:
+                self._sftp.cwd(base_path)
+                self._sftp.walktree(dir_name, handle_file, dir_handler, unknown_handler, recursive)
+            except Exception as e:
+                raise SftpError('Failed to download directory %s (%s)' % (path, e))
+
+            if delete_origin:
+                self.remove_dir(path)
+        else:
+            self._logger.warning('Skipping unknown file {}', path)
+            
+    def upload_file(self, source, to):
+
+        filename = local_path.basename(source)
+        destination = remote_path.join(to, filename)
+        destination_url = urljoin(self.prefix, destination)
+
+        if not os.path.exists(source):
+            self._logger.warning('File no longer exists: {}', source)
+
+        if not self.path_exists(to):
+            try:
+                self.make_dirs(to)
+            except Exception as e:
+                raise SftpError('Failed to create remote directory {} ({})', to, e)
+
+        if not self.is_dir(to):
+            raise SftpError('Not a directory: {}', to)
+
+        try:
+            self._put_file(source, destination)
+            self._logger.verbose('Successfully uploaded {} to {}', source, destination_url)
+        except IOError:
+            raise SftpError('Remote directory does not exist: {} ({})', to)
+        except Exception as e:
+            raise SftpError('Failed to upload {} ({})', source, e)
+
+    def remove_dir(self, path):
+        """
+        Remove a directory if it's empty
+        """
+        if self._sftp.exists(path) and not self._sftp.listdir(path):
+            self._logger.debug('Attempting to delete directory {}', path)
+            try:
+                self._sftp.rmdir(path)
+            except Exception as e:
+                self._logger.error('Failed to delete directory {} ({})', path, e)
+
+    def remove_file(self, path):
+        self._logger.debug('Deleting remote file {}', path)
+        try:
+            self._sftp.remove(path)
+        except Exception as e:
+            self._logger.error('Failed to delete file {} ({})', path, e)
+            return
+
+    def is_file(self, path):
+        return self._sftp.isfile(path)
+
+    def is_dir(self, path):
+        return self._sftp.isdir(path)
+
+    def path_exists(self, path):
+        return self._sftp.lexists(path)
+
+    def make_dirs(self, path):
+        return self._sftp.makedirs(path)
+
+    def connect(self):
+        tries = CONNECT_TRIES
+        retry_interval = RETRY_INTERVAL
+
+        self._sftp = None
+
+        self._logger.debug('Connecting to {}', self.host)
+
+        while not self._sftp:
+            try:
+                self._sftp = pysftp.Connection(
+                    host=self.host,
+                    username=self.username,
+                    private_key=self.private_key,
+                    password=self.password,
+                    port=self.port,
+                    private_key_pass=self.private_key_pass,
+                )
+                timeout = SOCKET_TIMEOUT
+                self._sftp.timeout = timeout
+                self._logger.verbose('Connected to {}', self.host)
+            except Exception as e:
+                if not tries:
+                    raise e
+                else:
+                    self._logger.debug('Caught exception: {}', e)
+                    self._logger.warning(
+                        'Failed to connect to {}; waiting {} seconds before retrying.',
+                        self.host,
+                        retry_interval,
+                    )
+                    time.sleep(retry_interval)
+                    tries -= 1
+                    retry_interval += RETRY_STEP
+
+    def close(self):
+        self._sftp.close()
+
+    def _put_file(self, source, destination):
+        return self._sftp.put(source, destination)
+
+    def _download_file(self, source, destination, delete_origin):
+        """
+        Download a file from source to destination
+        """
+
+        dir_name = remote_path.dirname(source)
+
+        destination = self._build_destination_path(source, destination)
+        destination_dir = local_path.dirname(destination)
+
+        if local_path.exists(destination):
+            self._logger.verbose('Skipping {} because destination file {} already exists. ', source, destination)
+            return
+
+        if not local_path.exists(destination_dir):
+            os.makedirs(destination_dir)
+
+        self._logger.verbose('Downloading file {} to {}', source, destination)
+
+        try:
+            self._sftp.get(source, destination)
+        except Exception as e:
+            self._logger.error('Failed to download {} ({})', source, e)
+            if local_path.exists(destination):
+                self._logger.debug('Removing partially downloaded file {}', destination)
+                os.remove(destination)
+            raise e
+
+        if delete_origin:
+            self.remove_file(source)
+            self.remove_dir(dir_name)
+
+    def _get_prefix(self):
+        """
+        Generate SFTP URL prefix
+        """
+        login_str = ''
+        port_str = ''
+
+        if self.username and self.password:
+            login_str = '%s:%s@' % (self.username, self.password)
+        elif self.username:
+            login_str = '%s@' % self.username
+
+        if self.port and self.port != 22:
+            port_str = ':%d' % self.port
+
+        return 'sftp://%s%s%s/' % (login_str, self.host, port_str)
+
+    @classmethod
+    def _build_destination_path(cls, path, destination):
+        relative_path = local_path.join(*remote_path.split(path))  # convert remote path style to local style
+        return local_path.join(destination, relative_path)
+
+
+class SftpError(Exception):
+    pass
+
+
+class HandlerBuilder:
+    """
+    Helper class for building PySftp single-argument node handlers.
+    """
+    def __init__(self, sftp, logger, url_prefix):
+        self._sftp = sftp
+        self._logger = logger
+        self._prefix = url_prefix
+
+    def get_file_handler(self, get_size, accumulator):
+        return partial(Handlers.handle_file, self._sftp, self._logger, self._prefix, get_size, accumulator)
+
+    def get_dir_handler(self, get_size, files_only, accumulator):
+        return partial(Handlers.handle_directory, self._sftp, self._logger, self._prefix, get_size, files_only,
+                       accumulator)
+
+    def get_unknown_handler(self):
+        return partial(Handlers.handle_unknown, self._logger)
+
+    def get_null_handler(self):
+        return partial(Handlers.null_node_handler, self._logger)
+
+
+class Handlers:
+    @classmethod
+    def handle_file(cls, sftp, logger, prefix, get_size, accumulator, path):
+        size_handler = partial(cls.file_size, sftp)
+        entry = cls.get_entry(sftp, logger, prefix, size_handler, get_size, path)
+        accumulator.append(entry)
+
+    @classmethod
+    def handle_directory(cls, sftp, logger, prefix, get_size, files_only, accumulator, path):
+        if files_only:
+            return
+
+        dir_size = partial(cls.dir_size, sftp)
+        entry = cls.get_entry(sftp, logger, prefix, dir_size, get_size, path)
+        accumulator.append(entry)
+
+    @staticmethod
+    def get_entry(sftp, logger, prefix, size_handler, get_size, path):
+
+        url = urljoin(prefix, quote(sftp.normalize(path)))
+        title = remote_path.basename(path)
+
+        entry = Entry(title, url)
+
+        if get_size:
+            try:
+                size = size_handler(path)
+            except Exception as e:
+                logger.error('Failed to get size for {} ({})', path, e)
+                size = -1
+            entry['content_size'] = size
+
+        return entry
+
+    @classmethod
+    def dir_size(cls, sftp, path):
+        sizes = []
+
+        size_accumulator = partial(cls.accumulate_file_size, sftp, sizes)
+        sftp.walktree(path, size_accumulator, size_accumulator, size_accumulator, True)
+
+        return sum(sizes)
+
+    @classmethod
+    def accumulate_file_size(cls, sftp, accumulator, path):
+        accumulator.append(cls.file_size(sftp, path))
+
+    @staticmethod
+    def file_size(sftp, path):
+        """
+        Helper function to get the size of a file node
+        """
+        return sftp.lstat(path).st_size
+
+    @staticmethod
+    def null_node_handler(logger, path):
+        logger.trace('null handler called  for {}', path)
+
+    @staticmethod
+    def handle_unknown(logger, path):
+        """
+        Skip unknown files
+        """
+        logger.warning('Skipping unknown file: {}', path)

--- a/flexget/components/ftp/sftp_client.py
+++ b/flexget/components/ftp/sftp_client.py
@@ -273,15 +273,15 @@ class SftpClient:
 
         def get_login_string() -> str:
             if self.username and self.password:
-                return '%s:%s@' % (self.username, self.password)
+                return f'{self.username}:{self.password}'
             elif self.username:
-                return '%s@' % self.username
+                return f'{self.username}@'
             else:
                 return ''
 
         def get_port_string() -> str:
             if self.port and self.port != 22:
-                return ':%d' % self.port
+                return f':{self.port}'
             else:
                 return ''
 

--- a/flexget/components/ftp/sftp_client.py
+++ b/flexget/components/ftp/sftp_client.py
@@ -74,7 +74,7 @@ class SftpClient:
                     directory, file_handler, dir_handler, unknown_handler, recursive
                 )
             except IOError as e:
-                logger.error(f'Failed to open {directory} ({e})')
+                logger.warning(f'Failed to open {directory} ({e})')
                 continue
 
         return entries

--- a/flexget/components/ftp/sftp_client.py
+++ b/flexget/components/ftp/sftp_client.py
@@ -138,7 +138,7 @@ class SftpClient:
         :param to: destination
         """
         if Path(source).is_dir():
-            logger.verbose('Skipping directory {}', source)
+            logger.verbose('Skipping directory {}', source) # type: ignore
         else:
             self._upload_file(source, to)
 


### PR DESCRIPTION
### Motivation for changes:
The original SFTP plugin is a bit of a spaghetti code mess. I've split it into a couple of classes to more make it easier to follow.

### Detailed changes:
- Create a SftpClient class and move inline PySftp node handlers into their own class as well.

### Log and/or tests output (preferably both):
SFTP Upload
```
2020-05-10 19:00:34 DEBUG    manager                       Figuring out config load paths
2020-05-10 19:00:34 DEBUG    manager                       Found config: /Users/password/Flexget/../config.yml
2020-05-10 19:00:34 DEBUG    manager                       Config file /Users/password/Flexget/../config.yml selected
2020-05-10 19:00:34 DEBUG    manager                       sys.defaultencoding: utf-8
2020-05-10 19:00:34 DEBUG    manager                       sys.getfilesystemencoding: utf-8
2020-05-10 19:00:34 DEBUG    manager                       flexget detected io encoding: utf-8
2020-05-10 19:00:34 DEBUG    manager                       os.path.supports_unicode_filenames: True
2020-05-10 19:00:34 DEBUG    plugin                        Trying to load plugins from: ['/Users/password/plugins', '/Users/password/Flexget/flexget/plugins']
2020-05-10 19:00:34 DEBUG    plugin                        Plugin `memusage` requires plugin `ext lib `guppy`` to load.
2020-05-10 19:00:34 DEBUG    stevedore.extension                 found extension EntryPoint.parse('addic7ed = subliminal.providers.addic7ed:Addic7edProvider')
2020-05-10 19:00:35 DEBUG    stevedore.extension                 found extension EntryPoint.parse('legendastv = subliminal.providers.legendastv:LegendasTVProvider')
2020-05-10 19:00:35 DEBUG    stevedore.extension                 found extension EntryPoint.parse('opensubtitles = subliminal.providers.opensubtitles:OpenSubtitlesProvider')
2020-05-10 19:00:35 DEBUG    stevedore.extension                 found extension EntryPoint.parse('podnapisi = subliminal.providers.podnapisi:PodnapisiProvider')
2020-05-10 19:00:35 DEBUG    stevedore.extension                 found extension EntryPoint.parse('shooter = subliminal.providers.shooter:ShooterProvider')
2020-05-10 19:00:35 DEBUG    stevedore.extension                 found extension EntryPoint.parse('subscenter = subliminal.providers.subscenter:SubsCenterProvider')
2020-05-10 19:00:35 DEBUG    stevedore.extension                 found extension EntryPoint.parse('thesubdb = subliminal.providers.thesubdb:TheSubDBProvider')
2020-05-10 19:00:35 DEBUG    stevedore.extension                 found extension EntryPoint.parse('tvsubtitles = subliminal.providers.tvsubtitles:TVsubtitlesProvider')
2020-05-10 19:00:35 DEBUG    stevedore.extension                 found extension EntryPoint.parse('metadata = subliminal.refiners.metadata:refine')
2020-05-10 19:00:35 DEBUG    stevedore.extension                 found extension EntryPoint.parse('omdb = subliminal.refiners.omdb:refine')
2020-05-10 19:00:35 DEBUG    stevedore.extension                 found extension EntryPoint.parse('tvdb = subliminal.refiners.tvdb:refine')
2020-05-10 19:00:35 DEBUG    plugin                        Trying to load components from: ['/Users/password/components', '/Users/password/Flexget/flexget/components']
2020-05-10 19:00:36 ERROR    plugin                        ValueError attempting to import `flexget.components.parsing.parsers.parser_guessit` (from /Users/password/Flexget/flexget/components/parsing/parsers/parser_guessit.py): unused keyword argument 'children'
2020-05-10 19:00:36 DEBUG    plugin                        Plugins took 2.58 seconds to load. 304 plugins in registry.
2020-05-10 19:00:37 DEBUG    manager                       Connecting to: sqlite:////Users/password/db-config.sqlite
2020-05-10 19:00:37 DEBUG    manager                       config_name: config
2020-05-10 19:00:37 DEBUG    manager                       config_base: /Users/password
2020-05-10 19:00:37 DEBUG    manager                       New config data loaded.
2020-05-10 19:00:37 DEBUG    schema                        current flexget version already exist in db 3.1.52.dev
2020-05-10 19:00:37 DEBUG    parsing                       setting default movie parser to internal. (options: {'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x10b92cbd0>})
2020-05-10 19:00:37 DEBUG    parsing                       setting default series parser to internal. (options: {'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x10b92cbd0>})
2020-05-10 19:00:37 DEBUG    cron_env                      Encoding utf-8 stored
2020-05-10 19:00:37 DEBUG    util.simple_persistence                 setting key terminal_encoding value 'utf-8'
2020-05-10 19:00:37 DEBUG    task_queue                    task queue shutdown requested
2020-05-10 19:00:37 INFO     ipc.rpyc                      server started on [127.0.0.1]:50940
2020-05-10 19:00:37 DEBUG    task          sftp-list       executing sftp-list
2020-05-10 19:00:37 DEBUG    disable       sftp-list       Disabled built-in plugin(s): seen
2020-05-10 19:00:37 DEBUG    sftp          sftp-list       Connecting to nigiri.local
2020-05-10 19:00:37 VERBOSE  sftp          sftp-list       Connected to nigiri.local
2020-05-10 19:00:37 DEBUG    backlog       sftp-list       0 entries purged from backlog
2020-05-10 19:00:37 VERBOSE  details       sftp-list       Produced 1 entries.
2020-05-10 19:00:37 VERBOSE  task          sftp-list       ACCEPTED: `test.txt` by accept_all plugin
2020-05-10 19:00:37 DEBUG    urlrewriter   sftp-list       Checking 1 entries
2020-05-10 19:00:37 DEBUG    sftp          sftp-list       Connecting to nigiri.local
2020-05-10 19:00:38 VERBOSE  sftp          sftp-list       Connected to nigiri.local
2020-05-10 19:00:38 VERBOSE  sftp          sftp-list       Skipping test.txt because destination file /Users/ieaston/test/ already exists.
2020-05-10 19:00:38 VERBOSE  details       sftp-list       Summary - Accepted: 1 (Rejected: 0 Undecided: 0 Failed: 0)
2020-05-10 19:00:38 DEBUG    disable       sftp-list       Re-enabled builtin plugin(s): seen
2020-05-10 19:00:38 DEBUG    util.simple_persistence sftp-list       Flushing simple persistence for task sftp-list to db.
2020-05-10 19:00:38 DEBUG    task_queue                    task queue shut down
2020-05-10 19:00:38 INFO     ipc.rpyc                      listener closed
2020-05-10 19:00:38 DEBUG    util.simple_persistence                 Flushing simple persistence for task None to db.
2020-05-10 19:00:38 DEBUG    manager                       Shutting down
2020-05-10 19:00:38 DEBUG    manager                       Removed /Users/password/.config-lock
(Flexget) password@nori Flexget % python3 flexget_vanilla.py -L debug -c ../config.yml exec --task sftp-upload
2020-05-10 19:53:30 DEBUG    manager                       Figuring out config load paths
2020-05-10 19:53:30 DEBUG    manager                       Found config: /Users/password/Flexget/../config.yml
2020-05-10 19:53:30 DEBUG    manager                       Config file /Users/password/Flexget/../config.yml selected
2020-05-10 19:53:30 DEBUG    manager                       sys.defaultencoding: utf-8
2020-05-10 19:53:30 DEBUG    manager                       sys.getfilesystemencoding: utf-8
2020-05-10 19:53:30 DEBUG    manager                       flexget detected io encoding: utf-8
2020-05-10 19:53:30 DEBUG    manager                       os.path.supports_unicode_filenames: True
2020-05-10 19:53:30 DEBUG    plugin                        Trying to load plugins from: ['/Users/password/plugins', '/Users/password/Flexget/flexget/plugins']
2020-05-10 19:53:30 DEBUG    plugin                        Plugin `memusage` requires plugin `ext lib `guppy`` to load.
2020-05-10 19:53:31 DEBUG    stevedore.extension                 found extension EntryPoint.parse('addic7ed = subliminal.providers.addic7ed:Addic7edProvider')
2020-05-10 19:53:31 DEBUG    stevedore.extension                 found extension EntryPoint.parse('legendastv = subliminal.providers.legendastv:LegendasTVProvider')
2020-05-10 19:53:31 DEBUG    stevedore.extension                 found extension EntryPoint.parse('opensubtitles = subliminal.providers.opensubtitles:OpenSubtitlesProvider')
2020-05-10 19:53:31 DEBUG    stevedore.extension                 found extension EntryPoint.parse('podnapisi = subliminal.providers.podnapisi:PodnapisiProvider')
2020-05-10 19:53:31 DEBUG    stevedore.extension                 found extension EntryPoint.parse('shooter = subliminal.providers.shooter:ShooterProvider')
2020-05-10 19:53:31 DEBUG    stevedore.extension                 found extension EntryPoint.parse('subscenter = subliminal.providers.subscenter:SubsCenterProvider')
2020-05-10 19:53:31 DEBUG    stevedore.extension                 found extension EntryPoint.parse('thesubdb = subliminal.providers.thesubdb:TheSubDBProvider')
2020-05-10 19:53:31 DEBUG    stevedore.extension                 found extension EntryPoint.parse('tvsubtitles = subliminal.providers.tvsubtitles:TVsubtitlesProvider')
2020-05-10 19:53:31 DEBUG    stevedore.extension                 found extension EntryPoint.parse('metadata = subliminal.refiners.metadata:refine')
2020-05-10 19:53:31 DEBUG    stevedore.extension                 found extension EntryPoint.parse('omdb = subliminal.refiners.omdb:refine')
2020-05-10 19:53:31 DEBUG    stevedore.extension                 found extension EntryPoint.parse('tvdb = subliminal.refiners.tvdb:refine')
2020-05-10 19:53:32 DEBUG    plugin                        Trying to load components from: ['/Users/password/components', '/Users/password/Flexget/flexget/components']
2020-05-10 19:53:33 ERROR    plugin                        ValueError attempting to import `flexget.components.parsing.parsers.parser_guessit` (from /Users/password/Flexget/flexget/components/parsing/parsers/parser_guessit.py): unused keyword argument 'private_names'
2020-05-10 19:53:33 DEBUG    plugin                        Plugins took 2.56 seconds to load. 304 plugins in registry.
2020-05-10 19:53:33 DEBUG    manager                       Connecting to: sqlite:////Users/password/db-config.sqlite
2020-05-10 19:53:33 DEBUG    manager                       config_name: config
2020-05-10 19:53:33 DEBUG    manager                       config_base: /Users/password
2020-05-10 19:53:33 DEBUG    manager                       New config data loaded.
2020-05-10 19:53:33 DEBUG    schema                        current flexget version already exist in db 3.1.52.dev
2020-05-10 19:53:33 DEBUG    parsing                       setting default movie parser to internal. (options: {'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x106b28bd0>})
2020-05-10 19:53:33 DEBUG    parsing                       setting default series parser to internal. (options: {'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x106b28bd0>})
2020-05-10 19:53:33 DEBUG    cron_env                      Encoding utf-8 stored
2020-05-10 19:53:33 DEBUG    util.simple_persistence                 setting key terminal_encoding value 'utf-8'
2020-05-10 19:53:33 DEBUG    task_queue                    task queue shutdown requested
2020-05-10 19:53:33 VERBOSE  task_queue                    There are 1 tasks to execute. Shutdown will commence when they have completed.
2020-05-10 19:53:33 INFO     ipc.rpyc                      server started on [127.0.0.1]:51155
2020-05-10 19:53:33 DEBUG    task          sftp-upload     executing sftp-upload
2020-05-10 19:53:33 DEBUG    disable       sftp-upload     Disabled built-in plugin(s): seen
2020-05-10 19:53:33 VERBOSE  filesystem    sftp-upload     Starting to scan folders.
2020-05-10 19:53:33 VERBOSE  filesystem    sftp-upload     Scanning folder /Users/ieaston/test/. Recursion is set to False.
2020-05-10 19:53:33 DEBUG    filesystem    sftp-upload     Scanning /Users/ieaston/test
2020-05-10 19:53:33 DEBUG    filesystem    sftp-upload     Checking if /Users/ieaston/test/test.txt qualifies to be added as an entry.
2020-05-10 19:53:33 DEBUG    backlog       sftp-upload     0 entries purged from backlog
2020-05-10 19:53:33 VERBOSE  details       sftp-upload     Produced 1 entries.
2020-05-10 19:53:33 VERBOSE  task          sftp-upload     ACCEPTED: `test` by accept_all plugin
2020-05-10 19:53:33 DEBUG    urlrewriter   sftp-upload     Checking 1 entries
2020-05-10 19:53:33 VERBOSE  details       sftp-upload     Summary - Accepted: 1 (Rejected: 0 Undecided: 0 Failed: 0)
2020-05-10 19:53:33 DEBUG    sftp          sftp-upload     Connecting to nigiri.local
2020-05-10 19:53:33 VERBOSE  sftp          sftp-upload     Connected to nigiri.local
2020-05-10 19:53:33 DEBUG    sftp          sftp-upload     Uploading file: /Users/ieaston/test/test.txt
2020-05-10 19:53:33 VERBOSE  sftp          sftp-upload     Successfully uploaded /Users/ieaston/test/test.txt to sftp://password:password@nigiri.local/test/test.txt
2020-05-10 19:53:33 DEBUG    disable       sftp-upload     Re-enabled builtin plugin(s): seen
2020-05-10 19:53:33 DEBUG    util.simple_persistence sftp-upload     Flushing simple persistence for task sftp-upload to db.
2020-05-10 19:53:34 DEBUG    task_queue                    task queue shut down
2020-05-10 19:53:34 INFO     ipc.rpyc                      listener closed
2020-05-10 19:53:34 DEBUG    util.simple_persistence                 Flushing simple persistence for task None to db.
2020-05-10 19:53:34 DEBUG    manager                       Shutting down
2020-05-10 19:53:34 DEBUG    manager                       Removed /Users/password/.config-lock
```

SFTP List/SFTP Download
```
2020-05-10 19:55:14 DEBUG    manager                       Figuring out config load paths
2020-05-10 19:55:14 DEBUG    manager                       Found config: /Users/password/Flexget/../config.yml
2020-05-10 19:55:14 DEBUG    manager                       Config file /Users/password/Flexget/../config.yml selected
2020-05-10 19:55:14 DEBUG    manager                       sys.defaultencoding: utf-8
2020-05-10 19:55:14 DEBUG    manager                       sys.getfilesystemencoding: utf-8
2020-05-10 19:55:14 DEBUG    manager                       flexget detected io encoding: utf-8
2020-05-10 19:55:14 DEBUG    manager                       os.path.supports_unicode_filenames: True
2020-05-10 19:55:14 DEBUG    plugin                        Trying to load plugins from: ['/Users/password/plugins', '/Users/password/Flexget/flexget/plugins']
2020-05-10 19:55:14 DEBUG    plugin                        Plugin `memusage` requires plugin `ext lib `guppy`` to load.
2020-05-10 19:55:15 DEBUG    stevedore.extension                 found extension EntryPoint.parse('addic7ed = subliminal.providers.addic7ed:Addic7edProvider')
2020-05-10 19:55:15 DEBUG    stevedore.extension                 found extension EntryPoint.parse('legendastv = subliminal.providers.legendastv:LegendasTVProvider')
2020-05-10 19:55:15 DEBUG    stevedore.extension                 found extension EntryPoint.parse('opensubtitles = subliminal.providers.opensubtitles:OpenSubtitlesProvider')
2020-05-10 19:55:15 DEBUG    stevedore.extension                 found extension EntryPoint.parse('podnapisi = subliminal.providers.podnapisi:PodnapisiProvider')
2020-05-10 19:55:15 DEBUG    stevedore.extension                 found extension EntryPoint.parse('shooter = subliminal.providers.shooter:ShooterProvider')
2020-05-10 19:55:15 DEBUG    stevedore.extension                 found extension EntryPoint.parse('subscenter = subliminal.providers.subscenter:SubsCenterProvider')
2020-05-10 19:55:15 DEBUG    stevedore.extension                 found extension EntryPoint.parse('thesubdb = subliminal.providers.thesubdb:TheSubDBProvider')
2020-05-10 19:55:15 DEBUG    stevedore.extension                 found extension EntryPoint.parse('tvsubtitles = subliminal.providers.tvsubtitles:TVsubtitlesProvider')
2020-05-10 19:55:15 DEBUG    stevedore.extension                 found extension EntryPoint.parse('metadata = subliminal.refiners.metadata:refine')
2020-05-10 19:55:15 DEBUG    stevedore.extension                 found extension EntryPoint.parse('omdb = subliminal.refiners.omdb:refine')
2020-05-10 19:55:15 DEBUG    stevedore.extension                 found extension EntryPoint.parse('tvdb = subliminal.refiners.tvdb:refine')
2020-05-10 19:55:16 DEBUG    plugin                        Trying to load components from: ['/Users/password/components', '/Users/password/Flexget/flexget/components']
2020-05-10 19:55:16 ERROR    plugin                        ValueError attempting to import `flexget.components.parsing.parsers.parser_guessit` (from /Users/password/Flexget/flexget/components/parsing/parsers/parser_guessit.py): unused keyword argument 'private_names'
2020-05-10 19:55:16 DEBUG    plugin                        Plugins took 2.46 seconds to load. 304 plugins in registry.
2020-05-10 19:55:17 DEBUG    manager                       Connecting to: sqlite:////Users/password/db-config.sqlite
2020-05-10 19:55:17 DEBUG    manager                       config_name: config
2020-05-10 19:55:17 DEBUG    manager                       config_base: /Users/password
2020-05-10 19:55:17 DEBUG    manager                       New config data loaded.
2020-05-10 19:55:17 DEBUG    schema                        current flexget version already exist in db 3.1.52.dev
2020-05-10 19:55:17 DEBUG    parsing                       setting default movie parser to internal. (options: {'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x10df62a10>})
2020-05-10 19:55:17 DEBUG    parsing                       setting default series parser to internal. (options: {'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x10df62a10>})
2020-05-10 19:55:17 DEBUG    cron_env                      Encoding utf-8 stored
2020-05-10 19:55:17 DEBUG    util.simple_persistence                 setting key terminal_encoding value 'utf-8'
2020-05-10 19:55:17 DEBUG    task_queue                    task queue shutdown requested
2020-05-10 19:55:17 VERBOSE  task_queue                    There are 1 tasks to execute. Shutdown will commence when they have completed.
2020-05-10 19:55:17 INFO     ipc.rpyc                      server started on [127.0.0.1]:51161
2020-05-10 19:55:17 DEBUG    task          sftp-list-download executing sftp-list-download
2020-05-10 19:55:17 DEBUG    disable       sftp-list-download Disabled built-in plugin(s): seen
2020-05-10 19:55:17 DEBUG    status        sftp-list-download Adding new task sftp-list-download
2020-05-10 19:55:17 DEBUG    sftp          sftp-list-download Connecting to nigiri.local
2020-05-10 19:55:17 VERBOSE  sftp          sftp-list-download Connected to nigiri.local
2020-05-10 19:55:18 DEBUG    backlog       sftp-list-download 0 entries purged from backlog
2020-05-10 19:55:18 VERBOSE  details       sftp-list-download Produced 1 entries.
2020-05-10 19:55:18 VERBOSE  task          sftp-list-download ACCEPTED: `test.txt` by accept_all plugin
2020-05-10 19:55:18 DEBUG    urlrewriter   sftp-list-download Checking 1 entries
2020-05-10 19:55:18 DEBUG    sftp          sftp-list-download Connecting to nigiri.local
2020-05-10 19:55:18 VERBOSE  sftp          sftp-list-download Connected to nigiri.local
2020-05-10 19:55:18 VERBOSE  sftp          sftp-list-download Downloading file test.txt to /Users/ieaston/test/
2020-05-10 19:55:18 VERBOSE  details       sftp-list-download Summary - Accepted: 1 (Rejected: 0 Undecided: 0 Failed: 0)
2020-05-10 19:55:18 DEBUG    disable       sftp-list-download Re-enabled builtin plugin(s): seen
2020-05-10 19:55:18 DEBUG    util.simple_persistence sftp-list-download Flushing simple persistence for task sftp-list-download to db.
2020-05-10 19:55:18 DEBUG    task_queue                    task queue shut down
2020-05-10 19:55:18 INFO     ipc.rpyc                      listener closed
2020-05-10 19:55:18 DEBUG    util.simple_persistence                 Flushing simple persistence for task None to db.
2020-05-10 19:55:18 DEBUG    manager                       Shutting down
2020-05-10 19:55:18 DEBUG    manager                       Removed /Users/password/.config-lock
```
#### To Do:

- Could use some tests

