### PR TITLE
Add move_data action to Transmission component

### DIFF
--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -295,7 +295,7 @@ class PluginTransmission(TransmissionBase):
                     'password': {'type': 'string'},
                     'action': {
                         'type': 'string',
-                        'enum': ['add', 'remove', 'purge', 'pause', 'resume', 'bypass_queue'],
+                        'enum': ['add', 'remove', 'purge', 'pause', 'resume', 'bypass_queue', 'move_data'],
                     },
                     'path': {'type': 'string'},
                     'max_up_speed': {'type': 'number'},
@@ -642,6 +642,9 @@ class PluginTransmission(TransmissionBase):
                 elif config['action'] == 'bypass_queue':
                     start_torrent(bypass_queue=True)
                     logger.info('resumed (bypass queue) {} in transmission', torrent_info.name)
+                elif config['action'] == 'move_data':
+                    self.client.move_torrent_data([torrent_info.id], config['path'])
+                    logger.info('set data location for {} to {} in transmission', torrent_info.name, config['path'])
 
             except TransmissionError as e:
                 logger.opt(exception=True).debug('TransmissionError')


### PR DESCRIPTION
### Motivation for changes:
I would like to download files to an "incomplete" directory before moving them to a different path to be acted on by my file system tasks so that it doesn't attempt to operate on incomplete data (e.g. multipart RAR archives).

### Detailed changes:
- Added move_data action to the transmission plugin

### Config usage if relevant (new plugin or updated schema):
```
  transmission-move-movies:
    priority: 203
    disable: [seen, seen_info_hash]
    from_transmission:
      <<: *transmission
    if:
      - transmission_status != 'seeding': reject
      - transmission_downloadDir == '/var/lib/transmission-daemon/downloads/incomplete/movies': accept
    transmission: 
      enabled: yes
      host: '{? transmission.host ?}'
      port: 9091
      username: '{? transmission.username  ?}'
      password: '{? transmission.password  ?}'
      action: move_data
      path: '/var/lib/transmission-daemon/downloads/movies'
```
### Log and/or tests output (preferably both):
```
2021-05-09 13:47:22 VERBOSE  details       transmission-move-movies Produced 10 entries.
2021-05-09 13:47:22 VERBOSE  task          transmission-move-movies ACCEPTED: `XXX` by if plugin because matched requirement: transmission_downloadDir == '/var/lib/transmission-daemon/downloads/movies'
2021-05-09 13:47:22 VERBOSE  details       transmission-move-movies Summary - Accepted: 1 (Rejected: 0 Undecided: 9 Failed: 0)
2021-05-09 13:47:22 VERBOSE  transmission  transmission-move-movies Moving XXX to "/var/lib/transmission-daemon/downloads/movies"
2021-05-09 13:47:22 INFO     transmission  transmission-move-movies set data location for XXX to /var/lib/transmission-daemon/downloads/movies in transmission
```
#### To Do:

- Wiki pages will need to be updated if/when this gets merged.