### PR TITLE
Fixed crash of the LostFilm plugin when page download failed

### DIFF
--- a/flexget/components/sites/sites/lostfilm.py
+++ b/flexget/components/sites/sites/lostfilm.py
@@ -206,7 +206,7 @@ class LostFilm:
             try:
                 response = task.requests.get(redirect_url, params=params)
             except RequestException as e:
-                logger.error('Failed to get lostfilm download page: {:s}'.format(e))
+                logger.error('Failed to get the redirect page: {}', e)
                 continue
 
             if response.status_code != 200:
@@ -240,7 +240,7 @@ class LostFilm:
             try:
                 response = task.requests.get(redirect_url)
             except RequestException as e:
-                logger.error('Could not connect to redirect url2: {:s}', e)
+                logger.error('Failed to get the download page: {}', e)
                 continue
 
             page = get_soup(response.content)

--- a/flexget/components/sites/sites/lostfilm.py
+++ b/flexget/components/sites/sites/lostfilm.py
@@ -208,6 +208,9 @@ class LostFilm:
             except RequestException as e:
                 logger.error('Failed to get the redirect page: {}', e)
                 continue
+            except Exception as e:
+                logger.error('Got unexpected exception when trying to get the redirect page: {}', e)
+                continue
 
             if response.status_code != 200:
                 if config.get('lf_session') is not None:
@@ -241,6 +244,9 @@ class LostFilm:
                 response = task.requests.get(redirect_url)
             except RequestException as e:
                 logger.error('Failed to get the download page: {}', e)
+                continue
+            except Exception as e:
+                logger.error('Got unexpected exception when trying to get the download page: {}', e)
                 continue
 
             page = get_soup(response.content)

--- a/flexget/components/sites/sites/lostfilm.py
+++ b/flexget/components/sites/sites/lostfilm.py
@@ -15,6 +15,12 @@ from flexget.utils.requests import RequestException
 from flexget.utils.soup import get_soup
 from flexget.utils import qualities
 from flexget.components.sites.utils import normalize_unicode
+try:
+    from cloudscraper.exceptions import CloudflareException, CaptchaException
+    cf_exceptions = (CloudflareException, CaptchaException)
+except ModuleNotFoundError:
+    cf_exceptions = ()
+    pass # cloudscraper module is optional
 
 __authors__ = 'danfocus, Karlson2k'
 
@@ -119,11 +125,11 @@ class LostFilm:
             proxy_handler = ProxyHandler(task.requests.proxies)
         try:
             rss = feedparser.parse(config['url'], handlers=[proxy_handler])
-        except Exception:
-            raise PluginError('Cannot parse rss feed')
+        except Exception as e:
+            raise PluginError('Cannot parse rss feed: {}', e)
         status = rss.get('status')
         if status != 200:
-            raise PluginError('Received %s status instead of 200 (OK)' % status)
+            raise PluginError('Received %s status instead of 200 (OK) when trying to download the RSS feed' % status)
         entries = []
         for idx, item in enumerate(rss.entries, 1):
             series_name_rus = series_name_org = None
@@ -208,7 +214,11 @@ class LostFilm:
             except RequestException as e:
                 logger.error('Failed to get the redirect page: {}', e)
                 continue
+            except cf_exceptions as e:
+                logger.error('Cannot pass CF page protection to get the redirect page: {}', e)
+                continue
             except Exception as e:
+                # Catch other errors related to download to avoid crash
                 logger.error('Got unexpected exception when trying to get the redirect page: {}', e)
                 continue
 
@@ -245,7 +255,11 @@ class LostFilm:
             except RequestException as e:
                 logger.error('Failed to get the download page: {}', e)
                 continue
+            except cf_exceptions as e:
+                logger.error('Cannot pass CF page protection to get the download page: {}', e)
+                continue
             except Exception as e:
+                # Catch other errors related to download to avoid crash
                 logger.error('Got unexpected exception when trying to get the download page: {}', e)
                 continue
 


### PR DESCRIPTION
### Motivation for changes:
Plugin crashed when download failed

