### PR TITLE
[fix] transmission: Handle rpc client exception

### DIFF
--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -86,6 +86,8 @@ class TransmissionBase:
             raise plugin.PluginError("Cannot connect to transmission: Connection timed out.")
         except requests.exceptions.ConnectionError as e:
             raise plugin.PluginError("Error connecting to transmission: %s" % e.args[0].reason)
+        except ValueError as e:
+            raise plugin.PluginError("Error connecting to transmission")
         return cli
 
     def torrent_info(self, torrent, config):


### PR DESCRIPTION
### Motivation for changes:

Avoid flexget crash when rpc client raises exception

### Detailed changes:
- The rpc client converting a json request and handling the decode erro, he does this raising a ValueError exception, added a handler to that. 

### Addressed issues:
- Fixes #2811

### Implemented feature requests:

### Config usage if relevant (new plugin or updated schema):
```
tasks:
  transmission_test:
    from_transmission:
      host: localhost
      port: 9091
      username: myusername
      password: mypassword
```
### Log and/or tests output (preferably both):
```
2021-04-28 11:01:36 ERROR    transmission-rpc transmission_test Error: Expecting value: line 1 column 1 (char 0)
2021-04-28 11:01:36 ERROR    transmission-rpc transmission_test Request: "{"tag": 0, "method": "session-get", "arguments": {}}"
2021-04-28 11:01:36 ERROR    transmission-rpc transmission_test HTTP data: "<h1>403: Forbidden</h1><p>Unauthorized IP Address.</p><p>Either disable the IP address whitelist or add your address to it.</p><p>If you're editing settings.json, see the 'rpc-whitelist' and 'rpc-whitelist-enabled' entries.</p><p>If you're still using ACLs, use a whitelist instead. See the transmission-daemon manpage for details.</p>"
2021-04-28 11:01:36 CRITICAL plugin        transmission_test Error connecting to transmission
2021-04-28 11:01:36 WARNING  task          transmission_test Aborting task (plugin: from_transmission)
```
#### To Do:

