### PR TITLE
[add] jinja split year: Jinja split name and year

### DIFF
--- a/flexget/tests/test_jinja_filters.py
+++ b/flexget/tests/test_jinja_filters.py
@@ -1,0 +1,43 @@
+import pytest
+
+
+class TestJinjaFilters:
+    config = """
+        tasks:
+          stripyear:
+            mock:
+              - {"title":"The Matrix (1999)", "url":"mock://local1" }
+              - {"title":"The Matrix", "url":"mock://local2" }
+              - {"title":"The Matrix 1999", "url":"mock://local3" }
+              - {"title":"2000", "url":"mock://local3" }
+              - {"title":"2000 (2020)", "url":"mock://local4" }
+              - {"title":"2000 2020", "url":"mock://local5" }
+                
+            accept_all: yes
+                
+            set:
+              name: "{{title|strip_year}}"
+              year: "{{title|get_year}}"
+    """
+
+    def test_stripyear(self, execute_task):
+        task = execute_task('stripyear')
+
+        assert len(task.accepted) == 6
+        assert task.accepted[0]['name'] == 'The Matrix'
+        assert task.accepted[0]['year'] == 1999
+
+        assert task.accepted[1]['name'] == 'The Matrix'
+        assert task.accepted[1]['year'] is None
+
+        assert task.accepted[2]['name'] == 'The Matrix'
+        assert task.accepted[2]['year'] == 1999
+
+        assert task.accepted[3]['name'] == 2000
+        assert task.accepted[3]['year'] is None
+
+        assert task.accepted[4]['name'] == 2000
+        assert task.accepted[4]['year'] == 2020
+
+        assert task.accepted[5]['name'] == 2000
+        assert task.accepted[5]['year'] == 2020

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -25,6 +25,7 @@ from loguru import logger
 from flexget.event import event
 from flexget.utils.lazy_dict import LazyDict
 from flexget.utils.pathscrub import pathscrub
+from flexget.utils.tools import split_title_year
 
 if TYPE_CHECKING:
     from flexget.entry import Entry
@@ -137,6 +138,14 @@ def filter_default(value, default_value: str = '', boolean: bool = True) -> str:
 
 
 filter_d = filter_default
+
+
+def filter_strip_year(name: str) -> str:
+    return split_title_year(name).title
+
+
+def filter_get_year(name: str) -> str:
+    return split_title_year(name).year
 
 
 def is_fs_file(pathname: Union[str, os.PathLike]) -> bool:


### PR DESCRIPTION
### Motivation for changes:

A clean way to split the year from the title with jinja, that is equal to the logic applied in flexget

### Detailed changes:
- add jinja filter strip_year
- add jinja filter get_year
- add test cases to Jinja filters (can accommodate more filters in the futer, to avoid multiple files per filter)

### Config usage if relevant (new plugin or updated schema):
```yaml
        tasks:
          stripyear:
            mock:
              - {"title":"The Matrix (1999)", "url":"mock://local1" }
              - {"title":"The Matrix", "url":"mock://local2" }
              - {"title":"The Matrix 1999", "url":"mock://local3" }
              - {"title":"2000", "url":"mock://local3" }
              - {"title":"2000 (2020)", "url":"mock://local4" }
              - {"title":"2000 2020", "url":"mock://local5" }
                
            accept_all: yes
                
            set:
              name: "{{title|strip_year}}"
              year: "{{title|get_year}}"
```
### Log and/or tests output (preferably both):
```yaml
name: The Matrix
year: 1999

name: The Matrix
year: None

name: The Matrix
year: 1999

name: 2000
year: None

name: 2000
year: 2020

name: 2000
year: 2020
```

