### PR TITLE
Fix verbose log message in decompress

### DIFF
--- a/flexget/components/archives/utils.py
+++ b/flexget/components/archives/utils.py
@@ -149,8 +149,6 @@ class Archive:
         except OSError as error:
             raise FSError(error)
 
-        logger.verbose('Extracted: {}', member)
-
 
 class RarArchive(Archive):
     """
@@ -232,6 +230,7 @@ class ArchiveInfo:
 
         try:
             archive.extract_file(self.info, destination)
+            logger.verbose('Extracted: {} to {}', self.path, destination)
         except Exception as error:
             if os.path.exists(destination):
                 logger.debug('Cleaning up partially extracted file: {}', destination)


### PR DESCRIPTION
### Motivation for changes:
Decompress is erroneously logging an object's location in memory rather than anything useful. 

For example:

```
Extracted: <rarfile.Rar3Info object at 0x7fe34c2b8860>
```

New log output:

```
Extracted: foo/bar to baz/bar
```

### Detailed changes:
- Move the log message and use string paths instead of trying to print a file-like object.

