### PR TITLE
Avoids running crossmatch from if no entries

### DIFF
--- a/flexget/plugins/filter/crossmatch.py
+++ b/flexget/plugins/filter/crossmatch.py
@@ -43,6 +43,10 @@ class CrossMatch:
         action = config['action']
         all_fields = config['all_fields']
 
+        if len(task.entries) == 0:
+          logger.trace('Stopping crossmatch filter because of no entries to check')
+          return
+        
         match_entries = aggregate_inputs(task, config['from'])
 
         # perform action on intersecting entries

--- a/flexget/plugins/filter/crossmatch.py
+++ b/flexget/plugins/filter/crossmatch.py
@@ -43,7 +43,7 @@ class CrossMatch:
         action = config['action']
         all_fields = config['all_fields']
 
-        if len(task.entries) == 0:
+        if not task.entries:
           logger.trace('Stopping crossmatch filter because of no entries to check')
           return
         


### PR DESCRIPTION
### Motivation for changes:

Avoids running the from input plugin if no entries to check. This is very useful if, for example, the from is using the "from_task" plugin. This will avoid running the task in the "from_task" if no entries exists to be matched.

### Detailed changes:
- Check the len of the entries iterator before running the from in crossmatch

