### PR TITLE
[fix] torznab: Fix None value in description

### DIFF
--- a/flexget/plugins/input/torznab.py
+++ b/flexget/plugins/input/torznab.py
@@ -190,7 +190,7 @@ class Torznab:
                 if child.tag in ['{http://torznab.com/schemas/2015/feed}attr', 'enclosure']:
                     continue
                 else:
-                    if child.tag in ['description', 'title']:
+                    if child.tag in ['description', 'title'] and child.text:
                         entry[child.tag] = child.text
             entries.append(entry)
         return entries


### PR DESCRIPTION
Torznab can receive None value in child.text which leads to generating entry
with None value in description.

Unfortunately `entry.get('description', '')` construct which is used almost
everywhere can't return default value when 'description' key exists in entry but
its value is None.

I believe that better option would be to use different method to handle
defaults and don't count on input plugins to provide correct values, but it
would take major effort to fix everywhere.