### PR TITLE
Update dockerfile to Python 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN pip install -U pip && \
                 cloudscraper && \
     rm -rf /wheels
 
-COPY --from=0 /flexget-ui-v2 /usr/local/lib/python3.8/site-packages/flexget/ui/v2/
+COPY --from=0 /flexget-ui-v2 /usr/local/lib/python3.9/site-packages/flexget/ui/v2/
 
 RUN mkdir /root/.flexget
 VOLUME /root/.flexget


### PR DESCRIPTION
### Motivation for changes:

There is a line with Python version in Dockerfile for deploying the web UI. `python:3-alpine` is now Python 3.9, this updates it accordingly.

