### PR TITLE
#3250 [fix] capture sequence type episodes with 4 digits

### DIFF
--- a/flexget/utils/parsers/series.py
+++ b/flexget/utils/parsers/series.py
@@ -87,7 +87,7 @@ class SeriesParser(TitleParser):
         [
             TitleParser.re_not_in_word(regexp)
             for regexp in [
-                r'(\d{1,3})(?:v(?P<version>\d))?',
+                r'(\d{1,4})(?:v(?P<version>\d))?',
                 r'(?:pt|part)\s?(\d+|%s)' % roman_numeral_re,
             ]
         ]


### PR DESCRIPTION
### Motivation for changes:
+999 sequence type episodes can't be captured (One Piece just reached its 1000 ep, but I don't think it's the only one with more than 999 episodes)
### Detailed changes:
- made the maximum number of digits 4 instead of 5 (don't think there's +9999 episodes series, but I could be wrong!)

### Addressed issues:
- Fixes #3250 

#### To Do:

- check the regex of other types too

