### PR TITLE
[change] yaml_list: sort yaml, key and encoding

### DIFF
--- a/flexget/components/managed_lists/lists/yaml_list.py
+++ b/flexget/components/managed_lists/lists/yaml_list.py
@@ -18,12 +18,12 @@ logger = logger.bind(name=PLUGIN_NAME)
 
 
 class YamlManagedList(MutableSet):
-    def __init__(self, path: str, fields: list, key: str, update: bool, encoding: str):
+    def __init__(self, path: str, fields: list, update: bool, encoding: str):
         self.filename = path
         self.fields = fields
         self.ecoding = encoding
         self.update = update
-        self.key = key
+        self.key = 'title'
         self.entries = []
         try:
             content = open(self.filename)
@@ -183,7 +183,6 @@ class YamlList:
                     'path': {'type': 'string'},
                     'fields': {'type': 'array', 'items': {'type': 'string'}},
                     'encoding': {'type': 'string', 'default': 'utf-8'},
-                    'key': {'type': 'string', 'default': 'title'},
                     'update': {'type': 'boolean', 'default': False},
                 },
                 'required': ['path'],
@@ -197,7 +196,6 @@ class YamlList:
             config = {'path': config}
         config.setdefault('fields', [])
         config.setdefault('encoding', 'utf-8')
-        config.setdefault('key', 'title')
         config.setdefault('update', False)
         return config
 

--- a/flexget/components/managed_lists/lists/yaml_list.py
+++ b/flexget/components/managed_lists/lists/yaml_list.py
@@ -59,7 +59,9 @@ class YamlManagedList(MutableSet):
             dict: Item with limited keys
         """
 
+
         # Title should allways be the first item
+        required_fields = []
         if self.key != 'title':
             required_fields = [self.key]
 
@@ -124,9 +126,7 @@ class YamlManagedList(MutableSet):
     def add(self, entry: Entry) -> None:
         exists = self.get(entry)
         if exists:
-            logger.warning(
-                f'Can\'t add entry "{self.key}" = "{exists.get(self.key)}", entry already exists in list'
-            )
+            logger.warning(f'Can\'t add entry "{self.key}" = "{exists.get(self.key)}", entry already exists in list')
             return
         self.entries.append(entry)
         self.save_yaml()

--- a/flexget/components/managed_lists/lists/yaml_list.py
+++ b/flexget/components/managed_lists/lists/yaml_list.py
@@ -130,7 +130,7 @@ class YamlManagedList(MutableSet):
             entry = exists
             index = self._remove_item(entry)
             if index >= 0:
-                self.entries.insert(index,entry)
+                self.entries.insert(index, entry)
         elif exists:
             logger.warning(
                 f'Can\'t add entry "{self.key}" = "{exists.get(self.key)}", entry already exists in list'

--- a/flexget/components/managed_lists/lists/yaml_list.py
+++ b/flexget/components/managed_lists/lists/yaml_list.py
@@ -59,7 +59,6 @@ class YamlManagedList(MutableSet):
             dict: Item with limited keys
         """
 
-
         # Title should allways be the first item
         if self.key != 'title':
             required_fields = [self.key]
@@ -125,7 +124,9 @@ class YamlManagedList(MutableSet):
     def add(self, entry: Entry) -> None:
         exists = self.get(entry)
         if exists:
-            logger.warning(f'Can\'t add entry "{self.key}" = "{exists.get(self.key)}", entry already exists in list')
+            logger.warning(
+                f'Can\'t add entry "{self.key}" = "{exists.get(self.key)}", entry already exists in list'
+            )
             return
         self.entries.append(entry)
         self.save_yaml()

--- a/flexget/components/managed_lists/lists/yaml_list.py
+++ b/flexget/components/managed_lists/lists/yaml_list.py
@@ -125,9 +125,7 @@ class YamlManagedList(MutableSet):
     def add(self, entry: Entry) -> None:
         exists = self.get(entry)
         if exists:
-            logger.warning(
-                f'Can\'t add entry "{self.key}" = "{exists.get(self.key)}", entry already exists in list'
-            )
+            logger.warning(f'Can\'t add entry "{self.key}" = "{exists.get(self.key)}", entry already exists in list')
             return
         self.entries.append(entry)
         self.save_yaml()

