### PR TITLE
Add type annotations to utils module

### DIFF
--- a/flexget/components/bittorrent/torrent_scrub.py
+++ b/flexget/components/bittorrent/torrent_scrub.py
@@ -63,7 +63,7 @@ class TorrentScrub:
 
             if mode in ("on", "all", "true"):
                 modified = bittorrent.clean_meta(
-                    metainfo, including_info=(mode == "all"), logger=logger.debug
+                    metainfo, including_info=(mode == "all"), log_func=logger.debug
                 )
             elif mode in ("resume", "rtorrent"):
                 if mode == "resume":

--- a/flexget/utils/cache.py
+++ b/flexget/utils/cache.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+from typing import Tuple
 
 import requests
 from loguru import logger
@@ -8,7 +9,13 @@ logger = logger.bind(name='utils.cache')
 
 
 # TODO refactor this to use lru_cache
-def cached_resource(url, base_dir, force=False, max_size=250, directory='cached_resources'):
+def cached_resource(
+    url: str,
+    base_dir: str,
+    force: bool = False,
+    max_size: int = 250,
+    directory: str = 'cached_resources'
+) -> Tuple[str, str]:
     """
     Caches a remote resource to local filesystem. Return a tuple of local file name and mime type, use primarily
     for API/WebUI.
@@ -25,7 +32,7 @@ def cached_resource(url, base_dir, force=False, max_size=250, directory='cached_
     directory = os.path.dirname(file_path)
 
     if not os.path.exists(file_path) or force:
-        logger.debug('caching {}', url)
+        logger.debug(f'caching {url}')
         response = requests.get(url)
         response.raise_for_status()
         mime_type = response.headers.get('content-type')
@@ -38,7 +45,7 @@ def cached_resource(url, base_dir, force=False, max_size=250, directory='cached_
         if not force:
             while size >= max_size:
                 logger.debug(
-                    'directory {} size is over the allowed limit of {}, trimming', size, max_size
+                    f'directory {size} size is over the allowed limit of {max_size}, trimming'
                 )
                 trim_dir(directory)
                 size = dir_size(directory) / (1024 * 1024.0)
@@ -48,7 +55,7 @@ def cached_resource(url, base_dir, force=False, max_size=250, directory='cached_
     return file_path, mime_type
 
 
-def dir_size(directory):
+def dir_size(directory: str) -> int:
     """
     Sums the size of all files in a given dir. Not recursive.
 
@@ -62,14 +69,14 @@ def dir_size(directory):
     return size
 
 
-def trim_dir(directory):
+def trim_dir(directory: str) -> None:
     """
     Removed the least accessed file on a given dir
 
     :param directory: Directory to check
     """
 
-    def access_time(f):
+    def access_time(f: str) -> float:
         return os.stat(os.path.join(directory, f)).st_atime
 
     files = sorted(os.listdir(directory), key=access_time)

--- a/flexget/utils/database.py
+++ b/flexget/utils/database.py
@@ -1,9 +1,10 @@
 import functools
 from datetime import datetime
+from typing import List, Union, Optional, Any
 
 from sqlalchemy import extract, func
 from sqlalchemy.ext.hybrid import Comparator, hybrid_property
-from sqlalchemy.orm import synonym
+from sqlalchemy.orm import synonym, SynonymProperty
 
 from flexget.entry import Entry
 from flexget.manager import Session
@@ -41,15 +42,16 @@ def with_session(*args, **kwargs):
         return decorator
 
 
-def pipe_list_synonym(name):
+def pipe_list_synonym(name: str) -> SynonymProperty:
     """Converts pipe separated text into a list"""
 
-    def getter(self):
+    def getter(self) -> Optional[List[str]]:
         attr = getattr(self, name)
         if attr:
             return attr.strip('|').split('|')
+        return None
 
-    def setter(self, value):
+    def setter(self, value: Union[str, List[str]]) -> None:
         if isinstance(value, str):
             setattr(self, name, value)
         else:
@@ -58,13 +60,13 @@ def pipe_list_synonym(name):
     return synonym(name, descriptor=property(getter, setter))
 
 
-def text_date_synonym(name):
+def text_date_synonym(name: str) -> SynonymProperty:
     """Converts Y-M-D date strings into datetime objects"""
 
