### PR TITLE
Fix extra spaces on torrentz with extra terms and change .eu domain

### DIFF
--- a/flexget/components/sites/sites/torrentz.py
+++ b/flexget/components/sites/sites/torrentz.py
@@ -44,7 +44,7 @@ class Torrentz:
         if isinstance(config, str):
             config = {'reputation': config}
         if config.get('extra_terms'):
-            config['extra_terms'] = ' ' + config['extra_terms']
+            config['extra_terms'] = ' ' + config['extra_terms'].strip()
         return config
 
     # TODO: The torrent_cache plugin is broken, so urlrewriting has been disabled for this plugin. #2307 #2363
@@ -66,8 +66,8 @@ class Torrentz:
         feed = REPUTATIONS[config['reputation']]
         entries = set()
         for search_string in entry.get('search_strings', [entry['title']]):
-            query = normalize_unicode(search_string + config.get('extra_terms', ''))
-            for domain in ['eu', 'is']:
+            query = normalize_unicode(search_string.strip() + config.get('extra_terms', ''))
+            for domain in ['is', 'pl']:
                 # urllib.quote will crash if the unicode string has non ascii characters, so encode in utf-8 beforehand
                 url = 'http://torrentz2.%s/%s?f=%s' % (domain, feed, quote(query.encode('utf-8')))
                 logger.debug('requesting: {}', url)


### PR DESCRIPTION
### Motivation for changes:

torrentz due long request string return Bad request response and change dead [.eu](https://torrentz.eu) domain with [.pl](https://torrentz.pl).

Looks like between more requests/searches keep adding more `%20` spaces

### Detailed changes:
- Remove/prevent unnecessary extra request spaces when have `extra_terms` configuration
- Change dead `.eu` domain with `.pl`

### Addressed issues:
N/A

### Implemented feature requests:
N/A

### Config usage if relevant (new plugin or updated schema):
```
      from:
        - torrentz: 
           reputation: good
           extra_terms: lat
```
### Log and/or tests output (preferably both):
```
2020-10-24 12:04:28 ERROR    discover      download-movies-spanish Error searching with torrentz: Error getting torrentz search results: 403 Client Error: Bad Requests for url: http://torrentz2.is/feed?f=Kiki%27s%20Delivery%20Service%20%281989%29%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20latino
```

