### PR TITLE
[fix] sftp_download - `to` property renders Jinja templates

### DIFF
--- a/flexget/components/ftp/sftp.py
+++ b/flexget/components/ftp/sftp.py
@@ -168,6 +168,13 @@ class SftpDownload:
         to: str = config['to']
 
         try:
+            to = render_from_entry(to, entry)
+        except RenderError as e:
+            logger.error('Could not render path: {}', to)
+            entry.fail(str(e))  # type: ignore
+            return
+
+        try:
             sftp.download(path, to, recursive, delete_origin)
         except SftpError as e:
             entry.fail(e)  # type: ignore


### PR DESCRIPTION
### Motivation for changes:
Docs say `sftp_download`'s `to` field can take a Jinja template. It doesn't. I needed this for a workflow of mine.

### Detailed changes:
- Call `render_from_entry` on `sftp_download`'s `to` field.

### Addressed issues:
- Never made an issue for it.

### Implemented feature requests:
- None

### Config usage if relevant (new plugin or updated schema):
```yaml
sftp_download:
  # I don't remember why I need the leading `/.`
  to: "/.{{destination_directory}}"
```
where in this case, `destination_directory` is a custom property set via `set`  on an entry. Moderately convoluted.

### Log and/or tests output (preferably both):
Unfortunately I don't have any, I've been running this fork in "production" (my personal media server) for nearly a year now apparently with no issues.

#### To Do:
- None

