### PR TITLE
Update series.py

### DIFF
--- a/flexget/utils/parsers/series.py
+++ b/flexget/utils/parsers/series.py
@@ -87,7 +87,7 @@ class SeriesParser(TitleParser):
         [
             TitleParser.re_not_in_word(regexp)
             for regexp in [
-                r'(\d{1,3})(?:v(?P<version>\d))?',
+                r'(\d+)(?:v(?P<version>\d))?',
                 r'(?:pt|part)\s?(\d+|%s)' % roman_numeral_re,
             ]
         ]


### PR DESCRIPTION
allow more than 3 digit sequences

### Motivation for changes:
at the moment, sequences are only allowed up to 3 digits. This change removes that limit
### Detailed changes:

- change sequence regex

### Addressed issues:
- Fixes #2178

### Implemented feature requests:
/

### Config usage if relevant (new plugin or updated schema):
/
### Log and/or tests output (preferably both):
-- Accepted: ---------------------------
title            : ***** - 1002 (1080p) .mkv
url              : *****
original_url     : *****
accepted_by      : series
content-disposition: False
content-length   : 29627
content_files    : ***** - 1002 (1080p) *****.mkv]
content_size     : *****
filename         : ******-1002-[1080P].torrent
imdb_id          : <LazyField - value will be determined when it is accessed>
imdb_url         : <LazyField - value will be determined when it is accessed>
isbd             : False
location         : /var/torrenttmp/jonas/*****-1002-[1080P].torrent
media_id         : <LazyField - value will be determined when it is accessed>
mime-type        : application/x-bittorrent
onlyfirst        : False
original_title   :*****n - 1002 (1080p) [*****].mkv
proper           : False
proper_count     : 0  
quality          : 1080p
reason           : quality wanted
release_group    : None
rss_pubdate      : 2021-04-17 11:31:55
season_pack      : None
series_episodes  : 1  
series_exact     : True
series_id        : 1002
series_id_type   : sequence
series_identified_by: sequence
series_name      : *****
series_parser    : <SeriesParseResult(data=[***** - 1002 (1080p) [*****].mkv,name=*****,id=1002,season=0,season_pack=None,episode=1002,quality=1080p,proper=0,special=False,status=OK)>
series_releases  : [9978]
series_season    : 2021
task             : *****
torrent          : <Torrent instance. Files: [{'name': '[***** - 1002 (1080p) [*****].mkv', 'size': 1500446219, 'path': ''}]>
torrent_info_hash: *****
tvdb_absolute_number: <LazyField - value will be determined when it is accessed>
tvdb_actors      : <LazyField - value will be determined when it is accessed>
tvdb_air_time    : <LazyField - value will be determined when it is accessed>
tvdb_airs_day_of_week: <LazyField - value will be determined when it is accessed>
tvdb_banner      : <LazyField - value will be determined when it is accessed>
tvdb_content_rating: <LazyField - value will be determined when it is accessed>
tvdb_ep_air_date : <LazyField - value will be determined when it is accessed>
tvdb_ep_directors: <LazyField - value will be determined when it is accessed>
tvdb_ep_id       : <LazyField - value will be determined when it is accessed>
tvdb_ep_image    : <LazyField - value will be determined when it is accessed>
tvdb_ep_name     : <LazyField - value will be determined when it is accessed>
tvdb_ep_overview : <LazyField - value will be determined when it is accessed>
tvdb_ep_rating   : <LazyField - value will be determined when it is accessed>
tvdb_episode     : <LazyField - value will be determined when it is accessed>
tvdb_first_air_date: <LazyField - value will be determined when it is accessed>
tvdb_genres      : <LazyField - value will be determined when it is accessed>
tvdb_id          : <LazyField - value will be determined when it is accessed>
tvdb_language    : <LazyField - value will be determined when it is accessed>
tvdb_network     : <LazyField - value will be determined when it is accessed>
tvdb_overview    : <LazyField - value will be determined when it is accessed>
tvdb_posters     : <LazyField - value will be determined when it is accessed>
tvdb_rating      : <LazyField - value will be determined when it is accessed>
tvdb_runtime     : <LazyField - value will be determined when it is accessed>
tvdb_season      : <LazyField - value will be determined when it is accessed>
tvdb_series_name : <LazyField - value will be determined when it is accessed>
tvdb_status      : <LazyField - value will be determined when it is accessed>
tvdb_url         : <LazyField - value will be determined when it is accessed>
zap2it_id        : <LazyField - value will be determined when it is accessed>


#### To Do:
/

