### PR TITLE
[fix] parsing: nested parsing select

### DIFF
--- a/flexget/components/parsing/plugin_parsing.py
+++ b/flexget/components/parsing/plugin_parsing.py
@@ -38,8 +38,6 @@ def init_parsers(manager):
 class PluginParsing:
     """Provides parsing framework"""
 
-    _selected = False
-
     @property
     def schema(self):
         # Create a schema allowing only our registered parsers to be used under the key of each parser type
@@ -56,22 +54,19 @@ class PluginParsing:
     def on_task_start(self, task, config):
         # Set up user selected parsers from config for this task run
         if config:
-            self._selected = True
             selected_parsers.append(config)
+        else:
+            selected_parsers.append({})
 
     def on_task_exit(self, task, config):
         # Restore default parsers for next task run
-        if self._selected:
-            self._selected = False
-            selected_parsers.pop()
+        selected_parsers.pop()
 
     on_task_abort = on_task_exit
 
     @property
     def selected(self) -> dict:
-        if not self._selected:
-            return {}
-        elif selected_parsers:
+        if selected_parsers:
             return selected_parsers[-1]
 
         return {}

--- a/flexget/components/parsing/plugin_parsing.py
+++ b/flexget/components/parsing/plugin_parsing.py
@@ -10,7 +10,7 @@ PARSER_TYPES = ['movie', 'series']
 parsers = {}
 # Mapping from parser type to the name of the default/selected parser for that type
 default_parsers = {}
-selected_parsers = {}
+selected_parsers = []
 
 
 # We need to wait until manager startup to access other plugin instances, to make sure they have all been loaded
@@ -38,6 +38,8 @@ def init_parsers(manager):
 class PluginParsing:
     """Provides parsing framework"""
 
+    _selected = False
+
     @property
     def schema(self):
         # Create a schema allowing only our registered parsers to be used under the key of each parser type
@@ -54,13 +56,25 @@ class PluginParsing:
     def on_task_start(self, task, config):
         # Set up user selected parsers from config for this task run
         if config:
-            selected_parsers.update(config)
+            self._selected = True
+            selected_parsers.append(config)
 
     def on_task_exit(self, task, config):
         # Restore default parsers for next task run
-        selected_parsers.clear()
+        if self._selected:
+            self._selected = False
+            selected_parsers.pop()
 
     on_task_abort = on_task_exit
+
+    @property
+    def selected(self) -> dict:
+        if not self._selected:
+            return {}
+        elif selected_parsers:
+            return selected_parsers[-1]
+
+        return {}
 
     def parse_series(self, data, name=None, **kwargs):
         """
@@ -72,7 +86,7 @@ class PluginParsing:
 
         :returns: An object containing the parsed information. The `valid` attribute will be set depending on success.
         """
-        parser = parsers['series'][selected_parsers.get('series', default_parsers.get('series'))]
+        parser = parsers['series'][self.selected.get('series', default_parsers.get('series'))]
         return parser.parse_series(data, name=name, **kwargs)
 
     def parse_movie(self, data, **kwargs):
@@ -83,7 +97,7 @@ class PluginParsing:
 
         :returns: An object containing the parsed information. The `valid` attribute will be set depending on success.
         """
-        parser = parsers['movie'][selected_parsers.get('movie') or default_parsers['movie']]
+        parser = parsers['movie'][self.selected.get('movie') or default_parsers['movie']]
         return parser.parse_movie(data, **kwargs)
 
 


### PR DESCRIPTION
### Motivation for changes:

When parsing plugin is used nested (from_task for example), or for example in a global template, the selection is cleared in on_task_exit, returning to the internal by default 

### Detailed changes:
- added a nested control to the selection, so that it's only removes the running task config.


### Config usage if relevant (new plugin or updated schema):
``` yaml
templates:
  global:
    parsing:
      movie: guessit
      series: guessit

tasks:
  task_input:
    disable:
      - remember_rejected
      - seen
      - retry_failed
      - seen_info_hash

    accept_all: yes

  get_guess_it:
    disable:
      - remember_rejected
      - seen
      - retry_failed
      - seen_info_hash

    mock:
      - { "title": "My.Series.S01E01.iNTERNAL.720p.x265-ZMNT" }

    configure_series:
      from:
        mock:
          - { "title": "My Series (2021)" }
      settings:
        parse_only: yes

```
