### PR TITLE
[add] Flood plugin

### DIFF
--- a/flexget/plugins/clients/flood.py
+++ b/flexget/plugins/clients/flood.py
@@ -1,36 +1,93 @@
 from loguru import logger
+from datetime import datetime
 from requests import Session
 from requests.exceptions import RequestException
+from sqlalchemy import Column, DateTime, String, Unicode
 
 from flexget import plugin
-from flexget.entry import Entry
+from flexget.db_schema import versioned_base, with_session
 from flexget.event import event
+from flexget.utils.database import json_synonym
+from flexget.entry import Entry
 from flexget.task import Task
 
 logger = logger.bind(name='flood')
+Base = versioned_base('flood_session', 0)
 
+class FloodSession(Base):
+    __tablename__ = 'flood_session'
+
+    url = Column(String, primary_key=True)
+    username = Column(Unicode, primary_key=True)
+
+    _cookies = Column('cookie', Unicode)
+    cookies = json_synonym('_cookies')
+    expires = Column(DateTime)
 
 class FloodClient:
-    def __init__(self):
+    def __init__(self, config: dict):
+        self.config = config
         self.session = Session()
         self.connected = False
 
     def _request(self, method: str, path: str, **kwargs):
+        if not self.connected and path != '/api/auth/authenticate':
+            raise plugin.PluginError('Flood is not connected.')
+            
         try:
-            return self.session.request(method, self.url + path, **kwargs)
+            return self.session.request(method, self.config['url'].strip('/') + path, **kwargs)
         except RequestException as e:
             raise plugin.PluginError(f'Flood Request Exception: {e}')
 
-    def authenticate(self, config):
-        self.url = config['url'].strip('/')
+    @with_session
+    def _save_session(self, session=None):
+        logger.debug('Saving session')
 