-    def getter(self):
+    def getter(self) -> Optional[datetime]:
         return getattr(self, name)
 
-    def setter(self, value):
+    def setter(self, value: Union[str, datetime]) -> None:
         if isinstance(value, str):
             try:
                 setattr(self, name, datetime.strptime(value, '%Y-%m-%d'))
@@ -77,13 +79,13 @@ def text_date_synonym(name):
     return synonym(name, descriptor=property(getter, setter))
 
 
-def entry_synonym(name):
+def entry_synonym(name: str) -> SynonymProperty:
     """Use serialization system to store Entries in db."""
 
-    def getter(self):
+    def getter(self) -> Any:
         return serialization.loads(getattr(self, name))
 
-    def setter(self, entry):
+    def setter(self, entry: Union[dict, Entry]) -> None:
         if isinstance(entry, dict):
             if entry.get('serializer') == 'Entry' and 'version' in entry and 'value' in entry:
                 # This is already a serialized form of entry
@@ -98,13 +100,13 @@ def entry_synonym(name):
     return synonym(name, descriptor=property(getter, setter))
 
 
-def json_synonym(name):
+def json_synonym(name: str) -> SynonymProperty:
     """Use json to serialize python objects for db storage."""
 
-    def getter(self):
+    def getter(self) -> Any:
         return json.loads(getattr(self, name), decode_datetime=True)
 
-    def setter(self, entry):
+    def setter(self, entry: Any) -> None:
         setattr(self, name, json.dumps(entry, encode_datetime=True))
 
     return synonym(name, descriptor=property(getter, setter))
@@ -113,13 +115,13 @@ def json_synonym(name):
 class CaseInsensitiveWord(Comparator):
     """Hybrid value representing a string that compares case insensitively."""
 
-    def __init__(self, word):
+    def __init__(self, word: Union[str, 'CaseInsensitiveWord']):
         if isinstance(word, CaseInsensitiveWord):
-            self.word = word.word
+            self.word: str = word.word
         else:
             self.word = word
 
-    def lower(self):
+    def lower(self) -> str:
         if isinstance(self.word, str):
             return self.word.lower()
         else:
@@ -130,10 +132,10 @@ class CaseInsensitiveWord(Comparator):
             other = CaseInsensitiveWord(other)
         return op(self.lower(), other.lower())
 
-    def __clause_element__(self):
+    def __clause_element__(self) -> str:
         return self.lower()
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.word
 
     def __getattr__(self, item):

--- a/flexget/utils/json.py
+++ b/flexget/utils/json.py
@@ -5,7 +5,9 @@ Plugins can just import the methods from this module.
 Also allows date and datetime objects to be encoded/decoded.
 """
 import datetime
-from collections import Iterable, Mapping
+from collections.abc import Iterable, Mapping
+from contextlib import suppress
+from typing import Union, Any
 
 from flexget.plugin import DependencyError
 
@@ -13,11 +15,11 @@ try:
     import simplejson as json
 except ImportError:
     try:
-        import json
+        import json  # type: ignore  # python/mypy#1153
     except ImportError:
         try:
             # Google Appengine offers simplejson via django
-            from django.utils import simplejson as json
+            from django.utils import simplejson as json  # type: ignore
         except ImportError:
             raise DependencyError(missing='simplejson')
 
@@ -37,15 +39,13 @@ class DTDecoder(json.JSONDecoder):
             try:
                 return datetime.datetime.strptime(dt_str, ISO8601_FMT)
             except (ValueError, TypeError):
-                try:
+                with suppress(ValueError, TypeError):
                     return datetime.datetime.strptime(dt_str, DATE_FMT)
-                except (ValueError, TypeError):
-                    pass
 
         return super().decode(obj, **kwargs)
 
 
-def _datetime_encoder(obj):
+def _datetime_encoder(obj: Union[datetime.datetime, datetime.date]) -> str:
     if isinstance(obj, datetime.datetime):
         return obj.strftime(ISO8601_FMT)
     elif isinstance(obj, datetime.date):
@@ -53,7 +53,7 @@ def _datetime_encoder(obj):
     raise TypeError
 
 
-def _datetime_decoder(dict_):
+def _datetime_decoder(dict_: dict) -> dict:
     for key, value in dict_.items():
         # The built-in `json` library will `unicode` strings, except for empty strings. patch this for
         # consistency so that `unicode` is always returned.
@@ -65,38 +65,35 @@ def _datetime_decoder(dict_):
             datetime_obj = datetime.datetime.strptime(value, ISO8601_FMT)
             dict_[key] = datetime_obj
         except (ValueError, TypeError):
-            try:
+            with suppress(ValueError, TypeError):
                 date_obj = datetime.datetime.strptime(value, DATE_FMT)
                 dict_[key] = date_obj.date()
-            except (ValueError, TypeError):
-                continue
 
     return dict_
 
 
-def _empty_unicode_decoder(dict_):
+def _empty_unicode_decoder(dict_: dict) -> dict:
     for key, value in dict_.items():
         # The built-in `json` library will `unicode` strings, except for empty strings. patch this for
         # consistency so that `unicode` is always returned.
         if value == b'':
             dict_[key] = ''
-            continue
     return dict_
 
 
-def dumps(*args, **kwargs):
+def dumps(*args, **kwargs) -> str:
     if kwargs.pop('encode_datetime', False):
         kwargs['default'] = _datetime_encoder
     return json.dumps(*args, **kwargs)
 
 
-def dump(*args, **kwargs):
+def dump(*args, **kwargs) -> None:
     if kwargs.pop('encode_datetime', False):
         kwargs['default'] = _datetime_encoder
     return json.dump(*args, **kwargs)
 
 
-def loads(*args, **kwargs):
+def loads(*args, **kwargs) -> Any:
     """
     :param bool decode_datetime: If `True`, dates in ISO8601 format will be deserialized to :class:`datetime.datetime`
       objects.
