### PR TITLE
[fix] Correct from_piratebay torrent ranks

### DIFF
--- a/flexget/plugins/input/from_piratebay.py
+++ b/flexget/plugins/input/from_piratebay.py
@@ -14,7 +14,7 @@ URL = 'https://apibay.org'
 LISTS = ['top', 'top48h', 'recent']
 
 # from lowest to highest, selecting a rank automatically accept higher ranks
-RANKS = ['all', 'member', 'vip', 'trusted', 'supermod']
+RANKS = ['all', 'user', 'trusted', 'vip', 'helper', 'moderator', 'supermod']
 
 CATEGORIES = {
     'All': 0,


### PR DESCRIPTION
### Motivation for changes:
- Bugfix.
### Detailed changes:
- 

### Addressed issues:
- Fixes the incorrect torrent ranks which causes from_pirateby to crash when it encounters an unknown rank (such as `moderator` or `helper`).


