### PR TITLE
Add no_data_ignore to discover

### DIFF
--- a/flexget/components/estimate_release/estimators/est_movies_bluray.py
+++ b/flexget/components/estimate_release/estimators/est_movies_bluray.py
@@ -33,6 +33,7 @@ class EstimatesMoviesBluray:
                     release_date = movie.release_date
         except LookupError as e:
             logger.debug(e)
+            release_date = False
         if release_date:
             logger.debug('received release date: {}', release_date)
         return release_date

--- a/flexget/components/estimate_release/estimators/est_series_tvmaze.py
+++ b/flexget/components/estimate_release/estimators/est_series_tvmaze.py
@@ -54,7 +54,7 @@ class EstimatesSeriesTVMaze:
             entity = lookup(**kwargs)
         except LookupError as e:
             logger.debug(str(e))
-            return
+            return False
         if entity and entity.airdate:
             logger.debug('received air-date: {}', entity.airdate)
             return entity.airdate

--- a/flexget/plugins/input/discover.py
+++ b/flexget/plugins/input/discover.py
@@ -90,8 +90,20 @@ class Discover:
                     {'type': 'string', 'default': 'strict', 'enum': ['loose', 'strict', 'ignore']},
                     {
                         'type': 'object',
-                        'properties': {'optimistic': {'type': 'string', 'format': 'interval'}},
+                        'properties': {
+                            'optimistic': {'type': 'string', 'format': 'interval'},
+                            'no_data_ignore': {'type': 'boolean'},
+                        },
                         'required': ['optimistic'],
+                    },
+                    {
+                        'type': 'object',
+                        'properties': {
+                            'mode':  {'type': 'string', 'default': 'strict', 'enum': ['loose', 'strict', 'ignore']},
+                            'no_data_ignore': {'type': 'boolean'},
+                        },
+                        'required': ['mode'],
+                        'additionalProperties': False,
                     },
                 ]
             },
@@ -181,7 +193,16 @@ class Discover:
         result = []
         for entry in entries:
             est_date = estimator.estimate(entry)
-            if est_date is None:
+            if est_date is False:
+                if estimation_mode['mode'] == 'strict' and estimation_mode['no_data_ignore'] == False:                    
+                    logger.debug('No data is present for {}, not possible to determin release date', entry['title'])
+                    entry.reject('has no data to determin release date')
+                    entry.complete()
+                else:
+                    logger.debug('No data is present for {}, but accepting because of no_data_ignore', entry['title'])
+                    result.append(entry)
+                continue
+            elif est_date is None:
                 logger.debug('No release date could be determined for {}', entry['title'])
                 if estimation_mode['mode'] == 'strict':
                     entry.reject('has no release date')
@@ -277,6 +298,7 @@ class Discover:
 
         config['release_estimations'].setdefault('mode', 'strict')
         config['release_estimations'].setdefault('optimistic', '0 days')
+        config['release_estimations'].setdefault('no_data_ignore', False)
 
         task.no_entries_ok = True
         entries = aggregate_inputs(task, config['what'])


### PR DESCRIPTION
### Motivation for changes:

When searching for a series with discover in strict, flexget only assumes the series if a release date can be found... This works ok if tvmaze contains the series, but in case a series doesn't exists in tvmaze (no information for the series) flexget will never download the series, but it can exists.

The solution is to put discover in loose, that will try to find the series and since it can't it will discover! The problem is that it will do the exact same thing to all the series, and try to find new episodes (some that don't exist), even to series that are maintain in tvmaze, making a LOT of unnecessary requests to the searches.

A new property is added no_data_ignore that will ignore the mode if no data exists in the searches, only if no data existes

### Detailed changes:
- In the TV Maze Lookup a check is made to see if data for the series exists, if not, False is returned, in the discover plugin if false is the result of the estimate_release and no_data_ignore is set to true, the entry is accepted, if the return is None (data exists for the series but not for the episode) the normal flow is executed.
- In the blue-ray search, if no data, False is returned and the logic abose is applied 

### Addressed issues:
- Fixes #2859

### Config usage if relevant (new plugin or updated schema):

teste_discover: a Series with no data in tvmaze, executed
teste_discover2: a Series that exists but with a episode that does not, not executed

```
  teste_discover:
    disable:
      - remember_rejected
      - seen
      - retry_failed
      - seen_info_hash
  
    series:
      - Powerbirds (2020):
          identified_by: ep

    discover:
      interval: 1 minute
      release_estimations:
        optimistic: 1 day
        no_data_ignore: yes
      what:
        - next_series_episodes:
            from_start: yes
      from:
        - flexget_archive: [teste]


  teste_discover2:
    disable:
      - remember_rejected
      - seen
      - retry_failed
      - seen_info_hash
  
    series:
      - Lost (2004):
          identified_by: ep
          begin: S80E01

    discover:
      interval: 1 minute
      release_estimations:
        optimistic: 30 days
        no_data_ignore: yes
      what:
        - next_series_episodes:
            from_start: yes
      from:
        - flexget_archive: [teste]

```
### Log and/or tests output (preferably both):

