### PR TITLE
Fix sftp_upload

### DIFF
--- a/flexget/components/ftp/sftp.py
+++ b/flexget/components/ftp/sftp.py
@@ -309,6 +309,7 @@ class SftpUpload:
             sftp.upload(location, to)
         except SftpError as e:
             entry.fail(str(e))  # type: ignore
+            return
 
         if delete_origin and Path(location).is_file():
             try:

--- a/flexget/components/ftp/sftp_client.py
+++ b/flexget/components/ftp/sftp_client.py
@@ -199,9 +199,10 @@ class SftpClient:
 
         :param path: path to build
         """
+
         if not self.path_exists(path):
             try:
-                self._sftp.mkdir(path)
+                self._sftp.makedirs(path)
             except Exception as e:
                 raise SftpError(f'Failed to create remote directory {path} ({str(e)})')
 


### PR DESCRIPTION
### Motivation for changes:
I'm using the format `Series Name (Year)/{{Season Number}}/Series Name(Year).ext` to rename my series and upload them to the media server with the `sftp_upload`plugin.

All was working fine until a a new series appeared and the content wasn't uploaded because of the file `[Errno 2] No such file`. Another issue is that the original file was deleted from the origin computer

### Detailed changes:
- Whenever there is a sftp file upload error, return before checking for the file deletion flag
- Check if parent directories of the file exist, and if not, create them

### Addressed issues:
N/A. Let me know if an issue is needed and I can create it.

### Implemented feature requests:
- N/A

### Config usage if relevant (new plugin or updated schema):
```yaml
    sftp_upload:
      host: "{? sftp.host ?}"
      username: "{? sftp.username ?}"
      to: "{? sftp.tv_path ?}/{{ tvdb_series_name }}/S{{ tvdb_season | pad(2) }}"
      delete_origin: yes
```

### Log and/or tests output (preferably both):
Before PR
```
➜ flexget execute --task move-series-server
2021-01-16 21:47:29 VERBOSE  task_queue                    There are 1 tasks to execute. Shutdown will commence when they have completed.
2021-01-16 21:47:29 VERBOSE  filesystem    move-series-server Starting to scan folders.
2021-01-16 21:47:29 VERBOSE  filesystem    move-series-server Scanning folder /home/guilherme/Videos/TV Shows. Recursion is set to False.
2021-01-16 21:47:29 VERBOSE  details       move-series-server Produced 1 entries.
2021-01-16 21:47:29 VERBOSE  task          move-series-server ACCEPTED: `Law.and.Order.SVU.S01E01` by accept_all plugin
2021-01-16 21:47:29 VERBOSE  details       move-series-server Summary - Accepted: 1 (Rejected: 0 Undecided: 0 Failed: 0)
2021-01-16 21:47:29 VERBOSE  sftp_client   move-series-server Connected to localhost
2021-01-16 21:47:29 ERROR    entry         move-series-server Failed Law.and.Order.SVU.S01E01 (Failed to create remote directory ./Videos/TV Shows/Law and Order Special Victims Unit/S01 (Failed to create remote directory ./Videos/TV Shows/Law and Order Special Victims Unit/S01 ([Errno 2] No such file)))
2021-01-16 21:47:29 VERBOSE  task          move-series-server FAILED: `Law.and.Order.SVU.S01E01` by sftp_upload plugin because failed to create remote directory ./Videos/TV Shows/Law and Order Special Victims Unit/S01 (Failed to create remote directory ./Videos/TV Shows/Law and Order Special Victims Unit/S01 ([Errno 2] No such file))
```
A detail is that the file is also deleted from the machine

After PR
```
➜ flexget execute --task move-series-server
2021-01-16 21:49:43 VERBOSE  task_queue                    There are 1 tasks to execute. Shutdown will commence when they have completed.
2021-01-16 21:49:43 VERBOSE  filesystem    move-series-server Starting to scan folders.
2021-01-16 21:49:43 VERBOSE  filesystem    move-series-server Scanning folder /home/guilherme/Videos//TV Shows. Recursion is set to False.
2021-01-16 21:49:43 VERBOSE  details       move-series-server Produced 1 entries.
2021-01-16 21:49:43 VERBOSE  task          move-series-server ACCEPTED: `Law.and.Order.SVU.S01E01` by accept_all plugin
2021-01-16 21:49:43 VERBOSE  details       move-series-server Summary - Accepted: 1 (Rejected: 0 Undecided: 0 Failed: 0)
2021-01-16 21:49:43 VERBOSE  sftp_client   move-series-server Connected to server
2021-01-16 21:49:44 VERBOSE  sftp_client   move-series-server Successfully uploaded /home/guilherme/Videos/TV Shows/Law.and.Order.SVU.S01E01.mkv to sftp://guilherme@server/Videos/TV Shows/Law and Order Special Victims Unit/S01/Law.and.Order.SVU.S01E01.mkv

```

#### To Do:

- [x] Don't check for origin deletion if there is an error on the upload
- [x] Create recursive directories if they don't exist on the server

