### PR TITLE
[fix] [Lostfilm Plugin] Upd ate regex according to new feed version

### DIFF
--- a/flexget/components/sites/sites/lostfilm.py
+++ b/flexget/components/sites/sites/lostfilm.py
@@ -18,7 +18,7 @@ __author__ = 'danfocus'
 logger = logger.bind(name='lostfilm')
 
 EPISODE_REGEXP = re.compile(r'.*/series/.*/season_(\d+)/episode_(\d+)/.*')
-LOSTFILM_ID_REGEXP = re.compile(r'.*static.lostfilm.tv/Images/(\d+)/Posters/.*')
+LOSTFILM_ID_REGEXP = re.compile(r'.*static\.lostfilm\..*/Images/(\d+)/Posters/.*')
 TEXT_REGEXP = re.compile(r'^\d+\s+сезон\s+\d+\s+серия\.\s(.+)\s\((.+)\)$')
 
 quality_map = {


### PR DESCRIPTION
### Motivation for changes:
According to changes of rss feed we need to change regex to set poster id properly.
```
<?xml version="1.0" encoding="utf-8" ?>
<rss version="0.91">
<channel>
<title>LostFilm.TV</title>
<description>Свежачок от LostFilm.TV</description>
<link>https://www.lostfilm.tv/</link>
<lastBuildDate>Wed, 21 Apr 2021 00:34:19 +0000</lastBuildDate>
<language>ru</language><item>
	<title>Город на холме (City on a Hill). Слишком белые и слишком глупые. (S02E04)</title>
	<description><![CDATA[<img src="//static.lostfilm.win/Images/437/Posters/image.jpg" alt="" /><br />]]></description>
	<pubDate>Wed, 21 Apr 2021 00:34:18 +0000</pubDate>
	<link>https://www.lostfilm.win/mr/series/City_on_a_Hill/season_2/episode_4/</link>
</item></channel>
</rss>
```

### Detailed changes:
- start using more generic regex (https://regex101.com/r/ATz1QL/1)


