### PR TITLE
update feedparser version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-FeedParser>=6.0.1
+FeedParser>=6.0.2
 SQLAlchemy >=1.3.10, <1.999
 PyYAML>=4.2b1
 # Beautifulsoup 4.5+ is required to support different versions of html5lib

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ cherrypy==18.4.0          # via -r requirements.in
 click==6.7                # via flask
 colorama==0.4.4           # via loguru
 colorclass==2.2.0         # via -r requirements.in
-feedparser==6.0.1         # via -r requirements.in
+feedparser==6.0.2         # via -r requirements.in
 flask-compress==1.4.0     # via -r requirements.in
 flask-cors==3.0.2         # via -r requirements.in
 flask-login==0.4.0        # via -r requirements.in


### PR DESCRIPTION
### Motivation for changes:

fix warning when installing flexget via pip for yanked version of feedparser

### Detailed changes:
- update feedparser version 6.0.1->6.0.2 in requirements file

### Addressed issues:
- Fixes # [2775](https://github.com/Flexget/Flexget/issues/2775)
