### PR TITLE
Imdb watchlist html parser fix

### DIFF
--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -178,7 +178,7 @@ class ImdbWatchlist:
         page = self.fetch_page(task, url, params, headers)
         soup = get_soup(page.text)
         try:
-            item_text = soup.find('div', class_='lister-total-num-results').string.split()
+            item_text = soup.find('div', {'class': ['lister-list-length', 'lister-total-num-results']}).text.split()
             total_item_count = int(item_text[0].replace(',', ''))
             logger.verbose('imdb list contains {} items', total_item_count)
         except AttributeError:

--- a/flexget/components/sites/sites/piratebay.py
+++ b/flexget/components/sites/sites/piratebay.py
@@ -8,12 +8,15 @@ from flexget.components.sites.urlrewriting import UrlRewritingError
 from flexget.components.sites.utils import normalize_unicode, torrent_availability
 from flexget.entry import Entry
 from flexget.event import event
-from flexget.utils.soup import get_soup
+
 from flexget.utils.tools import parse_filesize
+
+import json
+from urllib.parse import urlparse, parse_qs, urlencode
 
 logger = logger.bind(name='piratebay')
 
-URL = 'https://thepiratebay.org'
+URL = 'https://apibay.org' # for TOR: http://piratebayztemzmv.onion
 
 CATEGORIES = {
     'all': 0,
@@ -27,13 +30,26 @@ CATEGORIES = {
     'comics': 602,
 }
 
+# try to maintain compatibility with old config
 SORT = {
-    'default': 99,  # This is piratebay default, not flexget default.
-    'date': 3,
-    'size': 5,
-    'seeds': 7,
-    'leechers': 9,
+    'default': 'torrent_availability',
+    'date': 'torrent_timestamp',
+    'size': 'content_size',
+    'seeds': 'torrent_seeds',
+    'leechers': 'torrent_leeches',
 }
+
+# default trackers for magnet links
+TRACKERS = [
+    'udp://tracker.coppersurfer.tk:6969/announce',
+    'udp://9.rarbg.to:2920/announce',
+    'udp://tracker.opentrackr.org:1337',
+    'udp://tracker.internetwarriors.net:1337/announce',
+    'udp://tracker.leechers-paradise.org:6969/announce',
+    'udp://tracker.coppersurfer.tk:6969/announce',
+    'udp://tracker.pirateparty.gr:6969/announce',
+    'udp://tracker.cyberia.is:6969/announce',
+]
 
 
 class UrlRewritePirateBay:
@@ -75,11 +91,12 @@ class UrlRewritePirateBay:
         if self.url != url:
             self.url = url
             parsed_url = urlparse(url)
+            # most api mirrors share the same domain with frontend, except thepiratebay.org which uses apibay.org
             self.url_match = re.compile(
-                r'^%s://(?:torrents\.)?(%s)/.*$'
+                r'^%s://(?:[a-z0-9]+\.)?(?:thepiratebay\.org(?:\:\d+)?|%s)/description\.php\?id=(\d+)$'
                 % (re.escape(parsed_url.scheme), re.escape(parsed_url.netloc))
             )
-            self.url_search = re.compile(r'^%s/search/.*$' % (re.escape(url)))
+            self.url_search = re.compile(r'^(?:thepiratebay\.org(?:\:\d+)?|%s)/search\.php\?q=.*$' % (re.escape(url)))
 
     # urlrewriter API
     def url_rewritable(self, task, entry):
@@ -102,25 +119,15 @@ class UrlRewritePirateBay:
             # TODO: Close matching was taken out of search methods, this may need to be fixed to be more picky
             entry['url'] = results[0]['url']
         else:
-            # parse download page
-            entry['url'] = self.parse_download_page(entry['url'], task.requests)
-
-    @plugin.internet(logger)
-    def parse_download_page(self, url, requests):
-        page = requests.get(url).content
-        try:
-            soup = get_soup(page)
-            tag_div = soup.find('div', attrs={'class': 'download'})
-            if not tag_div:
-                raise UrlRewritingError('Unable to locate download link from url %s' % url)
-            tag_a = tag_div.find('a')
-            torrent_url = tag_a.get('href')
-            # URL is sometimes missing the schema
-            if torrent_url.startswith('//'):
-                torrent_url = urlparse(url).scheme + ':' + torrent_url
-            return torrent_url
-        except Exception as e:
-            raise UrlRewritingError(e)
+            torrent_id = self.url_match.match(entry['url']).group(1)
+            url = '%s/t.php?id=%s' % (self.url, torrent_id)
+            logger.debug('Getting info for torrent ID {}', torrent_id)
+            page = task.requests.get(url).content
+            json_result = json.loads(page)[0]
+            if json_result['id'] == '0':
+                raise UrlRewritingError("Torrent with ID does not exist.")
+            else:
+                entry['url'] = UrlRewritePirateBay.info_hash_to_magnet(json_result['info_hash'], json_result['name'])
 
     @plugin.internet(logger)
     def search(self, task, entry, config=None):
@@ -130,76 +137,80 @@ class UrlRewritePirateBay:
         if not isinstance(config, dict):
             config = {}
         self.set_urls(config.get('url', URL))
-        sort = SORT.get(config.get('sort_by', 'seeds'))
-        if config.get('sort_reverse'):
-            sort += 1
+        sort = SORT.get(config.get('sort_by', 'default'))
+        sort_reverse = bool(config.get('sort_reverse', 'True'))
         if isinstance(config.get('category'), int):
             category = config['category']
         else:
             category = CATEGORIES.get(config.get('category', 'all'))
-        filter_url = '/0/%d/%d' % (sort, category)
+        filter_url = '&cat=%s' % category
 
         entries = set()
         for search_string in entry.get('search_strings', [entry['title']]):
             query = normalize_unicode(search_string)
 
             # TPB search doesn't like dashes or quotes
-            query = query.replace('-', ' ').replace("'", " ")
+            # query = query.replace('-', ' ').replace("'", " ")
 
             # urllib.quote will crash if the unicode string has non ascii characters, so encode in utf-8 beforehand
-            url = '%s/search/%s%s' % (self.url, quote(query.encode('utf-8')), filter_url)
+            url = '%s/q.php?q=%s%s' % (self.url, quote(query.encode('utf-8')), filter_url)
             logger.debug('Using {} as piratebay search url', url)
             page = task.requests.get(url).content
-            soup = get_soup(page)
-            for link in soup.find_all('a', attrs={'class': 'detLink'}):
-                entry = Entry()
-                entry['title'] = self.extract_title(link)
-                if not entry['title']:
-                    logger.error('Malformed search result. No title or url found. Skipping.')
-                    continue
-                href = link.get('href')
-                if href.startswith('/'):  # relative link?
-                    href = self.url + href
-                entry['url'] = href
-                row = link.parent.parent.parent
-                description = row.find_all('a', attrs={'class': 'detDesc'})
-                if description and description[0].contents[0] == "piratebay ":
-                    logger.debug('Advertisement entry. Skipping.')
-                    continue
-                tds = row.find_all('td')
-                entry['torrent_seeds'] = int(tds[-2].contents[0])
-                entry['torrent_leeches'] = int(tds[-1].contents[0])
-                entry['torrent_availability'] = torrent_availability(
-                    entry['torrent_seeds'], entry['torrent_leeches']
-                )
-                # Parse content_size
-                size_text = link.find_next(attrs={'class': 'detDesc'}).get_text()
-                if size_text:
-                    size = re.search(r'Size (\d+(\.\d+)?\xa0(?:[PTGMK])?i?B)', size_text)
-                    if size:
-                        entry['content_size'] = parse_filesize(size.group(1))
-                    else:
-                        logger.error(
-                            'Malformed search result? Title: "{}", No size? {}',
-                            entry['title'],
-                            size_text,
-                        )
+            json_results = json.loads(page)
+            if len(json_results) == 0:
+                logger.error("Error while searching piratebay for %s." % search_string)
+            for result in json_results:
+                if result['id'] == '0':
+                    # JSON when no results found:
+                    # [{
+                    #    "id":"0",
+                    #    "name":"No results returned",
+                    #    "info_hash":"0000000000000000000000000000000000000000",
+                    #    "leechers":"0",
+                    #    "seeders":"0",
+                    #    "num_files":"0",
+                    #    "size":"0",
+                    #    "username":"",
+                    #    "added":"0",
+                    #    "status":"member",
+                    #    "category":"0",
+                    #    "imdb":"",
+                    #    "total_found":"1"
+                    # }]
+                    break
+                try:
+                    entry = Entry()
+                    entry['title'] = result['name']
+                    entry['torrent_seeds'] = int(result['seeders'])
+                    entry['torrent_leeches'] = int(result['leechers'])
+                    entry['torrent_timestamp'] = int(result['added'])
+                    entry['torrent_availability'] = torrent_availability(
+                        entry['torrent_seeds'], entry['torrent_leeches']
+                    )
+                    entry['content_size'] = result['size']
+                    entry['torrent_info_hash'] = result['info_hash']
+                    entry['url'] = UrlRewritePirateBay.info_hash_to_magnet(result['info_hash'], result['name'])
+                except KeyError:
+                    logger.error("Error when parsing an entry.")
 
                 entries.add(entry)
 
-        return sorted(entries, reverse=True, key=lambda x: x.get('torrent_availability'))
+        return sorted(entries, reverse=sort_reverse, key=lambda x: x.get(sort))
 
     @staticmethod
-    def extract_title(soup):
-        """Sometimes search results have no contents. This function tries to extract something sensible."""
-        if isinstance(soup.contents, list) and soup.contents:
-            return soup.contents[0]
-        if soup.get('href') and 'torrent' in soup.get('href'):
-            return soup.get('href').rsplit('/', 1)[-1]
-
+    def info_hash_to_magnet(info_hash, name):
+        magnet = {
+            'xt': f"urn:btih:{info_hash}",
+            'dn': name,
+            'tr': TRACKERS
+        }
+        magnet_qs = urlencode(magnet, doseq=True, safe=':')
+        magnet_uri = f"magnet:?{magnet_qs}"
+        return magnet_uri
 
 @event('plugin.register')
 def register_plugin():
     plugin.register(
         UrlRewritePirateBay, 'piratebay', interfaces=['urlrewriter', 'search', 'task'], api_ver=2
     )
+


### PR DESCRIPTION
### Motivation for changes:
imdb_watchlist fails to retrieve list 'ratings' because soup is unable to detect correct total_item_count. Different div classes are used for 'ratings' and 'lsXXXXXXXXX'.

### Detailed changes:
- Update parser to locate correct total_item_count on both lists.

### Addressed issues:
- Fixes list: ratings. All lists should now work as expected.

### Log and/or tests output (preferably both):
This is the log when retrieving list: ratings from imdb_watchlist
```
C:\Users\tuant\PycharmProjects\Flexget\venv\Scripts\python.exe C:/Users/tuant/PycharmProjects/Flexget/flexget_vanilla.py --loglevel=debug -c test-imdb_watchlist.yml execute --discover-now --now --no-cache
2020-08-04 16:58:01 DEBUG    manager                       Figuring out config load paths
2020-08-04 16:58:01 DEBUG    manager                       Found config: C:\Users\tuant\PycharmProjects\Flexget\test-imdb_watchlist.yml
2020-08-04 16:58:01 DEBUG    manager                       Config file C:\Users\tuant\PycharmProjects\Flexget\test-imdb_watchlist.yml selected
2020-08-04 16:58:01 DEBUG    manager                       sys.defaultencoding: utf-8
2020-08-04 16:58:01 DEBUG    manager                       sys.getfilesystemencoding: utf-8
2020-08-04 16:58:01 DEBUG    manager                       flexget detected io encoding: utf-8
2020-08-04 16:58:01 DEBUG    manager                       os.path.supports_unicode_filenames: True
2020-08-04 16:58:01 DEBUG    plugin                        Trying to load plugins from: ['C:\\Users\\tuant\\PycharmProjects\\Flexget\\plugins', 'C:\\Users\\tuant\\PycharmProjects\\Flexget\\flexget\\plugins']
2020-08-04 16:58:02 DEBUG    plugin                        Plugin `memusage` requires plugin `ext lib `guppy`` to load.
2020-08-04 16:58:02 DEBUG    plugin                        Trying to load components from: ['C:\\Users\\tuant\\PycharmProjects\\Flexget\\components', 'C:\\Users\\tuant\\PycharmProjects\\Flexget\\flexget\\components']
2020-08-04 16:58:02 DEBUG    plugin                        Plugins took 1.71 seconds to load. 306 plugins in registry.
2020-08-04 16:58:02 DEBUG    manager                       Connecting to: sqlite:///C:\\Users\\tuant\\PycharmProjects\\Flexget\\db-test-imdb_watchlist.sqlite
2020-08-04 16:58:02 DEBUG    manager                       config_name: test-imdb_watchlist
2020-08-04 16:58:02 DEBUG    manager                       config_base: C:\Users\tuant\PycharmProjects\Flexget
2020-08-04 16:58:02 DEBUG    manager                       New config data loaded.
2020-08-04 16:58:02 DEBUG    schema                        current flexget version already exist in db 3.1.68.dev
2020-08-04 16:58:02 DEBUG    parsing                       setting default movie parser to internal. (options: {'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x06B61880>, 'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x06B61940>})
2020-08-04 16:58:02 DEBUG    parsing                       setting default series parser to internal. (options: {'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x06B61880>, 'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x06B61940>})
2020-08-04 16:58:02 DEBUG    cron_env                      Encoding utf-8 stored
2020-08-04 16:58:02 DEBUG    util.simple_persistence                 setting key terminal_encoding value 'utf-8'
2020-08-04 16:58:02 DEBUG    task_queue                    task queue shutdown requested
2020-08-04 16:58:02 VERBOSE  task_queue                    There are 1 tasks to execute. Shutdown will commence when they have completed.
2020-08-04 16:58:02 INFO     ipc.rpyc                      server started on [127.0.0.1]:5947
2020-08-04 16:58:02 DEBUG    task          test-imdb_watchlist executing test-imdb_watchlist
2020-08-04 16:58:03 DEBUG    remember_rej  test-imdb_watchlist Task config has changed since last run, purging remembered entries.
2020-08-04 16:58:03 DEBUG    input_cache   test-imdb_watchlist cache name: imdb_watchlist_XXXXXXXXXXXXXXXXXXXX (has: )
2020-08-04 16:58:03 VERBOSE  imdb_watchlist test-imdb_watchlist Retrieving imdb list: ratings
2020-08-04 16:58:03 DEBUG    imdb_watchlist test-imdb_watchlist Requesting: http://www.imdb.com/user/urXXXXXXXX/ratings {'Accept-Language': 'en-us'}
2020-08-04 16:58:03 DEBUG    utils.requests test-imdb_watchlist GETing URL http://www.imdb.com/user/urXXXXXXXX/ratings with args () and kwargs {'params': {'view': 'detail', 'page': 1}, 'headers': {'Accept-Language': 'en-us'}, 'allow_redirects': True, 'timeout': 30}
2020-08-04 16:58:10 VERBOSE  imdb_watchlist test-imdb_watchlist No movies were found in imdb list: ratings
2020-08-04 16:58:10 DEBUG    input_cache   test-imdb_watchlist storing entries to cache imdb_watchlist_XXXXXXXXXXXXXXXXXXXX 
2020-08-04 16:58:10 CRITICAL task          test-imdb_watchlist BUG: Unhandled error in plugin imdb_watchlist: 'NoneType' object is not iterable
Traceback (most recent call last):

  File "C:\Users\tuant\AppData\Local\Programs\Python\Python38-32\lib\threading.py", line 890, in _bootstrap
    self._bootstrap_inner()
    |    -> <function Thread._bootstrap_inner at 0x031C1580>
    -> <Thread(task_queue, started daemon 13740)>

  File "C:\Users\tuant\AppData\Local\Programs\Python\Python38-32\lib\threading.py", line 932, in _bootstrap_inner
    self.run()
    |    -> <function Thread.run at 0x031C1418>
    -> <Thread(task_queue, started daemon 13740)>

  File "C:\Users\tuant\AppData\Local\Programs\Python\Python38-32\lib\threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
    |    |        |    |        |    -> {}
    |    |        |    |        -> <Thread(task_queue, started daemon 13740)>
    |    |        |    -> ()
    |    |        -> <Thread(task_queue, started daemon 13740)>
    |    -> <bound method TaskQueue.run of <flexget.task_queue.TaskQueue object at 0x06B7ABC8>>
    -> <Thread(task_queue, started daemon 13740)>

  File "C:\Users\tuant\PycharmProjects\Flexget\flexget\task_queue.py", line 46, in run
    self.current_task.execute()
    |    |            -> <function Task.execute at 0x04880418>
    |    -> <flexget.task.Task object at 0x06DC10E8>
    -> <flexget.task_queue.TaskQueue object at 0x06B7ABC8>

  File "C:\Users\tuant\PycharmProjects\Flexget\flexget\task.py", line 80, in wrapper
    return func(self, *args, **kw)
           |    |      |       -> {}
           |    |      -> ()
           |    -> <flexget.task.Task object at 0x06DC10E8>
           -> <function Task.execute at 0x048803D0>

  File "C:\Users\tuant\PycharmProjects\Flexget\flexget\task.py", line 710, in execute
    self._execute()
    |    -> <function Task._execute at 0x04880388>
    -> <flexget.task.Task object at 0x06DC10E8>

  File "C:\Users\tuant\PycharmProjects\Flexget\flexget\task.py", line 676, in _execute
    self.__run_task_phase(phase)
    |                     -> 'input'
    -> <flexget.task.Task object at 0x06DC10E8>

  File "C:\Users\tuant\PycharmProjects\Flexget\flexget\task.py", line 502, in __run_task_phase
    response = self.__run_plugin(plugin, phase, args)
               |                 |       |      -> (<flexget.task.Task object at 0x06DC10E8>, {'user_id': 'urXXXXXXXX', 'list': 'ratings', 'force_language': 'en-us', 'type': ['...
               |                 |       -> 'input'
               |                 -> <PluginInfo(name=imdb_watchlist)>
               -> <flexget.task.Task object at 0x06DC10E8>

> File "C:\Users\tuant\PycharmProjects\Flexget\flexget\task.py", line 535, in __run_plugin
    result = method(*args, **kwargs)
             |       |       -> {}
             |       -> (<flexget.task.Task object at 0x06DC10E8>, {'user_id': 'urXXXXXXXX', 'list': 'ratings', 'force_language': 'en-us', 'type': ['...
             -> <Event(name=plugin.imdb_watchlist.input,func=wrapped_func,priority=128)>

  File "C:\Users\tuant\PycharmProjects\Flexget\flexget\event.py", line 22, in __call__
    return self.func(*args, **kwargs)
           |    |     |       -> {}
           |    |     -> (<flexget.task.Task object at 0x06DC10E8>, {'user_id': 'urXXXXXXXX', 'list': 'ratings', 'force_language': 'en-us', 'type': ['...
           |    -> <bound method cached.__call__.<locals>.wrapped_func of <flexget.components.imdb.imdb_watchlist.ImdbWatchlist object at 0x06B5...
           -> <Event(name=plugin.imdb_watchlist.input,func=wrapped_func,priority=128)>

  File "C:\Users\tuant\PycharmProjects\Flexget\flexget\utils\cached_input.py", line 166, in wrapped_func
    cache = IterableCache(response, self.store_to_db if self.persist else None)
            |             |         |    |              |    -> datetime.timedelta(seconds=7200)
            |             |         |    |              -> <flexget.utils.cached_input.cached object at 0x0632D358>
            |             |         |    -> <function cached.store_to_db at 0x05687A48>
            |             |         -> <flexget.utils.cached_input.cached object at 0x0632D358>
            |             -> None
            -> <class 'flexget.utils.cached_input.IterableCache'>

  File "C:\Users\tuant\PycharmProjects\Flexget\flexget\utils\cached_input.py", line 213, in __init__
    self.iterable = iter(iterable)
    |                    -> None
    -> <flexget.utils.cached_input.IterableCache object at 0x072409D0>

TypeError: 'NoneType' object is not iterable
2020-08-04 16:58:10 CRITICAL manager       test-imdb_watchlist An unexpected crash has occurred. Writing crash report to C:\Users\tuant\PycharmProjects\Flexget\crash_report.2020.08.04.165810796082.log. Please verify you are running the latest version of flexget by using "flexget -V" from CLI or by using version_checker plugin at http://flexget.com/wiki/Plugins/version_checker. You are currently using version 3.1.68.dev
2020-08-04 16:58:10 DEBUG    manager       test-imdb_watchlist Traceback:
Traceback (most recent call last):

  File "C:\Users\tuant\AppData\Local\Programs\Python\Python38-32\lib\threading.py", line 890, in _bootstrap
    self._bootstrap_inner()
    |    -> <function Thread._bootstrap_inner at 0x031C1580>
    -> <Thread(task_queue, started daemon 13740)>

  File "C:\Users\tuant\AppData\Local\Programs\Python\Python38-32\lib\threading.py", line 932, in _bootstrap_inner
    self.run()
    |    -> <function Thread.run at 0x031C1418>
    -> <Thread(task_queue, started daemon 13740)>

  File "C:\Users\tuant\AppData\Local\Programs\Python\Python38-32\lib\threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
    |    |        |    |        |    -> {}
    |    |        |    |        -> <Thread(task_queue, started daemon 13740)>
    |    |        |    -> ()
    |    |        -> <Thread(task_queue, started daemon 13740)>
    |    -> <bound method TaskQueue.run of <flexget.task_queue.TaskQueue object at 0x06B7ABC8>>
    -> <Thread(task_queue, started daemon 13740)>

  File "C:\Users\tuant\PycharmProjects\Flexget\flexget\task_queue.py", line 46, in run
    self.current_task.execute()
    |    |            -> <function Task.execute at 0x04880418>
    |    -> <flexget.task.Task object at 0x06DC10E8>
    -> <flexget.task_queue.TaskQueue object at 0x06B7ABC8>

  File "C:\Users\tuant\PycharmProjects\Flexget\flexget\task.py", line 80, in wrapper
    return func(self, *args, **kw)
           |    |      |       -> {}
           |    |      -> ()
           |    -> <flexget.task.Task object at 0x06DC10E8>
           -> <function Task.execute at 0x048803D0>

  File "C:\Users\tuant\PycharmProjects\Flexget\flexget\task.py", line 710, in execute
    self._execute()
    |    -> <function Task._execute at 0x04880388>
    -> <flexget.task.Task object at 0x06DC10E8>

  File "C:\Users\tuant\PycharmProjects\Flexget\flexget\task.py", line 676, in _execute
    self.__run_task_phase(phase)
    |                     -> 'input'
    -> <flexget.task.Task object at 0x06DC10E8>

  File "C:\Users\tuant\PycharmProjects\Flexget\flexget\task.py", line 502, in __run_task_phase
    response = self.__run_plugin(plugin, phase, args)
               |                 |       |      -> (<flexget.task.Task object at 0x06DC10E8>, {'user_id': 'urXXXXXXXX', 'list': 'ratings', 'force_language': 'en-us', 'type': ['...
               |                 |       -> 'input'
               |                 -> <PluginInfo(name=imdb_watchlist)>
               -> <flexget.task.Task object at 0x06DC10E8>

> File "C:\Users\tuant\PycharmProjects\Flexget\flexget\task.py", line 535, in __run_plugin
    result = method(*args, **kwargs)
             |       |       -> {}
             |       -> (<flexget.task.Task object at 0x06DC10E8>, {'user_id': 'urXXXXXXXX', 'list': 'ratings', 'force_language': 'en-us', 'type': ['...
             -> <Event(name=plugin.imdb_watchlist.input,func=wrapped_func,priority=128)>

  File "C:\Users\tuant\PycharmProjects\Flexget\flexget\event.py", line 22, in __call__
    return self.func(*args, **kwargs)
           |    |     |       -> {}
           |    |     -> (<flexget.task.Task object at 0x06DC10E8>, {'user_id': 'urXXXXXXXX', 'list': 'ratings', 'force_language': 'en-us', 'type': ['...
           |    -> <bound method cached.__call__.<locals>.wrapped_func of <flexget.components.imdb.imdb_watchlist.ImdbWatchlist object at 0x06B5...
           -> <Event(name=plugin.imdb_watchlist.input,func=wrapped_func,priority=128)>

  File "C:\Users\tuant\PycharmProjects\Flexget\flexget\utils\cached_input.py", line 166, in wrapped_func
    cache = IterableCache(response, self.store_to_db if self.persist else None)
            |             |         |    |              |    -> datetime.timedelta(seconds=7200)
            |             |         |    |              -> <flexget.utils.cached_input.cached object at 0x0632D358>
            |             |         |    -> <function cached.store_to_db at 0x05687A48>
            |             |         -> <flexget.utils.cached_input.cached object at 0x0632D358>
            |             -> None
            -> <class 'flexget.utils.cached_input.IterableCache'>

  File "C:\Users\tuant\PycharmProjects\Flexget\flexget\utils\cached_input.py", line 213, in __init__
    self.iterable = iter(iterable)
    |                    -> None
    -> <flexget.utils.cached_input.IterableCache object at 0x072409D0>

TypeError: 'NoneType' object is not iterable
2020-08-04 16:58:10 WARNING  task          test-imdb_watchlist Aborting task (plugin: imdb_watchlist)
2020-08-04 16:58:10 DEBUG    task_queue                    task test-imdb_watchlist aborted: TaskAbort(reason=BUG: Unhandled error in plugin imdb_watchlist: 'NoneType' object is not iterable, silent=False)
2020-08-04 16:58:11 DEBUG    task_queue                    task queue shut down
2020-08-04 16:58:11 INFO     ipc.rpyc                      listener closed
2020-08-04 16:58:11 DEBUG    util.simple_persistence                 Flushing simple persistence for task None to db.
2020-08-04 16:58:11 INFO     ipc.rpyc                      server has terminated
2020-08-04 16:58:11 DEBUG    manager                       Shutting down
2020-08-04 16:58:11 DEBUG    manager                       Removed C:\Users\tuant\PycharmProjects\Flexget\.test-imdb_watchlist-lock

Process finished with exit code 0

```

