### PR TITLE
[add] series: special season

### DIFF
--- a/flexget/components/series/series.py
+++ b/flexget/components/series/series.py
@@ -696,7 +696,7 @@ class FilterSeries(FilterSeriesBase):
                     continue
 
             # skip special episodes if special handling has been turned off
-            if not config.get('specials', True) and entity.identified_by == 'special':
+            if not config.get('specials', True) and entity.is_special:
                 logger.debug('Skipping special episode as support is turned off.')
                 continue
 

--- a/flexget/utils/parsers/series.py
+++ b/flexget/utils/parsers/series.py
@@ -335,6 +335,7 @@ class SeriesParser(TitleParser):
                 data_parts.remove(part)
             elif part in self.specials:
                 self.special = True
+                self.special_title = True
                 data_parts.remove(part)
 
         data_stripped = ' '.join(data_parts).strip()
@@ -381,6 +382,9 @@ class SeriesParser(TitleParser):
                 self.id = (self.season, self.episode)
                 self.id_type = 'ep'
                 self.valid = True
+                if self.season == 0 and self.episode > 0:
+                    self.special = True
+                    self.special_season = True
                 if not (self.special and self.prefer_specials):
                     return
             else:


### PR DESCRIPTION
### Motivation for changes:

The special episode identify is expanded to add the special season S00, this will assume a episode as special

### Detailed changes:
- Store in the database if a episode is special, because now a episode can be identified_by = ep and be special, because season equals 0
- if the episode is special, continue with the logic

### Addressed issues:
- Fixes #2294

### Config usage if relevant (new plugin or updated schema):
```
tasks:
    series:
      - My Series:
          specials: no
```