```


2021-02-19 03:11:39 VERBOSE  discover      teste_discover  Discovering 1 titles ...
2021-02-19 03:11:39 INFO     discover      teste_discover  Ignoring interval because of --discover-now
2021-02-19 03:11:39 DEBUG    est_released  teste_discover  Powerbirds (2020) S01E01
2021-02-19 03:11:39 DEBUG    api_tvmaze    teste_discover  returning search params for series lookup: {'tvmaze_id': None, 'tvdb_id': None, 'tvrage_id': None, 'name': 'Powerbirds (2020)'}
2021-02-19 03:11:39 DEBUG    api_tvmaze    teste_discover  searching db tvmaze_series for the values [('tvmaze_id', None), ('tvdb_id', None), ('tvrage_id', None), ('name', 'Powerbirds (2020)')]
2021-02-19 03:11:39 DEBUG    api_tvmaze    teste_discover  did not find exact match for series Powerbirds (2020) in cache, looking in search table
2021-02-19 03:11:39 DEBUG    api_tvmaze    teste_discover  searching lookup table using title Powerbirds (2020)
2021-02-19 03:11:39 DEBUG    api_tvmaze    teste_discover  trying to fetch series Powerbirds (2020) from tvmaze
2021-02-19 03:11:39 DEBUG    api_tvmaze    teste_discover  querying tvmaze API with the following URL: https://api.tvmaze.com/singlesearch/shows
2021-02-19 03:11:39 DEBUG    utils.requests teste_discover  GETing URL https://api.tvmaze.com/singlesearch/shows with args () and kwargs {'params': {'embed': 'seasons', 'q': 'Powerbirds'}, 'allow_redirects': True, 'timeout': 30}
2021-02-19 03:11:40 DEBUG    est_series_tvmaze teste_discover  No data for Series Powerbirds (2020)


2021-02-19 03:11:40 DEBUG    discover      teste_discover  No data is present for Powerbirds (2020) S01E01, but accepting because of no_data_ignore


2021-02-19 03:11:40 VERBOSE  discover      teste_discover  Searching for `Powerbirds (2020) S01E01` with plugin `flexget_archive` (1 of 1)
2021-02-19 03:11:40 DEBUG    archive       teste_discover  looking for `Powerbirds 2020 S01E01` config: ['teste']
2021-02-19 03:11:40 DEBUG    archive       teste_discover  looking for `Powerbirds 2020 1x01` config: ['teste']
2021-02-19 03:11:40 DEBUG    archive       teste_discover  looking for `Powerbirds S01E01` config: ['teste']
2021-02-19 03:11:40 DEBUG    archive       teste_discover  looking for `Powerbirds 1x01` config: ['teste']
2021-02-19 03:11:40 DEBUG    archive       teste_discover  found 0 entries
2021-02-19 03:11:40 DEBUG    discover      teste_discover  No results from flexget_archive
2021-02-19 03:11:40 VERBOSE  discover      teste_discover  No search results for `Powerbirds (2020) S01E01`
2021-02-19 03:11:40 DEBUG    series.db     teste_discover  no episodes found for series `Powerbirds (2020)` with parameters season: None, downloaded: True
2021-02-19 03:11:40 DEBUG    series.db     teste_discover  no season packs found for series `Powerbirds (2020)` with parameters season: None, downloaded: True




2021-02-19 03:13:04 DEBUG    task          teste_discover2 executing teste_discover2
2021-02-19 03:13:04 DEBUG    disable       teste_discover2 Disabled plugins: retry_failed, seen, seen_info_hash, remember_rejected
2021-02-19 03:13:04 DEBUG    series        teste_discover2 adding series `Lost (2004)` `lost 2004` into db (on_task_start)
2021-02-19 03:13:04 DEBUG    series        teste_discover2 adding series `Lost (2004)` into db (on_task_start)
2021-02-19 03:13:04 DEBUG    series        teste_discover2 -> added `<Series(id=2,name=Lost (2004))>`
2021-02-19 03:13:04 DEBUG    series        teste_discover2 connecting series `Lost (2004)` to task `teste_discover2`
2021-02-19 03:13:04 DEBUG    series.db     teste_discover2 no episodes found for series `Lost (2004)` with parameters season: None, downloaded: True
2021-02-19 03:13:04 DEBUG    series.db     teste_discover2 no season packs found for series `Lost (2004)` with parameters season: None, downloaded: True
2021-02-19 03:13:04 DEBUG    series.db     teste_discover2 no episodes found for series `Lost (2004)` with parameters season: 80, downloaded: True
2021-02-19 03:13:04 DEBUG    series.db     teste_discover2 no season packs found for series `Lost (2004)` with parameters season: 80, downloaded: True
2021-02-19 03:13:04 DEBUG    next_series_episodes teste_discover2 backfill is not enabled; skipping older seasons
2021-02-19 03:13:04 VERBOSE  discover      teste_discover2 Discovering 1 titles ...
2021-02-19 03:13:04 INFO     discover      teste_discover2 Ignoring interval because of --discover-now
2021-02-19 03:13:04 DEBUG    est_released  teste_discover2 Lost (2004) S80E01
2021-02-19 03:13:04 DEBUG    api_tvmaze    teste_discover2 returning search params for series lookup: {'tvmaze_id': None, 'tvdb_id': None, 'tvrage_id': None, 'name': 'Lost (2004)'}
2021-02-19 03:13:04 DEBUG    api_tvmaze    teste_discover2 searching db tvmaze_series for the values [('tvmaze_id', None), ('tvdb_id', None), ('tvrage_id', None), ('name', 'Lost (2004)')]
2021-02-19 03:13:04 DEBUG    api_tvmaze    teste_discover2 did not find exact match for series Lost (2004) in cache, looking in search table
2021-02-19 03:13:04 DEBUG    api_tvmaze    teste_discover2 searching lookup table using title Lost (2004)
2021-02-19 03:13:04 DEBUG    api_tvmaze    teste_discover2 found series Lost from search table
2021-02-19 03:13:04 DEBUG    api_tvmaze    teste_discover2 returning series Lost from cache
2021-02-19 03:13:04 DEBUG    est_series_tvmaze teste_discover2 Searching api_tvmaze for episode
2021-02-19 03:13:04 DEBUG    est_series_tvmaze teste_discover2 show_name: Lost
2021-02-19 03:13:04 DEBUG    est_series_tvmaze teste_discover2 show_year: 2004
2021-02-19 03:13:04 DEBUG    est_series_tvmaze teste_discover2 series_season: 80
2021-02-19 03:13:04 DEBUG    est_series_tvmaze teste_discover2 series_episode: 1
2021-02-19 03:13:04 DEBUG    est_series_tvmaze teste_discover2 series_name: Lost (2004)
2021-02-19 03:13:04 DEBUG    api_tvmaze    teste_discover2 returning search params for series lookup: {'tvmaze_id': None, 'tvdb_id': None, 'tvrage_id': None, 'name': 'Lost (2004)'}
2021-02-19 03:13:04 DEBUG    api_tvmaze    teste_discover2 searching db tvmaze_series for the values [('tvmaze_id', None), ('tvdb_id', None), ('tvrage_id', None), ('name', 'Lost (2004)')]
2021-02-19 03:13:04 DEBUG    api_tvmaze    teste_discover2 did not find exact match for series Lost (2004) in cache, looking in search table
2021-02-19 03:13:04 DEBUG    api_tvmaze    teste_discover2 searching lookup table using title Lost (2004)
2021-02-19 03:13:04 DEBUG    api_tvmaze    teste_discover2 found series Lost from search table
2021-02-19 03:13:04 DEBUG    api_tvmaze    teste_discover2 returning series Lost from cache
2021-02-19 03:13:04 DEBUG    api_tvmaze    teste_discover2 searching for episode of show Lost in cache
2021-02-19 03:13:04 DEBUG    api_tvmaze    teste_discover2 fetching episode 1 season 80 for series_id 123 for tvmaze
2021-02-19 03:13:04 DEBUG    api_tvmaze    teste_discover2 querying tvmaze API with the following URL: https://api.tvmaze.com/shows/123/episodebynumber
2021-02-19 03:13:04 DEBUG    utils.requests teste_discover2 GETing URL https://api.tvmaze.com/shows/123/episodebynumber with args () and kwargs {'params': {'season': 80, 'number': 1}, 'allow_redirects': True, 'timeout': 30}
2021-02-19 03:13:04 DEBUG    est_series_tvmaze teste_discover2 404 Client Error: Not Found for url: https://api.tvmaze.com/shows/123/episodebynumber?season=80&number=1
2021-02-19 03:13:04 DEBUG    est_movies    teste_discover2 Unable to check release for Lost (2004) S80E01, tmdb_release and movie_year fields are not defined


2021-02-19 03:13:04 DEBUG    discover      teste_discover2 No release date could be determined for Lost (2004) S80E01


2021-02-19 03:13:04 DEBUG    series.db     teste_discover2 no episodes found for series `Lost (2004)` with parameters season: None, downloaded: True
2021-02-19 03:13:04 DEBUG    series.db     teste_discover2 no season packs found for series `Lost (2004)` with parameters season: None, downloaded: True
2021-02-19 03:13:04 DEBUG    backlog       teste_discover2 0 entries purged from backlog
2021-02-19 03:13:04 VERBOSE  details       teste_discover2 Task didn't produce any entries.


```