### PR TITLE
[add] imdb_list: change authenticate to cookies

### DIFF
--- a/flexget/components/managed_lists/lists/imdb_list.py
+++ b/flexget/components/managed_lists/lists/imdb_list.py
@@ -2,6 +2,8 @@ import csv
 import re
 from collections.abc import MutableSet
 from datetime import datetime
+from json import JSONDecodeError, loads as json_loads, load as json_load
+from pathlib import Path
 
 from loguru import logger
 from requests.exceptions import RequestException
@@ -64,12 +66,25 @@ class ImdbEntrySet(MutableSet):
         'type': 'object',
         'properties': {
             'login': {'type': 'string'},
-            'password': {'type': 'string'},
+            'cookies': {
+                'oneOf': [
+                    {'type': 'string', 'format': 'file'},
+                    {'type': 'string', 'format': 'json'},
+                    {
+                        'type': 'object',
+                        'properties': {
+                            'ubid-main': {'type': 'string'},
+                            'sess-at-main': {'type': 'string'},
+                        },
+                    },
+                ],
+                'error_oneOf': 'Please inform a dict with the cookies, a string in json format, or a path to the file',
+            },
             'list': {'type': 'string'},
             'force_language': {'type': 'string', 'default': 'en-us'},
         },
         'additionalProperties': False,
-        'required': ['login', 'password', 'list'],
+        'required': ['login', 'cookies', 'list'],
     }
 
     def __init__(self, config):
@@ -79,10 +94,48 @@ class ImdbEntrySet(MutableSet):
         self._session.headers.update({'Accept-Language': config.get('force_language', 'en-us')})
         self.user_id = None
         self.list_id = None
-        self.cookies = None
+        self.cookies = self.parse_cookies(config.get('cookies', None))
         self.hidden_value = None
         self._items = None
         self._authenticated = False
+
+    def parse_cookies(self, cookies):
+        required_fields = ['ubid-main', 'at-main']
+
+        if not cookies:
+            raise PluginError('Please inform the login cookies')
+
+        if isinstance(cookies, dict):
+            new_cookie = cookies
+        elif isinstance(cookies, str):
+            try:
+                new_cookie = json_loads(cookies)
+            except JSONDecodeError as e:
+                new_cookie = self.parse_cookies_file(cookies)
+
+        if not new_cookie:
+            raise PluginError(
+                'Invalid cookies format, please add a dict, a string in json or a path to a file in json'
+            )
+
+        for field in required_fields:
+            if field not in new_cookie:
+                raise PluginError(f'Invalid cookies format, missing \'{field}\'')
+
+        return new_cookie
+
+    def parse_cookies_file(self, path):
+        file = Path(path)
+        if not file.exists():
+            raise PluginError('Invalid cookies file format, file does not exist')
+
+        with file.open(encoding='utf-8') as data:
+            try:
+                contents = json_load(data)
+            except JSONDecodeError as e:
+                raise PluginError('Invalid cookies file format, file not in json')
+
+        return contents
 
     @property
     def session(self):
@@ -117,21 +170,33 @@ class ImdbEntrySet(MutableSet):
         """Authenticates a session with IMDB, and grabs any IDs needed for getting/modifying list."""
         cached_credentials = False
         with Session() as session:
-            user = (
-                session.query(IMDBListUser)
-                .filter(IMDBListUser.user_name == self.config.get('login'))
-                .one_or_none()
-            )
-            if user and user.cookies and user.user_id:
-                logger.debug('login credentials found in cache, testing')
-                self.user_id = user.user_id
-                if not self.get_user_id_and_hidden_value(cookies=user.cookies):
-                    logger.debug('cache credentials expired')
-                    user.cookies = None
-                    self._session.cookies.clear()
-                else:
-                    self.cookies = user.cookies
-                    cached_credentials = True
+            if self.cookies:
+                if not self.user_id:
+                    self.user_id = self.get_user_id_and_hidden_value(self.cookies)
+                if not self.user_id:
+                    raise PluginError(
+                        'Not possible to retrive userid, please check cookie information'
+                    )
+
+                user = IMDBListUser(self.config['login'], self.user_id, self.cookies)
+                self.cookies = user.cookies
+                cached_credentials = True
+            else:
+                user = (
+                    session.query(IMDBListUser)
+                    .filter(IMDBListUser.user_name == self.config.get('login'))
+                    .one_or_none()
+                )
+                if user and user.cookies and user.user_id:
+                    logger.debug('login credentials found in cache, testing')
+                    self.user_id = user.user_id
+                    if not self.get_user_id_and_hidden_value(cookies=user.cookies):
+                        logger.debug('cache credentials expired')
+                        user.cookies = None
+                        self._session.cookies.clear()
+                    else:
+                        self.cookies = user.cookies
+                        cached_credentials = True
             if not cached_credentials:
                 logger.debug('user credentials not found in cache or outdated, fetching from IMDB')
                 url_credentials = (

--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -4,6 +4,7 @@ import re
 from collections import defaultdict
 from typing import Any, Callable, Dict, List, Match, Optional, Pattern, Union
 from urllib.parse import parse_qsl, urlparse
+from json import JSONDecodeError, loads as json_loads
 
 import jsonschema
 from jsonschema import ValidationError
@@ -306,6 +307,19 @@ def is_valid_template(instance) -> bool:
     if not isinstance(instance, str_types):
         return True
     return get_template(instance) is not None
+
+
+@format_checker.checks('json', raises=ValueError)
+def is_json(instance) -> bool:
+    if not isinstance(instance, str):
+        return False
+
+    try:
+        decoded_json = json_loads(instance)
+    except JSONDecodeError as e:
+        raise ValueError('`%s` is not a valid json' % instance)
+
+    return True
 
 
 def set_error_message(error: jsonschema.ValidationError) -> None:


### PR DESCRIPTION
### Motivation for changes:

Imdb is always changing login system, keeps breaking the possibility to authenticate. I always used the cookies to login, even in new databases I ended up adding the cookies directly to the database, and they never changed! Allowing me to keep using imdb.

### Detailed changes:
- Removed password from the schema (BREAKING CHANGE)
- Added cookie via
    - dict
    - string (json)
    - load file (json) 

### Addressed issues:
- Fixes #2663

### Implemented feature requests:

### Config usage if relevant (new plugin or updated schema):
```yaml
  imdb_list:
    accept_all: yes
    imdb_list:
      login: myemail@email.com
      cookies:
        ubid-main: <<from browser cookie>>
        at-main: <<from browser cookie>>
      list: watchlist
```
```yaml
  imdb_list:
    accept_all: yes
    imdb_list:
      login: myemail@email.com
      cookies:  '{"ubid-main": "<<from browser cookie>>","at-main": "<<from browser cookie>>"}'
      list: watchlist
```
```yaml
  imdb_list:
    accept_all: yes
    imdb_list:
      login: myemail@email.com
      cookies:  '/path/to/my/cookies.json'
      list: watchlist
```
### Log and/or tests output (preferably both):

#### To Do:

- [ ] Would we like other file formats?
- [ ] Update wiki if merged
- [ ] Complete remove the authenticate via password logic?