flexget --debug execute --inject "My Series my special title"
```
2021-05-04 18:03:46 DEBUG    manager                       New config data loaded.
2021-05-04 18:03:46 DEBUG    schema                        entering flexget version 3.1.112.dev to db
2021-05-04 18:03:46 DEBUG    parsing                       setting default movie parser to internal. (options: {'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x7f986d62c5c0>, 'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x7f986d62c630>})
2021-05-04 18:03:46 DEBUG    parsing                       setting default series parser to internal. (options: {'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x7f986d62c5c0>, 'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x7f986d62c630>})
2021-05-04 18:03:46 DEBUG    cron_env                      Encoding utf-8 stored
2021-05-04 18:03:46 DEBUG    util.simple_persistence                 setting key terminal_encoding value 'utf-8'
2021-05-04 18:03:46 DEBUG    task_queue                    task queue shutdown requested
2021-05-04 18:03:46 INFO     ipc.rpyc                      server started on [127.0.0.1]:35077
2021-05-04 18:03:46 DEBUG    task          series_special  executing series_special
2021-05-04 18:03:46 DEBUG    task          series_special  Disabling input phase
2021-05-04 18:03:46 DEBUG    disable       series_special  Disabled plugins: retry_failed, seen, seen_info_hash, remember_rejected
2021-05-04 18:03:46 DEBUG    status        series_special  Adding new task series_special
2021-05-04 18:03:46 DEBUG    series        series_special  adding series `My Series` `my series` into db (on_task_start)
2021-05-04 18:03:46 DEBUG    series        series_special  adding series `My Series` into db (on_task_start)
2021-05-04 18:03:46 DEBUG    series        series_special  -> added `<Series(id=1,name=My Series)>`
2021-05-04 18:03:46 DEBUG    series        series_special  connecting series `My Series` to task `series_special`
2021-05-04 18:03:46 DEBUG    parser_internal series_special  Parsing series: `My Series my special title` kwargs: {'name': None}
2021-05-04 18:03:46 DEBUG    parser_internal series_special  Parsing series: `My Series my special title` kwargs: {'name': 'My Series', 'identified_by': 'auto', 'alternate_names': [], 'name_regexps': [], 'strict_name': False, 'allow_groups': [], 'date_yearfirst': None, 'date_dayfirst': None, 'special_ids': [], 'prefer_specials': None, 'assume_special': None, 'ep_regexps': [], 'date_regexps': [], 'sequence_regexps': [], 'id_regexps': []}
2021-05-04 18:03:46 DEBUG    parser_internal series_special  Parsing result: <SeriesParser(data=My Series my special title,name=My Series,id=my title,season=None,season_pack=None,episode=None,quality=unknown,proper=0,status=OK)> (in 2.550695999999686 ms)
2021-05-04 18:03:46 DEBUG    series        series_special  `My Series my special title` detected as `<SeriesParseResult(data=My Series my special title,name=My Series,id=my title,season=None,season_pack=None,episode=None,quality=unknown,proper=0,special=True,status=OK)>`, field: `title`
2021-05-04 18:03:46 DEBUG    series        series_special  series on_task_metainfo took 0.013944737000000096 to parse
2021-05-04 18:03:46 DEBUG    series.db     series_special  adding episode `my title` into series `My Series`
2021-05-04 18:03:46 DEBUG    series.db     series_special  -> added `<Episode(id=None,identifier=my title,season=None,number=None)>`
2021-05-04 18:03:46 DEBUG    series.db     series_special  adding release `<SeriesParseResult(data=My Series my special title,name=My Series,id=my title,season=None,season_pack=None,episode=None,quality=unknown,proper=0,special=True,status=OK)>`
2021-05-04 18:03:46 DEBUG    series.db     series_special  -> added `<Release(id=None,quality=unknown,downloaded=None,proper_count=0,title=My Series my special title)>`
2021-05-04 18:03:46 DEBUG    series        series_special  identified_by set to `auto` based on series history
2021-05-04 18:03:46 DEBUG    series        series_special  start with entities: ['My Series my special title']
2021-05-04 18:03:46 DEBUG    series        series_special  Skipping special episode as support is turned off.
2021-05-04 18:03:46 DEBUG    series        series_special  processing series took 0.019805851000000096
2021-05-04 18:03:46 DEBUG    urlrewriter   series_special  Checking 0 entries
2021-05-04 18:03:46 VERBOSE  details       series_special  Summary - Accepted: 0 (Rejected: 0 Undecided: 1 Failed: 0)
2021-05-04 18:03:46 WARNING  task          series_special  Task doesn't have any output plugins, you should add (at least) one!
2021-05-04 18:03:46 DEBUG    series        series_special  on_task_learn
2021-05-04 18:03:46 DEBUG    util.simple_persistence series_special  Flushing simple persistence for task series_special to db.
2021-05-04 18:03:47 DEBUG    task_queue                    task queue shut down
2021-05-04 18:03:47 INFO     ipc.rpyc                      listener closed
2021-05-04 18:03:47 DEBUG    util.simple_persistence                 Flushing simple persistence for task None to db.
2021-05-04 18:03:47 INFO     ipc.rpyc                      server has terminated
2021-05-04 18:03:47 DEBUG    manager                       Shutting down
```
flexget --debug execute --inject "My Series S00E01 My Title"
```
2021-05-04 18:05:27 DEBUG    manager                       New config data loaded.
2021-05-04 18:05:27 DEBUG    schema                        entering flexget version 3.1.112.dev to db
2021-05-04 18:05:27 DEBUG    parsing                       setting default movie parser to internal. (options: {'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x7f2e5d533550>, 'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x7f2e5d5335c0>})
2021-05-04 18:05:27 DEBUG    parsing                       setting default series parser to internal. (options: {'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x7f2e5d533550>, 'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x7f2e5d5335c0>})
2021-05-04 18:05:27 DEBUG    cron_env                      Encoding utf-8 stored
2021-05-04 18:05:27 DEBUG    util.simple_persistence                 setting key terminal_encoding value 'utf-8'
2021-05-04 18:05:27 DEBUG    task_queue                    task queue shutdown requested
2021-05-04 18:05:27 VERBOSE  task_queue                    There are 1 tasks to execute. Shutdown will commence when they have completed.
2021-05-04 18:05:27 INFO     ipc.rpyc                      server started on [127.0.0.1]:38363
2021-05-04 18:05:27 DEBUG    task          series_special  executing series_special
2021-05-04 18:05:27 DEBUG    task          series_special  Disabling input phase
2021-05-04 18:05:27 DEBUG    disable       series_special  Disabled plugins: seen_info_hash, seen, remember_rejected, retry_failed
2021-05-04 18:05:27 DEBUG    status        series_special  Adding new task series_special
2021-05-04 18:05:27 DEBUG    series        series_special  adding series `My Series` `my series` into db (on_task_start)
2021-05-04 18:05:27 DEBUG    series        series_special  adding series `My Series` into db (on_task_start)
2021-05-04 18:05:27 DEBUG    series        series_special  -> added `<Series(id=1,name=My Series)>`
2021-05-04 18:05:27 DEBUG    series        series_special  connecting series `My Series` to task `series_special`
2021-05-04 18:05:27 DEBUG    parser_internal series_special  Parsing series: `My Series S00E01 My Title` kwargs: {'name': None}
2021-05-04 18:05:27 DEBUG    parser_internal series_special  Parsing result: <SeriesParser(data=My Series S00E01 My Title,name=My Series,id=(0, 1),season=0,season_pack=None,episode=1,quality=unknown,proper=0,status=OK)> (in 5.858885999999952 ms)
2021-05-04 18:05:27 DEBUG    parser_internal series_special  Parsing series: `My Series S00E01 My Title` kwargs: {'name': 'My Series', 'identified_by': 'auto', 'alternate_names': [], 'name_regexps': [], 'strict_name': False, 'allow_groups': [], 'date_yearfirst': None, 'date_dayfirst': None, 'special_ids': [], 'prefer_specials': None, 'assume_special': None, 'ep_regexps': [], 'date_regexps': [], 'sequence_regexps': [], 'id_regexps': []}
2021-05-04 18:05:27 DEBUG    parser_internal series_special  Parsing result: <SeriesParser(data=My Series S00E01 My Title,name=My Series,id=(0, 1),season=0,season_pack=None,episode=1,quality=unknown,proper=0,status=OK)> (in 0.5026219999999526 ms)
2021-05-04 18:05:27 DEBUG    series        series_special  `My Series S00E01 My Title` detected as `<SeriesParseResult(data=My Series S00E01 My Title,name=My Series,id=(0, 1),season=0,season_pack=None,episode=1,quality=unknown,proper=0,special=True,status=OK)>`, field: `title`
2021-05-04 18:05:27 DEBUG    series        series_special  series on_task_metainfo took 0.012695785999999654 to parse
2021-05-04 18:05:27 DEBUG    series.db     series_special  adding episode `S00E01` into series `My Series`
2021-05-04 18:05:27 DEBUG    series.db     series_special  -> added `<Episode(id=None,identifier=S00E01,season=0,number=1)>`
2021-05-04 18:05:27 DEBUG    series.db     series_special  adding release `<SeriesParseResult(data=My Series S00E01 My Title,name=My Series,id=(0, 1),season=0,season_pack=None,episode=1,quality=unknown,proper=0,special=True,status=OK)>`
2021-05-04 18:05:27 DEBUG    series.db     series_special  -> added `<Release(id=None,quality=unknown,downloaded=None,proper_count=0,title=My Series S00E01 My Title)>`
2021-05-04 18:05:27 DEBUG    series.db     series_special  My Series episode type totals: {'ep': 1}
2021-05-04 18:05:27 VERBOSE  series.db     series_special  identified by is currently on `auto` for My Series. Multiple id types may be accepted until it locks in on the appropriate type.
2021-05-04 18:05:27 DEBUG    series        series_special  identified_by set to `auto` based on series history
2021-05-04 18:05:27 DEBUG    series        series_special  start with entities: ['My Series S00E01 My Title']
2021-05-04 18:05:27 DEBUG    series        series_special  Skipping special episode as support is turned off.
2021-05-04 18:05:27 DEBUG    series        series_special  processing series took 0.02762553099999998
2021-05-04 18:05:27 DEBUG    urlrewriter   series_special  Checking 0 entries
2021-05-04 18:05:27 VERBOSE  details       series_special  Summary - Accepted: 0 (Rejected: 0 Undecided: 1 Failed: 0)
2021-05-04 18:05:27 WARNING  task          series_special  Task doesn't have any output plugins, you should add (at least) one!
2021-05-04 18:05:27 DEBUG    series        series_special  on_task_learn
2021-05-04 18:05:27 DEBUG    util.simple_persistence series_special  Flushing simple persistence for task series_special to db.
2021-05-04 18:05:27 DEBUG    task_queue                    task queue shut down
2021-05-04 18:05:27 INFO     ipc.rpyc                      server has terminated
2021-05-04 18:05:27 INFO     ipc.rpyc                      listener closed
2021-05-04 18:05:27 DEBUG    util.simple_persistence                 Flushing simple persistence for task None to db.
2021-05-04 18:05:27 DEBUG    manager                       Shutting down

```
#### To Do:

- [ ] If Merged add test cases to pytest
