### PR TITLE
[Fix] respect base_url on v1

### DIFF
--- a/flexget/ui/v1/__init__.py
+++ b/flexget/ui/v1/__init__.py
@@ -45,7 +45,7 @@ def serve_app(path):
 @webui_app.route('/api/')
 @webui_app.route('/api/<path:path>', methods=HTTP_METHODS)
 def api_redirect(path='/'):
-    return redirect(request.full_path.replace('/v1', '', 1), 307)
+    return redirect(request.url.replace('/v1', '', 1), 307)
 
 
 @webui_app.route('/')


### PR DESCRIPTION
### Motivation for changes:
v1 didn't work with a base_url configured in v1. 

### Detailed changes:
- use url for the api redirect instead of full_path as `full_path` doesn't include the application prefix ([related docs](https://flask.palletsprojects.com/en/1.1.x/api/#flask.Request.full_path))

### Addressed issues:
- Fixes Flexget/webui#98

