### PR TITLE
Fix color-range matching

### DIFF
--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -157,10 +157,10 @@ _codecs = [
 ]
 
 _color_ranges = [
-    QualityComponent('color_range', 10, '8bit', r'8[^\w]?bit|hi8(p)?'),
-    QualityComponent('color_range', 20, '10bit', r'10[^\w]?bit|hi10(p)?'),
+    QualityComponent('color_range', 10, '8bit', r'8[^\w]?bits?|hi8p?'),
+    QualityComponent('color_range', 20, '10bit', r'10[^\w]?bits?|hi10p?'),
     QualityComponent('color_range', 40, 'hdrplus', r'hdr[^\w]?(\+|p|plus)'),
-    QualityComponent('color_range', 30, 'hdr', r'hdr([^\w]?(10))?'),
+    QualityComponent('color_range', 30, 'hdr', r'hdr([^\w]?10)?'),
     QualityComponent('color_range', 50, 'dolbyvision', r'(dolby[^\w]?vision|dv)'),
 ]
 


### PR DESCRIPTION
### Motivation for changes:
Quality plugin would match `10 bit` but not `10 bits`
### Detailed changes:
- Added optional plural to the word `bit`. Those expressions seem to be enclosed in boundary anchors (`\b`) during processing, so the whole word needs to be specified to match.
- Removed unnecessary groups from color range expressions

