### PR TITLE
[fix] Transmission file skipping with main_file_only

### DIFF
--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -579,7 +579,7 @@ class PluginTransmission(TransmissionBase):
                     if options['post'].get('main_file_only') and main_id is not None:
                         # Set Unwanted Files
                         options['change']['files_unwanted'] = [
-                            x for x in file_list if x not in dl_list
+                            x for x in range(len(file_list)) if x not in dl_list
                         ]
                         options['change']['files_wanted'] = dl_list
                         logger.debug(
@@ -600,7 +600,7 @@ class PluginTransmission(TransmissionBase):
                         else:
                             options['change']['files_unwanted'] = skip_list
                             options['change']['files_wanted'] = [
-                                x for x in file_list if x not in skip_list
+                                x for x in range(len(file_list)) if x not in skip_list
                             ]
                             logger.debug(
                                 'Downloading {} of {} files in torrent.',


### PR DESCRIPTION
### Motivation for changes:
- Extra files are not skipped when main_file_only is set

### Detailed changes:
- files_wanted and files_unwanted need to provide indices. Previously, these were providing the File objects themselves from the file_list, which Transmission can't recognize.

### Addressed issues:
- No issue raised. Noticed in my own environment.
- **May** fix #2806 - haven't tested as I don't use skip_files

### Implemented feature requests:
None

### Config usage if relevant (new plugin or updated schema):
None

### Log and/or tests output (preferably both):
Added debug line to verify. Previous:
```
2021-04-05 10:53:51 DEBUG    transmission  movies          applying changes {'files_unwanted': [File(name='Collateral.2004.1080p.BluRay.x265-RARBG/Collateral.2004.1080p.BluRay.x265-RARBG.mp4', size=2005951858, completed=0, priority='normal', selected=True), File(name='Collateral.2004.1080p.BluRay.x265-RARBG/RARBG.txt', size=30, completed=0, priority='normal', selected=True), File(name='Collateral.2004.1080p.BluRay.x265-RARBG/RARBG_DO_NOT_MIRROR.exe', size=99, completed=0, priority='normal', selected=True), File(name='Collateral.2004.1080p.BluRay.x265-RARBG/Subs/2_English.srt', size=87144, completed=0, priority='normal', selected=True)], 'files_wanted': [0]}
```
Now:
```
2021-04-05 11:06:01 DEBUG    transmission  movies          applying changes {'files_unwanted': [1, 2, 3], 'files_wanted': [0]}
```

#### To Do:
None