@@ -109,7 +106,7 @@ def loads(*args, **kwargs):
     return json.loads(*args, **kwargs)
 
 
-def load(*args, **kwargs):
+def load(*args, **kwargs) -> Any:
     """
     :param bool decode_datetime: If `True`, dates in ISO8601 format will be deserialized to :class:`datetime.datetime`
       objects.
@@ -122,7 +119,7 @@ def load(*args, **kwargs):
     return json.load(*args, **kwargs)
 
 
-def coerce(obj):
+def coerce(obj) -> Union[str, int, float, bool, dict, list, None]:
     """
     Coerce a data structure to a JSON serializable form.
 

--- a/flexget/utils/log.py
+++ b/flexget/utils/log.py
@@ -1,6 +1,7 @@
 """Logging utilities"""
 import hashlib
 from datetime import datetime, timedelta
+from typing import Optional, TYPE_CHECKING
 
 import loguru
 from loguru import logger
@@ -13,11 +14,15 @@ from flexget.utils.database import with_session
 from flexget.utils.sqlalchemy_utils import table_schema
 
 logger = logger.bind(name='util.log')
-Base = db_schema.versioned_base('log_once', 0)
+
+if TYPE_CHECKING:
+    Base = object
+else:
+    Base = db_schema.versioned_base('log_once', 0)
 
 
 @db_schema.upgrade('log_once')
-def upgrade(ver, session):
+def upgrade(ver: Optional[int], session: Session):
     if ver is None:
         logger.info('Adding index to md5sum column of log_once table.')
         table = table_schema('log_once', session)
@@ -35,15 +40,15 @@ class LogMessage(Base):
     md5sum = Column(String, unique=True)
     added = Column(DateTime, default=datetime.now())
 
-    def __init__(self, md5sum):
+    def __init__(self, md5sum: str) -> None:
         self.md5sum = md5sum
 
-    def __repr__(self):
-        return "<LogMessage('%s')>" % self.md5sum
+    def __repr__(self) -> str:
+        return f"<LogMessage('{self.md5sum}')>"
 
 
 @event('manager.db_cleanup')
-def purge(manager, session: Session):
+def purge(manager, session: Session) -> None:
     """Purge old messages from database"""
     old = datetime.now() - timedelta(days=365)
 