-        response = self._request(
-            'post',
-            '/api/auth/authenticate',
-            data={'username': config['username'], 'password': config['password']},
+        expires = next(x for x in self.session.cookies if x.name == 'jwt').expires
+        if not expires:
+            raise plugin.PluginError('Expires cannot be None')
+
+        flood_session = FloodSession(
+            url=self.config['url'].strip('/'),
+            username=self.config['username'],
+            cookies=dict(self.session.cookies),
+            expires=datetime.utcfromtimestamp(expires)
         )
 
+        session.merge(flood_session)
+        logger.debug('Saved session')
+
+    @with_session
+    def _restore_session(self, session=None):
+        logger.debug('Looking for saved session')
+
+        flood_session = (session.query(FloodSession)
+            .filter(
+                FloodSession.url == self.config['url'].strip('/'),
+                FloodSession.username == self.config['username']
+            )
+        ).one_or_none()
+
+        if flood_session and flood_session.expires > datetime.utcnow():
+            self.session.cookies.update(flood_session.cookies)
+            logger.debug('Found saved session')
+            return True
+        
+        logger.debug('Unable to find saved session')
+        return False
+    
+    def authenticate(self):
+        if self._restore_session():
+            self.connected = True
+            return self
+
+        response = self._request('post', '/api/auth/authenticate', data={
+            'username': self.config['username'],
+            'password': self.config['password']
+        })
+
         if response.status_code == 200:
+            self._save_session()
             self.connected = True
             logger.debug('Successfully logged into Flood')
         else:
@@ -39,44 +96,37 @@ class FloodClient:
 
         return self
 
-    def add_torrent_urls(
-        self, urls: list = None, destination: str = None, tags: list = None, start: bool = True
-    ):
-        if not self.connected:
-            raise plugin.PluginError('Flood is not connected.')
-
+    def add_torrent_urls(self, urls: list=None, destination: str=None, tags: list=None, start: bool=True):
         if not urls:
             raise plugin.PluginError('Parameter urls cannot be empty.')
 
         data = {
-            'urls': urls,
-            'destination': destination,
+            'urls': urls, 
             'start': start,
         }
 
+        if destination:
+            data['destination'] = destination
         if tags:
             data['tags'] = tags
-
+        
         response = self._request('post', '/api/torrents/add-urls', json=data)
 
         if response.status_code == 200:
             logger.debug('Successfully added torrent(s).')
         else:
-            # There's no sanity to the codes returned by Flood.
+            # There's no sanity to the codes returned by Flood. 
             # Both return 'code': -32602 and both return status 500.
             if response.text.find('the input is not a valid.') > 0:
                 raise plugin.PluginError('Not a valid torrent.')
             elif response.text.find('Info hash already used by another torrent.') > 0:
                 logger.debug('Torrent has already been added to Flood.')
             else:
-                raise plugin.PluginError(
-                    f'Failed to add torrent to Flood. Error {response.status_code}.'
-                )
-
+                raise plugin.PluginError(f'Failed to add torrent to Flood. Error {response.status_code}.')
 
 class OutputFlood:
     schema = {
-        'type': 'object',
+       'type': 'object',
         'properties': {
             'url': {'type': 'string'},
             'username': {'type': 'string'},
@@ -89,15 +139,11 @@ class OutputFlood:
 
     def add_entry(self, client: FloodClient, config: dict, task: Task, entry: Entry):
         url = entry.get('url', None)
-        path = entry.render(entry.get('path', config.get('path', None)))
+        path = entry.render(entry.get('path', config.get('path', '')))
         tags = entry.get('tags', config.get('tags', None))
 
         if tags and isinstance(tags, list):
-            tags = (
-                [entry.render(tag) for tag in tags]
-                if isinstance(tags, list)
-                else [entry.render(tags)]
-            )
+            tags = [ entry.render(tag) for tag in tags ] if isinstance(tags, list) else [ entry.render(tags) ]
 
         if task.manager.options.test:
             logger.info('Flood Test Mode')
@@ -105,7 +151,11 @@ class OutputFlood:
             logger.info('\tPath: {}', path)
             logger.info('\tTags: {}', tags)
         else:
-            client.add_torrent_urls(urls=[url], destination=path, tags=tags)
+            client.add_torrent_urls(
+                urls=[ url ], 
+                destination=path, 
+                tags=tags
+            )
 
     @plugin.priority(135)
     def on_task_output(self, task: Task, config: dict):
@@ -113,14 +163,11 @@ class OutputFlood:
         if not task.accepted:
             return
 
-        # We're re-authenticating ourselves every time we output
-        # Need to work out how to save the jwt to Flexget
-        flood = FloodClient().authenticate(config)
+        flood = FloodClient(config).authenticate()
 
         # Loop through each accepted entry and send it to Flood
         for entry in task.accepted:
             self.add_entry(flood, config, task, entry)
-
 
 @event('plugin.register')
 def register_plugin():

--- a/flexget/plugins/clients/flood.py
+++ b/flexget/plugins/clients/flood.py
@@ -82,21 +82,21 @@ class OutputFlood:
         kwargs = {}
 
         url = entry.get('url', None)
-        path = entry.get('path', config.get('path', None))
+        path = entry.render(entry.get('path', config.get('path', None)))
         tags = entry.get('tags', config.get('tags', None))
 
         if url:
             kwargs['urls'] = [ url ]
-        if path: 
+        if path:
             kwargs['destination'] = path
         # Because of the way that Flood wants things
-        # We've gotta check to see if the person has done 
+        # We've gotta check to see if the person has done
         # a list in their config or not.
         if tags:
             if isinstance(tags, list):
-                kwargs['tags'] = tags
+                kwargs['tags'] = [ entry.render(tag) for tag in tags ]
             else:
-                kwargs['tags'] = [ tags ]
+                kwargs['tags'] = [ entry.render(tags) ]
 
         if task.manager.options.test:
             logger.info('Flood Test Mode')

--- a/flexget/plugins/clients/flood.py
+++ b/flexget/plugins/clients/flood.py
@@ -3,14 +3,12 @@ from requests import Session
 from requests.exceptions import RequestException
 
 from flexget import plugin
-from flexget.event import event
-from requests import Session
-from loguru import logger
-
 from flexget.entry import Entry
+from flexget.event import event
 from flexget.task import Task
 
 logger = logger.bind(name='flood')
+
 
 class FloodClient:
     def __init__(self):
@@ -22,14 +20,15 @@ class FloodClient:
             return self.session.request(method, self.url + path, **kwargs)
         except RequestException as e:
             raise plugin.PluginError(f'Flood Request Exception: {e}')
-    
+
     def authenticate(self, config):
         self.url = config['url'].strip('/')
 
-        response = self._request('post', '/api/auth/authenticate', data={
-            'username': config['username'],
-            'password': config['password']
-        })
+        response = self._request(
+            'post',
+            '/api/auth/authenticate',
+            data={'username': config['username'], 'password': config['password']},
+        )
 
         if response.status_code == 200:
             self.connected = True
@@ -39,41 +38,45 @@ class FloodClient:
             raise plugin.PluginError('Incorrect username or password')
 
         return self
-    
-    def add_torrent_urls(self, urls: list=None, destination: str=None, tags: list=None, start: bool=True):
+
+    def add_torrent_urls(
+        self, urls: list = None, destination: str = None, tags: list = None, start: bool = True
+    ):
         if not self.connected:
             raise plugin.PluginError('Flood is not connected.')
-        
+
         if not urls:
             raise plugin.PluginError('Parameter urls cannot be empty.')
 
         data = {
-            'urls': urls, 
-            'destination': destination, 
+            'urls': urls,
+            'destination': destination,
             'start': start,
         }
 
         if tags:
             data['tags'] = tags
-        
+
         response = self._request('post', '/api/torrents/add-urls', json=data)
 
         if response.status_code == 200:
             logger.debug('Successfully added torrent(s).')
         else:
-            # There's no sanity to the codes returned by Flood. 
+            # There's no sanity to the codes returned by Flood.
             # Both return 'code': -32602 and both return status 500.
             if response.text.find('the input is not a valid.') > 0:
                 raise plugin.PluginError('Not a valid torrent.')
             elif response.text.find('Info hash already used by another torrent.') > 0:
                 logger.debug('Torrent has already been added to Flood.')
             else:
-                raise plugin.PluginError(f'Failed to add torrent to Flood. Error {response.status_code}.')
-    
+                raise plugin.PluginError(
+                    f'Failed to add torrent to Flood. Error {response.status_code}.'
+                )
+
 
 class OutputFlood:
     schema = {
-       'type': 'object',
+        'type': 'object',
         'properties': {
             'url': {'type': 'string'},
             'username': {'type': 'string'},
@@ -90,7 +93,11 @@ class OutputFlood:
         tags = entry.get('tags', config.get('tags', None))
 
         if tags and isinstance(tags, list):
-            tags = [ entry.render(tag) for tag in tags ] if isinstance(tags, list) else [ entry.render(tags) ]
+            tags = (
+                [entry.render(tag) for tag in tags]
+                if isinstance(tags, list)
+                else [entry.render(tags)]
+            )
 
         if task.manager.options.test:
             logger.info('Flood Test Mode')
@@ -98,11 +105,7 @@ class OutputFlood:
             logger.info('\tPath: {}', path)
             logger.info('\tTags: {}', tags)
         else:
-            client.add_torrent_urls(
-                urls=[ url ], 
-                destination=path, 
-                tags=tags
-            )
+            client.add_torrent_urls(urls=[url], destination=path, tags=tags)
 
     @plugin.priority(135)
     def on_task_output(self, task: Task, config: dict):
@@ -117,6 +120,7 @@ class OutputFlood:
         # Loop through each accepted entry and send it to Flood
         for entry in task.accepted:
             self.add_entry(flood, config, task, entry)
+
 
 @event('plugin.register')
 def register_plugin():

--- a/flexget/plugins/clients/flood.py
+++ b/flexget/plugins/clients/flood.py
@@ -1,0 +1,131 @@
+import os
+from loguru import logger
+from requests import Session
+from requests.exceptions import RequestException
+
+from flexget import plugin
+from flexget.event import event
+from flexget.utils.template import RenderError
+from os import error
+from requests import Session
+from loguru import logger
+import json
+import base64
+
+logger = logger.bind(name='flood')
+
+class OutputFlood:
+    schema = {
+       'type': 'object',
+        'properties': {
+            'host': {'type': 'string'},
+            'port': {'type': 'integer'},
+            'username': {'type': 'string'},
+            'password': {'type': 'string'},
+            'directory': {'type': 'string'},
+            'tags': {'type': 'array'},
+        },
+        'additionalProperties': False,
+    }
+
+    def __init__(self):
+        self.session = Session()
+        self.connected = False
+
+    def _request(self, method, url, **kwargs):
+        try:
+            return self.session.request(method, url, **kwargs)
+        except RequestException as e:
+            raise plugin.PluginError(f'Flood Request Exception: {e}')
+    
+    def authenticate(self, config):
+        response = self._request('post', '{}:{}/api/auth/authenticate'.format(config['host'], config['port']), data={
+            'username': config['username'],
+            'password': config['password']
+        })
+
+        if 'Failed login.' in response.text:
+            raise plugin.PluginError('Incorrect username or password')
+        else:
+            logger.debug('Successfully logged into Flood')
+            self.connected = True
+        return self.connected
+
+    """// POST /api/torrents/add-urls
+    export const addTorrentByURLSchema = object({
+      // URLs to download torrents from
+      urls: array(string()).nonempty(),
+      // Cookies to attach to requests, arrays of strings in the format "name=value" with domain as key
+      cookies: record(array(string())).optional(),
+      // Path of destination
+      destination: string().optional(),
+      // Tags
+      tags: array(string().regex(noComma, TAG_NO_COMMA_MESSAGE)).optional(),
+      // Whether destination is the base path [default: false]
+      isBasePath: boolean().optional(),
+      // Whether destination contains completed contents [default: false]
+      isCompleted: boolean().optional(),
+      // Whether contents of a torrent should be downloaded sequentially [default: false]
+      isSequential: boolean().optional(),
+      // Whether to use initial seeding mode [default: false]
+      isInitialSeeding: boolean().optional(),
+      // Whether to start torrent [default: false]
+      start: boolean().optional(),
+    });"""
+    def add_torrent_urls(self, config, urls):
+        if not self.connected:
+            raise plugin.PluginError('Not connected.')
+
+        response = self._request('post', '{}:{}/api/torrents/add-urls'.format(config['host'], config['port']), json={
+            'urls': urls,
+            'destination': config['directory'],
+            'tags': config['tags'],
+            'start': True
+        })
+
+        if response.status_code == 200:
+            logger.debug('Successfully added torrent to Flood')
+        else:
+            raise plugin.PluginError('Failed to add torrent to Flood. Error {}'.format(response.status_code))
+
+    """// POST /api/torrents/add-files
+    export const addTorrentByFileSchema = object({
+    // Torrent files in base64
+    files: array(string()).nonempty(),
+    // Path of destination
+    destination: string().optional(),
+    // Tags
+    tags: array(string().regex(noComma, TAG_NO_COMMA_MESSAGE)).optional(),
+    // Whether destination is the base path [default: false]
+    isBasePath: boolean().optional(),
+    // Whether destination contains completed contents [default: false]
+    isCompleted: boolean().optional(),
+    // Whether contents of a torrent should be downloaded sequentially [default: false]
+    isSequential: boolean().optional(),
+    // Whether to use initial seeding mode [default: false]
+    isInitialSeeding: boolean().optional(),
+    // Whether to start torrent [default: false]
+    start: boolean().optional(),
+    });"""
+    def add_torrent_files(self, config, data):
+        if not self.connected:
+            raise error('Not connected')
+
+        response = self._request('post', '{}:{}/api/torrents/add-files'.format(config['host'], config['port']), json=data)
+
+        if response.status_code == 200:
+            logger.debug('Successfully added torrent to Flood')
+        else:
+            raise plugin.PluginError('Failed to add torrent to Flood. Error {}'.format(response.status_code))
+
+    #@plugin.priority(120)
+    #def on_task_download(self, task, config):
+
+    @plugin.priority(135)
+    def on_task_output(self, task, config):
+        if task.accepted and self.authenticate(config):
+            self.add_torrent_urls(config, [entry['url'] for entry in task.accepted])
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(OutputFlood, 'flood', api_ver=2)


### PR DESCRIPTION
### Motivation for changes:
Decided to move from ruTorrent to Flood and there was no existing way to add torrents via flexget to Flood. (Which is just a pretty front-end for rTorrent).

### Detailed changes:
- Created a simple plugin 

### Config usage if relevant (new plugin or updated schema):
```yaml

flood:
  url: '...'
  username: '...'
  password: '...'
  directory: '...'
  tags:
    - ...
```

#### To Do:
- [x] Support saving jwt token to database
- [ ] Support for performing CRUD operations on Flood
- [ ] Support for downloading files through Flood 

