### PR TITLE
fix error in pyload plugin and identation in api_rottentomatoes

### DIFF
--- a/flexget/plugins/clients/pyload.py
+++ b/flexget/plugins/clients/pyload.py
@@ -152,7 +152,7 @@ class PluginPyLoad:
             remote_version = json.loads(api.get('getServerVersion').content)
         except RequestException as e:
             if e.response is not None and e.response.status_code == 404:
-                remote_version = json.loads(api.get('get_server_version').content)
+                remote_version = json.loads(api.get('getServerVersion').content)
             else:
                 raise e
 

--- a/flexget/plugins/clients/pyload.py
+++ b/flexget/plugins/clients/pyload.py
@@ -149,7 +149,7 @@ class PluginPyLoad:
 
         remote_version = None
         try:
-            remote_version = api.get('getServerVersion')
+            remote_version = json.loads(api.get('getServerVersion').content)
         except RequestException as e:
             if e.response is not None and e.response.status_code == 404:
                 remote_version = json.loads(api.get('get_server_version').content)

--- a/flexget/plugins/internal/api_rottentomatoes.py
+++ b/flexget/plugins/internal/api_rottentomatoes.py
@@ -32,7 +32,7 @@ MIN_DIFF = 0.01
 
 @db_schema.upgrade('api_rottentomatoes')
 def upgrade(ver, session):
-    if ver is 0:
+    if ver == 0:
         table_names = [
             'rottentomatoes_actors',
             'rottentomatoes_alternate_ids',
@@ -52,7 +52,7 @@ def upgrade(ver, session):
             session.execute(table.delete())
         table_add_column('rottentomatoes_actors', 'rt_id', String, session)
         ver = 1
-    if ver is 1:
+    if ver == 1:
         table = table_schema('rottentomatoes_search_results', session)
         session.execute(sql.delete(table, table.c.movie_id == None))
         ver = 2


### PR DESCRIPTION
### Motivation for changes:

In pyload.py the '.content' was missing to extract the version instead of the response code.

I didn't understand why the same request is repeated in the exception, but with a non-existent 'get_server_version' method instead of 'getServerVersion', I think it needs to be changed eventually, but in general now the plugin worked in my tests.

In 'api_rottentomatoes' the use of 'is' causes exception errors.

### Detailed changes:

```

        remote_version = None
        try:
-           remote_version = api.get('getServerVersion')
+           remote_version = json.loads(api.get('getServerVersion').content)
        except RequestException as e:
            if e.response is not None and e.response.status_code == 404:
-                remote_version = json.loads(api.get('get_server_version').content)
+               remote_version = json.loads(api.get('getServerVersion').content)
            else:
                raise e
```
__
```

@db_schema.upgrade('api_rottentomatoes')
def upgrade(ver, session):
-   if ver is 0:
+  if ver == 0:
        table_names = [
            'rottentomatoes_actors',
            'rottentomatoes_alternate_ids',
@@ -52,7 +52,7 @@ def upgrade(ver, session):
            session.execute(table.delete())
        table_add_column('rottentomatoes_actors', 'rt_id', String, session)
        ver = 1
-   if ver is 1:
+  if ver == 1:
        table = table_schema('rottentomatoes_search_results', session)
        session.execute(sql.delete(table, table.c.movie_id == None))
        ver = 2


```
### Addressed issues:
- Fixes # .

### Implemented feature requests:
- Feathub #[XX](https://feathub.com/Flexget/Flexget/+XX).

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
```
paste output here
```
#### To Do:

- [ ] Stuff..

