### PR TITLE
[change] Pyload: Support for Group Links

### DIFF
--- a/flexget/plugins/clients/pyload.py
+++ b/flexget/plugins/clients/pyload.py
@@ -193,7 +193,7 @@ class PluginPyLoad:
 
             parsed = result.json()
 
-            urls = []
+            urls = entry.get('urls', [])
 
             # check for preferred hoster
             for name in hoster:


### PR DESCRIPTION
### Motivation for changes:

RSS plugin allows to use `group_links` option to generate one entry with multiple
URLs, but Pyload wasn't using it.

I was fighting with this for months before I checked the source code and have been using pyloads parsing feature instead. It never cross my mind that it wouldn't be implemented at all.

### Detailed changes:
- Simply load `urls` from `entry` when present.

