### PR TITLE
Merge configs from series dict

### DIFF
--- a/flexget/components/series/series.py
+++ b/flexget/components/series/series.py
@@ -312,7 +312,7 @@ class FilterSeriesBase:
                             'Series `{}` is configured multiple times in series plugin.', series
                         )
                     # Combine the config dicts for both instances of the show
-                    unique_series[series].update(series_settings)
+                    merge_dict_from_to(series_settings, unique_series[series])
         # Turn our all_series dict back into a list
         # sort by reverse alpha, so that in the event of 2 series with common prefix, more specific is parsed first
         return [{s: unique_series[s]} for s in sorted(unique_series, reverse=True)]


### PR DESCRIPTION
### Motivation for changes:

As stated in the bug report:

Series setting from configure_series and series to be merged together

### Detailed changes:
The main issue was on the merging of the configs, we where using the native dict update method, this updates all the properties, but also updates the lists, replacing them. So the solution was simple:
- Replace "update" with the "merge_dict_from_to" from flexget.util 

### Addressed issues:
- Fixes #2863

### Implemented feature requests:
- None

### Config usage if relevant (new plugin or updated schema):
```
tasks:
  test:
    configure_series:
      from:
        mock:
          - url: 'mock://127.0.0.1/item1'
            title: "Show"
            configure_series_alternate_name: ['ECSAN']
      settings:
        identified_by: sequence
        alternate_name: ['SAN']
    series:
      - Show:
          alternate_name: ['AN']
          begin: 1
    discover:
      what: 
        - next_series_episodes: yes
      from:
        - flexget_archive: yes
      release_estimations: ignore
```
### Log and/or tests output (preferably both):
```
2021-04-26 12:46:48 VERBOSE  discover      test            Discovering 1 titles ...
2021-04-26 12:46:48 INFO     discover      test            Ignoring interval because of --discover-now
2021-04-26 12:46:48 VERBOSE  discover      test            Searching for `Show 01` with plugin `flexget_archive` (1 of 1)
2021-04-26 12:46:48 DEBUG    archive       test            looking for `Show 01` config: True
2021-04-26 12:46:48 DEBUG    archive       test            looking for `Show 1` config: True
2021-04-26 12:46:48 DEBUG    archive       test            looking for `Show 001` config: True
2021-04-26 12:46:48 DEBUG    archive       test            looking for `ECSAN 01` config: True
2021-04-26 12:46:48 DEBUG    archive       test            looking for `ECSAN 1` config: True
2021-04-26 12:46:48 DEBUG    archive       test            looking for `ECSAN 001` config: True
2021-04-26 12:46:48 DEBUG    archive       test            looking for `SAN 01` config: True
2021-04-26 12:46:48 DEBUG    archive       test            looking for `SAN 1` config: True
2021-04-26 12:46:48 DEBUG    archive       test            looking for `SAN 001` config: True
2021-04-26 12:46:48 DEBUG    archive       test            looking for `AN 01` config: True
2021-04-26 12:46:48 DEBUG    archive       test            looking for `AN 1` config: True
2021-04-26 12:46:48 DEBUG    archive       test            looking for `AN 001` config: True
2021-04-26 12:46:48 DEBUG    archive       test            found 0 entries

```
#### To Do:

