### PR TITLE
[change] `series_forget`: Episode identifier is now optional. Optional `forget` parameter (originally would just remove)

### DIFF
--- a/flexget/components/series/series_forget.py
+++ b/flexget/components/series/series_forget.py
@@ -9,24 +9,47 @@ logger = logger.bind(name='series_forget')
 
 
 class OutputSeriesRemove:
-    schema = {'type': 'boolean'}
+    schema = {
+        'oneOf': [
+            {'type': 'boolean'},
+            {'type': 'object', 'properties': {'forget': {'type': 'boolean'}}},
+        ],
+    }
 
     def on_task_output(self, task, config):
         if not config:
             return
+        if isinstance(config, bool):
+            config = {'forget': False}
+        forget = config['forget']
+
         for entry in task.accepted:
-            if 'series_name' in entry and 'series_id' in entry:
-                try:
-                    db.remove_series_entity(entry['series_name'], entry['series_id'])
-                    logger.info(
-                        'Removed episode `{}` from series `{}` download history.',
-                        entry['series_id'],
-                        entry['series_name'],
-                    )
-                except ValueError:
-                    logger.debug(
-                        'Series ({}) or id ({}) unknown.', entry['series_name'], entry['series_id']
-                    )
+            if 'series_name' in entry:
+                if 'series_id' in entry:
+                    try:
+                        db.remove_series_entity(entry['series_name'], entry['series_id'], forget)
+                        logger.info(
+                            'Removed `{}`episode `{}` from series `{}` download history.',
+                            'and forgot ' if forget else '',
+                            entry['series_id'],
+                            entry['series_name'],
+                        )
+                    except ValueError:
+                        logger.debug(
+                            'Series ({}) or id ({}) unknown.',
+                            entry['series_name'],
+                            entry['series_id'],
+                        )
+                else:
+                    try:
+                        db.remove_series(entry['series_name'], forget)
+                        logger.info(
+                            'Removed `{}`series `{}` download history.',
+                            'and forgot ' if forget else '',
+                            entry['series_name'],
+                        )
+                    except ValueError:
+                        logger.debug('Series ({}) unknown.', entry['series_name'])
 
 
 @event('plugin.register')

--- a/flexget/components/series/series_forget.py
+++ b/flexget/components/series/series_forget.py
@@ -29,7 +29,7 @@ class OutputSeriesRemove:
                     try:
                         db.remove_series_entity(entry['series_name'], entry['series_id'], forget)
                         logger.info(
-                            'Removed `{}`episode `{}` from series `{}` download history.',
+                            'Removed {}episode `{}` from series `{}` download history.',
                             'and forgot ' if forget else '',
                             entry['series_id'],
                             entry['series_name'],
@@ -44,7 +44,7 @@ class OutputSeriesRemove:
                     try:
                         db.remove_series(entry['series_name'], forget)
                         logger.info(
-                            'Removed `{}`series `{}` download history.',
+                            'Removed {}series `{}` download history.',
                             'and forgot ' if forget else '',
                             entry['series_name'],
                         )

--- a/flexget/components/series/series_remove.py
+++ b/flexget/components/series/series_remove.py
@@ -5,7 +5,7 @@ from flexget.event import event
 
 from . import db
 
-logger = logger.bind(name='series_forget')
+logger = logger.bind(name='series_remove')
 
 
 class OutputSeriesRemove:


### PR DESCRIPTION
### Motivation for changes:
Was looking for a way to remove a show from `series` plugin from within a task (akin to CLI command `flexget  series <remove | forget> <show_name> [episode]` and bumped into this undocumented plugin.
### Detailed changes:
- Brought its functionality more in line with the `flexget series <remove | forget>` CLI command:
  - Episode is now optional
  - Despite the plugin name, originally it would just remove the show, added option to forget.

### Config usage if relevant (new plugin or updated schema):
```diff
  series_forget: yes
+ series_forget:
+   forget: yes
```
#### To Do:

- [ ] Document this (under series, Lists or on its own?)
- [x] Rename to `series_remove` to avoid confusion with the `forget` parameter? Shouldn't break many existing configs since it is not documented (yet).

