### PR TITLE
Torznab: Add timeout parameter

### DIFF
--- a/flexget/plugins/input/torznab.py
+++ b/flexget/plugins/input/torznab.py
@@ -165,7 +165,7 @@ class Torznab:
         logger.info('Fetching URL: {}', url)
 
         try:
-            response = task.requests.get(url, timeout=self.timeout))
+            response = task.requests.get(url, timeout=self.timeout)
         except RequestException as e:
             raise PluginError("Failed fetching '{}': {}".format(url, e))
 

--- a/flexget/plugins/input/torznab.py
+++ b/flexget/plugins/input/torznab.py
@@ -9,6 +9,7 @@ from flexget.entry import Entry
 from flexget.event import event
 from flexget.plugin import PluginError
 from flexget.utils.requests import RequestException
+from flexget.utils.tools import parse_timedelta
 
 logger = logger.bind(name='torznab')
 
@@ -33,6 +34,7 @@ class Torznab:
                     'default': 'search',
                 },
                 'website': {'type': 'string', 'format': 'url'},
+                'timeout': {"type": "string", "format": "interval"},
             },
             'required': ['website', 'apikey'],
             'additionalProperties': False,
@@ -74,6 +76,8 @@ class Torznab:
     def _setup(self, task, config):
         """Set up parameters"""
         self.base_url = config['website'].rstrip('/')
+        config.setdefault('timeout', '30 seconds')
+        self.timeout = parse_timedelta(config['timeout']).total_seconds()
         self.supported_params = []
         if config['searcher'] == 'tv':
             config['searcher'] = 'tvsearch'
@@ -87,7 +91,7 @@ class Torznab:
     def _setup_caps(self, task, searcher, categories):
         """Gets the capabilities of the torznab indexer and matches it with the provided configuration"""
 
-        response = task.requests.get(self._build_url(t='caps'))
+        response = task.requests.get(self._build_url(t='caps'), timeout=self.timeout)
         logger.debug('Raw caps response {}', response.content)
         root = ElementTree.fromstring(response.content)
         self._setup_searcher(root, searcher, categories)
@@ -161,7 +165,7 @@ class Torznab:
         logger.info('Fetching URL: {}', url)
 
         try:
-            response = task.requests.get(url)
+            response = task.requests.get(url, timeout=self.timeout))
         except RequestException as e:
             raise PluginError("Failed fetching '{}': {}".format(url, e))
 


### PR DESCRIPTION
### Motivation for changes:
This is needed for under some environments with many sources on the torznab, the answer will take more than 30 seconds.
Let the user configure this to adapt according to their needs.


### Detailed changes:
- Added a new timeout parameter to the torznab input plugin.

### Config usage if relevant (new plugin or updated schema):
```
timeout : 120s
```
