### PR TITLE
Add `timestamp_finished` to `from_rtorrent`

### DIFF
--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -3,6 +3,7 @@ import re
 import socket
 from io import BytesIO
 from time import sleep
+from datetime import datetime
 from urllib.parse import urljoin, urlparse, urlsplit
 from xmlrpc import client as xmlrpc_client
 
@@ -184,6 +185,7 @@ class RTorrent:
         'ratio',
         'base_path',
         'load_date',
+        'timestamp_finished',
     )
 
     required_fields = ('hash', 'name', 'base_path')
@@ -234,7 +236,7 @@ class RTorrent:
             fields = list(self.default_fields)
 
         if reverse:
-            for field in ['up.total', 'down.total', 'down.rate']:
+            for field in ['up.total', 'down.total', 'down.rate', 'timestamp.finished']:
                 if field in fields:
                     fields[fields.index(field)] = field.replace('.', '_')
             return fields
@@ -243,7 +245,7 @@ class RTorrent:
             if required_field not in fields:
                 fields.insert(0, required_field)
 
-        for field in ['up_total', 'down_total', 'down_rate']:
+        for field in ['up_total', 'down_total', 'down_rate', 'timestamp_finished']:
             if field in fields:
                 fields[fields.index(field)] = field.replace('_', '.')
 
@@ -708,6 +710,9 @@ class RTorrentInputPlugin(RTorrentPluginBase):
 
             for attr, value in torrent.items():
                 entry[attr] = value
+            
+            if 'timestamp_finished' in entry:
+                entry['timestamp_finished'] = datetime.fromtimestamp(entry['timestamp_finished'])
 
             entries.append(entry)
 


### PR DESCRIPTION
This commit adds `timestamp_finished` as default field to `from_rtorrent` which is time when torrent has completed.
If torrent has not completed, it has value of `datetime.datetime(1970, 1, 1, 1, 0)`.

### Motivation for changes:
`from_rtorrent` currently does not provide information about time when torrent completed downloading. This information is useful for keeping seeding torrent for a set period of time before moving/deletion of data files.

### Detailed changes:
- Add `timestamp_finished` to default fields.
- Converts epoch value received from rTorrent to `datetime.datetime` value.

### Addressed issues:

### Implemented feature requests:

### Config usage if relevant (new plugin or updated schema):
```
tasks:
  debug:
    from_rtorrent:
      uri: "{? rtorrent ?}"
      fields:
        - timestamp_finished
```
### Log and/or tests output (preferably both):
```
title            : Shadow.in.the.Cloud.2020.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HEVC.HYBRID.REMUX-FraMeSToR.mkv
url              : /var/run/user/.rtorrent.sock/E69FC65399C98B99ECEA4F064C6377805F6AA37A
original_url     : /var/run/user/.rtorrent.sock/E69FC65399C98B99ECEA4F064C6377805F6AA37A
base_path        : /home/user/Downloads/Shadow.in.the.Cloud.2020.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HEVC.HYBRID.REMUX-FraMeSToR.mkv
hash             : E69FC65399C98B99ECEA4F064C6377805F6AA37A
media_id         : None
name             : Shadow.in.the.Cloud.2020.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HEVC.HYBRID.REMUX-FraMeSToR.mkv
original_title   : Shadow.in.the.Cloud.2020.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HEVC.HYBRID.REMUX-FraMeSToR.mkv
path             : /home/user/Downloads/Shadow.in.the.Cloud.2020.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HEVC.HYBRID.REMUX-FraMeSToR.mkv
quality          : 2160p bluray h265 dtshd
task             : debug
timestamp_finished: 2021-04-12 15:51:12
torrent_info_hash: E69FC65399C98B99ECEA4F064C6377805F6AA37A
```
#### To Do:

