### PR TITLE
add ettvcentral.com domain to ettv rewriter

### DIFF
--- a/flexget/components/sites/sites/ettv.py
+++ b/flexget/components/sites/sites/ettv.py
@@ -12,6 +12,7 @@ logger = logger.bind(name='ettv')
 DOMAINS = [
     'www.ettv.to',
     'www.ettvdl.com',
+    'www.ettvcentral.com',
 ]
 
 


### PR DESCRIPTION
### Motivation for changes:
ETTV has moved

### Detailed changes:
- add ettvcentral.com to the list of ETTV domains
