### PR TITLE
[fix] alpharatio: handle invalid values

### DIFF
--- a/flexget/components/sites/sites/alpharatio.py
+++ b/flexget/components/sites/sites/alpharatio.py
@@ -307,10 +307,7 @@ class SearchAlphaRatio:
                     'torrent_leeches': leeches_idx,
                 }
 
-                for mapping in mappings_int:
-                    dest = mapping
-                    src = mappings_int[mapping]
-
+                for dest, src in mappings_int.items():
                     if not src in torrent_info:
                         continue
 

--- a/flexget/components/sites/sites/alpharatio.py
+++ b/flexget/components/sites/sites/alpharatio.py
@@ -295,14 +295,33 @@ class SearchAlphaRatio:
                 e['url'] = url
                 e['torrent_tags'] = torrent_tags
                 if not size:
-                    logger.error(
+                    logger.debug(
                         'No size found! Please create a Github issue. Size received: {}', size_col
                     )
                 else:
                     e['content_size'] = parse_filesize(size.group(0))
-                e['torrent_snatches'] = int(torrent_info[snatches_idx].text)
-                e['torrent_seeds'] = int(torrent_info[seeds_idx].text)
-                e['torrent_leeches'] = int(torrent_info[leeches_idx].text)
+
+                mappings_int = {
+                    'torrent_snatches': snatches_idx,
+                    'torrent_seeds': seeds_idx,
+                    'torrent_leeches': leeches_idx,
+                }
+
+                for mapping in mappings_int:
+                    dest = mapping
+                    src = mappings_int[mapping]
+
+                    if not src in torrent_info:
+                        continue
+
+                    # Some values are tagged with a ',' insted of a '.', replace them
+                    value = torrent_info[src].text.replace(',', '.')
+
+                    try:
+                        e[dest] = int(value)
+                    except ValueError as e:
+                        logger.debug('Invalid \'{}\' with \'{}\'', dest, value)
+                        continue
 
                 entries.add(e)
 


### PR DESCRIPTION
### Motivation for changes:
Better hande of invalid values in alpharatio

### Detailed changes:
- handle invalid ints with try, try to replace invalid ',' with '.' if present

### Addressed issues:
- Fixes #2812

#### To Do:

- [x] Testing needed, I don't have a alpharatio account, asking @frankyw or anyone with a account help for testing

