### PR TITLE
flexget/manager.py: Updated logging level for Daemon running messages

### DIFF
--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -499,7 +499,7 @@ class Manager:
                 logger.error('There does not appear to be a daemon running.')
                 return
             if options.action == 'status':
-                logger.info('Daemon running. (PID: {})', os.getpid())
+                logger.debug('Daemon running. (PID: {})', os.getpid())
             elif options.action == 'stop':
                 tasks = (
                     'all queued tasks (if any) have'


### PR DESCRIPTION
### Motivation for changes:
"Daemon running" messages were filling up the INFO level log. The messages don't really add any value, so should really only be used during debug.

### Detailed changes:
- a single line change of logger.info to logger.debug on line 502 of manager.py

### Addressed issues:
- Fixes #2729 

### Log and/or tests output (preferably both):
```
(flexget) ---:~/Flexget$ pytest -n auto
==================================================== test session starts ====================================================
platform linux -- Python 3.8.5, pytest-5.1.3, py-1.9.0, pluggy-0.13.1
rootdir: /home/---/Flexget, inifile: setup.cfg, testpaths: flexget/tests
plugins: xdist-1.29.0, forked-1.3.0, cov-2.5.1
gw0 [1354]
...s.................................................................................ss.............................s [  8%]
ssss.........s................ssssss..................s..............................s......s........................ [ 17%]
.............s..........s.........................s.................................................................. [ 25%]
..................................................................................................................... [ 34%]
...................................................................................................................x. [ 43%]
.............X....................................................................................................... [ 51%]
..................................................................................................................... [ 60%]
...........................s..X......................X..........................s..x......................x.......... [ 69%]
............................ssss.s..........................................X........................................ [ 77%]
.......x............................X................................................................................ [ 86%]
..................................................................................................................... [ 95%]
...................................................................                                                   [100%]
===================================================== warnings summary ======================================================
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
/home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120
  /home/---/flexget/lib/python3.8/site-packages/flask_restx/namespace.py:120: DeprecationWarning: The parser attribute is deprecated, use expect instead
    handle_deprecations(doc)

/home/---/flexget/lib/python3.8/site-packages/dateutil/parser.py:587
  /home/---/flexget/lib/python3.8/site-packages/dateutil/parser.py:587: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    if (isinstance(tzinfos, collections.Callable) or

/home/---/flexget/lib/python3.8/site-packages/sqlalchemy/orm/query.py:195
  /home/---/flexget/lib/python3.8/site-packages/sqlalchemy/orm/query.py:195: SADeprecationWarning: Plain string expression passed to Query() should be explicitly declared using literal_column(); automatic coercion of this value will be removed in SQLAlchemy 1.4
    entity_wrapper(self, ent)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
====================== 1317 passed, 28 skipped, 4 xfailed, 5 xpassed, 47 warnings in 388.76s (0:06:28) ======================


```




