### PR TITLE
Compatibility update for CloudScraper 1.2.40

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -26,7 +26,7 @@ flask-restplus==0.10.1
 flask-compress>=1.2.1
 flask-login>=0.4.0
 flask-cors>=2.1.2
-pyparsing>=2.0.3
+pyparsing>=2.4.7
 zxcvbn-python
 progressbar==2.5
 more-itertools

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ plumbum==1.6.3            # via rpyc
 portend==2.6              # via cherrypy
 progressbar==2.5          # via -r requirements.in
 pynzb==0.1.0              # via -r requirements.in
-pyparsing==2.2.0          # via -r requirements.in
+pyparsing==2.4.7          # via -r requirements.in
 pyrss2gen==1.1            # via -r requirements.in
 python-dateutil==2.6.1    # via -r requirements.in, aniso8601, guessit
 pytz==2017.2              # via apscheduler, flask-restful, flask-restplus, tempora, tzlocal


### PR DESCRIPTION
### Motivation for changes:
Solving dependency conflict between Flexget and CloudScraper
### Detailed changes:
- Updated `pyparsing==2.2.0` to `pyparsing==2.4.7` on `requirements.in` and `requirements.txt`

### Addressed issues:
- Fixes #2666 .
