### PR TITLE
[add] `anilist`: Include more metadata (`al_date_start`, `al_date_end`, `mal_id`)

### DIFF
--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -156,10 +156,10 @@ class AniList(object):
                                 raise plugin.PluginWarning(f'Couldn\'t fetch additional IDs - {e}')
 
                             entry = Entry()
-                            entry['al_id'] = anime.get('id') or ids.get('anilist')
+                            entry['al_id'] = anime.get('id', ids.get('anilist'))
                             entry['anidb_id'] = ids.get('anidb')
                             entry['kitsu_id'] = ids.get('kitsu')
-                            entry['mal_id'] = anime.get('idMal') or ids.get('myanimelist')
+                            entry['mal_id'] = anime.get('idMal', ids.get('myanimelist'))
                             entry['al_banner'] = anime.get('bannerImage')
                             entry['al_cover'] = anime.get('coverImage', {}).get('large')
                             entry['al_date_end'] = (

--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -147,12 +147,10 @@ class AniList(object):
 
                         if has_selected_type and has_selected_release_status:
                             try:
-                                ids = (
-                                    task.requests.post(
-                                        'https://relations.yuna.moe/api/ids',
-                                        json={'anilist': anime.get('id')},
-                                    ).json()
-                                )
+                                ids = task.requests.post(
+                                    'https://relations.yuna.moe/api/ids',
+                                    json={'anilist': anime.get('id')},
+                                ).json()
                             except RequestException as e:
                                 ids = {}
                                 raise plugin.PluginWarning(f'Couldn\'t fetch additional IDs - {e}')


### PR DESCRIPTION
### Motivation for changes:
Needed the airing dates (start and end) for additional filtering in my config.
Could also use other databases' IDs - AniDB in particular - to optimize Plex matching by automatically generating `anidb2.id` files for ASS\HAMA upon entry acceptance)

### Detailed changes:
- Additional fields on existing GraphQL request
- New request to API that crossmatches different Databases
- Renamed `al_idMal` field for more sensible `mal_id`

### Config usage if relevant (new plugin or updated schema):
```diff
- {{al_idMal}}
+ {{mal_id}}
+ {{al_date_start}} {{al_date_end}}
```
