### PR TITLE
Added proxy support for feedparser

### DIFF
--- a/flexget/components/sites/sites/lostfilm.py
+++ b/flexget/components/sites/sites/lostfilm.py
@@ -4,6 +4,7 @@
 import re
 
 import feedparser
+from urllib.request import ProxyHandler
 from loguru import logger
 
 from flexget import plugin
@@ -61,8 +62,11 @@ class LostFilm:
         config = self.build_config(config)
         if config is False:
             return
+        proxy_handler = None
+        if task.requests.proxies is not None:
+            proxy_handler = ProxyHandler(task.requests.proxies)
         try:
-            rss = feedparser.parse(config['url'])
+            rss = feedparser.parse(config['url'], handlers=[proxy_handler])
         except Exception:
             raise PluginError('Cannot parse rss feed')
         status = rss.get('status')


### PR DESCRIPTION
### Motivation for changes:
lostfilm.tv is banned in Russia. This patch allow to use [proxy](https://flexget.com/Plugins/proxy) plugin with LostFilm component.

### Detailed changes:
Added ProxyHandler to feedparser handlers 

### Log and/or tests output (preferably both):
```
2021-04-23 21:52:58 VERBOSE  proxy         LostFilm        Setting proxy to {'https': 'http://login:password@proxy.server:8080'}
```