### PR TITLE
[fix] filelist_api: NameError: name 'valid_extras'

### DIFF
--- a/flexget/components/sites/sites/filelist_api.py
+++ b/flexget/components/sites/sites/filelist_api.py
@@ -99,7 +99,7 @@ class SearchFileList:
             )
 
         # extras: internal release, moderated torrent, freeleech
-        params.update({extra: 1 for extra in valid_extras if config.get(extra)})
+        params.update({extra: 1 for extra in self.valid_extras if config.get(extra)})
 
         # set season/episode if series
         if entry.get('series_episode'):


### PR DESCRIPTION
Fixes a crash in the new `filelist_api` plugin:

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/flexget/task.py", line 535, in __run_plugin
    result = method(*args, **kwargs)
  File "/usr/lib/python3.8/site-packages/flexget/event.py", line 22, in __call__
    return self.func(*args, **kwargs)
  File "/usr/lib/python3.8/site-packages/flexget/plugins/input/discover.py", line 294, in on_task_input
    return self.execute_searches(config, entries, task)
  File "/usr/lib/python3.8/site-packages/flexget/plugins/input/discover.py", line 134, in execute_searches
    search_results = search.search(task=task, entry=entry, config=plugin_config)
  File "/usr/lib/python3.8/site-packages/flexget/plugin.py", line 127, in wrapped_func
    return func(*args, **kwargs)
  File "/usr/lib/python3.8/site-packages/flexget/components/sites/sites/filelist_api.py", line 102, in search
    params.update({extra: 1 for extra in valid_extras if config.get(extra)})
NameError: name 'valid_extras' is not defined
```

Done through the GitHub UI, so I haven't tested this, but it sure seems like a simple and obvious fix.

### Motivation for changes:

### Detailed changes:
- 

### Addressed issues:
- Fixes # .

### Implemented feature requests:
- Feathub #[XX](https://feathub.com/Flexget/Flexget/+XX).

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
```
paste output here
```
#### To Do:

- [ ] Stuff..

