### PR TITLE
lostfilm plugin: updated to support the latest site changes

### DIFF
--- a/flexget/components/sites/sites/lostfilm.py
+++ b/flexget/components/sites/sites/lostfilm.py
@@ -39,7 +39,14 @@ quality_map = {
     'HD': '720p.ac3.h264',
 }
 
-LOSTFILM_URL = 'https://lostfilm.tv/rss.xml'
+# All URLs must have '/' at the end
+SITE_URLS = [
+    'https://www.lostfilmtv.site/',
+    'https://www.lostfilm.run/',
+    'https://www.lostfilm.uno/',
+    'https://www.lostfilm.win/',
+    'https://www.lostfilm.tv/',
+]
 
 SIMPLIFY_MAP = str.maketrans({
     '&': ' and ',
@@ -75,17 +82,23 @@ class LostFilm:
     Advanced usage:
 
       lostfilm:
-        url: <url>
         lf_session: <lf_session_cookie_value>
         prefilter: no
+        site_urls:
+          - "http://www.example.com/"
+          - "https://www.example.org/"
     """
 
     schema = {
         'type': ['boolean', 'string', 'object'],
         'properties': {
-            'url': {'type': 'string', 'format': 'url'},
             'lf_session': {'type': 'string'},
             'prefilter': {'type': 'boolean'},
+            'site_urls': {
+                'type': [ 'string', 'array'],
+                'format': 'url',
+                'items': {'type': 'string', 'format': 'url'},
+            }
          },
         'additionalProperties': False,
     }
@@ -101,35 +114,68 @@ class LostFilm:
         else:
             cfg = dict(config)
             cfg['enabled'] = True
-        cfg.setdefault('url', LOSTFILM_URL)
         cfg.setdefault('prefilter', True)
+        if isinstance(cfg.get('site_urls'), str):
+            cfg['site_urls'] = [config['site_urls']]
+        if not cfg.get('site_urls'):
+            cfg['site_urls'] = SITE_URLS
+        else:
+            site_urls = []
+            for url in cfg['site_urls']:
+                if url.endswith('/'):
+                    site_urls.append(url)
+                else:
+                    site_urls.append(url + "/")
+            cfg['site_urls'] = site_urls
         return cfg
 
     def on_task_input(self, task, config):
         config = self.build_config(config)
+        logger.trace('Config is {}', config)
         if not config['enabled']:
             return
         if config.get('lf_session') is not None:
             task.requests.cookies.set('lf_session', config['lf_session'])
             logger.debug('lf_session is set')
+        task.requests.headers.update({'Cache-Control': 'no-cache',
+                                      'Pragma': 'no-cache'})
         prefilter_list = set()
         if config['prefilter']:
             prefilter_list = self._get_series(task)
             if prefilter_list:
                 logger.verbose('Generated pre-filter list with {} entries', len(prefilter_list))
             else:
-                logger.info('Pre-filter list is empty. No series names are configured?')
+                logger.warning('Pre-filter list is empty. No series names are configured?')
 
         proxy_handler = None
         if task.requests.proxies is not None:
             proxy_handler = ProxyHandler(task.requests.proxies)
-        try:
-            rss = feedparser.parse(config['url'], handlers=[proxy_handler])
-        except Exception as e:
-            raise PluginError('Cannot parse rss feed: {}', e)
-        status = rss.get('status')
-        if status != 200:
-            raise PluginError('Received %s status instead of 200 (OK) when trying to download the RSS feed' % status)
+
+        site_urls = config['site_urls']
+        tried_urls = []
+
+        while site_urls:
+            rss_url = site_urls[0] + "rss.xml" # If RSS url changes, update it here
+            logger.trace('Trying to get and parse the RSS feed: {}', rss_url)
+            try:
+                rss = feedparser.parse(rss_url, handlers=[proxy_handler],
+                          request_headers={'Cache-Control': 'no-cache',
+                                           'Pragma': 'no-cache'})
+                status = rss.get('status')
+                if status == 200:
+                    logger.verbose('Received RSS feed from {}', rss_url)
+                    break
+                logger.info('Received {} status instead of 200 (OK) when trying to download the RSS feed {}', status, rss_url)
+            except Exception as e:
+                logger.info('Cannot get or parse the RSS feed {}. Error: {}', rss_url, e)
+            rss = None
+            tried_urls.append(site_urls.pop(0))
+
+        if not rss:
+            raise PluginError('Cannot get the RSS feed')
+        # Use failed site locations as the last resot option for the redirect page
+        site_urls.extend(tried_urls)
+
         entries = []
         for idx, item in enumerate(rss.entries, 1):
             series_name_rus = series_name_org = None
@@ -177,9 +223,9 @@ class LostFilm:
                         else:
                             logger.debug('Force adding the last RSS item to the result to avoid warning of empty output')
                     else:
-                        logger.trace('"{}" was foung in the list of configured series', series_name_org)
+                        logger.trace('"{}" was found in the list of configured series', series_name_org)
                 else:
-                    logger.trace('Not skipping RSS item as series names may be detected incorrectly')
+                    logger.debug('Not skipping RSS item as series names may be detected incorrectly')
 
             if item.get('description') is None:
                 logger.warning('RSS item doesn\'t have a description, skipping')
@@ -201,47 +247,57 @@ class LostFilm:
                 series_name_org = link_match['sr_org2'].replace('_', ' ')
                 season_num = int(link_match['season'])
                 episode_num = int(link_match['episode'])
-                logger.verbose('Using imprecise information from RSS item link')
+                logger.verbose('Using imprecise information from RSS item \'link\'')
 
             logger.trace(('Processing RSS entry: names: series "{}", series ru "{}", episode ru "{}"; '
                           'numbers: season "{}", episode "{}", lostfilm id "{}"; perfect detect: {}'),
                            series_name_org, series_name_rus, episode_name_rus,
                            season_num, episode_num, lostfilm_id, perfect_match)
             params = {'c': lostfilm_id, 's': season_num, 'e': episode_num}
-            redirect_url = 'https://www.lostfilm.tv/v_search.php'
-            try:
-                response = task.requests.get(redirect_url, params=params)
-            except RequestException as e:
-                logger.error('Failed to get the redirect page: {}', e)
-                continue
-            except cf_exceptions as e:
-                logger.error('Cannot pass CF page protection to get the redirect page: {}', e)
-                continue
-            except Exception as e:
-                # Catch other errors related to download to avoid crash
-                logger.error('Got unexpected exception when trying to get the redirect page: {}', e)
-                continue
 
-            if response.status_code != 200:
+            tried_urls = []
+            while site_urls:
+                redirect_url = site_urls[0] + 'v_search.php'
+                logger.trace('Trying to get the redirect page: {}', redirect_url)
+                try:
+                    response = task.requests.get(redirect_url, params=params)
+                    if response.status_code == 200:
+                        logger.debug('The redirect page is downloaded from {}', redirect_url)
+                        break
+                    logger.verbose('Got status {} while retriving the redirect page {}', response.status_code, redirect_url)
+                except RequestException as e:
+                    logger.verbose('Failed to get the redirect page from {}. Error: {}', redirect_url, e)
+                except cf_exceptions as e:
+                    logger.verbose('Cannot bypass CF page protection to get the redirect page {}. Error: {}', redirect_url, e)
+                except Exception as e:
+                    # Catch other errors related to download to avoid crash
+                    logger.warning('Got unexpected exception when trying to get the redirect page. Error: {}', redirect_url, e)
+                response = None
+                tried_urls.append(site_urls.pop(0))
+
+            # Use failed site locations as the last resot option for the next attempts
+            site_urls.extend(tried_urls)
+
+            if not response:
                 if config.get('lf_session') is not None:
-                    logger.error('Got status {} while retriving lostfilm.tv torrent download page. ' \
-                                 'Check whether "lf_session" parameter is correct.', response.status_code)
+                    logger.error('Failed to get the redirect page. ' \
+                                 'Check whether "lf_session" parameter is correct.')
                 else:
-                    logger.error('Got status {} while retriving lostfilm.tv torrent download page. ' \
-                                 'Specify your "lf_session" cookie value in plugin parameters.', response.status_code)
+                    logger.error('Failed to get the redirect page. ' \
+                                 'Specify your "lf_session" cookie value in plugin parameters.')
                 continue
 
             page = get_soup(response.content)
 
-            redirect_url = None
+            download_page_url = None
             find_item = page.find('html', recursive=False)
             if find_item is not None:
                 find_item = find_item.find('head', recursive=False)
                 if find_item is not None:
                     find_item = find_item.find('meta', attrs={'http-equiv': "refresh"}, recursive=False)
                     if find_item is not None and find_item.has_attr('content') and find_item['content'].startswith('0; url=http'):
-                        redirect_url = find_item['content'][7:]
-            if not redirect_url:
+                        download_page_url = find_item['content'][7:]
+            if not download_page_url:
                 if config.get('lf_session') is not None:
                     logger.error('Links were not foung on lostfilm.tv torrent download page. ' \
                                  'Check whether "lf_session" parameter is correct.')
@@ -251,16 +307,16 @@ class LostFilm:
                 continue
 
             try:
-                response = task.requests.get(redirect_url)
+                response = task.requests.get(download_page_url)
             except RequestException as e:
-                logger.error('Failed to get the download page: {}', e)
+                logger.error('Failed to get the download page {}. Error: {}', download_page_url, e)
                 continue
             except cf_exceptions as e:
-                logger.error('Cannot pass CF page protection to get the download page: {}', e)
+                logger.error('Cannot pass CF page protection to get the download page {}. Error: {}', download_page_url, e)
                 continue
             except Exception as e:
                 # Catch other errors related to download to avoid crash
-                logger.error('Got unexpected exception when trying to get the download page: {}', e)
+                logger.error('Got unexpected exception when trying to get the download page {}. Error: {}', download_page_url, e)
                 continue
 
             page = get_soup(response.content)
@@ -273,16 +329,16 @@ class LostFilm:
                     if title_org_div.endswith(', сериал') and len(title_org_div) != 8:
                         series_name_org = title_org_div[:-8]
                     else:
-                        logger.verbose('Cannot parse text on the final download page for original series name')
+                        logger.info('Cannot parse text on the final download page for original series name')
                 else:
-                    logger.verbose('Cannot parse the final download page for original series name')
+                    logger.info('Cannot parse the final download page for original series name')
 
                 find_item = page.find('div', class_='inner-box--title')
                 if find_item is not None and \
                    find_item.text.strip():
                     series_name_rus = find_item.text.strip()
                 else:
-                    logger.verbose('Cannot parse the final download page for russian series name')
+                    logger.info('Cannot parse the final download page for russian series name')
 
             find_item = page.find('div', class_='inner-box--text')
             if find_item is not None:
@@ -300,9 +356,9 @@ class LostFilm:
                       info_match['ep_rus'].strip():
                         episode_name_rus = info_match['ep_rus'].strip()
                 else:
-                    logger.verbose('Cannot parse text on the final download page for episode names')
+                    logger.info('Cannot parse text on the final download page for episode names')
             else:
-                logger.verbose('Cannot parse the final download page for episode names')
+                logger.info('Cannot parse the final download page for episode names')
 
             r_type = ''
             find_item = page.find('div', class_='inner-box--link main')
@@ -347,7 +403,7 @@ class LostFilm:
                 if quality_map.get(lf_quality):
                     quality = quality_map.get(lf_quality)
                 else:
-                    logger.verbose('Download item has unknown quality indicator: {}', lf_quality)
+                    logger.info('Download item has unknown quality indicator: {}', lf_quality)
                     quality = lf_quality
                 if series_name_org:
                     new_title = '.'.join(
@@ -413,7 +469,7 @@ class LostFilm:
     @staticmethod
     def _get_series(task):
         if not task.config.get('series'):
-            logger.debug('No series plugin in the task')
+            logger.warning('No series plugin in the task')
             return None
 
         names_list = set()


### PR DESCRIPTION
### Motivation for changes:
LostFilm site is moving from one location to another and have troubles from time to time when accessed via some specific addresses.

### Detailed changes:
* Implemented the list of URLs instead of the single site address
* All URLs are tried one-by-one, in the specified order
* The first working URL is used for all requests during the session / task
* If the URL is failed, all URLs are re-used again including previously failed as the last options
* The list of URLs can be customised via plugin parameters
* A single address could be used in parameters, efficiently disables multi-URL feature
* Custom RSS URL option is removed, RSS is accessed as site URL + '/rss.xml'
This plugin can handle only RSS feed from lostfilm site. The relative address is always the same, there is no need to customize it. The site address is now configurable and used for both RSS feed and for other pages as well.
* Unrelated: adjusted log levels, some typos fixed

### Addressed issues:
- Fixes https://github.com/Flexget/Flexget/issues/2983

### Config usage if relevant (new plugin or updated schema):
```
      lostfilm:
        lf_session: <lf_session_cookie_value>
        site_urls:
          - "https://www.lostfilm.run/"
          - "https://www.lostfilm.uno/"
```
or with single site URL:
```
      lostfilm:
        lf_session: <lf_session_cookie_value>
        site_urls: "https://www.lostfilmtv.site/"
```
#### To Do:

- [ ] Update Wiki if accepted.