--- a/flexget/components/managed_lists/lists/yaml_list.py
+++ b/flexget/components/managed_lists/lists/yaml_list.py
@@ -58,9 +58,11 @@ class YamlManagedList(MutableSet):
         Returns:
             dict: Item with limited keys
         """
-        required_fields = ['title']
-        if self.key not in required_fields:
-            required_fields.append(self.key)
+
+        required_fields = [self.key]
+
+        # Title should allways be the first item
+        required_fields.insert(0,'title')
 
         if not self.fields:
             fields = [k for k in item if not k.startswith('_') and k not in required_fields]
@@ -121,7 +123,7 @@ class YamlManagedList(MutableSet):
     def add(self, entry: Entry) -> None:
         exists = self.get(entry)
         if exists:
-            logger.warning('Can\'t add entry, entry already exists in list')
+            logger.warning(f'Can\'t add entry "{self.key}" = "{exists.get(self.key)}", entry already exists in list')
             return
         self.entries.append(entry)
         self.save_yaml()

--- a/flexget/components/managed_lists/lists/yaml_list.py
+++ b/flexget/components/managed_lists/lists/yaml_list.py
@@ -59,7 +59,6 @@ class YamlManagedList(MutableSet):
             dict: Item with limited keys
         """
 
-
         # Title should allways be the first item
         required_fields = []
         if self.key != 'title':
@@ -126,7 +125,9 @@ class YamlManagedList(MutableSet):
     def add(self, entry: Entry) -> None:
         exists = self.get(entry)
         if exists:
-            logger.warning(f'Can\'t add entry "{self.key}" = "{exists.get(self.key)}", entry already exists in list')
+            logger.warning(
+                f'Can\'t add entry "{self.key}" = "{exists.get(self.key)}", entry already exists in list'
+            )
             return
         self.entries.append(entry)
         self.save_yaml()

--- a/flexget/components/managed_lists/lists/yaml_list.py
+++ b/flexget/components/managed_lists/lists/yaml_list.py
@@ -59,10 +59,12 @@ class YamlManagedList(MutableSet):
             dict: Item with limited keys
         """
 
-        required_fields = [self.key]
 
         # Title should allways be the first item
-        required_fields.insert(0,'title')
+        if self.key != 'title':
+            required_fields = [self.key]
+
+        required_fields.append('title')
 
         if not self.fields:
             fields = [k for k in item if not k.startswith('_') and k not in required_fields]

--- a/flexget/tests/test_yaml_list.py
+++ b/flexget/tests/test_yaml_list.py
@@ -61,6 +61,26 @@ class TestYamlLists(object):
                   path: '{{yaml_dir}}/yaml_list1.yaml'
                   fields:
                     - newfield
+
+          yaml_list_update:
+            disable: seen
+            accept_all: yes
+            mock:
+              - {'title':'My Entry 1 1080p HDTV','new':'teste1','trash':'trash1'}
+              - {'title':'My Entry 2 1080p HDTV','new':'teste2','trash':'trash2'}
+
+            list_add:
+              - yaml_list:
+                  update: yes 
+                  path: '{{yaml_dir}}/yaml_list1.yaml'
+                  fields:
+                    - new
+
+          yaml_list_load:
+            disable: seen
+            accept_all: yes
+            yaml_list: '{{yaml_dir}}/yaml_list1.yaml'
+
     """
 
     @pytest.fixture
@@ -134,3 +154,27 @@ class TestYamlLists(object):
         # Check ok field
         assert task.accepted[0]['newfield'] == 'new'
         assert task.accepted[1]['newfield'] == 'new'
+
+    def test_list_update(self, execute_task):
+        task = execute_task('yaml_list_create')
+        assert len(task.accepted) == 3
+
+        task = execute_task('yaml_list_update')
+        assert len(task.accepted) == 2
+
+        task = execute_task('yaml_list_load')
+        assert len(task.accepted) == 3
+
+        # Checks matched
+        assert task.accepted[0]['title'] == 'My Entry 1 1080p HDTV'
+        assert task.accepted[1]['title'] == 'My Entry 2 1080p HDTV'
+        assert task.accepted[2]['title'] == 'My Entry 3 1080p HDTV'
+
+        # Checks update
+        assert task.accepted[0]['new'] == 'teste1'
+        assert task.accepted[1]['new'] == 'teste2'
+        assert not 'new' in task.accepted[2]
+
+        # Checks not update
+        assert not 'trash' in task.accepted[0]
+        assert not 'trash' in task.accepted[1]


### PR DESCRIPTION
### Motivation for changes:

- Sort yaml output: To make it more readble, the output is sorted by keys, but keeps title and key fields on the top
- yaml encoding: Allow to inform the file encoding, making it usable in other languages

### Detailed changes:
- Sort yaml output: sort the fields and add title and key to the top, add sort_keys FALSE to the yaml_dump
- yaml encoding: add encoding to the config, default utf-8 and add that encoding to the yaml_dump

