### PR TITLE
fix syntax of upgrade function

### DIFF
--- a/flexget/plugins/clients/pyload.py
+++ b/flexget/plugins/clients/pyload.py
@@ -152,7 +152,7 @@ class PluginPyLoad:
             remote_version = json.loads(api.get('getServerVersion').content)
         except RequestException as e:
             if e.response is not None and e.response.status_code == 404:
-                remote_version = json.loads(api.get('get_server_version').content)
+                remote_version = json.loads(api.get('getServerVersion').content)
             else:
                 raise e
 

--- a/flexget/plugins/clients/pyload.py
+++ b/flexget/plugins/clients/pyload.py
@@ -149,7 +149,7 @@ class PluginPyLoad:
 
         remote_version = None
         try:
-            remote_version = api.get('getServerVersion')
+            remote_version = json.loads(api.get('getServerVersion').content)
         except RequestException as e:
             if e.response is not None and e.response.status_code == 404:
                 remote_version = json.loads(api.get('get_server_version').content)

--- a/flexget/plugins/internal/api_rottentomatoes.py
+++ b/flexget/plugins/internal/api_rottentomatoes.py
@@ -32,7 +32,7 @@ MIN_DIFF = 0.01
 
 @db_schema.upgrade('api_rottentomatoes')
 def upgrade(ver, session):
-    if ver is 0:
+    if ver == 0:
         table_names = [
             'rottentomatoes_actors',
             'rottentomatoes_alternate_ids',
@@ -52,7 +52,7 @@ def upgrade(ver, session):
             session.execute(table.delete())
         table_add_column('rottentomatoes_actors', 'rt_id', String, session)
         ver = 1
-    if ver is 1:
+    if ver == 1:
         table = table_schema('rottentomatoes_search_results', session)
         session.execute(sql.delete(table, table.c.movie_id == None))
         ver = 2


### PR DESCRIPTION
### Motivation for changes:
Objective is fix this error:
`api_rottentomatoes.py:35: SyntaxWarning: "is" with a literal. Did you mean "=="?
`

### Detailed changes:
- `if ver is 0:` changed to `if ver == 0:`

### Addressed issues:
- Fixes # .
`api_rottentomatoes.py in line 35`
`api_rottentomatoes.py in line 55`

### Implemented feature requests:
- Feathub #[XX](https://feathub.com/Flexget/Flexget/+XX).

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
```
paste output here
```
#### To Do:

- [ ] Stuff..

