### PR TITLE
rewrite imdb_id to imdbid

### DIFF
--- a/flexget/components/sites/sites/newznab.py
+++ b/flexget/components/sites/sites/newznab.py
@@ -120,7 +120,7 @@ class Newznab:
             return []
 
         imdb_id = arg_entry['imdb_id'].replace('tt', '')
-        config['params']['imdb_id'] = imdb_id
+        config['params']['imdbid'] = imdb_id
         return self.fill_entries_for_url(config['url'], config['params'], task)
 
     def do_search_all(self, arg_entry, task, config=None):


### PR DESCRIPTION
Newznab indexers won't accept wrong parameter

### Motivation for changes:
The Newznab plugin is sending the wrong parameter for the IMDB id in it's request. Newznab is expecting to receive _imdbi_ but this plugin is sending it as _imdb_id.
Here the url to the newznab api: https://newznab.readthedocs.io/en/latest/misc/api/?highlight=imdbid#movie-search

### Detailed changes:
- Just changed the parameter for the request to _imdbid_

