### PR TITLE
python3 related code base cleanup

### DIFF
--- a/dev_tools.py
+++ b/dev_tools.py
@@ -87,7 +87,7 @@ def bundle_webui():
         # Just stashed the old webui zip on a random github release for easy hosting.
         # It doesn't get updated anymore, we should probably stop bundling it with releases soon.
         download_extract('https://github.com/Flexget/Flexget/releases/download/v3.0.6/webui_v1.zip', os.path.join(ui_path, 'v1'))
-    except IOError as e:
+    except OSError as e:
         click.echo('Unable to download and extract WebUI v1 due to %e' % str(e))
         raise click.Abort()
 
@@ -111,7 +111,7 @@ def bundle_webui():
             click.echo('Unable to find dist.zip in assets')
             raise click.Abort()
         download_extract(v2_package, os.path.join(ui_path, 'v2'))
-    except (IOError, ValueError) as e:
+    except (OSError, ValueError) as e:
         click.echo('Unable to download and extract WebUI v2 due to %s' % str(e))
         raise click.Abort()
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,8 +47,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'FlexGet'
-copyright = u'2011, FlexGet'
+project = 'FlexGet'
+copyright = '2011, FlexGet'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -219,7 +219,7 @@ latex_documents = [('index', 'FlexGet.tex', u'FlexGet Documentation', u'FlexGet'
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [('index', 'flexget', u'FlexGet Documentation', [u'FlexGet'], 1)]
+man_pages = [('index', 'flexget', 'FlexGet Documentation', ['FlexGet'], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -234,8 +234,8 @@ texinfo_documents = [
     (
         'index',
         'FlexGet',
-        u'FlexGet Technical Documentation',
-        u'FlexGet',
+        'FlexGet Technical Documentation',
+        'FlexGet',
         'FlexGet',
         'Automation tool.',
         'Miscellaneous',

--- a/flexget/__init__.py
+++ b/flexget/__init__.py
@@ -16,7 +16,7 @@ def main(args=None):
 
         try:
             manager = Manager(args)
-        except (IOError, ValueError) as e:
+        except (OSError, ValueError) as e:
             if _is_debug():
                 import traceback
 
@@ -39,7 +39,7 @@ def main(args=None):
                 )
             else:
                 manager.start()
-        except (IOError, ValueError) as e:
+        except (OSError, ValueError) as e:
             if _is_debug():
                 import traceback
 

--- a/flexget/api/core/server.py
+++ b/flexget/api/core/server.py
@@ -412,7 +412,7 @@ class ServerLogAPI(APIResource):
                         fh.seek(stream_from_byte)
                         line = fh.readline().decode(sys.getfilesystemencoding())
                         stream_from_byte = fh.tell()
-                except IOError:
+                except OSError:
                     yield '{}'
                     continue
 

--- a/flexget/components/archives/utils.py
+++ b/flexget/components/archives/utils.py
@@ -116,7 +116,7 @@ class Archive:
             for volume in volumes:
                 os.remove(volume)
                 logger.verbose('Deleted archive: {}', volume)
-        except (IOError, os.error) as error:
+        except OSError as error:
             raise FSError(error)
 
     def volumes(self):
@@ -146,7 +146,7 @@ class Archive:
             with self.open(member) as source:
                 with open(destination, 'wb') as target:
                     shutil.copyfileobj(source, target)
-        except (IOError, os.error) as error:
+        except OSError as error:
             raise FSError(error)
 
         logger.verbose('Extracted: {}', member)
@@ -275,7 +275,7 @@ def is_archive(path):
         if archive:
             archive.close()
             return True
-    except (IOError, ArchiveError) as error:
+    except (OSError, ArchiveError) as error:
         logger.debug('Failed to open file as archive: {} ({})', path, error)
 
     return False

--- a/flexget/components/bittorrent/torrent_alive.py
+++ b/flexget/components/bittorrent/torrent_alive.py
@@ -114,7 +114,7 @@ def get_udp_seeds(url, info_hash):
         # set recieve size of 8 + 12 bytes
         res = clisocket.recv(20)
 
-    except IOError as e:
+    except OSError as e:
         logger.warning('Socket Error: {}', e)
         return 0
     # Check for UDP error packet
@@ -148,7 +148,7 @@ def get_http_seeds(url, info_hash):
     except BadStatusLine as e:
         logger.warning('Error BadStatusLine: {}', e)
         return 0
-    except IOError as e:
+    except OSError as e:
         logger.warning('Server error: {}', e)
         return 0
     if not data:

--- a/flexget/components/ftp/ftp_download.py
+++ b/flexget/components/ftp/ftp_download.py
@@ -74,7 +74,7 @@ class OutputFtp:
     def check_connection(self, ftp, config, ftp_url, current_path):
         try:
             ftp.voidcmd("NOOP")
-        except (IOError, ftplib.Error):
+        except (OSError, ftplib.Error):
             ftp = self.ftp_connect(config, ftp_url, current_path)
         return ftp
 

--- a/flexget/components/ftp/sftp.py
+++ b/flexget/components/ftp/sftp.py
@@ -275,7 +275,7 @@ class SftpList:
         for dir in dirs:
             try:
                 sftp.walktree(dir, handle_file, handle_dir, handle_unknown, recursive)
-            except IOError as e:
+            except OSError as e:
                 logger.error('Failed to open {} ({})', dir, e)
                 continue
 
@@ -580,7 +580,7 @@ class SftpUpload:
         try:
             sftp.put(localpath=location, remotepath=destination)
             logger.verbose('Successfully uploaded {} to {}', location, destination_url)
-        except IOError as e:
+        except OSError as e:
             logger.error('Remote directory does not exist: {} ({})', to)
             entry.fail('Remote directory does not exist: %s (%s)' % to)
             return

--- a/flexget/components/imdb/utils.py
+++ b/flexget/components/imdb/utils.py
@@ -67,7 +67,7 @@ def extract_id(url):
 
 def make_url(imdb_id):
     """Return IMDb URL of the given ID"""
-    return u'https://www.imdb.com/title/%s/' % imdb_id
+    return 'https://www.imdb.com/title/%s/' % imdb_id
 
 
 class ImdbSearch:
@@ -149,7 +149,7 @@ class ImdbSearch:
     def search(self, name):
         """Return array of movie details (dict)"""
         logger.debug('Searching: {}', name)
-        url = u'https://www.imdb.com/find'
+        url = 'https://www.imdb.com/find'
         # This may include Shorts and TV series in the results
         params = {'q': name, 's': 'tt'}
 

--- a/flexget/components/irc/irc.py
+++ b/flexget/components/irc/irc.py
@@ -322,7 +322,7 @@ class IRCConnection(SimpleIRCBot):
         if not os.path.exists(base_dir):  # will only try to create the default `trackers` dir
             try:
                 os.mkdir(base_dir)
-            except IOError as e:
+            except OSError as e:
                 raise TrackerFileError(e)
         logger.info(
             'Tracker file not found on disk. Attempting to fetch tracker config file from Github.'
@@ -330,7 +330,7 @@ class IRCConnection(SimpleIRCBot):
         tracker = None
         try:
             tracker = requests.get(base_url + tracker_config_file)
-        except (requests.RequestException, IOError):
+        except (requests.RequestException, OSError):
             pass
         if not tracker:
             try:
@@ -351,7 +351,7 @@ class IRCConnection(SimpleIRCBot):
                     tracker = requests.get(base_url + name)
                     tracker_name = name
                     break
-            except (requests.RequestException, IOError) as e:
+            except (requests.RequestException, OSError) as e:
                 raise TrackerFileError(e)
         if not tracker:
             raise TrackerFileError(
@@ -899,7 +899,7 @@ class IRCConnectionManager:
                 if not conn and self.config.get(conn_name):
                     try:
                         self.restart_connection(conn_name, self.config[conn_name])
-                    except IOError as e:
+                    except OSError as e:
                         logger.error(e)
                 elif not conn.is_alive() and conn.running:
                     if conn_name not in schedule:
@@ -916,7 +916,7 @@ class IRCConnectionManager:
                         )
                         try:
                             self.restart_connection(conn_name, conn.config)
-                        except IOError as e:
+                        except OSError as e:
                             logger.error(e)
                         # remove it from the schedule
                         del schedule[conn_name]
@@ -954,7 +954,7 @@ class IRCConnectionManager:
                 conn = IRCConnection(config, conn_name)
                 irc_connections[conn_name] = conn
                 config_hash['names'][conn_name] = get_config_hash(config)
-            except (MissingConfigOption, TrackerFileParseError, TrackerFileError, IOError) as e:
+            except (MissingConfigOption, TrackerFileParseError, TrackerFileError, OSError) as e:
                 logger.error(e)
                 if conn_name in irc_connections:
                     del irc_connections[conn_name]  # remove it from the list of connections
@@ -1012,7 +1012,7 @@ class IRCConnectionManager:
             try:
                 new_irc_connections[name] = IRCConnection(conf, name)
                 config_hash['names'][name] = hash
-            except (MissingConfigOption, TrackerFileParseError, TrackerFileError, IOError) as e:
+            except (MissingConfigOption, TrackerFileParseError, TrackerFileError, OSError) as e:
                 logger.error('Failed to update config. Error when updating {}: {}', name, e)
                 return
 

--- a/flexget/components/irc/irc.py
+++ b/flexget/components/irc/irc.py
@@ -694,7 +694,7 @@ class IRCConnection(SimpleIRCBot):
         # Clean up the messages
         lines = [MESSAGE_CLEAN.sub('', line) for line in self.line_cache[channel][nickname]]
 
-        logger.debug('Received line(s): {}', u'\n'.join(lines))
+        logger.debug('Received line(s): {}', '\n'.join(lines))
 
         # Generate some entries
         if self.linepatterns:

--- a/flexget/components/irc/irc.py
+++ b/flexget/components/irc/irc.py
@@ -273,7 +273,7 @@ class IRCConnection(SimpleIRCBot):
         :return: the parsed XML
         """
         try:
-            with io.open(path, 'rb') as xml_file:
+            with open(path, 'rb') as xml_file:
                 return parse(xml_file).getroot()
         except Exception as e:
             raise TrackerFileParseError('Unable to parse tracker config file %s: %s' % (path, e))
@@ -361,7 +361,7 @@ class IRCConnection(SimpleIRCBot):
 
         # If we got this far, let's save our work :)
         save_path = os.path.join(base_dir, tracker_name)
-        with io.open(save_path, 'wb') as tracker_file:
+        with open(save_path, 'wb') as tracker_file:
             for chunk in tracker.iter_content(8192):
                 tracker_file.write(chunk)
         return cls.read_tracker_config(save_path)

--- a/flexget/components/irc/irc.py
+++ b/flexget/components/irc/irc.py
@@ -1,4 +1,3 @@
-import io
 import os
 import re
 import threading

--- a/flexget/components/notify/notifiers/email.py
+++ b/flexget/components/notify/notifiers/email.py
@@ -123,7 +123,7 @@ class EmailNotifier:
                 # Forcing to use `str` type
                 logger.debug('logging in to smtp server using username: {}', self.username)
                 self.mail_server.login(self.username, self.password)
-        except (IOError, SMTPAuthenticationError) as e:
+        except (OSError, SMTPAuthenticationError) as e:
             raise PluginWarning(str(e))
 
     schema = {

--- a/flexget/components/series/utils.py
+++ b/flexget/components/series/utils.py
@@ -1,8 +1,8 @@
-TRANSLATE_MAP = {ord(u'&'): u' and '}
-for char in u'\'\\':
-    TRANSLATE_MAP[ord(char)] = u''
-for char in u'_./-,[]():':
-    TRANSLATE_MAP[ord(char)] = u' '
+TRANSLATE_MAP = {ord('&'): ' and '}
+for char in '\'\\':
+    TRANSLATE_MAP[ord(char)] = ''
+for char in '_./-,[]():':
+    TRANSLATE_MAP[ord(char)] = ' '
 
 
 def normalize_series_name(name):
@@ -10,5 +10,5 @@ def normalize_series_name(name):
     name = name.lower()
     name = name.replace('&amp;', ' and ')
     name = name.translate(TRANSLATE_MAP)  # Replaced some symbols with spaces
-    name = u' '.join(name.split())
+    name = ' '.join(name.split())
     return name

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -624,7 +624,7 @@ class Manager:
         if not self.config_path:
             return
         sha1_hash = hashlib.sha1()
-        with io.open(self.config_path, 'rb') as f:
+        with open(self.config_path, 'rb') as f:
             while True:
                 data = f.read(65536)
                 if not data:
@@ -641,7 +641,7 @@ class Manager:
         :raises: `ValueError` if there is a problem loading the config file
         """
         fire_event('manager.before_config_load', self)
-        with io.open(self.config_path, 'r', encoding='utf-8') as f:
+        with open(self.config_path, 'r', encoding='utf-8') as f:
             try:
                 raw_config = f.read()
             except UnicodeDecodeError:
@@ -850,7 +850,7 @@ class Manager:
         """
         if self.lockfile and os.path.exists(self.lockfile):
             result = {}
-            with io.open(self.lockfile, encoding='utf-8') as f:
+            with open(self.lockfile, encoding='utf-8') as f:
                 lines = [l for l in f.readlines() if l]
             for line in lines:
                 try:
@@ -900,7 +900,7 @@ class Manager:
             if not self._has_lock:
                 # Exit if there is an existing lock.
                 if self.check_lock():
-                    with io.open(self.lockfile, encoding='utf-8') as f:
+                    with open(self.lockfile, encoding='utf-8') as f:
                         pid = f.read()
                     print(
                         'Another process (%s) is running, will exit.' % pid.split('\n')[0],
@@ -926,7 +926,7 @@ class Manager:
 
     def write_lock(self, ipc_info: Optional[dict] = None) -> None:
         assert self._has_lock
-        with io.open(self.lockfile, 'w', encoding='utf-8') as f:
+        with open(self.lockfile, 'w', encoding='utf-8') as f:
             f.write('PID: %s\n' % os.getpid())
             if ipc_info:
                 for key in sorted(ipc_info):

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -534,12 +534,12 @@ class Manager:
             # to always return unicode objects
             return self.construct_scalar(node)
 
-        yaml.Loader.add_constructor(u'tag:yaml.org,2002:str', construct_yaml_str)
-        yaml.SafeLoader.add_constructor(u'tag:yaml.org,2002:str', construct_yaml_str)
+        yaml.Loader.add_constructor('tag:yaml.org,2002:str', construct_yaml_str)
+        yaml.SafeLoader.add_constructor('tag:yaml.org,2002:str', construct_yaml_str)
 
         # Set up the dumper to not tag every string with !!python/unicode
         def unicode_representer(dumper, uni):
-            node = yaml.ScalarNode(tag=u'tag:yaml.org,2002:str', value=uni)
+            node = yaml.ScalarNode(tag='tag:yaml.org,2002:str', value=uni)
             return node
 
         yaml.add_representer(str, unicode_representer)

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -559,7 +559,7 @@ class Manager:
         Find and load the configuration file.
 
         :param bool create: If a config file is not found, and create is True, one will be created in the home folder
-        :raises: `IOError` when no config file could be found, and `create` is False.
+        :raises: `OSError` when no config file could be found, and `create` is False.
         """
         home_path = os.path.join(os.path.expanduser('~'), '.flexget')
         options_config = os.path.expanduser(self.options.config)
@@ -609,9 +609,9 @@ class Manager:
         elif not config:
             logger.critical('Failed to find configuration file {}', options_config)
             logger.info('Tried to read from: {}', ', '.join(possible))
-            raise IOError('No configuration file found.')
+            raise OSError('No configuration file found.')
         if not os.path.isfile(config):
-            raise IOError('Config `%s` does not appear to be a file.' % config)
+            raise OSError('Config `%s` does not appear to be a file.' % config)
 
         logger.debug('Config file {} selected', config)
         self.config_path = config
@@ -740,7 +740,7 @@ class Manager:
         logger.debug('backing up old config to {} before new save', backup_path)
         try:
             shutil.copy(self.config_path, backup_path)
-        except (OSError, IOError) as e:
+        except OSError as e:
             logger.warning('Config backup creation failed: {}', str(e))
             raise
         return backup_path
@@ -752,7 +752,7 @@ class Manager:
         # Back up the user's current config before overwriting
         try:
             self.backup_config()
-        except (OSError, IOError):
+        except OSError:
             return
         with open(self.config_path, 'w') as config_file:
             config_file.write(yaml.dump(self.user_config, default_flow_style=False))

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -5,7 +5,6 @@ import copy  # noqa
 import errno  # noqa
 import fnmatch  # noqa
 import hashlib  # noqa
-import io  # noqa
 import os  # noqa
 import shutil  # noqa
 import signal  # noqa

--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -143,8 +143,8 @@ class internet:
             except ValueError as e:
                 logger.opt(exception=True).debug('decorator caught ValueError. handled traceback:')
                 raise PluginError(e)
-            except IOError as e:
-                logger.opt(exception=True).debug('decorator caught ioerror. handled traceback:')
+            except OSError as e:
+                logger.opt(exception=True).debug('decorator caught OSError. handled traceback:')
                 if hasattr(e, 'reason'):
                     raise PluginError('Failed to reach server. Reason: %s' % e.reason, self.logger)
                 elif hasattr(e, 'code'):
@@ -152,7 +152,7 @@ class internet:
                         'The server couldn\'t fulfill the request. Error code: %s' % e.code,
                         self.logger,
                     )
-                raise PluginError('IOError when connecting to server: %s' % e, self.logger)
+                raise PluginError('OSError when connecting to server: %s' % e, self.logger)
 
         return wrapped_func
 

--- a/flexget/plugins/clients/pyload.py
+++ b/flexget/plugins/clients/pyload.py
@@ -139,7 +139,7 @@ class PluginPyLoad:
 
         try:
             session = api.get_session(config)
-        except IOError:
+        except OSError:
             raise plugin.PluginError('pyLoad not reachable', logger)
         except plugin.PluginError:
             raise

--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -205,7 +205,7 @@ class RTorrent:
         parsed_uri = urlparse(uri)
 
         if self.username and self.password and parsed_uri.scheme not in ['http', 'https']:
-            raise IOError('Username and password only supported on http(s)')
+            raise OSError('Username and password only supported on http(s)')
 
         # Determine the proxy server
         if parsed_uri.scheme in ['http', 'https']:
@@ -216,7 +216,7 @@ class RTorrent:
             self.uri = parsed_uri.path
             sp = create_proxy
         else:
-            raise IOError('Unsupported scheme %s for uri %s' % (parsed_uri.scheme, self.uri))
+            raise OSError('Unsupported scheme %s for uri %s' % (parsed_uri.scheme, self.uri))
 
         # Use a special transport if http(s)
         if parsed_uri.scheme in ['http', 'https']:
@@ -507,7 +507,7 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
                         continue
                     self.update_entry(client, entry, config)
 
-        except IOError as e:
+        except OSError as e:
             raise plugin.PluginError("Couldn't connect to rTorrent: %s" % str(e))
 
     def delete_entry(self, client, entry):
@@ -619,7 +619,7 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
             try:
                 with open(entry['file'], 'rb') as f:
                     torrent_raw = f.read()
-            except IOError as e:
+            except OSError as e:
                 entry.fail('Failed to add to rTorrent %s' % str(e))
                 return
 
@@ -692,7 +692,7 @@ class RTorrentInputPlugin(RTorrentPluginBase):
 
         try:
             torrents = client.torrents(config['view'], fields=fields)
-        except (IOError, xmlrpc_client.Error) as e:
+        except (OSError, xmlrpc_client.Error) as e:
             task.abort('Could not get torrents (%s): %s' % (config['view'], e))
             return
 

--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -46,7 +46,7 @@ class TransmissionBase:
                 config['username'], _, config['password'] = netrc(netrc_path).authenticators(
                     config['host']
                 )
-            except IOError as e:
+            except OSError as e:
                 logger.error('netrc: unable to open: {}', e.filename)
             except NetrcParseError as e:
                 logger.error('netrc: {}, file: {}, line: {}', e.msg, e.filename, e.lineno)

--- a/flexget/plugins/input/html.py
+++ b/flexget/plugins/input/html.py
@@ -267,7 +267,7 @@ class InputHtml:
                 continue
 
             # strip unicode white spaces
-            title = title.replace(u'\u200B', u'').strip()
+            title = title.replace('\u200B', '').strip()
 
             # in case the title contains xxxxxxx.torrent - foooo.torrent clean it a bit (get up to first .torrent)
             # TODO: hack

--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -433,7 +433,7 @@ class InputRSS:
                 break
 
             # remove annoying zero width spaces
-            entry.title = entry.title.replace(u'\u200B', u'')
+            entry.title = entry.title.replace('\u200B', '')
 
             # helper
             # TODO: confusing? refactor into class member ...

--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -369,7 +369,7 @@ class InputRSS:
                         'Received invalid RSS content from task %s (%s)'
                         % (task.name, config['url'])
                     )
-                elif isinstance(ex, http.client.BadStatusLine) or isinstance(ex, IOError):
+                elif isinstance(ex, http.client.BadStatusLine) or isinstance(ex, OSError):
                     raise ex  # let the @internet decorator handle
                 else:
                     # all other bozo errors

--- a/flexget/plugins/operate/cookies.py
+++ b/flexget/plugins/operate/cookies.py
@@ -118,7 +118,7 @@ class PluginCookies:
                         'Adding cookie for {}. key: {} value: {}', item[0], item[4], item[5]
                     )
                     count += 1
-                except IOError:
+                except OSError:
 
                     def to_hex(x):
                         return ''.join([hex(ord(c))[2:].zfill(2) for c in x])
@@ -177,7 +177,7 @@ class PluginCookies:
             try:
                 cj.load(filename=cookie_file, ignore_expires=True)
                 logger.debug('{} cookies loaded', cookie_type)
-            except (http.cookiejar.LoadError, IOError):
+            except (http.cookiejar.LoadError, OSError):
                 import sys
 
                 raise plugin.PluginError(

--- a/flexget/plugins/operate/formlogin.py
+++ b/flexget/plugins/operate/formlogin.py
@@ -1,4 +1,3 @@
-import io
 import os
 import socket
 

--- a/flexget/plugins/operate/formlogin.py
+++ b/flexget/plugins/operate/formlogin.py
@@ -78,7 +78,7 @@ class FormLogin:
                 if not os.path.isdir(received):
                     os.mkdir(received)
                 filename = os.path.join(received, '%s.formlogin.html' % task.name)
-                with io.open(filename, 'wb') as f:
+                with open(filename, 'wb') as f:
                     f.write(response.content)
                 logger.critical(
                     'I have saved the login page content to {} for you to view', filename

--- a/flexget/plugins/operate/include.py
+++ b/flexget/plugins/operate/include.py
@@ -1,4 +1,3 @@
-import io
 import os
 
 import yaml

--- a/flexget/plugins/operate/include.py
+++ b/flexget/plugins/operate/include.py
@@ -39,7 +39,7 @@ class PluginInclude:
             file = os.path.expanduser(file_name)
             if not os.path.isabs(file):
                 file = os.path.join(task.manager.config_base, file)
-            with io.open(file, encoding='utf-8') as inc_file:
+            with open(file, encoding='utf-8') as inc_file:
                 include = yaml.safe_load(inc_file)
                 inc_file.flush()
             errors = process_config(include, plugin.plugin_schemas(interface='task'))

--- a/flexget/plugins/output/download.py
+++ b/flexget/plugins/output/download.py
@@ -221,13 +221,13 @@ class PluginDownload:
         except BadStatusLine as e:
             logger.warning('Failed to reach server. Reason: {}', getattr(e, 'message', 'N/A'))
             return 'BadStatusLine'
-        except IOError as e:
+        except OSError as e:
             if hasattr(e, 'reason'):
                 logger.warning('Failed to reach server. Reason: {}', e.reason)
             elif hasattr(e, 'code'):
                 logger.warning("The server couldn't fulfill the request. Error code: {}", e.code)
-            logger.opt(exception=True).debug('IOError')
-            return 'IOError'
+            logger.opt(exception=True).debug('OSError')
+            return 'OSError'
         except ValueError as e:
             # Probably unknown url type
             msg = 'ValueError %s' % e
@@ -508,7 +508,7 @@ class PluginDownload:
 
                 try:
                     shutil.move(entry['file'], destfile)
-                except (IOError, OSError) as err:
+                except (OSError, OSError) as err:
                     # ignore permission errors, see ticket #555
                     import errno
 

--- a/flexget/plugins/output/download.py
+++ b/flexget/plugins/output/download.py
@@ -1,5 +1,4 @@
 import hashlib
-import io
 import mimetypes
 import os
 import shutil

--- a/flexget/plugins/output/download.py
+++ b/flexget/plugins/output/download.py
@@ -170,7 +170,7 @@ class PluginDownload:
         logger.error(
             'Error retrieving {}, the error page has been saved to {}', entry['title'], filename
         )
-        with io.open(filename, 'wb') as outfile:
+        with open(filename, 'wb') as outfile:
             outfile.write(page)
 
     def get_temp_files(
@@ -299,7 +299,7 @@ class PluginDownload:
         tmp_dir = tempfile.mkdtemp(dir=tmp_path)
         fname = hashlib.md5(url.encode('utf-8', 'replace')).hexdigest()
         datafile = os.path.join(tmp_dir, fname)
-        outfile = io.open(datafile, 'wb')
+        outfile = open(datafile, 'wb')
         try:
             for chunk in response.iter_content(chunk_size=150 * 1024, decode_unicode=False):
                 outfile.write(chunk)

--- a/flexget/plugins/output/move.py
+++ b/flexget/plugins/output/move.py
@@ -126,7 +126,7 @@ class BaseFileOps:
                             )
                 # execute action in subclasses
                 self.handle_entry(task, config, entry, siblings)
-            except (OSError, IOError) as err:
+            except OSError as err:
                 entry.fail(str(err))
                 continue
 

--- a/flexget/plugins/output/rss.py
+++ b/flexget/plugins/output/rss.py
@@ -1,7 +1,6 @@
 import base64
 import datetime
 import hashlib
-import io
 import os
 
 from loguru import logger

--- a/flexget/plugins/output/rss.py
+++ b/flexget/plugins/output/rss.py
@@ -300,7 +300,7 @@ class OutputRSS:
             except LookupError:
                 logger.critical('Unknown encoding {}', config['encoding'])
                 return
-            except IOError:
+            except OSError:
                 # TODO: plugins cannot raise PluginWarnings in terminate event ..
                 logger.critical('Unable to write {}', fn)
                 return

--- a/flexget/plugins/output/rss.py
+++ b/flexget/plugins/output/rss.py
@@ -293,7 +293,7 @@ class OutputRSS:
 
         # write rss
         fn = os.path.expanduser(config['file'])
-        with io.open(fn, 'wb') as file:
+        with open(fn, 'wb') as file:
             try:
                 logger.verbose('Writing output rss to {}', fn)
                 rss.write_xml(file, encoding=config['encoding'])

--- a/flexget/tests/api_tests/test_server_api.py
+++ b/flexget/tests/api_tests/test_server_api.py
@@ -66,7 +66,7 @@ class TestServerAPI:
                 'test': {
                     'mock': [{'title': 'entry 1'}],
                     'rss': {
-                        'url': u'http://test/rss',
+                        'url': 'http://test/rss',
                         'group_links': False,
                         'ascii': False,
                         'escape': False,

--- a/flexget/tests/api_tests/test_tasks_api.py
+++ b/flexget/tests/api_tests/test_tasks_api.py
@@ -29,7 +29,7 @@ class TestTaskAPI:
                 'config': {
                     'mock': [{'title': 'entry 1'}],
                     'rss': {
-                        'url': u'http://test/rss',
+                        'url': 'http://test/rss',
                         'group_links': False,
                         'ascii': False,
                         'escape': False,
@@ -52,7 +52,7 @@ class TestTaskAPI:
             'config': {
                 'mock': [{'title': 'entry 1'}],
                 'rss': {
-                    'url': u'http://test/rss',
+                    'url': 'http://test/rss',
                     'group_links': False,
                     'ascii': False,
                     'escape': False,
@@ -97,7 +97,7 @@ class TestTaskAPI:
             'config': {
                 'mock': [{'title': 'entry 1'}],
                 'rss': {
-                    'url': u'http://test/rss',
+                    'url': 'http://test/rss',
                     'group_links': False,
                     'ascii': False,
                     'escape': False,

--- a/flexget/tests/test_imdb_parser.py
+++ b/flexget/tests/test_imdb_parser.py
@@ -27,8 +27,8 @@ class TestImdbParser:
         }, 'Actors not parsed correctly'
         assert parser.directors == {'nm0001741': 'Bryan Singer'}, 'Directors not parsed correctly'
         print(parser.genres)
-        assert len(set(parser.genres).intersection([u'crime', u'mystery', u'thriller'])) == len(
-            [u'crime', u'mystery', u'thriller']
+        assert len(set(parser.genres).intersection(['crime', 'mystery', 'thriller'])) == len(
+            ['crime', 'mystery', 'thriller']
         ), 'Genres not parsed correctly'
         assert parser.imdb_id == 'tt0114814', 'ID not parsed correctly'
         assert (
@@ -49,7 +49,7 @@ class TestImdbParser:
         assert parser.url == 'https://www.imdb.com/title/tt0114814/', 'URL not parsed correctly'
         assert 400000 < parser.votes < 1000000, 'Votes not parsed correctly'
         assert parser.year == 1995, 'Year not parsed correctly'
-        expected_keywords = {u'criminal', u'suspect', u'criminal mastermind', u'dirty cop', u'burying a body'}
+        expected_keywords = {'criminal', 'suspect', 'criminal mastermind', 'dirty cop', 'burying a body'}
         assert len(expected_keywords.intersection(parser.plot_keywords)) == len(expected_keywords),\
             'Parsed plot keywords missing items from the expected result'
         assert len(expected_keywords) == len(parser.plot_keywords),\

--- a/flexget/tests/test_misc.py
+++ b/flexget/tests/test_misc.py
@@ -198,8 +198,8 @@ class TestHtmlUtils:
         """utils decode_html"""
         from flexget.utils.tools import decode_html
 
-        assert decode_html('&lt;&#51;') == u'<3'
-        assert decode_html('&#x2500;') == u'\u2500'
+        assert decode_html('&lt;&#51;') == '<3'
+        assert decode_html('&#x2500;') == '\u2500'
 
     @pytest.mark.skip(reason='FAILS - DISABLED')
     def test_encode_html(self):

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -133,7 +133,7 @@ class TestRTorrentClient:
                 assert False, 'Invalid hash returned'
 
         assert mocked_proxy.system.multicall.called_with(
-            (['main', 'd.directory_base=', 'd.name=', 'd.hash=', u'd.custom1='],)
+            (['main', 'd.directory_base=', 'd.name=', 'd.hash=', 'd.custom1='],)
         )
 
     def test_update(self, mocked_proxy):

--- a/flexget/tests/test_seriesparser.py
+++ b/flexget/tests/test_seriesparser.py
@@ -562,7 +562,7 @@ class TestSeriesParser:
         assert not s.valid
 
     def test_unicode(self, parse):
-        s = parse(name=u'abc äää abc', data=u'abc.äää.abc.s01e02')
+        s = parse(name='abc äää abc', data='abc.äää.abc.s01e02')
         assert s.season == 1
         assert s.episode == 2
 

--- a/flexget/tests/test_trakt_list_interface.py
+++ b/flexget/tests/test_trakt_list_interface.py
@@ -147,20 +147,20 @@ class TestTraktList:
 
         entry = Entry(
             **{
-                u'trakt_show_slug': u'game-of-thrones',
-                u'original_url': u'https://trakt.tv/shows/game-of-thrones/seasons/4/episodes/5',
-                u'url': u'https://trakt.tv/shows/game-of-thrones/seasons/4/episodes/5',
-                u'series_season': 4,
-                u'tvdb_id': 121361,
-                u'series_name': u'Game of Thrones (2011)',
-                u'imdb_id': u'tt0944947',
-                u'series_id': u'S04E05',
-                u'series_episode': 5,
-                u'trakt_episode_id': 73674,
-                u'title': u'Game of Thrones (2011) S04E05 First of His Name',
-                u'trakt_show_id': 1390,
-                u'trakt_ep_name': u'First of His Name',
-                u'tvrage_id': 24493,
+                'trakt_show_slug': 'game-of-thrones',
+                'original_url': 'https://trakt.tv/shows/game-of-thrones/seasons/4/episodes/5',
+                'url': 'https://trakt.tv/shows/game-of-thrones/seasons/4/episodes/5',
+                'series_season': 4,
+                'tvdb_id': 121361,
+                'series_name': 'Game of Thrones (2011)',
+                'imdb_id': 'tt0944947',
+                'series_id': 'S04E05',
+                'series_episode': 5,
+                'trakt_episode_id': 73674,
+                'title': 'Game of Thrones (2011) S04E05 First of His Name',
+                'trakt_show_id': 1390,
+                'trakt_ep_name': 'First of His Name',
+                'tvrage_id': 24493,
             }
         )
 
@@ -178,11 +178,11 @@ class TestTraktList:
 
         entry = Entry(
             **{
-                u'series_name': u'Game of Thrones (2011)',
-                u'series_id': u'S04E05',
-                u'series_episode': 5,
-                u'series_season': 4,
-                u'title': u'Game of Thrones (2011) S04E05 First of His Name',
+                'series_name': 'Game of Thrones (2011)',
+                'series_id': 'S04E05',
+                'series_episode': 5,
+                'series_season': 4,
+                'title': 'Game of Thrones (2011) S04E05 First of His Name',
             }
         )
 

--- a/flexget/tests/test_tvmaze.py
+++ b/flexget/tests/test_tvmaze.py
@@ -404,8 +404,8 @@ class TestTVMazeShowLookup:
     def test_show_with_non_ascii_chars(self, execute_task):
         task = execute_task('test_show_with_non_ascii_chars')
         entry = task.entries[0]
-        assert entry['tvmaze_series_name'] == u'Unit\xe9 9', (
-            u'series id should be Unit\xe9 9, instead its %s' % entry['tvmaze_series_name']
+        assert entry['tvmaze_series_name'] == 'Unit\xe9 9', (
+            'series id should be Unit\xe9 9, instead its %s' % entry['tvmaze_series_name']
         )
         assert entry['tvmaze_series_id'] == 8652, (
             'series id should be 8652, instead its %s' % entry['tvmaze_series_id']

--- a/flexget/utils/bittorrent.py
+++ b/flexget/utils/bittorrent.py
@@ -255,7 +255,7 @@ class Torrent:
                         item[field] = item[field].decode(self.content.get('encoding', 'cp1252'))
                     except UnicodeError:
                         # Broken beyond anything reasonable
-                        fallback = item[field].decode('utf-8', 'replace').replace(u'\ufffd', '_')
+                        fallback = item[field].decode('utf-8', 'replace').replace('\ufffd', '_')
                         logger.warning(
                             '{}={!r} field in torrent {!r} is wrongly encoded, falling back to `{}`',
                             field,

--- a/flexget/utils/cache.py
+++ b/flexget/utils/cache.py
@@ -1,5 +1,4 @@
 import hashlib
-import io
 import os
 
 import requests

--- a/flexget/utils/cache.py
+++ b/flexget/utils/cache.py
@@ -44,7 +44,7 @@ def cached_resource(url, base_dir, force=False, max_size=250, directory='cached_
                 trim_dir(directory)
                 size = dir_size(directory) / (1024 * 1024.0)
 
-        with io.open(file_path, 'wb') as file:
+        with open(file_path, 'wb') as file:
             file.write(content)
     return file_path, mime_type
 

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -148,7 +148,7 @@ def _wrap_urlopen(url: str, timeout: Optional[int] = None) -> requests.Response:
     """
     try:
         raw = urlopen(url, timeout=timeout)
-    except IOError as e:
+    except OSError as e:
         msg = 'Error getting %s: %s' % (url, e)
         logger.error(msg)
         raise RequestException(msg)

--- a/update-changelog.py
+++ b/update-changelog.py
@@ -99,7 +99,7 @@ if __name__ == '__main__':
     except IndexError:
         print('No filename specified, using changelog.md')
         filename = 'changelog.md'
-    with io.open(filename, encoding='utf-8') as logfile:
+    with open(filename, encoding='utf-8') as logfile:
         pre_lines, start_comment, tail = isplit('<!---', logfile)
         active_lines, end_comment, tail = isplit('<!---', tail)
         post_lines = list(tail)
@@ -150,7 +150,7 @@ if __name__ == '__main__':
 
     if modified:
         print('Writing modified changelog.')
-        with io.open(filename, 'w', encoding='utf-8') as logfile:
+        with open(filename, 'w', encoding='utf-8') as logfile:
             logfile.writelines(pre_lines)
             logfile.write('<!---{0}--->\n'.format(commit.hexsha))
             logfile.writelines(cur_ver.to_md_lines())

--- a/update-changelog.py
+++ b/update-changelog.py
@@ -1,6 +1,5 @@
 import collections
 import datetime
-import io
 import re
 import sys
 


### PR DESCRIPTION
### Motivation for changes:
clean code base since python2 support is dropped

### Detailed changes:
- remove `u` string
- `io.open()` -> `open()`
- `IOError` -> `OSError`
### Addressed issues:
- NA

### Implemented feature requests:
- NA
### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
```
paste output here
```
#### To Do:

- NA

