### PR TITLE
Upgrade console tools, and --dump

### DIFF
--- a/flexget/plugins/output/dump.py
+++ b/flexget/plugins/output/dump.py
@@ -104,7 +104,7 @@ class OutputDump:
         for state in dumpstates:
             console.rule(state.title(), style=states[state])
             if getattr(task, state):
-                dump(task.undecided, task.options.debug, eval_lazy, trace, title)
+                dump(getattr(task, state), task.options.debug, eval_lazy, trace, title)
             else:
                 console(f'No {state} entries', style='italic')
         if not dumpstates:

--- a/flexget/plugins/output/dump.py
+++ b/flexget/plugins/output/dump.py
@@ -34,7 +34,9 @@ def dump(entries, debug=False, eval_lazy=False, trace=False, title_only=False):
 
     for entry in entries:
         entry_table = TerminalTable(
-            'field', ':', 'value',
+            'field',
+            ':',
+            'value',
             show_header=False,
             show_edge=False,
             pad_edge=False,
@@ -48,7 +50,9 @@ def dump(entries, debug=False, eval_lazy=False, trace=False, title_only=False):
             if title_only and field != 'title':
                 continue
             if entry.is_lazy(field) and not eval_lazy:
-                value = '[italic]<LazyField - value will be determined when it is accessed>[/italic]'
+                value = (
+                    '[italic]<LazyField - value will be determined when it is accessed>[/italic]'
+                )
             else:
                 try:
                     value = entry[field]
@@ -70,7 +74,9 @@ def dump(entries, debug=False, eval_lazy=False, trace=False, title_only=False):
         if trace:
             console('── Processing trace:', style='italic')
             trace_table = TerminalTable(
-                'Plugin', 'Operation', 'Message',
+                'Plugin',
+                'Operation',
+                'Message',
                 show_edge=False,
                 pad_edge=False,
             )

--- a/flexget/plugins/output/dump.py
+++ b/flexget/plugins/output/dump.py
@@ -96,36 +96,19 @@ class OutputDump:
         eval_lazy = 'eval' in task.options.dump_entries
         trace = 'trace' in task.options.dump_entries
         title = 'title' in task.options.dump_entries
-        states = ['accepted', 'rejected', 'failed', 'undecided']
-        dumpstates = [s for s in states if s in task.options.dump_entries]
-        specificstates = dumpstates
+        states = {'accepted': 'green', 'rejected': 'red', 'failed': 'yellow', 'undecided': 'none'}
+        dumpstates = [s for s in states if getattr(task, s)]
+        specificstates = [s for s in states if s in task.options.dump_entries]
+        if specificstates:
+            dumpstates = specificstates
+        for state in dumpstates:
+            console.rule(state.title(), style=states[state])
+            if getattr(task, state):
+                dump(task.undecided, task.options.debug, eval_lazy, trace, title)
+            else:
+                console(f'No {state} entries', style='italic')
         if not dumpstates:
-            dumpstates = states
-        undecided = [entry for entry in task.all_entries if entry.undecided]
-        if 'undecided' in dumpstates:
-            console.rule('Undecided', style='gray')
-            if undecided:
-                dump(undecided, task.options.debug, eval_lazy, trace, title)
-            elif specificstates:
-                console('No undecided entries', style='italic')
-        if 'accepted' in dumpstates:
-            console.rule('Accepted', style='green')
-            if task.accepted:
-                dump(task.accepted, task.options.debug, eval_lazy, trace, title)
-            elif specificstates:
-                console('No accepted entries', style='italic')
-        if 'rejected' in dumpstates:
-            console.rule('Rejected', style='red')
-            if task.rejected:
-                dump(task.rejected, task.options.debug, eval_lazy, trace, title)
-            elif specificstates:
-                console('No rejected entries', style='italic')
-        if 'failed' in dumpstates:
-            console.rule('Failed', style='yellow')
-            if task.failed:
-                dump(task.failed, task.options.debug, eval_lazy, trace, title)
-            elif specificstates:
-                console('No failed entries', style='italic')
+            console('No entries were produced', style='italic')
 
 
 @event('plugin.register')

--- a/flexget/plugins/output/dump.py
+++ b/flexget/plugins/output/dump.py
@@ -48,12 +48,12 @@ def dump(entries, debug=False, eval_lazy=False, trace=False, title_only=False):
             if title_only and field != 'title':
                 continue
             if entry.is_lazy(field) and not eval_lazy:
-                value = '<LazyField - value will be determined when it is accessed>'
+                value = '[italic]<LazyField - value will be determined when it is accessed>[/italic]'
             else:
                 try:
                     value = entry[field]
                 except KeyError:
-                    value = '<LazyField - lazy lookup failed>'
+                    value = '[italic]<LazyField - lazy lookup failed>[/italic]'
             if field.rsplit('_', maxsplit=1)[-1] == 'url':
                 renderable = f'[link={value}][repr.url]{value}[/repr.url][/link]'
             elif isinstance(value, str):

--- a/flexget/plugins/output/dump_config.py
+++ b/flexget/plugins/output/dump_config.py
@@ -1,6 +1,7 @@
 from argparse import SUPPRESS
 
 from loguru import logger
+from rich.syntax import Syntax
 
 from flexget import options, plugin
 from flexget.event import event
@@ -19,9 +20,10 @@ class OutputDumpConfig:
         if task.options.dump_config:
             import yaml
 
-            console('--- config from task: %s' % task.name)
-            console(yaml.safe_dump(task.config))
-            console('---')
+            console.rule(f'config from task: {task.name}')
+            syntax = Syntax(yaml.safe_dump(task.config).strip(), 'yaml')
+            console(syntax)
+            console.rule()
             task.abort(silent=True)
         if task.options.dump_config_python:
             console(task.config)

--- a/flexget/terminal.py
+++ b/flexget/terminal.py
@@ -28,9 +28,7 @@ class _Console(rich.console.Console):
         """
         self.print(text, *args, **kwargs)
 
-    def print(
-        self, *args, **kwargs
-    ) -> None:
+    def print(self, *args, **kwargs) -> None:
         # Also capture calls directly to console.print
         _patchable_console(*args, **kwargs)
 
@@ -232,6 +230,3 @@ def _patchable_console(*args, **kwargs):
         console._print(*args, **kwargs)
     finally:
         console.file = None
-
-
-

--- a/flexget/terminal.py
+++ b/flexget/terminal.py
@@ -6,6 +6,7 @@ from typing import Any, Iterator, Optional, TextIO
 import rich
 import rich.box
 import rich.console
+import rich.rule
 import rich.segment
 import rich.table
 import rich.text
@@ -42,6 +43,19 @@ GITHUB_BOX: rich.box.Box = rich.box.Box(
 """,
     ascii=True,
 )
