### PR TITLE
Accept highest allowed quality entry from timeframe

### DIFF
--- a/flexget/components/series/series.py
+++ b/flexget/components/series/series.py
@@ -861,7 +861,7 @@ class FilterSeries(FilterSeriesBase):
 
     def process_timeframe_target(self, config, entries, downloaded=None):
         """
-        Accepts first episode matching the quality configured for the series.
+        Accepts episode having the maximum allowed quality configured for the series.
 
         :return: True if accepted something
         """
@@ -871,7 +871,7 @@ class FilterSeries(FilterSeriesBase):
                 logger.debug('Target quality already achieved.')
                 return True
         # scan for quality
-        for entry in entries:
+        for entry in sorted(entries, key=lambda entry: entry['quality'], reverse=True):
             if req.allows(entry['quality']):
                 logger.debug(
                     'Accepted by series. `{}` meets quality requirement `{}`.', entry['title'], req

--- a/flexget/tests/test_series.py
+++ b/flexget/tests/test_series.py
@@ -1372,6 +1372,19 @@ class TestTimeframe:
             mock:
             - title: q test s01e01 hdtv
 
+          test_max_target_quality:
+            template: no_global
+            series:
+              - test:
+                  timeframe: 0 hours
+                  quality: 720p-1080p
+                  target: dd+5.1
+            mock:
+              - {title: 'Test.S01E01.720p.WEB-DL.DDP5.1.x264-FlexGet'}
+              - {title: 'Test.S01E01.1080p.WEB-DL.DDP5.1.x264-FlexGet'}
+              - {title: 'Test.S01E01.1080p.WEB-DL.AAC5.1.x264-FlexGet'}
+              - {title: 'Test.S01E01.2160p.WEB-DL.DDP5.1.x264-FlexGet'}
+
     """
 
     def test_no_waiting(self, execute_task):
@@ -1466,6 +1479,13 @@ class TestTimeframe:
         age_series(hours=6)
         task = execute_task('test_with_quality_2')
         assert task.accepted, 'Timeframe should have passed'
+
+    def test_max_target_quality(self, execute_task):
+        task = execute_task('test_max_target_quality')
+        assert task.find_entry(
+            'accepted', title='Test.S01E01.1080p.WEB-DL.DDP5.1.x264-FlexGet'
+        ), 'should have accepted max target quality'
+        assert len(task.accepted) == 1
 
 
 class TestBacklog:


### PR DESCRIPTION
### Motivation for changes:

If multiple entries are found within timeframe that meet the target criteria, the first entry that satisfied the criteria is chosen instead of the one with the highest quality.

### Detailed changes:

Sort timeframe entries by quality so that the entry with highest allowed target quality is accepted instead of the first seen entry.

### Addressed issues:

- Should also fix #2448