@@ -59,7 +64,7 @@ def log_once(
     once_level: str = 'INFO',
     suppressed_level: str = 'VERBOSE',
     session: Session = None,
-):
+) -> Optional[bool]:
     """
     Log message only once using given logger`. Returns False if suppressed logging.
     When suppressed, `suppressed_level` level is still logged.
@@ -70,7 +75,7 @@ def log_once(
     if not manager:
         logger.warning('DB not initialized. log_once will not work properly.')
         logger.log(once_level, message)
-        return
+        return None
 
     digest = hashlib.md5()
     digest.update(message.encode('latin1', 'replace'))  # ticket:250

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -1,10 +1,11 @@
+import abc
 import logging
 import time
 
 # Allow some request objects to be imported from here instead of requests
 import warnings
 from datetime import datetime, timedelta
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, TYPE_CHECKING
 from urllib.parse import urlparse
 from urllib.request import urlopen
 
@@ -27,6 +28,11 @@ logging.getLogger('urllib3').setLevel(logging.WARNING)
 WAIT_TIME = timedelta(seconds=60)
 # Remembers sites that have timed out
 unresponsive_hosts = TimedDict(WAIT_TIME)
+
+if TYPE_CHECKING:
+    from typing import TypedDict
+    StateCacheDict = TypedDict('StateCacheDict',
+                               {'tokens': Union[float, int], 'last_update': datetime})
 
 
 def is_unresponsive(url: str) -> bool:
@@ -54,13 +60,13 @@ def set_unresponsive(url: str) -> None:
     unresponsive_hosts[host] = True
 
 
-class DomainLimiter:
+class DomainLimiter(abc.ABC):
     def __init__(self, domain: str) -> None:
         self.domain = domain
 
-    def __call__(self):
+    @abc.abstractmethod
+    def __call__(self) -> None:
         """This method will be called once before every request to the domain."""
-        raise NotImplementedError
 
 
 class TokenBucketLimiter(DomainLimiter):
@@ -72,7 +78,7 @@ class TokenBucketLimiter(DomainLimiter):
 
     # This is just an in memory cache right now, it works for the daemon, and across tasks in a single execution
     # but not for multiple executions via cron. Do we need to store this to db?
-    state_cache = {}
+    state_cache: Dict[str, 'StateCacheDict'] = {}
 
     def __init__(
         self,
@@ -134,7 +140,7 @@ class TokenBucketLimiter(DomainLimiter):
 class TimedLimiter(TokenBucketLimiter):
     """Enforces a minimum interval between requests to a given domain."""
 
-    def __init__(self, domain: str, interval: Union[str, timedelta]):
+    def __init__(self, domain: str, interval: Union[str, timedelta]) -> None:
         super().__init__(domain, 1, interval)
 
 
@@ -149,7 +155,7 @@ def _wrap_urlopen(url: str, timeout: Optional[int] = None) -> requests.Response:
     try:
         raw = urlopen(url, timeout=timeout)
     except OSError as e:
-        msg = 'Error getting %s: %s' % (url, e)
+        msg = f'Error getting {url}: {e}'
         logger.error(msg)
         raise RequestException(msg)
     resp = requests.Response()
@@ -162,7 +168,7 @@ def _wrap_urlopen(url: str, timeout: Optional[int] = None) -> requests.Response:
     return resp
 
 
-def limit_domains(url: str, limit_dict: Dict[str, DomainLimiter]):
+def limit_domains(url: str, limit_dict: Dict[str, DomainLimiter]) -> None:
     """
     If this url matches a domain in `limit_dict`, run the limiter.
 
@@ -183,12 +189,12 @@ class Session(requests.Session):
 
     def __init__(self, timeout: int = 30, max_retries: int = 1, **kwargs) -> None:
         """Set some defaults for our session if not explicitly defined."""
-        super().__init__(**kwargs)
+        super().__init__()
         self.timeout = timeout
         self.stream = True
         self.adapters['http://'].max_retries = max_retries
         # Stores min intervals between requests for certain sites
-        self.domain_limiters = {}
+        self.domain_limiters: Dict[str, DomainLimiter] = {}
         self.headers.update({'User-Agent': 'FlexGet/%s (www.flexget.com)' % version})
 
     def add_cookiejar(self, cookiejar):
@@ -235,8 +241,8 @@ class Session(requests.Session):
         # Raise Timeout right away if site is known to timeout
         if is_unresponsive(url):
             raise requests.Timeout(
-                'Requests to this site (%s) have timed out recently. Waiting before trying again.'
-                % urlparse(url).hostname
+                f'Requests to this site ({urlparse(url).hostname}) have timed out recently. '
+                'Waiting before trying again.'
             )
 
         # Run domain limiters for this url
