### PR TITLE
Handle both old and new case for database_uri

### DIFF
--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -792,7 +792,7 @@ class Manager:
             logger.critical('Failed to check SQLAlchemy version, you may need to upgrade it')
 
         # SQLAlchemy
-        if self.database_uri is None:
+        if self.database_uri in ['', None]:
             # in case running on windows, needs double \\
             filename = self.db_filename.replace('\\', '\\\\')
             self.database_uri = f'sqlite:///{filename}'


### PR DESCRIPTION
I found this case when installing the latest version of flexget. 
It defaults to an empty string instead of, I presume, the previous default of `None`.

I'm not sure if it's worthwhile keeping the `None` as a case but figured it was the 
"safer" option just in case. Also feels like `if not self.database_uri` should be just enough as well?

### Motivation for changes:

Failing to start flexget from a fresh install from the latest version on Pypi
