### PR TITLE
ci: build and push docker image to github docker registry

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,52 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches:
+      - develop
+    tags:
+      - v*.*.*
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Base Docker Image
+        run: docker build --tag flexget:tmp .
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        if: github.event_name == 'push'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - uses: actions/github-script@v5
+        if: github.event_name == 'push'
+        name: Docker Push
+        with:
+          debug: true
+          script: |
+            const ref = context.ref
+            const versions = []
+            if (ref.startsWith('refs/tags/v')){
+              const tag = ref.substring(11)
+              const [major, minor, _] = tag.split('.')
+              versions.push('latest', tag, `${major}.${minor}`, major)
+            } else if (ref.startsWith('refs/heads/')) {
+              versions.push(ref.substring(11))
+            } else {
+              console.log(ref)
+            }
+            console.log(versions)
+            for (const version of versions) {
+              const dst = `ghcr.io/${context.actor.toLowerCase()}/flexget:${version}`
+              await exec.exec(`docker tag flexget:tmp ${dst}`)
+              await exec.exec(`docker push ${dst}`)
+            }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/python:3-alpine
+FROM docker.io/python:3.9-alpine
 ENV PYTHONUNBUFFERED 1
 
 RUN apk add --no-cache --upgrade \
@@ -25,7 +25,7 @@ RUN wget https://github.com/Flexget/webui/releases/latest/download/dist.zip && \
     unzip dist.zip && \
     rm dist.zip
 
-FROM docker.io/python:3-alpine
+FROM docker.io/python:3.9-alpine
 ENV PYTHONUNBUFFERED 1
 
 RUN apk add --no-cache --upgrade \


### PR DESCRIPTION
### Motivation for changes:

flexget current has a `Dockerfile`, but no docker image available.

new workflow will release a docker image as `ghcr.io/flexget/flexget` on [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)

- for `develop` branch, docker image will be tagged as `ghcr.io/flexget/flexget:develop`
- for a tag `v1.2.3`, docker image will be tagged as `1.2.3`, `1.2`, `1` and  `latest`

On pull-request, a docker image will be built but won't be pushed to registry.

### Detailed changes:
- add a ci to build and push docker image

