### PR TITLE
[change] API - Add type annotations to api module

### DIFF
--- a/flexget/api/app.py
+++ b/flexget/api/app.py
@@ -2,15 +2,20 @@ import json
 import os
 import re
 from collections import deque
+from contextlib import suppress
 from functools import partial, wraps
+from typing import Callable, List, Dict, Union, Mapping, Tuple, TYPE_CHECKING
 
-from flask import Flask, jsonify, make_response, request
+from jsonschema.exceptions import ValidationError as SchemaValidationError
+from flask import Flask, Response, jsonify, make_response, request, Request
 from flask_compress import Compress
 from flask_cors import CORS
 from flask_restx import Api as RestxAPI
-from flask_restx import Resource
+from flask_restx import Resource, Model
+from flask_restx.reqparse import RequestParser
 from jsonschema import RefResolutionError
 from loguru import logger
+from sqlalchemy.orm import Session
 from werkzeug.http import generate_etag
 
 from flexget import manager
@@ -24,6 +29,18 @@ __version__ = '1.8.0'
 
 logger = logger.bind(name='api')
 
+if TYPE_CHECKING:
+    from typing import TypedDict
+    _TypeDict = TypedDict('_TypeDict', {'type': str})
+
+    class MessageDict(_TypeDict):
+        properties: Dict[str, _TypeDict]
+        required: List[str]
+
+    PaginationHeaders = TypedDict(
+        'PaginationHeaders', {'Link': str, 'Total-Count': int, 'Count': int}
+    )
+
 
 class APIClient:
     """
@@ -32,13 +49,13 @@ class APIClient:
     It skips http, and is only usable from within the running flexget process.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.app = api_app.test_client()
 
-    def __getattr__(self, item):
+    def __getattr__(self, item: str) -> 'APIEndpoint':
         return APIEndpoint('/api/' + item, self.get_endpoint)
 
-    def get_endpoint(self, url, data=None, method=None):
+    def get_endpoint(self, url: str, data=None, method: str = None):
         if method is None:
             method = 'POST' if data is not None else 'GET'
         auth_header = dict(Authorization='Token %s' % api_key())
@@ -53,7 +70,7 @@ class APIClient:
 
 
 class APIEndpoint:
-    def __init__(self, endpoint, caller):
+    def __init__(self, endpoint: str, caller: Callable) -> None:
         self.endpoint = endpoint
         self.caller = caller
 
@@ -62,11 +79,11 @@ class APIEndpoint:
 
     __getitem__ = __getattr__
 
-    def __call__(self, data=None, method=None):
+    def __call__(self, data=None, method: str = None):
         return self.caller(self.endpoint, data=data, method=method)
 
 
-def api_version(f):
+def api_version(f: Callable[..., Response]):
     """ Add the 'API-Version' header to all responses """
 
     @wraps(f)
@@ -83,7 +100,7 @@ class APIResource(Resource):
 
     method_decorators = [with_session, api_version]
 
-    def __init__(self, api, *args, **kwargs):
+    def __init__(self, api: RestxAPI, *args, **kwargs) -> None:
         self.manager = manager.manager
         super().__init__(api, *args, **kwargs)
 
@@ -95,7 +112,12 @@ class API(RestxAPI):
       - methods to auto document and handle :class:`ApiError` responses
     """
 
-    def validate(self, model, schema_override=None, description=None):
+    def validate(
+        self,
+        model: Model,
+        schema_override: Dict[str, List[Dict[str, str]]] = None,
+        description=None
+    ):
         """
         When a method is decorated with this, json data submitted to the endpoint will be validated with the given
         `model`. This also auto-documents the expected model, as well as the possible :class:`ValidationError` response.
@@ -121,13 +143,13 @@ class API(RestxAPI):
 
         return decorator
 
-    def response(self, code_or_apierror, description='Success', model=None, **kwargs):
+    def response(self, code_or_apierror, description: str = 'Success', model=None, **kwargs):
         """
         Extends :meth:`flask_restx.Api.response` to allow passing an :class:`ApiError` class instead of
         response code. If an `ApiError` is used, the response code, and expected response model, is automatically
         documented.
         """
-        try:
+        with suppress(TypeError):  # If first argument isn't a class this happens
             if issubclass(code_or_apierror, APIError):
                 description = code_or_apierror.description or description
                 return self.doc(
@@ -139,12 +161,15 @@ class API(RestxAPI):
                     },
                     **kwargs,
                 )
-        except TypeError:
-            # If first argument isn't a class this happens
-            pass
         return self.doc(responses={code_or_apierror: (description, model)}, **kwargs)
 
-    def pagination_parser(self, parser=None, sort_choices=None, default=None, add_sort=None):
+    def pagination_parser(
+        self,
+        parser: RequestParser = None,
+        sort_choices: List[str] = None,
+        default: str = None,
+        add_sort: bool = None
+    ) -> RequestParser:
         """
         Return a standardized pagination parser, to be used for any endpoint that has pagination.
 
@@ -191,7 +216,7 @@ api = API(
     format_checker=format_checker,
 )
 
