### PR TITLE
Update qualities.py

### DIFF
--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -119,6 +119,7 @@ _resolutions = [
     QualityComponent('resolution', 10, '360p'),
     QualityComponent('resolution', 20, '368p', '368p?'),
     QualityComponent('resolution', 30, '480p', '480p?'),
+    QualityComponent('resolution', 35, '540p', '540p?'),
     QualityComponent('resolution', 40, '576p', '576p?'),
     QualityComponent('resolution', 45, 'hr'),
     QualityComponent('resolution', 50, '720i'),


### PR DESCRIPTION
add 540p support, as used by some anime releases (for whatever reason...)

### Motivation for changes:

adds support to new quality 540p ( https://en.wikipedia.org/wiki/Graphics_display_resolution#960_%C3%97_540_(qHD))

### Detailed changes:
-  adds 540p Quality

### Addressed issues:
/

### Implemented feature requests:
/

### Config usage if relevant (new plugin or updated schema):
allows:
```
quality: 540p

```
### Log and/or tests output (preferably both):
/
#### To Do:

/

