### PR TITLE
[fix] series - Added hook to add season to accepted season on any entry acceptance

### DIFF
--- a/flexget/components/series/series.py
+++ b/flexget/components/series/series.py
@@ -5,6 +5,7 @@ import time
 from collections import defaultdict
 from copy import copy
 from datetime import datetime
+from typing import List, Union
 
 from loguru import logger
 from sqlalchemy import not_
@@ -622,7 +623,19 @@ class FilterSeries(FilterSeriesBase):
         :param series_entries: dict mapping Episodes or Seasons to entries for that episode or season_pack
         :param config: Series configuration
         """
-        accepted_seasons = []
+        accepted_seasons: List[int] = []
+
+        def _exclude_season_on_accept(
+            series_entity: Union[db.Season, db.Episode], accepted_seasons_list: List[int]
+        ):
+            # need to reject all other episode/season packs for an accepted season during the task,
+            # can't wait for task learn phase
+            if series_entity.is_season:
+                logger.debug(
+                    'adding season number `{}` to accepted seasons for this task',
+                    series_entity.season,
+                )
+                accepted_seasons_list.append(series_entity.season)
 
         # sort for season packs first, order by season number ascending. Uses -1 in case entity does not return a
         # season number or sort will crash
@@ -631,6 +644,15 @@ class FilterSeries(FilterSeriesBase):
         ):
             if not entries:
                 continue
+
+            # Add season exclude hook to all entries so it will get added to list in all code paths of entry acceptance
+            for entry in entries:
+                entry.add_hook(
+                    'accept',
+                    _exclude_season_on_accept,
+                    series_entity=entity,
+                    accepted_seasons_list=accepted_seasons,
+                )
 
             reason = None
 
@@ -652,7 +674,7 @@ class FilterSeries(FilterSeriesBase):
             # Determine episode threshold for season pack
             ep_threshold = season_packs['threshold'] if season_packs else 0
 
-            # check that a season ack for this season wasn't already accepted in this task run
+            # check that a season pack for this season wasn't already accepted in this task run
             if entity.season in accepted_seasons:
                 for entry in entries:
                     entry.reject(
@@ -776,14 +798,6 @@ class FilterSeries(FilterSeriesBase):
             # Just pick the best ep if we get here
             reason = reason or 'choosing first acceptable match'
             best.accept(reason)
-
-            # need to reject all other episode/season packs for an accepted season during the task,
-            # can't wait for task learn phase
-            if entity.is_season:
-                logger.debug(
-                    'adding season number `{}` to accepted seasons for this task', entity.season
-                )
-                accepted_seasons.append(entity.season)
 
     def process_propers(self, config, episode, entries):
         """

--- a/flexget/components/series/series.py
+++ b/flexget/components/series/series.py
@@ -630,7 +630,7 @@ class FilterSeries(FilterSeriesBase):
             series_entity: Union[db.Season, db.Episode],
             accepted_seasons_list: List[int],
             **kwargs,
-        ):
+        ) -> None:
             # need to reject all other episode/season packs for an accepted season during the task,
             # can't wait for task learn phase
             if series_entity.is_season:

--- a/flexget/components/series/series.py
+++ b/flexget/components/series/series.py
@@ -648,8 +648,8 @@ class FilterSeries(FilterSeriesBase):
             # Add season exclude hook to all entries so it will get added to list in all code paths of entry acceptance
             for entry in entries:
                 entry.add_hook(
-                    'accept',
-                    _exclude_season_on_accept,
+                    action='accept',
+                    func=_exclude_season_on_accept,
                     series_entity=entity,
                     accepted_seasons_list=accepted_seasons,
                 )

--- a/flexget/components/series/series.py
+++ b/flexget/components/series/series.py
@@ -626,7 +626,10 @@ class FilterSeries(FilterSeriesBase):
         accepted_seasons: List[int] = []
 
         def _exclude_season_on_accept(
-            series_entity: Union[db.Season, db.Episode], accepted_seasons_list: List[int]
+            *args,
+            series_entity: Union[db.Season, db.Episode],
+            accepted_seasons_list: List[int],
+            **kwargs,
         ):
             # need to reject all other episode/season packs for an accepted season during the task,
             # can't wait for task learn phase

--- a/flexget/tests/test_series.py
+++ b/flexget/tests/test_series.py
@@ -2495,6 +2495,35 @@ class TestSeriesSeasonPack:
         assert task.find_entry('accepted', title='bro.s02.720p.HDTV-Flexget')
 
 
+class TestSeriesSeasonPackAdvanced:
+    _config = """
+    tasks:
+      timeframe_and_target:
+        parsing:
+          series: internal
+        mock:
+          - title: "foo S01 720p hdtv h264"
+          - title: "foo S01E01 720p hdtv h264"
+        series:
+          - foo:
+              identified_by: ep
+              quality: 720p|1080p webrip+
+              timeframe: 4 hours
+              target: 720p webrip+ h264+      
+              season_packs: true
+    """
+
+    @pytest.fixture()
+    def config(self):
+        """Overrides outer config fixture since season pack support does not work with guessit parser"""
+        return self._config
+
+    def test_season_pack_with_timeframe_and_target(self, execute_task):
+        task = execute_task('timeframe_and_target')
+        assert task.find_entry('accepted', title="foo S01 720p hdtv h264")
+        assert not task.find_entry('accepted', title="foo S01E01 720p hdtv h264")
+
+
 class TestSeriesDDAudio:
     _config = """
       templates:


### PR DESCRIPTION
### Motivation for changes:

In case a season pack was not using the main code path, its number was not added to the exclusion list and other episode from the same task would be accepted as well.

### Detailed changes:
- Add an acceptance hook to all entries early in the filtering phase so any accepted entry which is a season pack will go through the logic of adding its number to exclusion list.

### Addressed issues:
- Fixes #2849 

