### PR TITLE
fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/python:3-alpine
+FROM docker.io/python:3.9-alpine
 ENV PYTHONUNBUFFERED 1
 
 RUN apk add --no-cache --upgrade \
@@ -25,7 +25,7 @@ RUN wget https://github.com/Flexget/webui/releases/latest/download/dist.zip && \
     unzip dist.zip && \
     rm dist.zip
 
-FROM docker.io/python:3-alpine
+FROM docker.io/python:3.9-alpine
 ENV PYTHONUNBUFFERED 1
 
 RUN apk add --no-cache --upgrade \


### PR DESCRIPTION
### Motivation for changes:

`python:3-alpine` become `3.10` after python3.10 is released.

But `greenlet==1.0.0` is broken in python3.10, so current dockerfile is not buildable anymore

### Detailed changes:
- set base docker image to `python:3.9-alpine`