+
+
+class Rule(rich.rule.Rule):
+    """TODO: This is probably silly, and not worth it.
+    Allows a left align with a little indent. e.g. --- Example ------...
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        text = rich.text.Text()
+        text = text.append(self.characters * 3 + ' ', style=self.style)
+        text.append(self.title, style='rule.text')
+        self.title = text
 
 
 class TerminalTable(rich.table.Table):

--- a/flexget/terminal.py
+++ b/flexget/terminal.py
@@ -47,7 +47,7 @@ class _Console(rich.console.Console):
         indent: int = 3,
     ) -> None:
         rule = rich.rule.Rule(title, characters=characters, style=style, align=align)
-        if indent:
+        if indent and title:
             if not isinstance(rule.title, rich.text.Text):
                 rule.title = self.render_str(rule.title, style="rule.text")
             text = rich.text.Text()


### PR DESCRIPTION
### Motivation for changes:

Make --dump output prettier, and nicer to use.

### Detailed changes:
For console api:
- flexget.terminal.console is now a [rich console](https://rich.readthedocs.io/en/latest/console.html)
  - It can still be called like a function for backwards compatibility.
  - Small tweak to rich's `console.rule` which allows 'indent' property, to make rules with titles look better.
 
For --dump:
- tables are used to make sure all fields/values line up no matter length
- tables format long values better for easier reading
- Sections for different entry states have prettier dividers with colors.
- Entry fields that aren't strings have colors
- list/dict entry fields get pretty printed for easier parsing
- _url entry fields are clickable links

For --dump-config:
- section off each task config better
- syntax highlight the config
### Log and/or tests output (preferably both):
`--dump`
![image](https://user-images.githubusercontent.com/187133/150058754-0bbfa9c8-4888-40e5-918d-39417f27b220.png)
`--dump-config`
![image](https://user-images.githubusercontent.com/187133/150060022-bbf70f9f-cd6a-4a3d-99df-2a6c8cea68e6.png)