@@ -253,7 +259,7 @@ class Session(requests.Session):
 
         try:
             logger.debug(
-                '{}ing URL {} with args {} and kwargs {}', method.upper(), url, args, kwargs
+                f'{method.upper()}ing URL {url} with args {args} and kwargs {kwargs}'
             )
             result = super().request(method, url, *args, **kwargs)
         except requests.Timeout:

--- a/flexget/utils/serialization.py
+++ b/flexget/utils/serialization.py
@@ -9,8 +9,8 @@ ISO8601_FMT = '%Y-%m-%dT%H:%M:%SZ'
 
 
 def serialize(value: Any) -> Any:
-    """
-    Convert an object to JSON serializable format.
+    """Convert an object to JSON serializable format.
+
     :param value: Object to serialize.
     :return: JSON serializable representation of this object.
     """
@@ -31,8 +31,8 @@ def serialize(value: Any) -> Any:
 
 
 def deserialize(value: Any) -> Any:
-    """
-    Restore an object stored with this serialization system to its original format.
+    """Restore an object stored with this serialization system to its original format.
+
     :param value: Serialized representation of the object.
     :return: Deserialized object.
     """
@@ -48,9 +48,7 @@ def deserialize(value: Any) -> Any:
 
 
 def dumps(value: Any) -> str:
-    """
-    Dump an object to text using the serialization system.
-    """
+    """Dump an object to text using the serialization system."""
     serialized = serialize(value)
     try:
         return json.dumps(serialized)
@@ -59,9 +57,7 @@ def dumps(value: Any) -> str:
 
 
 def loads(value: str) -> Any:
-    """
-    Restore an object from JSON text created by `dumps`
-    """
+    """Restore an object from JSON text created by `dumps`"""
     return deserialize(json.loads(value))
 
 
@@ -97,13 +93,11 @@ class Serializer(ABC):
     @abstractmethod
     def serialize(cls, value: Any) -> Any:
         """This method should be implemented to return a plain python datatype which is json serializable."""
-        pass
 
     @classmethod
     @abstractmethod
     def deserialize(cls, data: Any, version: int) -> Any:
         """Returns an instance of the original class, recreated from the serialized form."""
-        pass
 
 
 class DateTimeSerializer(Serializer):
@@ -116,7 +110,7 @@ class DateTimeSerializer(Serializer):
         return value.strftime(ISO8601_FMT)
 
     @classmethod
-    def deserialize(cls, data, version: int) -> datetime.datetime:
+    def deserialize(cls, data: str, version: int) -> datetime.datetime:
         return datetime.datetime.strptime(data, ISO8601_FMT)
 
 
@@ -130,7 +124,7 @@ class DateSerializer(Serializer):
         return value.strftime(DATE_FMT)
 
     @classmethod
-    def deserialize(cls, data, version: int) -> datetime.date:
+    def deserialize(cls, data: str, version: int) -> datetime.date:
         return datetime.datetime.strptime(data, DATE_FMT).date()
 
 
@@ -140,11 +134,11 @@ class SetSerializer(Serializer):
         return isinstance(value, set)
 
     @classmethod
-    def serialize(cls, value: set):
+    def serialize(cls, value: set) -> list:
         return serialize(list(value))
 
     @classmethod
-    def deserialize(cls, data, version: int) -> set:
+    def deserialize(cls, data: list, version: int) -> set:
         return set(deserialize(data))
 
 
@@ -154,18 +148,19 @@ class TupleSerializer(Serializer):
         return isinstance(value, tuple)
 
     @classmethod
-    def serialize(cls, value: set):
+    def serialize(cls, value: tuple) -> list:
         return serialize(list(value))
 
     @classmethod
-    def deserialize(cls, data, version) -> tuple:
-        return tuple(deserialize(data))
+    def deserialize(cls, data: list, version: int) -> tuple:
+        return tuple(deserialize(data))  # type: ignore
 
 
 def _serializer_for(value) -> Optional[Type[Serializer]]:
     for s in Serializer.__subclasses__():
         if s.serializer_handles(value):
             return s
+    return None
 
 
 def _deserializer_for(serializer_name: str) -> Type[Serializer]:

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -8,7 +8,7 @@ import os
 import queue
 import re
 import sys
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from collections.abc import MutableMapping
 from datetime import datetime, timedelta
 from html.entities import name2codepoint
