### PR TITLE
Expand scope of disable plugin

### DIFF
--- a/flexget/components/estimate_release/estimate_release.py
+++ b/flexget/components/estimate_release/estimate_release.py
@@ -21,9 +21,13 @@ class EstimateRelease:
         """
 
         logger.debug(entry['title'])
-        estimators = [
-            e.instance.estimate for e in plugin.get_plugins(interface='estimate_release')
-        ]
+        # If the entry is in a task context, use the task interface to get estimator plugins, so that we don't get ones
+        # that are disabled on that task.
+        if entry.task:
+            get_plugins = entry.task.get_plugins
+        else:
+            get_plugins = plugin.get_plugins
+        estimators = [e.instance.estimate for e in get_plugins(interface='estimate_release')]
         for estimator in sorted(
             estimators, key=lambda e: getattr(e, 'priority', plugin.PRIORITY_DEFAULT), reverse=True
         ):

--- a/flexget/components/series/configure_series.py
+++ b/flexget/components/series/configure_series.py
@@ -6,6 +6,7 @@ from flexget.event import event
 from flexget.plugin import PluginError
 
 from . import series as plugin_series
+from ...utils.tools import aggregate_inputs
 
 logger = logger.bind(name='configure_series')
 
@@ -46,38 +47,26 @@ class ConfigureSeries(plugin_series.FilterSeriesBase):
     def on_task_prepare(self, task, config):
 
         series = {}
-        for input_name, input_config in config.get('from', {}).items():
-            input_plugin = plugin.get_plugin_by_name(input_name)
-            method = input_plugin.phase_handlers['input']
-            try:
-                result = method(task, input_config)
-            except PluginError as e:
-                logger.warning('Error during input plugin {}: {}', input_name, e)
-                continue
-            if not result:
-                logger.warning('Input {} did not return anything', input_name)
-                continue
+        for entry in aggregate_inputs(task, [config.get('from', {})]):
+            s = series.setdefault(entry['title'], {})
+            if entry.get('tvdb_id'):
+                s['set'] = {'tvdb_id': entry['tvdb_id']}
 
-            for entry in result:
-                s = series.setdefault(entry['title'], {})
-                if entry.get('tvdb_id'):
-                    s['set'] = {'tvdb_id': entry['tvdb_id']}
-
-                # Allow configure_series to set anything available to series
-                for key, schema in self.settings_schema['properties'].items():
-                    if 'configure_series_' + key in entry:
-                        errors = process_config(
-                            entry['configure_series_' + key], schema, set_defaults=False
+            # Allow configure_series to set anything available to series
+            for key, schema in self.settings_schema['properties'].items():
+                if 'configure_series_' + key in entry:
+                    errors = process_config(
+                        entry['configure_series_' + key], schema, set_defaults=False
+                    )
+                    if errors:
+                        logger.debug(
+                            'not setting series option {} for {}. errors: {}',
+                            key,
+                            entry['title'],
+                            errors,
                         )
-                        if errors:
-                            logger.debug(
-                                'not setting series option {} for {}. errors: {}',
-                                key,
-                                entry['title'],
-                                errors,
-                            )
-                        else:
-                            s[key] = entry['configure_series_' + key]
+                    else:
+                        s[key] = entry['configure_series_' + key]
 
         if not series:
             logger.info('Did not get any series to generate series configuration')

--- a/flexget/components/sites/urlrewrite_search.py
+++ b/flexget/components/sites/urlrewrite_search.py
@@ -43,7 +43,7 @@ class PluginSearch:
             return
 
         plugins = {}
-        for p in plugin.get_plugins(interface='search'):
+        for p in task.get_plugins(interface='search'):
             plugins[p.name] = p.instance
 
         # search accepted

--- a/flexget/components/sites/urlrewriting.py
+++ b/flexget/components/sites/urlrewriting.py
@@ -35,7 +35,7 @@ class PluginUrlRewriting:
     # API method
     def url_rewritable(self, task, entry):
         """Return True if entry is urlrewritable by registered rewriter."""
-        for urlrewriter in plugin.get_plugins(interface='urlrewriter'):
+        for urlrewriter in task.get_plugins(interface='urlrewriter'):
             if urlrewriter.name in self.disabled_rewriters:
                 logger.trace("Skipping rewriter {} since it's disabled", urlrewriter.name)
                 continue
@@ -56,7 +56,7 @@ class PluginUrlRewriting:
                     'URL rewriting was left in infinite loop while rewriting url for %s, '
                     'some rewriter is returning always True' % entry
                 )
-            for urlrewriter in plugin.get_plugins(interface='urlrewriter'):
+            for urlrewriter in task.get_plugins(interface='urlrewriter'):
                 name = urlrewriter.name
                 if name in self.disabled_rewriters:
                     logger.trace("Skipping rewriter {} since it's disabled", name)

--- a/flexget/plugins/filter/if_condition.py
+++ b/flexget/plugins/filter/if_condition.py
@@ -82,7 +82,11 @@ class FilterIf:
 
                     methods = {}
                     for plugin_name, plugin_config in action.items():
-                        p = plugin.get_plugin_by_name(plugin_name)
+                        try:
+                            p = task.get_plugin_by_name(plugin_name)
+                        except ValueError as e:
+                            logger.debug('{}', e)
+                            continue
                         method = p.phase_handlers.get(phase)
                         if method:
                             methods[method] = (fake_task, plugin_config)

--- a/flexget/plugins/filter/proper_movies.py
+++ b/flexget/plugins/filter/proper_movies.py
@@ -82,7 +82,7 @@ class FilterProperMovies:
                 raise plugin.PluginError('Invalid time format', logger)
 
         # throws DependencyError if not present aborting task
-        imdb_lookup = plugin.get_plugin_by_name('imdb_lookup').instance
+        imdb_lookup = task.get_plugin_by_name('imdb_lookup').instance
 
         for entry in task.entries:
             parser = plugin.get('parsing', self).parse_movie(entry['title'])

--- a/flexget/plugins/input/inputs.py
+++ b/flexget/plugins/input/inputs.py
@@ -2,6 +2,7 @@ from loguru import logger
 
 from flexget import plugin
 from flexget.event import event
+from flexget.utils.tools import aggregate_inputs
 
 logger = logger.bind(name='inputs')
 
@@ -33,37 +34,7 @@ class PluginInputs:
     }
 
     def on_task_input(self, task, config):
-        entry_titles = set()
-        entry_urls = set()
-        for item in config:
-            for input_name, input_config in item.items():
-                input = plugin.get_plugin_by_name(input_name)
-                method = input.phase_handlers['input']
-                try:
-                    result = method(task, input_config)
-                except plugin.PluginError as e:
-                    logger.warning('Error during input plugin {}: {}', input_name, e)
-                    continue
-                if not result:
-                    msg = 'Input %s did not return anything' % input_name
-                    if getattr(task, 'no_entries_ok', False):
-                        logger.verbose(msg)
-                    else:
-                        logger.warning(msg)
-                    continue
-                for entry in result:
-                    if entry['title'] in entry_titles:
-                        logger.debug('Title `{}` already in entry list, skipping.', entry['title'])
-                        continue
-                    urls = ([entry['url']] if entry.get('url') else []) + entry.get('urls', [])
-                    if any(url in entry_urls for url in urls):
-                        logger.debug(
-                            'URL for `{}` already in entry list, skipping.', entry['title']
-                        )
-                        continue
-                    yield entry
-                    entry_titles.add(entry['title'])
-                    entry_urls.update(urls)
+        return aggregate_inputs(task, config)
 
 
 @event('plugin.register')

--- a/flexget/plugins/input/limit.py
+++ b/flexget/plugins/input/limit.py
@@ -35,7 +35,11 @@ class PluginLimit:
 
     def on_task_input(self, task, config):
         for input_name, input_config in config['from'].items():
-            input = plugin.get_plugin_by_name(input_name)
+            try:
+                input = task.get_plugin_by_name(input_name)
+            except ValueError as e:
+                logger.debug('{}', e)
+                continue
             method = input.phase_handlers['input']
             try:
                 result = method(task, input_config)

--- a/flexget/plugins/operate/sequence.py
+++ b/flexget/plugins/operate/sequence.py
@@ -34,7 +34,11 @@ class PluginSequence:
             for item in config:
                 for plugin_name, plugin_config in item.items():
                     if phase in plugin.get_phases_by_plugin(plugin_name):
-                        method = plugin.get_plugin_by_name(plugin_name).phase_handlers[phase]
+                        try:
+                            method = task.get_plugin_by_name(plugin_name).phase_handlers[phase]
+                        except ValueError as exc:
+                            logger.debug('{}', exc)
+                            continue
                         logger.debug('Running plugin {}', plugin_name)
                         result = method(task, plugin_config)
                         if phase == 'input' and result:

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -508,7 +508,12 @@ def aggregate_inputs(task: 'Task', inputs: List[dict]) -> List['Entry']:
     entry_locations = set()
     for item in inputs:
         for input_name, input_config in item.items():
-            input = plugin.get_plugin_by_name(input_name)
+            try:
+                input = task.get_plugin_by_name(input_name)
+            except ValueError as e:
+                # Plugin is disabled in this task
+                logger.debug('Error getting `{}` plugin: {}', input_name, e)
+                continue
             method = input.phase_handlers['input']
             try:
                 result = method(task, input_config)


### PR DESCRIPTION
### Motivation for changes:
This is a revival of #2295. Part of that PR I already merged in because it made sense and the old way was causing bugs. e8a474654672caf6c667a5e40c3dde5c8000f5fc Right now, it's hard or impossible to disable certain plugins like estimators or urlrewriters which don't get configured directly in a task. disable plugin also does not currently work for plugins that are run by other plugins. e.g. inside sequence, or configure_series, or limit

### Detailed changes:

- Adds get_plugin_by_name method to `Task`s. This throws a ValueError if the plugin is disabled. (is that the best error to throw?)
- Adds get_plugins method to `Task`s. This just skips any plugins disabled on that task.
Any plugins should use these methods over the functions provided in `flexget.plugin` when executing anything in a task context.

TODO:
- [ ] Decide if this is good.
- [ ] Update disable_urlrewriters plugin in favor of this method.
- [ ] Add some more tests
- [ ] Make it work for parsers?
- [ ] Make it work for the movie_metainfo plugins?