### PR TITLE
Changed regexp for ID

### DIFF
--- a/flexget/components/sites/sites/lostfilm.py
+++ b/flexget/components/sites/sites/lostfilm.py
@@ -18,7 +18,7 @@ __author__ = 'danfocus'
 logger = logger.bind(name='lostfilm')
 
 EPISODE_REGEXP = re.compile(r'.*/series/.*/season_(\d+)/episode_(\d+)/.*')
-LOSTFILM_ID_REGEXP = re.compile(r'.*static.lostfilm.tv/Images/(\d+)/Posters/.*')
+LOSTFILM_ID_REGEXP = re.compile(r'.*static.lostfilm.\w+/Images/(\d+)/Posters/.*')
 TEXT_REGEXP = re.compile(r'^\d+\s+сезон\s+\d+\s+серия\.\s(.+)\s\((.+)\)$')
 
 quality_map = {


### PR DESCRIPTION
While LostFilm often changes it top-level domain, it must not be considered when finding ID of serie.

### Motivation for changes:
LostFilm changes it top-level domain often.
### Detailed changes:
- Regexp finding ID of serie was changed to not take in account top-level domain.
