### PR TITLE
Use timezone aware now in transmission.py

### DIFF
--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -123,13 +123,13 @@ class TransmissionBase:
 
         if torrent.seedIdleMode == 1:  # use torrent's own idle limit
             idle_limit_ok = (
-                torrent.date_active + timedelta(minutes=torrent.seedIdleLimit) < datetime.now()
+                torrent.date_active + timedelta(minutes=torrent.seedIdleLimit) < datetime.now(torrent.date_active.tzinfo)
             )
         elif torrent.seedIdleMode == 0:  # use global rules
             if session.idle_seeding_limit_enabled:
                 idle_limit_ok = (
                     torrent.date_active + timedelta(minutes=session.idle_seeding_limit)
-                    < datetime.now()
+                    < datetime.now(torrent.date_active.tzinfo)
                 )
 
         return seed_limit_ok, idle_limit_ok

--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -1,6 +1,6 @@
 import base64
-import re
 import os
+import re
 from datetime import datetime, timedelta
 from fnmatch import fnmatch
 from functools import partial
@@ -123,13 +123,13 @@ class TransmissionBase:
 
         if torrent.seedIdleMode == 1:  # use torrent's own idle limit
             idle_limit_ok = (
-                torrent.date_active + timedelta(minutes=torrent.seedIdleLimit) < datetime.now(torrent.date_active.tzinfo)
+                torrent.date_active + timedelta(minutes=torrent.seedIdleLimit) < datetime.now().astimezone()
             )
         elif torrent.seedIdleMode == 0:  # use global rules
             if session.idle_seeding_limit_enabled:
                 idle_limit_ok = (
                     torrent.date_active + timedelta(minutes=session.idle_seeding_limit)
-                    < datetime.now(torrent.date_active.tzinfo)
+                    < datetime.now().astimezone()
                 )
 
         return seed_limit_ok, idle_limit_ok

--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -1,6 +1,6 @@
 import base64
-import os
 import re
+import os
 from datetime import datetime, timedelta
 from fnmatch import fnmatch
 from functools import partial


### PR DESCRIPTION
### Motivation for changes:
- Fix #3084 

### Detailed changes:
- Use offset-aware `now` instead of offset-naive one.

### Addressed issues:
- Fixes #3084.

