### PR TITLE
[add] qbittorrent: Pass tag(s) when adding torrents to client

### DIFF
--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -7,7 +7,7 @@ from requests.exceptions import RequestException
 
 from flexget import plugin
 from flexget.event import event
-from flexget.utils.template import RenderError, render
+from flexget.utils.template import RenderError
 
 logger = logger.bind(name='qbittorrent')
 
@@ -228,7 +228,6 @@ class OutputQBitTorrent:
             if label:
                 form_data['label'] = label  # qBittorrent v3.3.3-
                 form_data['category'] = label  # qBittorrent v3.3.4+
-
             try:
                 tags = entry.render(",".join([
                                     ",".join(config.get('tags', '')),
@@ -324,3 +323,4 @@ class OutputQBitTorrent:
 @event('plugin.register')
 def register_plugin():
     plugin.register(OutputQBitTorrent, 'qbittorrent', api_ver=2)
+    

--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -45,7 +45,7 @@ class OutputQBitTorrent:
                     'verify_cert': {'type': 'boolean'},
                     'path': {'type': 'string'},
                     'label': {'type': 'string'},
-                    'tags': {'type': 'array'},
+                    'tags': {'type': 'array', 'items': {'type': 'string'}},
                     'maxupspeed': {'type': 'integer'},
                     'maxdownspeed': {'type': 'integer'},
                     'fail_html': {'type': 'boolean'},

--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -207,7 +207,7 @@ class OutputQBitTorrent:
         config.setdefault('use_ssl', False)
         config.setdefault('verify_cert', True)
         config.setdefault('label', '')
-        config.setdefault('tags', '')
+        config.setdefault('tags', [])
         config.setdefault('maxupspeed', 0)
         config.setdefault('maxdownspeed', 0)
         config.setdefault('fail_html', True)

--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -223,19 +223,18 @@ class OutputQBitTorrent:
                     form_data['savepath'] = save_path
             except RenderError as e:
                 logger.error('Error setting path for {}: {}', entry['title'], e)
-            
+
             label = entry.render(entry.get('label', config.get('label', '')))
             if label:
                 form_data['label'] = label  # qBittorrent v3.3.3-
                 form_data['category'] = label  # qBittorrent v3.3.4+
-            
+
             tags = entry.get('tags', []) + config.get('tags', [])
             if tags:
                 try:
                     form_data['tags'] = entry.render(",".join(tags))
                 except RenderError as e:
-                    logger.error('Error rendering tags for {}: {}',
-                                entry['title'], e)
+                    logger.error('Error rendering tags for {}: {}', entry['title'], e)
                     form_data['tags'] = ",".join(tags)
 
             add_paused = entry.get('add_paused', config.get('add_paused'))

--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -223,25 +223,24 @@ class OutputQBitTorrent:
                     form_data['savepath'] = save_path
             except RenderError as e:
                 logger.error('Error setting path for {}: {}', entry['title'], e)
-            
+
             label = entry.render(entry.get('label', config.get('label', '')))
             if label:
                 form_data['label'] = label  # qBittorrent v3.3.3-
                 form_data['category'] = label  # qBittorrent v3.3.4+
             try:
-                tags = entry.render(",".join([
-                                    ",".join(config.get('tags', '')),
-                                    ",".join(entry.get('tags', ''))
-                                    ]).strip(","))
+                tags = entry.render(
+                    ",".join(
+                        [",".join(config.get('tags', '')), ",".join(entry.get('tags', ''))]
+                    ).strip(",")
+                )
                 if tags:
                     form_data['tags'] = tags
             except RenderError as e:
-                logger.error('Error rendering tags for {}: {}',
-                             entry['title'], e)
-                form_data['tags'] = ",".join([
-                    ",".join(config.get('tags', '')),
-                    ",".join(entry.get('tags', ''))
-                    ]).strip(",")
+                logger.error('Error rendering tags for {}: {}', entry['title'], e)
+                form_data['tags'] = ",".join(
+                    [",".join(config.get('tags', '')), ",".join(entry.get('tags', ''))]
+                ).strip(",")
 
             add_paused = entry.get('add_paused', config.get('add_paused'))
             if add_paused:
@@ -323,4 +322,3 @@ class OutputQBitTorrent:
 @event('plugin.register')
 def register_plugin():
     plugin.register(OutputQBitTorrent, 'qbittorrent', api_ver=2)
-    

--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -223,24 +223,20 @@ class OutputQBitTorrent:
                     form_data['savepath'] = save_path
             except RenderError as e:
                 logger.error('Error setting path for {}: {}', entry['title'], e)
-
+            
             label = entry.render(entry.get('label', config.get('label', '')))
             if label:
                 form_data['label'] = label  # qBittorrent v3.3.3-
                 form_data['category'] = label  # qBittorrent v3.3.4+
-            try:
-                tags = entry.render(
-                    ",".join(
-                        [",".join(config.get('tags', '')), ",".join(entry.get('tags', ''))]
-                    ).strip(",")
-                )
-                if tags:
-                    form_data['tags'] = tags
-            except RenderError as e:
-                logger.error('Error rendering tags for {}: {}', entry['title'], e)
-                form_data['tags'] = ",".join(
-                    [",".join(config.get('tags', '')), ",".join(entry.get('tags', ''))]
-                ).strip(",")
+            
+            tags = entry.get('tags', []) + config.get('tags', [])
+            if tags:
+                try:
+                    form_data['tags'] = entry.render(",".join(tags))
+                except RenderError as e:
+                    logger.error('Error rendering tags for {}: {}',
+                                entry['title'], e)
+                    form_data['tags'] = ",".join(tags)
 
             add_paused = entry.get('add_paused', config.get('add_paused'))
             if add_paused:


### PR DESCRIPTION
### Motivation for changes:
Qbittorrent has a tag feature which is not yet supported by Flexget's qbittorrent-plugin.
### Detailed changes:
- Added Tags to be passed by Qbittorrent-plugin to Qbittorrent. 
- Renders entry specific tags as well as static tags from config.

### Config usage if relevant (new plugin or updated schema):

Optional config if tags are to be used.
```
templates:
  qbt:
    qbittorrent:
      tags:
        - Flexget
tasks
  Testtask:
    template:
      - qbt
    set:
      tags:
        - '{{quality.resolution}}'
        - Test
```
### Log and/or tests output (preferably both):
```
2021-12-06 21:30:05 INFO     qbittorrent   test-qbt        Would add torrent to qBittorrent with:
2021-12-06 21:30:05 INFO     qbittorrent   test-qbt        File: None
2021-12-06 21:30:05 INFO     qbittorrent   test-qbt        Label: None
2021-12-06 21:30:05 INFO     qbittorrent   test-qbt        Tags: Flexget,1080p
2021-12-06 21:30:05 INFO     qbittorrent   test-qbt        Paused: true
```
