### PR TITLE
add transmission-rpc version range

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN pip install -U pip && \
                 --no-index \
                 -f /wheels \
                 FlexGet \
-                transmission-rpc \
+                'transmission-rpc>=3.0.0,<4.0.0' \
                 deluge-client \
                 cloudscraper && \
     rm -rf /wheels


### PR DESCRIPTION
### Motivation for changes:
 avoid upstream break changes

### Detailed changes:
install rpc library with `transmission-rpc>=3.0.0,<4.0.0`

