### PR TITLE
[fix] telegram notifier: Handles chat migrations

### DIFF
--- a/flexget/components/notify/notifiers/telegram.py
+++ b/flexget/components/notify/notifiers/telegram.py
@@ -316,10 +316,10 @@ class TelegramNotifier:
                 logger.debug("Chat migrated to id {}", e.new_chat_id)
                 try:
                     self._bot.sendMessage(chat_id=e.new_chat_id, text=msg, **kwargs)
+                    self._replace_chat_id(chat_id, e.new_chat_id, session)
                 except TelegramError as e:
                     raise PluginWarning(e.message)
 
-                self._replace_chat_id(chat_id, e.new_chat_id, session)
             except TelegramError as e:
                 if kwargs.get('parse_mode'):
                     logger.warning(

--- a/flexget/components/notify/notifiers/telegram.py
+++ b/flexget/components/notify/notifiers/telegram.py
@@ -10,7 +10,7 @@ from flexget.plugin import PluginError, PluginWarning
 
 try:
     import telegram
-    from telegram.error import TelegramError
+    from telegram.error import TelegramError, ChatMigrated
     from telegram.utils.request import NetworkError
 except ImportError:
     telegram = None
@@ -192,11 +192,13 @@ class TelegramNotifier:
         """
         Send a Telegram notification
         """
+
+        session = Session()
         chat_ids = self._real_init(Session(), config)
 
         if not chat_ids:
             return
-        self._send_msgs(message, chat_ids)
+        self._send_msgs(message, chat_ids, session)
 
     def _parse_config(self, config):
         """
@@ -288,7 +290,18 @@ class TelegramNotifier:
                 'old python-telegram-bot ({0})'.format(telegram.__version__)
             )
 
-    def _send_msgs(self, msg, chat_ids):
+    def _replace_chat_id(self, old_id, new_id, session):
+        upd_usernames, upd_fullnames, upd_groups = self._get_bot_updates()
+        for group in upd_groups:
+            grp = upd_groups.get(group)
+            if grp.id == new_id:
+                old_data = session.query(ChatIdEntry).filter(ChatIdEntry.id == old_id).first()
+                session.delete(old_data)
+                entry = ChatIdEntry(id=grp.id, group=grp.title)
+                self._update_db(session, [entry])
+                break
+
+    def _send_msgs(self, msg, chat_ids, session):
         kwargs = dict()
         if self._parse_mode == 'markdown':
             kwargs['parse_mode'] = telegram.ParseMode.MARKDOWN
@@ -299,6 +312,14 @@ class TelegramNotifier:
             try:
                 logger.debug('sending msg to telegram servers: {}', msg)
                 self._bot.sendMessage(chat_id=chat_id, text=msg, **kwargs)
+            except ChatMigrated as e:
+                logger.debug("Chat migrated to id {}", e.new_chat_id)
+                try:
+                    self._bot.sendMessage(chat_id=e.new_chat_id, text=msg, **kwargs)
+                except TelegramError as e:
+                    raise PluginWarning(e.message)
+
+                self._replace_chat_id(chat_id, e.new_chat_id, session)
             except TelegramError as e:
                 if kwargs.get('parse_mode'):
                     logger.warning(
@@ -497,7 +518,8 @@ class TelegramNotifier:
             elif update.channel_post:
                 chat = update.channel_post.chat
             else:
-                raise PluginError('Unknown update type encountered: %s' % update)
+                continue
+                # raise PluginError('Unknown update type encountered: %s' % update)
 
             if chat.type == 'private':
                 usernames[chat.username] = chat


### PR DESCRIPTION
### Motivation for changes:

The chats sometimes can migrate to a new ID, for example when a group chat is converted to superchat, this would not allow to send more messages. 

### Detailed changes:
- Handle the ChatMigrated exeption and capture the new chat ID, delete the old chat ID from the database and add the new one. Send the message to the new id

### Addressed issues:
- Fixes #2771

### Implemented feature requests:

### Config usage if relevant (new plugin or updated schema):
```
tasks:
  notify:
    disable:
      - remember_rejected
      - seen
      - retry_failed
      - seen_info_hash

    accept_all: yes
    notify:
      entries:
        title: "My Title"
        message: "My Message"
        what: accepted
        via:
          - telegram:
              bot_token: "<<token>>"
              parse_mode: html
              recipients:
                - { group: "<<group>>" }
```
### Log and/or tests output (preferably both):
```
2021-04-29 14:32:49 DEBUG    telegram.vendor.ptb_urllib3.urllib3.connectionpool notify          https://api.telegram.org:443 "POST /<<toke>>/sendMessage HTTP/1.1" 400 154
2021-04-29 14:32:49 DEBUG    telegram      notify          Chat migrated to id -<<newid>>
2021-04-29 14:32:49 DEBUG    telegram.bot  notify          Entering: send_message
MESSAGE
POSTING
2021-04-29 14:32:49 DEBUG    telegram.vendor.ptb_urllib3.urllib3.connectionpool notify          https://api.telegram.org:443 "POST /<<toke>>/sendMessage HTTP/1.1" 200 238
2021-04-29 14:32:49 DEBUG    telegram.bot  notify          {'message_id': 4, 'date': 1619703169, 'chat': {'id': -<<newid>>, 'type': 'supergroup', 'title': 'MyGroup'}, 'text': 'My Message', 'entities': [], 'caption_entities': [], 'photo': [], 'new_chat_members': [], 'new_chat_photo': [], 'delete_chat_photo': False, 'group_chat_created': False, 'supergroup_chat_created': False, 'channel_chat_created': False, 'from': {'id': <<myid>>, 'first_name': 'Flexget', 'is_bot': True, 'username': '<<mybotname>>'}}
2021-04-29 14:32:49 DEBUG    telegram.bot  notify          Exiting: send_message
2021-04-29 14:32:49 VERBOSE  notify        notify          Successfully sent a notification to `telegram`
```
#### To Do:
