### PR TITLE
Remove addic7ed from subliminal fallback providers

### DIFF
--- a/flexget/plugins/output/subtitles_subliminal.py
+++ b/flexget/plugins/output/subtitles_subliminal.py
@@ -16,7 +16,16 @@ try:
 
     PROVIDERS = provider_manager.names()
 except ImportError:
-    PROVIDERS = ['opensubtitles', 'thesubdb', 'podnapisi', 'addic7ed', 'tvsubtitles']
+    PROVIDERS = [
+        'argenteam',
+        'legendastv',
+        'opensubtitles',
+        'opensubtitlesvip',
+        'podnapisi',
+        'shooter',
+        'thesubdb',
+        'tvsubtitles',
+    ]
 
 AUTHENTICATION_SCHEMA = dict((provider, {'type': 'object'}) for provider in PROVIDERS)
 
@@ -41,12 +50,12 @@ class PluginSubliminal:
           alternatives:
             - eng
           exact_match: no
-          providers: addic7ed, opensubtitles
+          providers: legendastv, opensubtitles
           single: no
           directory: /disk/subtitles
           hearing_impaired: yes
           authentication:
-            addic7ed:
+            legendastv:
               username: myuser
               passsword: mypassword
     """


### PR DESCRIPTION
### Motivation for changes:
The last version of subliminal has an indentation issue in `addic7ed` and will be disable in the next release due a captcha error

https://github.com/Diaoul/subliminal/issues/1005#issuecomment-629037571
https://github.com/Diaoul/subliminal/issues/966#issuecomment-623117304

### Detailed changes:
- Update subliminal fallback providers
- Remove `addic7ed` from fallback provider

### Addressed issues:
- N/A

### Implemented feature requests:
- N/A

### Config usage if relevant (new plugin or updated schema):
```
N/A
```
### Log and/or tests output (preferably both):
```
2020-10-24 11:59:36 ERROR    stevedore.extension                 Could not load 'addic7ed': unexpected indent (addic7ed.py, line 234)
```


