### PR TITLE
Dockerfile transmission-rpc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY . /flexget
 
 RUN pip install -U pip && \
     pip wheel -e /flexget && \
-    pip wheel transmissionrpc && \
+    pip wheel transmission-rpc && \
     pip wheel deluge-client && \
     pip wheel cloudscraper
 
@@ -40,7 +40,7 @@ RUN pip install -U pip && \
                 --no-index \
                 -f /wheels \
                 FlexGet \
-                transmissionrpc \
+                transmission-rpc \
                 deluge-client \
                 cloudscraper && \
     rm -rf /wheels

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM docker.io/python:3-alpine
 ENV PYTHONUNBUFFERED 1
 
 RUN apk add --no-cache --upgrade \
@@ -25,7 +25,7 @@ RUN wget https://github.com/Flexget/webui/releases/latest/download/dist.zip && \
     unzip dist.zip && \
     rm dist.zip
 
-FROM python:3-alpine
+FROM docker.io/python:3-alpine
 ENV PYTHONUNBUFFERED 1
 
 RUN apk add --no-cache --upgrade \


### PR DESCRIPTION
### Motivation for changes:

Pull correct transmission dependency as a followup to #2791 

### Detailed changes:
- Replaces transmissionrpc by transmission-rpc on pip commands
- Explicitly specify the pulling registry of the base image while we are at it

