### PR TITLE
Log filter plugin

### DIFF
--- a/flexget/log.py
+++ b/flexget/log.py
@@ -9,7 +9,7 @@ import sys
 import threading
 import uuid
 import warnings
-from typing import Iterator
+from typing import Callable, Iterator
 
 import loguru
 from loguru import logger
@@ -96,6 +96,22 @@ _startup_buffer_id = None
 _logging_started = False
 # Stores the last 100 debug messages
 debug_buffer = collections.deque(maxlen=100)
+_log_filters = []  # Stores filter functions
+
+
+def _log_filterer(record):
+    """This is the function we add to our loguru handlers. It will dynamically use all filters we add later."""
+    return all(f(record) for f in _log_filters)
+
+
+def add_filter(func: Callable[['loguru.Record'], bool]):
+    """Adds a filter function to the log handlers."""
+    _log_filters.append(func)
+
+
+def remove_filter(func: Callable[['loguru.Record'], bool]):
+    """Removes a filter function from the log handlers."""
+    _log_filters.remove(func)
 
 
 def initialize(unit_test: bool = False) -> None:
@@ -168,6 +184,7 @@ def start(
             retention=int(os.environ.get(ENV_MAXCOUNT, 9)),
             encoding='utf-8',
             format=LOG_FORMAT,
+            filter=_log_filterer,
         )
 
     # without --cron we log to console
@@ -181,7 +198,13 @@ def start(
             # Auto-detection for colorize doesn't seem to work properly for PyCharm.
             if "PYCHARM_HOSTED" in os.environ:
                 colorize = True
-            logger.add(safe_stdout, level=level, format=LOG_FORMAT, colorize=colorize)
+            logger.add(
+                safe_stdout,
+                level=level,
+                format=LOG_FORMAT,
+                colorize=colorize,
+                filter=_log_filterer,
+            )
 
     # flush what we have stored from the plugin initialization
     global _startup_buffer, _startup_buffer_id

--- a/flexget/plugins/operate/log_filter.py
+++ b/flexget/plugins/operate/log_filter.py
@@ -1,0 +1,63 @@
+from loguru import logger
+
+from flexget import log, plugin
+from flexget.event import event
+
+logger = logger.bind(name='log_filter')
+
+
+class MyFilter:
+    def __init__(self, config):
+        self.config = config
+
+    def __call__(self, record):
+        for plugin_name, filter_strings in self.config.items():
+            for filter_string in filter_strings:
+                if record['name'] == plugin_name and filter_string in record['message']:
+                    return False
+        return True
+
+
+class LogFilter(object):
+    """
+    Prevent entries with specific text from being logged.
+
+    Example::
+      log_filter:
+        some.context:
+          - in a galaxy
+          - far far away
+        another.context:
+          - whatever text
+          - what the heck?
+
+    """
+
+    schema = {
+        'type': 'object',
+        'additionalProperties': {
+            'type': 'array',
+            'items': {'type': 'string'},
+            'minItems': 1,
+            'additionalProperties': 'string',
+        },
+    }
+
+    @plugin.priority(255)
+    def on_task_start(self, task, config):
+        task.log_filter = MyFilter(config)
+        log.add_filter(task.log_filter)
+        logger.debug('Log filter added (config: {})', config)
+
+    @plugin.priority(-255)
+    def on_task_exit(self, task, config):
+        if getattr(task, 'log_filter', None):
+            log.remove_filter(task.log_filter)
+            del task.log_filter
+
+    on_task_abort = on_task_exit
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(LogFilter, 'log_filter', api_ver=2)


### PR DESCRIPTION
### Motivation for changes:

Converts [log_filter](https://github.com/tarzasai/.flexget/blob/master/plugins/log_filter.py) plugin by @tarzasai to work with the new loguru logging system

### Detailed changes:
- Adds `add_filter` and `remove_filter` to the flexget logging system, which allows changing filters after the handlers have been created.

#### To Do:

- [ ] Consider how useful this is/ whether there are better solutions.
- [ ] Consider whether people will use this then want support based on an incomplete log. (maybe exclude the filter from crash report files somehow?)
- [ ] consider whether this should be at root rather than task level
- [ ] Consider config format. Maybe something a bit more flexible like:
```yaml
log_filter:
- level: debug
  logger: backlog
- message: blahblah
  task: mytask  # This would be if it gets configured at root level
```

