### PR TITLE
Switch from flask-restplus to flask-restx

### DIFF
--- a/flexget/api/app.py
+++ b/flexget/api/app.py
@@ -7,8 +7,8 @@ from functools import partial, wraps
 from flask import Flask, jsonify, make_response, request
 from flask_compress import Compress
 from flask_cors import CORS
-from flask_restplus import Api as RestPlusAPI
-from flask_restplus import Resource
+from flask_restx import Api as RestxAPI
+from flask_restx import Resource
 from jsonschema import RefResolutionError
 from loguru import logger
 from werkzeug.http import generate_etag
@@ -88,9 +88,9 @@ class APIResource(Resource):
         super().__init__(api, *args, **kwargs)
 
 
-class API(RestPlusAPI):
+class API(RestxAPI):
     """
-    Extends a flask restplus :class:`flask_restplus.Api` with:
+    Extends a flask restx :class:`flask_restx.Api` with:
       - methods to make using json schemas easier
       - methods to auto document and handle :class:`ApiError` responses
     """
@@ -123,7 +123,7 @@ class API(RestPlusAPI):
 
     def response(self, code_or_apierror, description='Success', model=None, **kwargs):
         """
-        Extends :meth:`flask_restplus.Api.response` to allow passing an :class:`ApiError` class instead of
+        Extends :meth:`flask_restx.Api.response` to allow passing an :class:`ApiError` class instead of
         response code. If an `ApiError` is used, the response code, and expected response model, is automatically
         documented.
         """

--- a/flexget/api/core/authentication.py
+++ b/flexget/api/core/authentication.py
@@ -4,7 +4,7 @@ from flask import request
 from flask import session as flask_session
 from flask_login import LoginManager
 from flask_login.utils import current_app, current_user, login_user
-from flask_restplus import inputs
+from flask_restx import inputs
 from werkzeug.security import check_password_hash
 
 from flexget.api import api_app

--- a/flexget/api/core/cached.py
+++ b/flexget/api/core/cached.py
@@ -1,5 +1,5 @@
 from flask.helpers import send_file
-from flask_restplus import inputs
+from flask_restx import inputs
 from requests import RequestException
 
 from flexget.api import APIResource, api

--- a/flexget/api/core/plugins.py
+++ b/flexget/api/core/plugins.py
@@ -1,7 +1,7 @@
 from math import ceil
 
 from flask import jsonify, request
-from flask_restplus import inputs
+from flask_restx import inputs
 from loguru import logger
 
 from flexget.api import APIResource, api

--- a/flexget/api/core/tasks.py
+++ b/flexget/api/core/tasks.py
@@ -6,7 +6,7 @@ from json import JSONEncoder
 from queue import Empty, Queue
 
 from flask import Response, jsonify, request
-from flask_restplus import inputs
+from flask_restx import inputs
 
 from flexget.api import APIResource, api
 from flexget.api.app import (

--- a/flexget/components/irc/api.py
+++ b/flexget/components/irc/api.py
@@ -1,5 +1,5 @@
 from flask import jsonify
-from flask_restplus import inputs
+from flask_restx import inputs
 
 from flexget.api import APIResource, api
 from flexget.api.app import (

--- a/flexget/components/pending_approval/api.py
+++ b/flexget/components/pending_approval/api.py
@@ -1,7 +1,7 @@
 from math import ceil
 
 from flask import jsonify, request
-from flask_restplus import inputs
+from flask_restx import inputs
 from sqlalchemy.orm.exc import NoResultFound
 
 from flexget.api import APIResource, api

--- a/flexget/components/seen/api.py
+++ b/flexget/components/seen/api.py
@@ -2,7 +2,7 @@ from math import ceil
 from urllib.parse import unquote
 
 from flask import jsonify, request
-from flask_restplus import inputs
+from flask_restx import inputs
 from sqlalchemy.orm.exc import NoResultFound
 
 from flexget.api import APIResource, api

--- a/flexget/components/series/api.py
+++ b/flexget/components/series/api.py
@@ -2,7 +2,7 @@ import copy
 from math import ceil
 
 from flask import jsonify, request
-from flask_restplus import inputs
+from flask_restx import inputs
 from sqlalchemy.orm.exc import NoResultFound
 
 from flexget import plugin

--- a/flexget/components/status/api.py
+++ b/flexget/components/status/api.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from math import ceil
 
 from flask import jsonify, request
-from flask_restplus import inputs
+from flask_restx import inputs
 from loguru import logger
 from sqlalchemy.orm.exc import NoResultFound
 

--- a/flexget/components/thetvdb/api.py
+++ b/flexget/components/thetvdb/api.py
@@ -1,5 +1,5 @@
 from flask import jsonify
-from flask_restplus import inputs
+from flask_restx import inputs
 
 from flexget.api import APIResource, api
 from flexget.api.app import BadRequest, NotFoundError, etag

--- a/flexget/components/tmdb/api.py
+++ b/flexget/components/tmdb/api.py
@@ -1,5 +1,5 @@
 from flask import jsonify
-from flask_restplus import inputs
+from flask_restx import inputs
 
 from flexget import plugin
 from flexget.api import APIResource, api

--- a/flexget/components/trakt/api.py
+++ b/flexget/components/trakt/api.py
@@ -1,7 +1,7 @@
 import copy
 
 from flask import jsonify, redirect
-from flask_restplus import inputs
+from flask_restx import inputs
 
 from flexget.api import APIResource, api
 from flexget.api.app import NotFoundError, etag

--- a/flexget/components/tvmaze/api.py
+++ b/flexget/components/tvmaze/api.py
@@ -1,5 +1,5 @@
 from flask import jsonify
-from flask_restplus import inputs
+from flask_restx import inputs
 
 from flexget.api import APIResource, api
 from flexget.api.app import BadRequest, NotFoundError, etag

--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ loguru>=0.4.1
 cherrypy>=18.0.0
 flask>=0.7
 flask-restful>=0.3.3
-flask-restplus==0.10.1
+flask-restx==0.2.0
 flask-compress>=1.2.1
 flask-login>=0.4.0
 flask-cors>=2.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ flask-compress==1.4.0     # via -r requirements.in
 flask-cors==3.0.2         # via -r requirements.in
 flask-login==0.4.0        # via -r requirements.in
 flask-restful==0.3.6      # via -r requirements.in
-flask-restplus==0.10.1    # via -r requirements.in
+flask-restx==0.2.0        # via -r requirements.in
 flask==1.0.2              # via -r requirements.in, flask-compress, flask-cors, flask-login, flask-restful, flask-restplus
 guessit==3.1.0            # via -r requirements.in
 html5lib==0.999999999     # via -r requirements.in


### PR DESCRIPTION
### Motivation for changes:
Flask-RESTPlus is abandoned, and is no longer compatible with the latest version of  werkzeug, on which it depends. The community has forked the project, and created Flask-RESTX, which seems to be a drop-in replacement.

### Detailed changes:
- change `flask-restplus==0.10.1` out for `flask-restx==0.2.0` (the latest stable release of flask-restx).
- change all references to `flask_restplus` to `flask_restx`

### Addressed issues:
- Fixes https://github.com/Flexget/Flexget/issues/2681 .

#### To Do:

- The API test `test_crash_logs_without_crash_log` fails, but the same seems to happen with `develop`, so I think that test was already broken

