### PR TITLE
Improve AniList Logging

### DIFF
--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -93,9 +93,9 @@ class AniList(object):
             selected_list_name = [selected_list_name]
         selected_list_name = [i.lower() for i in selected_list_name]
 
-        logger.debug('Selected List Status: {}', selected_list_status)
-        logger.debug('Selected Release Status: {}', selected_release_status)
-        logger.debug('Selected Formats: {}', selected_formats)
+        logger.debug(f'Selected List Status: {selected_list_status}')
+        logger.debug(f'Selected Release Status: {selected_release_status}')
+        logger.debug(f'Selected Formats: {selected_formats}')
 
         req_variables = {'user': config['username']}
         req_chunk = 1
@@ -120,11 +120,13 @@ class AniList(object):
                 )
                 list_response = list_response.json()['data']
             except RequestException as e:
-                raise plugin.PluginError(f'Error reading list - {e}')
+                logger.error(f'Error reading list: {e}')
+                break
             except ValueError as e:
-                raise plugin.PluginError(f'Invalid JSON response {e}')
+                logger.error(f'Invalid JSON response: {e}')
+                break
 
-            logger.debug('JSON output: {}', list_response)
+            logger.trace(f'JSON output: {list_response}')
             for list_status in list_response.get('collection', {}).get('statuses', []):
                 if selected_list_name and (
                     list_status.get('name')
@@ -147,14 +149,13 @@ class AniList(object):
                                 'https://relations.yuna.moe/api/ids',
                                 json={'anilist': anime.get('id')},
                             ).json()
+                            logger.debug(f'Additional IDs: {ids}')
                         except RequestException as e:
+                            logger(f'Couldn\'t fetch additional IDs: {e}')
+                        if not ids or not isinstance(ids, dict):
                             ids = {}
-                            raise plugin.PluginWarning(f'Couldn\'t fetch additional IDs - {e}')
 
-                        if not ids:
-                            ids = {}
-                            raise plugin.PluginWarning(f'Additional IDs not available.')
-
+                        logger.debug(f'Anime Entry: {anime}')
                         entry = Entry()
                         entry['al_id'] = anime.get('id', ids.get('anilist'))
                         entry['anidb_id'] = ids.get('anidb')

--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -151,7 +151,7 @@ class AniList(object):
                             ).json()
                             logger.debug(f'Additional IDs: {ids}')
                         except RequestException as e:
-                            logger(f'Couldn\'t fetch additional IDs: {e}')
+                            logger.verbose(f'Couldn\'t fetch additional IDs: {e}')
                         if not ids or not isinstance(ids, dict):
                             ids = {}
 


### PR DESCRIPTION
### Motivation for changes:
Plugin would generate crash reports when the AniList API was down, caused by raising an exception while handling an exception

### Detailed changes:
- Convert all logger calls to f-strings
- Don't raise exceptions to avoid crash reports.

### Addressed issues:
```
CRITICAL task_queue                    BUG: Unhandled exception during task queue run loop.
Traceback (most recent call last):
  File "github/flexget/flexget/plugins/input/anilist.py", line 119, in on_task_input
    json={'query': req_query, 'variables': req_variables},
  File "github/flexget/lib/site-packages/requests/sessions.py", line 590, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "github/flexget/flexget/utils/requests.py", line 271, in request
    result.raise_for_status()
  File "github/flexget/lib/site-packages/requests/models.py", line 953, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://graphql.anilist.co/

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "github/flexget/flexget/task_queue.py", line 47, in run
    self.current_task.execute()
  File "github/flexget/flexget/task.py", line 87, in wrapper
    return func(self, *args, **kw)
  File "github/flexget/flexget/task.py", line 727, in execute
    self._execute()
  File "github/flexget/flexget/task.py", line 696, in _execute
    self.__run_task_phase(phase)
  File "github/flexget/flexget/task.py", line 517, in __run_task_phase
    for e in response:
  File "github/flexget/flexget/utils/cached_input.py", line 231, in __iter__
    for item in self.iterable:
  File "github/flexget/flexget/plugins/input/anilist.py", line 123, in on_task_input
    raise plugin.PluginWarning(f'Error reading list - {e}')
flexget.plugin.PluginError: Error reading list - 403 Client Error: Forbidden for url: https://graphql.anilist.co/
```