-base_message = {
+base_message: "MessageDict" = {
     'type': 'object',
     'properties': {
         'status_code': {'type': 'integer'},
@@ -210,7 +235,7 @@ class APIError(Exception):
     status = 'Error'
     response_model = base_message_schema
 
-    def __init__(self, message=None, payload=None):
+    def __init__(self, message: str = None, payload=None) -> None:
         self.message = message
         self.payload = payload
 
@@ -300,14 +325,18 @@ class ValidationError(APIError):
         'parent',
     )
 
-    def __init__(self, validation_errors, message='validation error'):
+    def __init__(
+        self,
+        validation_errors: List[SchemaValidationError],
+        message: str = 'validation error'
+    ) -> None:
         payload = {
             'validation_errors': [self._verror_to_dict(error) for error in validation_errors]
         }
         super().__init__(message, payload=payload)
 
-    def _verror_to_dict(self, error):
-        error_dict = {}
+    def _verror_to_dict(self, error: SchemaValidationError) -> Mapping[str, Union[str, list]]:
+        error_dict: Dict[str, Union[str, list]] = {}
         for attr in self.verror_attrs:
             if isinstance(getattr(error, attr), deque):
                 error_dict[attr] = list(getattr(error, attr))
@@ -319,7 +348,7 @@ class ValidationError(APIError):
 empty_response = api.schema_model('empty', {'type': 'object'})
 
 
-def success_response(message, status_code=200, status='success'):
+def success_response(message: str, status_code: int = 200, status: str = 'success') -> Response:
     rsp_dict = {'message': message, 'status_code': status_code, 'status': status}
     rsp = jsonify(rsp_dict)
     rsp.status_code = status_code
@@ -334,17 +363,17 @@ def success_response(message, status_code=200, status='success'):
 @api.errorhandler(Conflict)
 @api.errorhandler(NotModified)
 @api.errorhandler(PreconditionFailed)
-def api_errors(error):
+def api_errors(error: APIError) -> Tuple[dict, int]:
     return error.to_dict(), error.status_code
 
 
 @with_session
-def api_key(session=None):
+def api_key(session: Session = None) -> str:
     logger.debug('fetching token for internal lookup')
-    return session.query(User).first().token
+    return session.query(User).first().token  # type: ignore
 
 
-def etag(method=None, cache_age=0):
+def etag(method: Callable = None, cache_age: int = 0):
     """
     A decorator that add an ETag header to the response and checks for the "If-Match" and "If-Not-Match" headers to
      return an appropriate response.
@@ -394,7 +423,12 @@ def etag(method=None, cache_age=0):
     return wrapped
 
 
-def pagination_headers(total_pages, total_items, page_count, request):
+def pagination_headers(
+    total_pages: int,
+    total_items: int,
+    page_count: int,
+    request: Request
+) -> 'PaginationHeaders':
     """
     Creates the `Link`. 'Count' and  'Total-Count' headers, to be used for pagination traversing
 
@@ -411,7 +445,7 @@ def pagination_headers(total_pages, total_items, page_count, request):
     page = int(request.args.get('page', 1))
 
     # Build the base template
-    LINKTEMPLATE = '<{}?per_page={}&'.format(url, per_page)
+    link_with_params = f'<{url}?per_page={per_page}&'
 
     # Removed page and per_page from query string
     query_string = re.sub(br'per_page=\d+', b'', request.query_string)
@@ -419,14 +453,14 @@ def pagination_headers(total_pages, total_items, page_count, request):
     query_string = re.sub(b'&{2,}', b'&', query_string)
 
     # Add all original query params
-    LINKTEMPLATE += query_string.decode().lstrip('&') + '&page={}>; rel="{}"'
+    link_with_params += query_string.decode().lstrip('&')
 
     link_string = ''
 
     if page > 1:
-        link_string += LINKTEMPLATE.format(page - 1, 'prev') + ', '
+        link_string += f'{link_with_params}&page={page-1}>; rel="prev", '
     if page < total_pages:
-        link_string += LINKTEMPLATE.format(page + 1, 'next') + ', '
-    link_string += LINKTEMPLATE.format(total_pages, 'last')
+        link_string += f'{link_with_params}&page={page+1}>; rel="next", '
+    link_string += f'{link_with_params}&page={total_pages}>; rel="last"'
 
     return {'Link': link_string, 'Total-Count': total_items, 'Count': page_count}

--- a/flexget/api/core/authentication.py
+++ b/flexget/api/core/authentication.py
@@ -1,10 +1,13 @@
 import base64
+from contextlib import suppress
+from typing import Optional
 
-from flask import request
+from flask import request, Request, Response
 from flask import session as flask_session
 from flask_login import LoginManager
 from flask_login.utils import current_app, current_user, login_user
 from flask_restx import inputs
+from sqlalchemy.orm import Session
 from werkzeug.security import check_password_hash
 
 from flexget.api import api_app
@@ -18,42 +21,37 @@ login_manager.init_app(api_app)
 
 @login_manager.request_loader
 @with_session
-def load_user_from_request(request, session=None):
+def load_user_from_request(request: Request, session: Session = None) -> Optional[User]:
     auth_value = request.headers.get('Authorization')
 
     if not auth_value:
-        return
+        return None
 
     # Login using api key
     if auth_value.startswith('Token'):
-        try:
+        with suppress(TypeError, ValueError):
             token = auth_value.replace('Token ', '', 1)
             return session.query(User).filter(User.token == token).first()
-        except (TypeError, ValueError):
-            pass
 
     # Login using basic auth
     if auth_value.startswith('Basic'):
-        try:
-            credentials = base64.b64decode(auth_value.replace('Basic ', '', 1))
+        with suppress(TypeError, ValueError, UnicodeDecodeError):
+            credentials = base64.b64decode(auth_value.replace('Basic ', '', 1)).decode()
             username, password = credentials.split(':')
             user = session.query(User).filter(User.name == username).first()
             if user and user.password and check_password_hash(user.password, password):
                 return user
-            else:
-                return None
-        except (TypeError, ValueError):
-            pass
+    return None
 
 
 @login_manager.user_loader
 @with_session
-def load_user(username, session=None):
+def load_user(username: str, session: Session = None) -> Optional[User]:
     return session.query(User).filter(User.name == username).first()
 
 
 @api_app.before_request
-def check_valid_login():
+def check_valid_login() -> Optional[Response]:
     # Allow access to root, login and swagger documentation without authentication
     if (
         request.path == '/'
@@ -62,10 +60,11 @@ def check_valid_login():
         or request.path.startswith('/swagger')
         or request.method == 'OPTIONS'
     ):
-        return
+        return None
 
     if not current_user.is_authenticated:
         return current_app.login_manager.unauthorized()
+    return None
 
 
 # API Authentication and Authorization
@@ -97,7 +96,7 @@ class LoginAPI(APIResource):
     @api.response(Unauthorized)
     @api.response(200, 'Login successful', model=base_message_schema)
     @api.doc(parser=login_parser)
-    def post(self, session=None):
+    def post(self, session: Session = None) -> Response:
         """ Login with username and password """
         data = request.json
         user_name = data.get('username')
@@ -123,7 +122,7 @@ class LoginAPI(APIResource):
 @auth_api.route('/logout/')
 class LogoutAPI(APIResource):
     @api.response(200, 'Logout successful', model=base_message_schema)
-    def post(self, session=None):
+    def post(self, session: Session = None) -> Response:
         """ Logout and clear session cookies """
         flask_session.clear()
         resp = success_response('User logged out')

--- a/flexget/api/core/cached.py
+++ b/flexget/api/core/cached.py
@@ -1,6 +1,8 @@
+from flask import Response
 from flask.helpers import send_file
 from flask_restx import inputs
 from requests import RequestException
+from sqlalchemy.orm import Session
 
 from flexget.api import APIResource, api
 from flexget.api.app import APIError, BadRequest
@@ -22,7 +24,7 @@ class CachedResource(APIResource):
     @api.response(BadRequest)
     @api.response(APIError)
     @api.doc(parser=cached_parser)
-    def get(self, session=None):
+    def get(self, session: Session = None) -> Response:
         """ Cache remote resources """
         args = cached_parser.parse_args()
         url = args.get('url')
@@ -30,7 +32,7 @@ class CachedResource(APIResource):
         try:
             file_path, mime_type = cached_resource(url, self.manager.config_base, force=force)
         except RequestException as e:
-            raise BadRequest('Request Error: {}'.format(e.args[0]))
+            raise BadRequest(f'Request Error: {e.args[0]}')
         except OSError as e:
-            raise APIError('Error: {}'.format(str(e)))
+            raise APIError(f'Error: {e}')
         return send_file(file_path, mimetype=mime_type)

--- a/flexget/api/core/database.py
+++ b/flexget/api/core/database.py
@@ -1,4 +1,5 @@
-from flask import jsonify, request
+from flask import jsonify, request, Response
+from sqlalchemy.orm import Session
 
 from flexget.api import APIResource, api
 from flexget.api.app import BadRequest, base_message_schema, success_response
@@ -29,8 +30,9 @@ input_schema = api.schema_model('db_schema', ObjectsContainer.database_input_obj
 class DBOperation(APIResource):
     @api.validate(input_schema)
     @api.response(200, model=base_message_schema)
-    def post(self, session=None):
+    def post(self, session: Session = None) -> Response:
         """Perform DB operations"""
+        msg = ''
         data = request.json
         operation = data['operation']
         if operation == 'cleanup':
@@ -44,19 +46,19 @@ class DBOperation(APIResource):
             plugin_name = data.get('plugin_name')
             if not plugin_name:
                 raise BadRequest(
-                    '\'plugin_name\' attribute must be used when trying to reset plugin'
+                    "'plugin_name' attribute must be used when trying to reset plugin"
                 )
             try:
                 reset_schema(plugin_name)
-                msg = 'Plugin {} DB reset was successful'.format(plugin_name)
+                msg = f'Plugin {plugin_name} DB reset was successful'
             except ValueError:
-                raise BadRequest('The plugin {} has no stored schema to reset'.format(plugin_name))
+                raise BadRequest(f'The plugin {plugin_name} has no stored schema to reset')
         return success_response(msg)
 
 
 @db_api.route('/plugins/')
 class DBCleanup(APIResource):
     @api.response(200, model=plugins_schema)
-    def get(self, session=None):
+    def get(self, session: Session = None) -> Response:
         """List resettable DB plugins"""
         return jsonify(sorted(list(plugin_schemas)))

--- a/flexget/api/core/format_checker.py
+++ b/flexget/api/core/format_checker.py
@@ -1,3 +1,6 @@
+from flask import Response
+from sqlalchemy.orm import Session
+
 from flexget.api import APIResource, api
 from flexget.api.app import base_message_schema, success_response
 
@@ -33,7 +36,7 @@ format_checker_schema = api.schema_model('format_checker', ObjectContainer.forma
 class SchemaTest(APIResource):
     @api.validate(format_checker_schema)
     @api.response(200, model=base_message_schema)
-    def post(self, session=None):
+    def post(self, session: Session = None) -> Response:
         """ Validate flexget custom schema"""
         # If validation passed, all is well
         return success_response('payload is valid')

--- a/flexget/api/core/plugins.py
+++ b/flexget/api/core/plugins.py
@@ -1,11 +1,14 @@
 from math import ceil
+from typing import List, Optional, TYPE_CHECKING
 
-from flask import jsonify, request
+from flask import jsonify, request, Response
 from flask_restx import inputs
 from loguru import logger
+from sqlalchemy.orm import Session
 
 from flexget.api import APIResource, api
 from flexget.api.app import BadRequest, NotFoundError, etag, pagination_headers
+from flexget.config_schema import JsonSchema
 from flexget.plugin import DependencyError, get_plugin_by_name, get_plugins
 
 logger = logger.bind(name='plugins')
@@ -58,8 +61,22 @@ plugins_parser.add_argument(
     'phase', case_sensitive=False, help='Show plugins that act on this phase'
 )
 
+if TYPE_CHECKING:
+    from typing import TypedDict
+    _PhaseHandler = TypedDict('_PhaseHandler', {'phase': str, 'priority': int})
 
-def plugin_to_dict(plugin):
+    class PluginDict(TypedDict, total=False):
+        name: str
+        api_ver: int
+        builtin: bool
+        category: Optional[str]
+        debug: bool
+        interfaces: Optional[List[str]]
+        phase_handlers: List[_PhaseHandler]
+        schema: Optional[JsonSchema]
+
+
+def plugin_to_dict(plugin) -> 'PluginDict':
     return {
         'name': plugin.name,
         'api_ver': plugin.api_ver,
@@ -81,7 +98,7 @@ class PluginsAPI(APIResource):
     @api.response(BadRequest)
     @api.response(NotFoundError)
     @api.doc(parser=plugins_parser)
-    def get(self, session=None):
+    def get(self, session: Session = None) -> Response:
         """ Get list of registered plugins """
         args = plugins_parser.parse_args()
 
@@ -114,7 +131,7 @@ class PluginsAPI(APIResource):
         total_pages = int(ceil(total_items / float(per_page)))
 
         if page > total_pages and total_pages != 0:
-            raise NotFoundError('page %s does not exist' % page)
+            raise NotFoundError(f'page {page} does not exist')
 
         # Actual results in page
         actual_size = min(per_page, len(sliced_list))
@@ -135,7 +152,7 @@ class PluginAPI(APIResource):
     @api.response(BadRequest)
     @api.response(200, model=plugin_schema)
     @api.doc(parser=plugin_parser, params={'plugin_name': 'Name of the plugin to return'})
-    def get(self, plugin_name, session=None):
+    def get(self, plugin_name: str, session=None):
         """ Return plugin data by name"""
         args = plugin_parser.parse_args()
         try:

--- a/flexget/api/core/schema.py
+++ b/flexget/api/core/schema.py
@@ -1,5 +1,6 @@
-from flask import jsonify, request
+from flask import jsonify, request, Response
 from jsonschema import RefResolutionError
+from sqlalchemy.orm import Session
 
 from flexget.api import APIResource, api
 from flexget.api.app import NotFoundError
@@ -13,7 +14,7 @@ schema_api_list = api.schema_model(
 )
 
 
-def rewrite_ref(identifier, base_url):
+def rewrite_ref(identifier: str, base_url: str) -> str:
     """
     The refs in the schemas are arbitrary identifiers, and cannot be used as-is as real network locations.
     This rewrites any of those arbitrary refs to be real urls servable by this endpoint.
@@ -25,10 +26,8 @@ def rewrite_ref(identifier, base_url):
     return identifier
 
 
-def rewrite_refs(schema, base_url):
-    """
-    Make sure any $refs in the schema point properly back to this endpoint.
-    """
+def rewrite_refs(schema, base_url: str):
+    """Make sure any $refs in the schema point properly back to this endpoint."""
     if isinstance(schema, dict):
         if '$ref' in schema:
             return {'$ref': rewrite_ref(schema['$ref'], base_url)}
@@ -41,7 +40,7 @@ def rewrite_refs(schema, base_url):
 @schema_api.route('/')
 class SchemaAllAPI(APIResource):
     @api.response(200, model=schema_api_list)
-    def get(self, session=None):
+    def get(self, session: Session = None) -> Response:
         """ List all schema definitions """
         schemas = []
         for path in schema_paths:
@@ -56,7 +55,7 @@ class SchemaAllAPI(APIResource):
 @api.response(NotFoundError)
 class SchemaAPI(APIResource):
     @api.response(200, model=schema_api_list)
-    def get(self, path, session=None):
+    def get(self, path: str, session: Session = None) -> Response:
         """ Get schema definition """
         try:
             schema = resolve_ref(request.full_path)

--- a/flexget/api/core/tasks.py
+++ b/flexget/api/core/tasks.py
@@ -4,9 +4,11 @@ import copy
 from datetime import datetime, timedelta
 from json import JSONEncoder
 from queue import Empty, Queue
+from typing import Dict, TYPE_CHECKING, Any
 
 from flask import Response, jsonify, request
 from flask_restx import inputs
+from sqlalchemy.orm import Session
 
 from flexget.api import APIResource, api
 from flexget.api.app import (
@@ -198,7 +200,7 @@ class TasksAPI(APIResource):
     @etag
     @api.response(200, model=tasks_list_schema)
     @api.doc(parser=tasks_parser)
-    def get(self, session=None):
+    def get(self, session: Session = None) -> Response:
         """ List all tasks """
 
         active_tasks = {
@@ -218,7 +220,7 @@ class TasksAPI(APIResource):
     @api.response(201, description='Newly created task', model=task_return_schema)
     @api.response(Conflict)
     @api.response(APIError)
-    def post(self, session=None):
+    def post(self, session: Session = None) -> Response:
         """ Add new task """
         data = request.json
 
@@ -257,10 +259,10 @@ class TaskAPI(APIResource):
     @etag
     @api.response(200, model=task_return_schema)
     @api.response(NotFoundError, description='task not found')
-    def get(self, task, session=None):
+    def get(self, task, session: Session = None) -> Response:
         """ Get task config """
         if task not in self.manager.user_config.get('tasks', {}):
-            raise NotFoundError('task `%s` not found' % task)
+            raise NotFoundError(f'task `{task}` not found')
 
         return jsonify({'name': task, 'config': self.manager.user_config['tasks'][task]})
 
@@ -268,14 +270,14 @@ class TaskAPI(APIResource):
     @api.response(200, model=task_return_schema)
     @api.response(NotFoundError)
     @api.response(BadRequest)
-    def put(self, task, session=None):
+    def put(self, task, session: Session = None) -> Response:
         """ Update tasks config """
         data = request.json
 
         new_task_name = data['name']
 
         if task not in self.manager.user_config.get('tasks', {}):
-            raise NotFoundError('task `%s` not found' % task)
+            raise NotFoundError(f'task `{task}` not found')
 
         if 'tasks' not in self.manager.user_config:
             self.manager.user_config['tasks'] = {}
@@ -313,7 +315,7 @@ class TaskAPI(APIResource):
 
     @api.response(200, model=base_message_schema, description='deleted task')
     @api.response(NotFoundError)
-    def delete(self, task, session=None):
+    def delete(self, task, session: Session = None) -> Response:
         """ Delete a task """
         try:
             self.manager.config['tasks'].pop(task)
@@ -370,7 +372,7 @@ def _task_info_dict(task):
 @tasks_api.route('/queue/')
 class TaskQueueAPI(APIResource):
     @api.response(200, model=task_api_queue_schema)
-    def get(self, session=None):
+    def get(self, session: Session = None) -> Response:
         """ List task(s) in queue for execution """
         tasks = [_task_info_dict(task) for task in self.manager.task_queue.run_queue.queue]
 
@@ -387,6 +389,12 @@ class ExecuteLog(Queue):
         self.put(json.dumps({'log': s}))
 
 
+if TYPE_CHECKING:
+    from typing import TypedDict
+    StreamTaskDict = TypedDict(
+        'StreamTaskDict', {'queue': ExecuteLog, 'last_update': datetime, 'args': Dict[str, Any]}
+    )
+    _streams: Dict[str, StreamTaskDict]
 _streams = {}
 
 # Another namespace for the same endpoint
@@ -399,7 +407,7 @@ inject_api = api.namespace('inject', description='Entry injection API')
 class TaskExecutionParams(APIResource):
     @etag(cache_age=3600)
     @api.response(200, model=task_execution_params)
-    def get(self, session=None):
+    def get(self, session: Session = None) -> Response:
         """ Execute payload parameters """
         return jsonify(ObjectsContainer.task_execution_input)
 
@@ -412,14 +420,14 @@ class TaskExecutionAPI(APIResource):
     @api.response(BadRequest)
     @api.response(200, model=task_api_execute_schema)
     @api.validate(task_execution_schema)
-    def post(self, session=None):
+    def post(self, session: Session = None) -> Response:
         """ Execute task and stream results """
         data = request.json
         for task in data.get('tasks'):
             if task.lower() not in [
                 t.lower() for t in self.manager.user_config.get('tasks', {}).keys()
             ]:
-                raise NotFoundError('task %s does not exist' % task)
+                raise NotFoundError(f'task {task} does not exist')
 
         queue = ExecuteLog()
         output = queue if data.get('loglevel') else None
@@ -571,7 +579,7 @@ _phase_percents = {
 }
 
 
-def update_stream(task, status='pending'):
+def update_stream(task, status: str = 'pending') -> None:
     if task.current_phase in _phase_percents:
         task.stream['percent'] = _phase_percents[task.current_phase]
 
@@ -624,6 +632,6 @@ def finish_task(task):
 
 
 @event('task.execute.before_plugin')
-def track_progress(task, plugin_name):
+def track_progress(task, plugin_name: str):
     if task.stream and task.stream['args'].get('progress'):
         update_stream(task, status='running')

--- a/flexget/api/core/user.py
+++ b/flexget/api/core/user.py
@@ -1,5 +1,6 @@
-from flask import jsonify, request
+from flask import jsonify, request, Response
 from flask_login import current_user
+from sqlalchemy.orm import Session
 
 from flexget.api import APIResource, api
 from flexget.api.app import BadRequest, base_message_schema, success_response
@@ -37,7 +38,7 @@ class UserManagementAPI(APIResource):
         description='Change user password. A score of at least 3 is needed.'
         'See https://github.com/dropbox/zxcvbn for details'
     )
-    def put(self, session=None):
+    def put(self, session: Session = None) -> Response:
         """ Change user password """
         user = current_user
         data = request.json
@@ -53,13 +54,13 @@ class UserManagementAPI(APIResource):
 class UserManagementTokenAPI(APIResource):
     @api.response(200, 'Successfully got user token', user_token_response_schema)
     @api.doc(description='Get current user token')
-    def get(self, session=None):
+    def get(self, session: Session = None) -> Response:
         token = current_user.token
         return jsonify({'token': token})
 
     @api.response(200, 'Successfully changed user token', user_token_response_schema)
     @api.doc(description='Get new user token')
-    def put(self, session=None):
+    def put(self, session: Session = None) -> Response:
         """ Change current user token """
         token = generate_token(username=current_user.name, session=session)
         return jsonify({'token': token})

--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -2,10 +2,11 @@ import datetime
 import os
 import re
 from collections import defaultdict
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union, List, Pattern, Match
 from urllib.parse import parse_qsl, urlparse
 
 import jsonschema
+from jsonschema import ValidationError
 from jsonschema.compat import int_types, str_types
 from loguru import logger
 
@@ -20,6 +21,14 @@ CURRENT_SCHEMA_VERSION = 'http://json-schema.org/draft-04/schema#'
 # Type hint for json schemas. (If we upgrade to a newer json schema version, the type might allow more than dicts.)
 JsonSchema = Dict[str, Any]
 schema_paths: Dict[str, Union[JsonSchema, Callable[..., JsonSchema]]] = {}
+
+
+class ConfigValidationError(ValidationError):
+    json_pointer: str
+
+
+class ConfigError(ValueError):
+    errors: List[ConfigValidationError]
 
 
 # TODO: Rethink how config key and schema registration work
@@ -105,7 +114,11 @@ def resolve_ref(uri: str) -> JsonSchema:
     raise jsonschema.RefResolutionError("%s could not be resolved" % uri)
 
 
-def process_config(config: Any, schema: Optional[JsonSchema] = None, set_defaults: bool = True):
+def process_config(
+    config: Any,
+    schema: Optional[JsonSchema] = None,
+    set_defaults: bool = True
+) -> List[ConfigValidationError]:
     """
     Validates the config, and sets defaults within it if `set_defaults` is set.
     If schema is not given, uses the root config schema.
@@ -120,7 +133,7 @@ def process_config(config: Any, schema: Optional[JsonSchema] = None, set_default
     if set_defaults:
         validator.VALIDATORS['properties'] = validate_properties_w_defaults
     try:
-        errors = list(validator.iter_errors(config))
+        errors: List[ValidationError] = list(validator.iter_errors(config))
     finally:
         validator.VALIDATORS['properties'] = jsonschema.Draft4Validator.VALIDATORS['properties']
     # Customize the error messages
@@ -199,35 +212,35 @@ def is_quality_req(instance):
 
 
 @format_checker.checks('time', raises=ValueError)
-def is_time(time_string):
+def is_time(time_string) -> bool:
     if not isinstance(time_string, str_types):
         return True
     return parse_time(time_string) is not None
 
 
 @format_checker.checks('interval', raises=ValueError)
-def is_interval(interval_string):
+def is_interval(interval_string) -> bool:
     if not isinstance(interval_string, str_types):
         return True
     return parse_interval(interval_string) is not None
 
 
 @format_checker.checks('size', raises=ValueError)
-def is_size(size_string):
+def is_size(size_string) -> bool:
     if not isinstance(size_string, (str_types, int_types)):
         return True
     return parse_size(size_string) is not None
 
 
 @format_checker.checks('percent', raises=ValueError)
-def is_percent(percent_string):
+def is_percent(percent_string) -> bool:
     if not isinstance(percent_string, str_types):
         return True
     return parse_percent(percent_string) is not None
 
 
 @format_checker.checks('regex', raises=ValueError)
-def is_regex(instance):
+def is_regex(instance) -> Union[bool, Pattern]:
     if not isinstance(instance, str_types):
         return True
     try:
@@ -237,7 +250,7 @@ def is_regex(instance):
 
 
 @format_checker.checks('file', raises=ValueError)
-def is_file(instance):
+def is_file(instance) -> bool:
     if not isinstance(instance, str_types):
         return True
     if os.path.isfile(os.path.expanduser(instance)):
@@ -246,7 +259,7 @@ def is_file(instance):
 
 
 @format_checker.checks('path', raises=ValueError)
-def is_path(instance):
+def is_path(instance) -> bool:
     if not isinstance(instance, str_types):
         return True
     # Only validate the part of the path before the first identifier to be replaced
@@ -261,7 +274,7 @@ def is_path(instance):
 
 # TODO: jsonschema has a format checker for uri if rfc3987 is installed, perhaps we should use that
 @format_checker.checks('url')
-def is_url(instance):
+def is_url(instance) -> Union[None, bool, Match]:
     if not isinstance(instance, str_types):
         return True
     regexp = (
@@ -273,7 +286,7 @@ def is_url(instance):
 
 
 @format_checker.checks('episode_identifier', raises=ValueError)
-def is_episode_identifier(instance):
+def is_episode_identifier(instance) -> bool:
     if not isinstance(instance, (str_types, int)):
         return True
     return parse_episode_identifier(instance) is not None
@@ -287,13 +300,13 @@ def is_episode_or_season_id(instance):
 
 
 @format_checker.checks('file_template', raises=ValueError)
-def is_valid_template(instance):
+def is_valid_template(instance) -> bool:
     if not isinstance(instance, str_types):
         return True
     return get_template(instance) is not None
 
 
-def set_error_message(error: jsonschema.ValidationError):
+def set_error_message(error: jsonschema.ValidationError) -> None:
     """
     Create user facing error message from a :class:`jsonschema.ValidationError` `error`
 
@@ -301,19 +314,19 @@ def set_error_message(error: jsonschema.ValidationError):
     # First, replace default error messages with our custom ones
     if error.validator == 'type':
         if isinstance(error.validator_value, str):
-            valid_types = [error.validator_value]
+            valid_types_list = [error.validator_value]
         else:
-            valid_types = list(error.validator_value)
+            valid_types_list = list(error.validator_value)
         # Replace some types with more pythony ones
         replace = {'object': 'dict', 'array': 'list'}
-        valid_types = [replace.get(t, t) for t in valid_types]
+        valid_types_list = [replace.get(t, t) for t in valid_types_list]
         # Make valid_types into an english list, with commas and 'or'
-        valid_types = ', '.join(valid_types[:-2] + ['']) + ' or '.join(valid_types[-2:])
+        valid_types = ', '.join(valid_types_list[:-2] + ['']) + ' or '.join(valid_types_list[-2:])
         if isinstance(error.instance, dict):
-            error.message = 'Got a dict, expected: %s' % valid_types
+            error.message = f'Got a dict, expected: {valid_types}'
         if isinstance(error.instance, list):
-            error.message = 'Got a list, expected: %s' % valid_types
-        error.message = 'Got `%s`, expected: %s' % (error.instance, valid_types)
+            error.message = f'Got a list, expected: {valid_types}'
+        error.message = f'Got `{error.instance}`, expected: {valid_types}'
     elif error.validator == 'format':
         if error.cause:
             error.message = str(error.cause)

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -34,6 +34,7 @@ from sqlalchemy.ext.declarative import declarative_base  # noqa
 from sqlalchemy.orm import sessionmaker  # noqa
 
 # These need to be declared before we start importing from other flexget modules, since they might import them
+from flexget.config_schema import ConfigError
 from flexget.utils.sqlalchemy_utils import ContextSession  # noqa
 from flexget.utils.tools import get_current_flexget_version, io_encoding, pid_exists  # noqa
 
@@ -344,7 +345,7 @@ class Manager:
         """
         # When we are in test mode, we use a different lock file and db
         if self.options.test:
-            self.lockfile = os.path.join(self.config_base, '.test-%s-lock' % self.config_name)
+            self.lockfile = os.path.join(self.config_base, f'.test-{self.config_name}-lock')
         # If another process is started, send the execution to the running process
         ipc_info = self.check_ipc_info()
         # If we are connecting to a running daemon, we don't want to log to the log file,
@@ -372,7 +373,7 @@ class Manager:
             return
         if self.options.test:
             logger.info('Test mode, creating a copy from database ...')
-            db_test_filename = os.path.join(self.config_base, 'test-%s.sqlite' % self.config_name)
+            db_test_filename = os.path.join(self.config_base, f'test-{self.config_name}.sqlite')
             if os.path.exists(self.db_filename):
                 shutil.copy(self.db_filename, db_test_filename)
                 logger.info('Test database created')
@@ -620,14 +621,14 @@ class Manager:
             logger.info('Tried to read from: {}', ', '.join(possible))
             raise OSError('No configuration file found.')
         if not os.path.isfile(config):
-            raise OSError('Config `%s` does not appear to be a file.' % config)
+            raise OSError(f'Config `{config}` does not appear to be a file.')
 
         logger.debug('Config file {} selected', config)
         self.config_path = config
         self.config_name = os.path.splitext(os.path.basename(config))[0]
         self.config_base = os.path.normpath(os.path.dirname(config))
-        self.lockfile = os.path.join(self.config_base, '.%s-lock' % self.config_name)
-        self.db_filename = os.path.join(self.config_base, 'db-%s.sqlite' % self.config_name)
+        self.lockfile = os.path.join(self.config_base, f'.{self.config_name}-lock')
+        self.db_filename = os.path.join(self.config_base, f'db-{self.config_name}.sqlite')
 
     def hash_config(self) -> Optional[str]:
         if not self.config_path:
@@ -680,7 +681,7 @@ class Manager:
                 if isinstance(e, yaml.MarkedYAMLError):
                     lines = 0
                     if e.problem is not None:
-                        print(' Reason: %s\n' % e.problem)
+                        print(f' Reason: {e.problem}\n')
                         if e.problem == 'mapping values are not allowed here':
                             print(' ----> MOST LIKELY REASON: Missing : from end of the line!')
                             print('')
@@ -724,7 +725,7 @@ class Manager:
         old_config = self.config
         try:
             self.config = self.validate_config(config)
-        except ValueError as e:
+        except ConfigError as e:
             for error in getattr(e, 'errors', []):
                 logger.critical('[{}] {}', error.json_pointer, error.message)
             logger.debug('invalid config, rolling back')
@@ -737,14 +738,14 @@ class Manager:
     def backup_config(self) -> str:
         backup_path = os.path.join(
             self.config_base,
-            '%s-%s.bak' % (self.config_name, datetime.now().strftime('%y%m%d%H%M%S')),
+            f'{self.config_name}-{datetime.now().strftime("%y%m%d%H%M%S")}.bak',
         )
 
-        logger.debug('backing up old config to {} before new save', backup_path)
+        logger.debug(f'backing up old config to {backup_path} before new save')
         try:
             shutil.copy(self.config_path, backup_path)
         except OSError as e:
-            logger.warning('Config backup creation failed: {}', str(e))
+            logger.warning(f'Config backup creation failed: {e}')
             raise
         return backup_path
 
@@ -781,7 +782,7 @@ class Manager:
         conf = fire_event('manager.before_config_validate', conf, self)
         errors = config_schema.process_config(conf)
         if errors:
-            err = ValueError('Did not pass schema validation.')
+            err = ConfigError('Did not pass schema validation.')
             err.errors = errors
             raise err
         else:
@@ -823,7 +824,7 @@ class Manager:
                 'If you\'re running correct version of Python then it is not equipped with SQLite.\n'
                 'You can try installing `pysqlite`. If you have compiled python yourself, '
                 'recompile it with SQLite support.\n'
-                'Error: %s' % e,
+                f'Error: {e}',
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -909,7 +910,7 @@ class Manager:
                         file=sys.stderr,
                     )
                     print(
-                        'If you\'re sure there is no other instance running, delete %s'
+                        "If you're sure there is no other instance running, delete %s"
                         % self.lockfile,
                         file=sys.stderr,
                     )
@@ -929,10 +930,10 @@ class Manager:
     def write_lock(self, ipc_info: dict = None) -> None:
         assert self._has_lock
         with open(self.lockfile, 'w', encoding='utf-8') as f:
-            f.write('PID: %s\n' % os.getpid())
+            f.write(f'PID: {os.getpid()}\n')
             if ipc_info:
                 for key in sorted(ipc_info):
-                    f.write('%s: %s\n' % (key, ipc_info[key]))
+                    f.write(f'{key}: {ipc_info[key]}\n')
 
     def release_lock(self) -> None:
         try:
@@ -940,9 +941,9 @@ class Manager:
         except OSError as e:
             if e.errno != errno.ENOENT:
                 raise
-            logger.debug('Lockfile {} not found', self.lockfile)
+            logger.debug(f'Lockfile {self.lockfile} not found')
         else:
-            logger.debug('Removed {}', self.lockfile)
+            logger.debug(f'Removed {self.lockfile}')
 
     def daemonize(self) -> None:
         """Daemonizes the current process. Returns the new pid"""
@@ -965,7 +966,7 @@ class Manager:
                 # exit first parent
                 sys.exit(0)
         except OSError as e:
-            sys.stderr.write('fork #1 failed: %d (%s)\n' % (e.errno, e.strerror))
+            sys.stderr.write(f'fork #1 failed: {e.errno} ({e.strerror})\n')
             sys.exit(1)
 
         # decouple from parent environment
@@ -982,10 +983,10 @@ class Manager:
                 # exit from second parent
                 sys.exit(0)
         except OSError as e:
-            sys.stderr.write('fork #2 failed: %d (%s)\n' % (e.errno, e.strerror))
+            sys.stderr.write(f'fork #2 failed: {e.errno} ({e.strerror})\n')
             sys.exit(1)
 
-        logger.info('Daemonize complete. New PID: {}', os.getpid())
+        logger.info(f'Daemonize complete. New PID: {os.getpid()}')
         # redirect standard file descriptors
         sys.stdout.flush()
         sys.stderr.flush()

--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -342,9 +342,7 @@ class PluginInfo(dict):
                     handler_prio = method.priority
                 else:
                     handler_prio = PRIORITY_DEFAULT
-                event = add_phase_handler(
-                    'plugin.%s.%s' % (self.name, phase), method, handler_prio
-                )
+                event = add_phase_handler(f'plugin.{self.name}.{phase}', method, handler_prio)
                 # provides backwards compatibility
                 event.plugin = self
                 self.phase_handlers[phase] = event


### PR DESCRIPTION
### Motivation for changes:
Continuation of #2751, `api` module

### Detailed changes:
- Added type annotations to api module
- Changed "rel" links generation in `pagination_headers()` (equivalent results, obviously). To me, it's more readable compared to the template parameter replacement method, but, as it's just my opinion, I can revert it if you wish
- [`TypedDict`](https://docs.python.org/3/library/typing.html#typing.TypedDict) usage is wrapped inside `if TYPE_CHECKING` blocks, as it's available on versions >= 3.8.
- Adding `Session` annotation for API methods introduced "new" mypy warnings like the following (previously ignored, as inferred type was `Any` cause of missing annotations):
```Item "None" of "Optional[Session]" has no attribute "query"```
Should all go away when typing decorators that mess with the arguments is implemented. Relevant issues: python/typing/issues/193 , python/mypy#3157
- Changed some `try: ... except Exception: pass` to use [`contextlib.suppress`](https://docs.python.org/3/library/contextlib.html#contextlib.suppress) instead

### Log and/or tests output (preferably both):
```
============== 1317 passed, 28 skipped, 4 xfailed, 5 xpassed, 59 warnings in 188.89s (0:03:08) ===============
```