### PR TITLE
[change] Sonarr - Handle when the title or id is not found in the entry object

### DIFF
--- a/flexget/components/managed_lists/lists/sonarr_list.py
+++ b/flexget/components/managed_lists/lists/sonarr_list.py
@@ -156,6 +156,11 @@ class SonarrSet(MutableSet):
         elif len(lookup_results) > 1:
             logger.debug('got multiple results for Sonarr, using first one')
         show = lookup_results[0]
+
+        if show.get("id"):
+            logger.debug('entry {} already exists in Sonarr list as show {}', entry, show)
+            return show
+
         logger.debug('using show {}', show)
 
         # Getting root folder


### PR DESCRIPTION
Handle when the title or id is not found in the entry object which means a match is not found.. However the lookup of shows in sonarr returns a show that already exists.
