### PR TITLE
[fix] manual: actually allow running in from_task context

### DIFF
--- a/flexget/plugins/operate/manual.py
+++ b/flexget/plugins/operate/manual.py
@@ -18,10 +18,8 @@ class ManualTask:
             return
         # If --task hasn't been specified disable this plugin
         if (
-            not task.options.tasks
-            or task.name not in task.options.tasks
-            or not task.options.allow_manual
-        ):
+            not task.options.tasks or task.name not in task.options.tasks
+        ) and not task.options.allow_manual:
             logger.debug(
                 'Disabling task {}, task can only run in manual mode (via API/CLI)', task.name
             )

--- a/flexget/tests/test_from_task.py
+++ b/flexget/tests/test_from_task.py
@@ -2,6 +2,7 @@ class TestFromTask(object):
     config = """
         tasks:
           subtask:
+            manual: yes
             mock:
             - title: subtask entry 1
               other_field: 5


### PR DESCRIPTION
### Motivation for changes:

`from_task` + `manual` is documented to work, and was clearly designed to work, but doesn't actually work because the boolean logic checking the `allow_manual` option is broken.

cc @gazpachoking who implemented `from_task`

### Detailed changes:
- Fixed the broken boolean logic
- Modified the from_task test to actually exercise this code path.

(Note: also re-formatted with Black.)