### PR TITLE
Fix remux quality handling

### DIFF
--- a/flexget/components/parsing/parsers/parser_guessit.py
+++ b/flexget/components/parsing/parsers/parser_guessit.py
@@ -138,6 +138,9 @@ class ParserGuessit:
         if 'region 5' in other or 'region c' in other:
             source.append('r5')
 
+        if 'remux' in other and any(bd in source for bd in ['bluray', 'ultra hd bluray']):
+            source = ['remux']
+
         return source
 
     def _quality(self, guessit_result):

--- a/flexget/tests/test_movieparser.py
+++ b/flexget/tests/test_movieparser.py
@@ -66,6 +66,12 @@ class TestParser:
         assert movie.year == 2013, 'failed to parse year from %s' % movie.data
         assert movie.quality.name == '720p h264'
 
+        movie = parse('Just.High.Quality.2019.1080p.BluRay.REMUX.AVC.DTS-HD.MA5.1-FlexGet')
+        assert movie.quality.name == '1080p remux h264 dtshd'
+
+        movie = parse('Ultra.High.Quality.2021.UHD.BluRay.2160p.TrueHD.Atmos.7.1.HEVC.REMUX-FlexGet')
+        assert movie.quality.name == '2160p remux h265 truehd'
+
     def test_multiple_property_values(self, parse):
         """ Test correct parsing for title's with multiple propertie definitions """
         movie = parse(

--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -145,13 +145,13 @@ _sources = [
     QualityComponent('source', 150, 'hdtv', r'a?hdtv(?:[\W_]?rip)?'),
     QualityComponent('source', 160, 'webdl', r'web(?:[\W_]?(dl|hd))?'),
     QualityComponent('source', 170, 'dvdrip', r'dvd(?:[\W_]?rip)?'),
-    QualityComponent('source', 175, 'remux'),
-    QualityComponent('source', 180, 'bluray', r'(?:b[dr][\W_]?rip|blu[\W_]?ray(?:[\W_]?rip)?)'),
+    QualityComponent('source', 175, 'bluray', r'(?:b[dr][\W_]?rip|blu[\W_]?ray(?:[\W_]?rip)?)'),
+    QualityComponent('source', 180, 'remux'),
 ]
 _codecs = [
     QualityComponent('codec', 10, 'divx'),
     QualityComponent('codec', 20, 'xvid'),
-    QualityComponent('codec', 30, 'h264', '[hx].?264'),
+    QualityComponent('codec', 30, 'h264', '[hx].?264|avc'),
     QualityComponent('codec', 35, 'vp9'),
     QualityComponent('codec', 40, 'h265', '[hx].?265|hevc'),
 ]


### PR DESCRIPTION
### Motivation for changes:
Remuxes are incorrectly parsed as `bluray` quality.
Also quality score of `remux` should be higher than `bluray` as remuxes merely contain the original, untouched video and audio streams multiplexed into single file container where as `bluray` releases are considered encodes from the original source.

I'm uncertain whether DVD remuxes are considered a thing or not so they're not part of this PR.


### Detailed changes:
- If `guessit` detects entry source either as `bluray` or `ultra hd bluray` and `remux` is found on `other` [properties](https://doc.guessit.io/properties/) mark source as `remux`
- `remux` should have higher quality than `bluray`
- As a bonus detect `AVC` as `h264`