@@ -50,32 +50,27 @@ def str_to_int(string: str) -> Optional[int]:
         return None
 
 
-def convert_bytes(bytes: Union[int, float]) -> str:
+def convert_bytes(bytes_num: Union[int, float]) -> str:
     """Returns given bytes as prettified string."""
 
-    bytes = float(bytes)
-    if bytes >= 1099511627776:
-        terabytes = bytes / 1099511627776
-        size = '%.2fT' % terabytes
-    elif bytes >= 1073741824:
-        gigabytes = bytes / 1073741824
-        size = '%.2fG' % gigabytes
-    elif bytes >= 1048576:
-        megabytes = bytes / 1048576
-        size = '%.2fM' % megabytes
-    elif bytes >= 1024:
-        kilobytes = bytes / 1024
-        size = '%.2fK' % kilobytes
-    else:
-        size = '%.2fb' % bytes
-    return size
+    bytes_num = float(bytes_num)
+    units_prefixes = OrderedDict({
+        'T': 1099511627776,  # 1024 ** 4
+        'G': 1073741824,  # 1024 ** 3
+        'M': 1048576,  # 1024 ** 2
+        'K': 1024,
+    })
+    for unit, threshold in units_prefixes.items():
+        if bytes_num > threshold:
+            return f'{bytes_num/threshold:.2f}{unit}'
+    return f'{bytes_num:.2f}b'
 
 
 class MergeException(Exception):
-    def __init__(self, value):
+    def __init__(self, value: str):
         self.value = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         return repr(self.value)
 
 
@@ -147,12 +142,9 @@ def merge_dict_from_to(d1: dict, d2: dict) -> None:
                 elif isinstance(v, (str, bool, int, float, type(None))):
                     pass
                 else:
-                    raise Exception(
-                        'Unknown type: %s value: %s in dictionary' % (type(v), repr(v))
-                    )
-            elif isinstance(v, (str, bool, int, float, list, type(None))) and isinstance(
-                d2[k], (str, bool, int, float, list, type(None))
-            ):
+                    raise Exception(f'Unknown type: {type(v)} value: {repr(v)} in dictionary')
+            elif (isinstance(v, (str, bool, int, float, list, type(None))) and
+                  isinstance(d2[k], (str, bool, int, float, list, type(None)))):
                 # Allow overriding of non-container types with other non-container types
                 pass
             else:
