### PR TITLE
Tvdb NoneType Name Error

### DIFF
--- a/flexget/components/thetvdb/api_tvdb.py
+++ b/flexget/components/thetvdb/api_tvdb.py
@@ -574,7 +574,8 @@ def lookup_series(name=None, tvdb_id=None, only_cached=False, session=None, lang
             try:
                 updated_series = TVDBSeries(series.id, language)
                 series = session.merge(updated_series)
-                _update_search_strings(series, session, search=name)
+                if series and series.name:
+                    _update_search_strings(series, session, search=name)
             except LookupError as e:
                 logger.warning(
                     'Error while updating from tvdb ({}), using cached data.', e.args[0]

--- a/flexget/components/thetvdb/api_tvdb.py
+++ b/flexget/components/thetvdb/api_tvdb.py
@@ -205,6 +205,11 @@ class TVDBSeries(Base):
         self._banner = series['banner']
         self._genres = [TVDBGenre(id=name) for name in series['genre']] if series['genre'] else []
 
+        if not self.name:
+            raise LookupError(
+                f'Not possible to get name to series with id {self.id} in language \'{self.language}\''
+            )
+
         if self.first_aired is None:
             logger.debug(
                 'Falling back to getting first episode aired date for series {}', self.name


### PR DESCRIPTION
### Motivation for changes:
Some errors my occur (I detected this because I had this error) if no name is detected in tvdb. The method _update_search_strings will try to make lower() and this will make the system crash

### Detailed changes:
- Add if series and series.name to vaidate is existes before updating the search strings

### Log and/or tests output (preferably both):
```
2021-02-27 03:48:21 ERROR    lazy_lookup   AutoExtract>t_AutoExtract_GetFiles Unhandled error in lazy lookup plugin: 'NoneType' object has no attribute 'lower'
Traceback (most recent call last):
  File "/home/downloader/flexget/lib/python3.7/site-packages/flexget/utils/lazy_dict.py", line 41, in __getitem__
    callee.func(self.store, *(callee.args or []), **(callee.kwargs or {}))
  File "/home/downloader/flexget/lib/python3.7/site-packages/flexget/components/thetvdb/thetvdb_lookup.py", line 122, in lazy_series_lookup
    return self.series_lookup(entry, language, self.series_map)
  File "/home/downloader/flexget/lib/python3.7/site-packages/flexget/utils/database.py", line 30, in wrapper
    return func(*args, **kwargs)
  File "/home/downloader/flexget/lib/python3.7/site-packages/flexget/components/thetvdb/thetvdb_lookup.py", line 111, in series_lookup
    session=session,
  File "/home/downloader/flexget/lib/python3.7/site-packages/flexget/utils/database.py", line 27, in wrapper
    return func(*args, **kwargs)
  File "/home/downloader/flexget/lib/python3.7/site-packages/flexget/components/thetvdb/api_tvdb.py", line 577, in lookup_series
    _update_search_strings(series, session, search=name)
  File "/home/downloader/flexget/lib/python3.7/site-packages/flexget/components/thetvdb/api_tvdb.py", line 520, in _update_search_strings
    add = [series.name.lower()] + aliases + searches
AttributeError: 'NoneType' object has no attribute 'lower'

```