Relevant log part:
``` log
 During handling of the above exception, another exception occurred:
 Traceback (most recent call last):
   File "/usr/lib/python3.8/threading.py", line 890, in _bootstrap
     self._bootstrap_inner()
     |    -> <function Thread._bootstrap_inner at 0x7f683666ce50>
     -> <Thread(task_queue, started daemon 140084510713600)>
   File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
     self.run()
     |    -> <function Thread.run at 0x7f683666cb80>
     -> <Thread(task_queue, started daemon 140084510713600)>
   File "/usr/lib/python3.8/threading.py", line 870, in run
     self._target(*self._args, **self._kwargs)
     |    |        |    |        |    -> {}
     |    |        |    |        -> <Thread(task_queue, started daemon 140084510713600)>
     |    |        |    -> ()
     |    |        -> <Thread(task_queue, started daemon 140084510713600)>
     |    -> <bound method TaskQueue.run of <flexget.task_queue.TaskQueue object at 0x7f682ebac9a0>>
     -> <Thread(task_queue, started daemon 140084510713600)>
   File "/usr/local/lib/python3.8/dist-packages/flexget/task_queue.py", line 46, in run
     self.current_task.execute()
     |    |            -> <function Task.execute at 0x7f6833a14f70>
     |    -> <flexget.task.Task object at 0x7f68145b6070>
     -> <flexget.task_queue.TaskQueue object at 0x7f682ebac9a0>
   File "/usr/local/lib/python3.8/dist-packages/flexget/task.py", line 87, in wrapper
     return func(self, *args, **kw)
            |    |      |       -> {}
            |    |      -> ()
            |    -> <flexget.task.Task object at 0x7f68145b6070>
            -> <function Task.execute at 0x7f6833a14ee0>
   File "/usr/local/lib/python3.8/dist-packages/flexget/task.py", line 722, in execute
     self._execute()
     |    -> <function Task._execute at 0x7f6833a14e50>
     -> <flexget.task.Task object at 0x7f68145b6070>
   File "/usr/local/lib/python3.8/dist-packages/flexget/task.py", line 688, in _execute
     self.__run_task_phase(phase)
     |                     -> 'input'
     -> <flexget.task.Task object at 0x7f68145b6070>
   File "/usr/local/lib/python3.8/dist-packages/flexget/task.py", line 514, in __run_task_phase
     response = self.__run_plugin(plugin, phase, args)
                |                 |       |      -> (<flexget.task.Task object at 0x7f68145b6070>, 'eba3e887187cb5d5d7c98eb1c2f14db0.330812')
                |                 |       -> 'input'
                |                 -> <PluginInfo(name=lostfilm)>
                -> <flexget.task.Task object at 0x7f68145b6070>
 > File "/usr/local/lib/python3.8/dist-packages/flexget/task.py", line 547, in __run_plugin
     result = method(*args, **kwargs)
              |       |       -> {}
              |       -> (<flexget.task.Task object at 0x7f68145b6070>, 'eba3e887187cb5d5d7c98eb1c2f14db0.330812')
              -> <Event(name=plugin.lostfilm.input,func=on_task_input,priority=128)>
   File "/usr/local/lib/python3.8/dist-packages/flexget/event.py", line 20, in __call__
     return self.func(*args, **kwargs)
            |    |     |       -> {}
            |    |     -> (<flexget.task.Task object at 0x7f68145b6070>, 'eba3e887187cb5d5d7c98eb1c2f14db0.330812')
            |    -> <bound method LostFilm.on_task_input of <flexget.components.sites.sites.lostfilm.LostFilm object at 0x7f682ec84c70>>
            -> <Event(name=plugin.lostfilm.input,func=on_task_input,priority=128)>
   File "/usr/local/lib/python3.8/dist-packages/flexget/components/sites/sites/lostfilm.py", line 209, in on_task_input
     logger.error('Failed to get lostfilm download page: {:s}'.format(e))
     |      -> <function Logger.error at 0x7f6835e2c790>
     -> <loguru.logger handlers=[(id=2, level=10, sink=<lambda>), (id=3, level=20, sink='/dev/null'), (id=4, level=20, sink=<stdout>)]>
 TypeError: unsupported format string passed to ConnectionError.__format__
 2021-05-13 11:27:23 CRITICAL task_queue                    BUG: Unhandled exception during task queue run loop.
```

### Changes

Fixed crash, updated error log descriptions.