@@ -174,20 +166,19 @@ class ReList(list):
     """
 
     # Set the default flags
-    flags = re.IGNORECASE | re.UNICODE
+    flags = re.IGNORECASE
 
     def __init__(self, *args, **kwargs) -> None:
         """Optional :flags: keyword argument with regexp flags to compile with"""
         if 'flags' in kwargs:
-            self.flags = kwargs['flags']
-            del kwargs['flags']
+            self.flags = kwargs.pop('flags')
         list.__init__(self, *args, **kwargs)
 
-    def __getitem__(self, k) -> Pattern:
+    def __getitem__(self, k) -> Pattern:  # type: ignore
         # Doesn't support slices. Do we care?
         item = list.__getitem__(self, k)
         if isinstance(item, str):
-            item = re.compile(item, re.IGNORECASE | re.UNICODE)
+            item = re.compile(item, self.flags)
             self[k] = item
         return item
 
@@ -217,7 +208,7 @@ else:
         io_encoding = 'ascii'
 
 
-def parse_timedelta(value: Union[timedelta, str]) -> timedelta:
+def parse_timedelta(value: Union[timedelta, str, None]) -> timedelta:
     """Parse a string like '5 days' into a timedelta object. Also allows timedeltas to pass through."""
     if isinstance(value, timedelta):
         # Allow timedelta objects to pass through
@@ -231,9 +222,9 @@ def parse_timedelta(value: Union[timedelta, str]) -> timedelta:
         unit += 's'
     params = {unit: float(amount)}
     try:
-        return timedelta(**params)
+        return timedelta(**params)  # type: ignore
     except TypeError:
-        raise ValueError('Invalid time format \'%s\'' % value)
+        raise ValueError(f"Invalid time format '{value}'")
 
 
 def multiply_timedelta(interval: timedelta, number: Union[int, float]) -> timedelta:
@@ -296,7 +287,7 @@ class TimedDict(MutableMapping):
 
     def __init__(self, cache_time: Union[timedelta, str] = '5 minutes'):
         self.cache_time = parse_timedelta(cache_time)
-        self._store = dict()
+        self._store: dict = {}
         self._last_prune = datetime.now()
 
     def _prune(self):
@@ -356,6 +347,8 @@ def split_title_year(title: str) -> Tuple[str, Optional[int]]:
     # We only recognize years from the 2nd and 3rd millennium, FlexGetters from the year 3000 be damned!
     match = re.search(r'(.*?)\(?([12]\d{3})?\)?$', title)
 
+    if not match:
+        return title, None
     title = match.group(1).strip()
     year_match = match.group(2)
 
@@ -378,7 +371,7 @@ def get_latest_flexget_version_number() -> Optional[str]:
         data = requests.get('https://pypi.python.org/pypi/FlexGet/json').json()
         return data.get('info', {}).get('version')
     except requests.RequestException:
-        return
+        return None
 
 
 def get_current_flexget_version() -> str:
@@ -402,7 +395,7 @@ def parse_filesize(text_size: str, si: bool = True) -> float:
     )
     if not parsed_size:
         raise ValueError('%s does not look like a file size' % text_size)
-    amount = parsed_size.group(1)
+    amount_str = parsed_size.group(1)
     unit = parsed_size.group(2)
     if not unit.endswith('b'):
         raise ValueError('%s does not look like a file size' % text_size)
@@ -413,7 +406,7 @@ def parse_filesize(text_size: str, si: bool = True) -> float:
     if unit not in prefix_order:
         raise ValueError('%s does not look like a file size' % text_size)
     order = prefix_order[unit]
-    amount = float(amount.replace(',', '').replace(' ', ''))
+    amount = float(amount_str.replace(',', '').replace(' ', ''))
     base = 1000 if si else 1024
     return (amount * (base ** order)) / 1024 ** 2
 
@@ -454,7 +447,7 @@ def parse_episode_identifier(
     :raises ValueError: If ep_id does not match any valid types
     """
     error = None
-    identified_by = None
+    identified_by = ''
     entity_type = 'episode'
     if isinstance(ep_id, int):
         if ep_id <= 0:
@@ -475,7 +468,7 @@ def parse_episode_identifier(
                 error = 'sequence type episode must be higher than 0'
             identified_by = 'sequence'
         except ValueError:
-            error = '`%s` is not a valid episode identifier.' % ep_id
+            error = f'`{ep_id}` is not a valid episode identifier.'
     if error:
         raise ValueError(error)
     return identified_by, entity_type


### PR DESCRIPTION
### Motivation for changes:
Continuation of #2751, utils module

### Detailed changes:
- Added type annotations to api module
- Changed some docstrings to better conform to [PEP257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings)
- Renamed some variables that shadowed built-ins (checked usages to make sure nothing broke)
- `bitorrent.py`: Changed `decode_item()` to use the iterator from `tokenize()` rather than a partial `next()` callable (more readable IMHO)
 - `requests.py`: Removed `**kwargs` from call of super (`requests.Session`), as it expects nothing
- `template.py`: Changed `locale.format()` to `locale.format_str`, as the format is deprecated
- `tools.py`: Refactored `convert_bytes` implementation to a more concise and readable one (IMHO)
- `simple_persistence.py`: Skipped, as deprecated

Note: in `tools.py`, `ReList` class, the `flags` kwarg is stored, but never used. It's okay since no usages of the class provide it, but perhaps the following line should be changed (if flags is a single value, or a similar approach if we expect a list)
```diff
- item = re.compile(item, re.IGNORECASE | re.UNICODE)
+ item = re.compile(item, re.IGNORECASE | re.UNICODE | self.flags)
```

### Log and/or tests output (preferably both):
```
============== 1317 passed, 28 skipped, 4 xfailed, 5 xpassed, 59 warnings in 186.14s (0:03:06) ===============

❯ dmypy run -- --ignore-missing-imports --follow-imports=skip flexget/utils | tail -1
# before
Found 52 errors in 9 files (checked 22 source files)
# after
Found 7 errors in 4 files (checked 22 source files)
```
