### PR TITLE
Pending list filter option

### DIFF
--- a/flexget/components/imdb/utils.py
+++ b/flexget/components/imdb/utils.py
@@ -25,7 +25,7 @@ requests.headers.update(
 )
 
 # give imdb a little break between requests (see: http://flexget.com/ticket/129#comment:1)
-requests.add_domain_limiter(TimedLimiter('imdb.com', '3 seconds'))
+requests.add_domain_limiter(TimedLimiter('imdb.com', '1 seconds'))
 
 
 def is_imdb_url(url):

--- a/flexget/components/imdb/utils.py
+++ b/flexget/components/imdb/utils.py
@@ -25,7 +25,7 @@ requests.headers.update(
 )
 
 # give imdb a little break between requests (see: http://flexget.com/ticket/129#comment:1)
-requests.add_domain_limiter(TimedLimiter('imdb.com', '1 seconds'))
+requests.add_domain_limiter(TimedLimiter('imdb.com', '3 seconds'))
 
 
 def is_imdb_url(url):

--- a/flexget/tests/test_pending_list.py
+++ b/flexget/tests/test_pending_list.py
@@ -12,10 +12,20 @@ class TestListInterface:
           list_get:
             pending_list: test_list
 
-          list_get_including_pending:
+          list_get_pending:
             pending_list:
-              list_name: "test_list"
-              include_pending: True
+              list_name: 'test_list'
+              include: 'pending'
+               
+          list_get_approved:
+            pending_list:
+              list_name: 'test_list'
+              include: 'approved'
+               
+          list_get_all:
+            pending_list:
+              list_name: 'test_list'
+              include: 'all'
                
           pending_list_add:
             mock:
@@ -74,9 +84,23 @@ class TestListInterface:
         task = execute_task('list_get')
         assert len(task.entries) == 0
 
-    def test_list_match_include_pending(self, execute_task):
+    def test_list_get_include(self, execute_task):
         task = execute_task('pending_list_add')
         assert len(task.entries) == 2
 
-        task = execute_task('list_get_including_pending')
+        with Session() as session:
+            entry = session.query(PendingListList).first().entries.first()
+            entry.approved = True
+
+        with Session() as session:
+            entries = session.query(PendingListList).first().entries.all()
+            print(entries)
+
+        task = execute_task('list_get_all')
         assert len(task.entries) == 2
+
+        task = execute_task('list_get_pending')
+        assert len(task.entries) == 1
+
+        task = execute_task('list_get_approved')
+        assert len(task.entries) == 1

--- a/flexget/tests/test_pending_list.py
+++ b/flexget/tests/test_pending_list.py
@@ -12,6 +12,11 @@ class TestListInterface:
           list_get:
             pending_list: test_list
 
+          list_get_including_pending:
+            pending_list:
+              list_name: "test_list"
+              include_pending: True
+               
           pending_list_add:
             mock:
               - {title: 'title 1', url: "http://mock.url/file1.torrent"}
@@ -28,6 +33,7 @@ class TestListInterface:
             list_match:
               from:
                 - pending_list: test_list
+
     """
 
     def test_list_add(self, execute_task):
@@ -67,3 +73,10 @@ class TestListInterface:
 
         task = execute_task('list_get')
         assert len(task.entries) == 0
+
+    def test_list_match_include_pending(self, execute_task):
+        task = execute_task('pending_list_add')
+        assert len(task.entries) == 2
+
+        task = execute_task('list_get_including_pending')
+        assert len(task.entries) == 2

--- a/flexget/tests/test_pending_list.py
+++ b/flexget/tests/test_pending_list.py
@@ -92,10 +92,6 @@ class TestListInterface:
             entry = session.query(PendingListList).first().entries.first()
             entry.approved = True
 
-        with Session() as session:
-            entries = session.query(PendingListList).first().entries.all()
-            print(entries)
-
         task = execute_task('list_get_all')
         assert len(task.entries) == 2
 


### PR DESCRIPTION
### Motivation for changes:
Add ability to include items which are pending approval to preform tasks such as

1.clean-ups if older then x days.
2. For shows/movies released on netflix the rating/score on imdb can be empty meaning some end up in pending approval. A few days later people have voted, if it is a high voted movie then having the ability to filter on "pending approval" items will allow you to auto approve if the rating changes.

### Config usage if relevant (new plugin or updated schema):
```
          list_get_pending:
            pending_list:
              list_name: "test_list"
              include: "pending"

          list_get_approved:
            pending_list:
              list_name: "test_list"
              include: "approved"

          list_get_all:
            pending_list:
              list_name: "test_list"
              include: "all"

```
