### PR TITLE
[fix] free_space: Use keyword arguments to pass key_filename #3323

### DIFF
--- a/flexget/plugins/operate/free_space.py
+++ b/flexget/plugins/operate/free_space.py
@@ -20,10 +20,12 @@ def get_free_space(config, task):
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         try:
             ssh.connect(
-                config['host'],
-                config['port'],
-                config['user'],
-                config['ssh_key_filepath'],
+                config.get('host'),
+                config.get('port', 22),
+                config.get('user'),
+                config.get('password', None),
+                config.get('pkey', None),
+                config.get('ssh_key_filepath'),
                 timeout=5000,
             )
         except Exception as e:


### PR DESCRIPTION
### Motivation for changes:
free_space plugin incorrectly uses password instead of key pair to access remote server.

### Detailed changes:
- Use keyword arguments to pass key_filename to fix where the password was incorrectly used to access a remote server

### Addressed issues:
- Fixes # 3323

### Log and/or tests output (preferably both):
```
2022-01-22 13:46:22 DEBUG    urlrewriter   chdbits         Checking 6 entries
2022-01-22 13:46:22 DEBUG    paramiko.transport                 starting thread (client mode): 0x208c6550
2022-01-22 13:46:22 DEBUG    paramiko.transport                 Local version/idstring: SSH-2.0-paramiko_2.9.2
2022-01-22 13:46:23 DEBUG    paramiko.transport                 Remote version/idstring: SSH-2.0-OpenSSH_8.2p1 Ubuntu-4ubuntu0.4
2022-01-22 13:46:23 INFO     paramiko.transport                 Connected (version 2.0, client OpenSSH_8.2p1)
2022-01-22 13:46:23 DEBUG    paramiko.transport                 === Key exchange possibilities ===
2022-01-22 13:46:23 DEBUG    paramiko.transport                 kex algos: curve25519-sha256, curve25519-sha256@libssh.org, ecdh-sha2-nistp256, ecdh-sha2-nistp384, ecdh-sha2-nistp521, diffie-hellman-group-exchange-sha256, diffie-hellman-group16-sha512, diffie-hellman-group18-sha512, diffie-hellman-group14-sha256
2022-01-22 13:46:23 DEBUG    paramiko.transport                 server key: rsa-sha2-512, rsa-sha2-256, ssh-rsa, ecdsa-sha2-nistp256, ssh-ed25519
2022-01-22 13:46:23 DEBUG    paramiko.transport                 client encrypt: chacha20-poly1305@openssh.com, aes128-ctr, aes192-ctr, aes256-ctr, aes128-gcm@openssh.com, aes256-gcm@openssh.com
2022-01-22 13:46:23 DEBUG    paramiko.transport                 server encrypt: chacha20-poly1305@openssh.com, aes128-ctr, aes192-ctr, aes256-ctr, aes128-gcm@openssh.com, aes256-gcm@openssh.com
2022-01-22 13:46:23 DEBUG    paramiko.transport                 client mac: umac-64-etm@openssh.com, umac-128-etm@openssh.com, hmac-sha2-256-etm@openssh.com, hmac-sha2-512-etm@openssh.com, hmac-sha1-etm@openssh.com, umac-64@openssh.com, umac-128@openssh.com, hmac-sha2-256, hmac-sha2-512, hmac-sha1
2022-01-22 13:46:23 DEBUG    paramiko.transport                 server mac: umac-64-etm@openssh.com, umac-128-etm@openssh.com, hmac-sha2-256-etm@openssh.com, hmac-sha2-512-etm@openssh.com, hmac-sha1-etm@openssh.com, umac-64@openssh.com, umac-128@openssh.com, hmac-sha2-256, hmac-sha2-512, hmac-sha1
2022-01-22 13:46:23 DEBUG    paramiko.transport                 client compress: none, zlib@openssh.com
2022-01-22 13:46:23 DEBUG    paramiko.transport                 server compress: none, zlib@openssh.com
2022-01-22 13:46:23 DEBUG    paramiko.transport                 client lang: <none>
2022-01-22 13:46:23 DEBUG    paramiko.transport                 server lang: <none>
2022-01-22 13:46:23 DEBUG    paramiko.transport                 kex follows: False
2022-01-22 13:46:23 DEBUG    paramiko.transport                 === Key exchange agreements ===
2022-01-22 13:46:23 DEBUG    paramiko.transport                 Kex: curve25519-sha256@libssh.org
2022-01-22 13:46:23 DEBUG    paramiko.transport                 HostKey: ssh-ed25519
2022-01-22 13:46:23 DEBUG    paramiko.transport                 Cipher: aes128-ctr
2022-01-22 13:46:23 DEBUG    paramiko.transport                 MAC: hmac-sha2-256
2022-01-22 13:46:23 DEBUG    paramiko.transport                 Compression: none
2022-01-22 13:46:23 DEBUG    paramiko.transport                 === End of kex handshake ===
2022-01-22 13:46:23 DEBUG    paramiko.transport                 kex engine KexCurve25519 specified hash_algo <built-in function openssl_sha256>
2022-01-22 13:46:23 DEBUG    paramiko.transport                 Switch to new keys ...
2022-01-22 13:46:23 DEBUG    paramiko.transport chdbits         Adding ssh-ed25519 host key for [xxx.xxx.xxx.xxx]:xxx: b'43ad06e3a691d5fd19c9d94d9ed84994'
2022-01-22 13:46:23 DEBUG    paramiko.transport                 Got EXT_INFO: {'server-sig-algs': b'ssh-ed25519,sk-ssh-ed25519@openssh.com,ssh-rsa,rsa-sha2-256,rsa-sha2-512,ssh-dss,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,sk-ecdsa-sha2-nistp256@openssh.com'}
2022-01-22 13:46:23 DEBUG    paramiko.transport chdbits         Trying discovered key b'7543e4f8f9e70cdb6eaa3b3e58c17afe' in /config/.ssh/id_rsa
2022-01-22 13:46:24 DEBUG    paramiko.transport                 userauth is OK
2022-01-22 13:46:24 DEBUG    paramiko.transport                 Finalizing pubkey algorithm for key of type 'ssh-rsa'
2022-01-22 13:46:24 DEBUG    paramiko.transport                 Our pubkey algorithm list: ['rsa-sha2-512', 'rsa-sha2-256', 'ssh-rsa']
2022-01-22 13:46:24 DEBUG    paramiko.transport                 Server-side algorithm list: ['ssh-ed25519', 'sk-ssh-ed25519@openssh.com', 'ssh-rsa', 'rsa-sha2-256', 'rsa-sha2-512', 'ssh-dss', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'sk-ecdsa-sha2-nistp256@openssh.com']
2022-01-22 13:46:24 DEBUG    paramiko.transport                 Agreed upon 'rsa-sha2-512' pubkey algorithm
2022-01-22 13:46:24 INFO     paramiko.transport                 Authentication (publickey) successful!
2022-01-22 13:46:24 DEBUG    paramiko.transport chdbits         [chan 0] Max packet in: 32768 bytes
2022-01-22 13:46:26 DEBUG    paramiko.transport                 Received global request "hostkeys-00@openssh.com"
2022-01-22 13:46:26 DEBUG    paramiko.transport                 Rejecting "hostkeys-00@openssh.com" global request from server.
2022-01-22 13:46:26 DEBUG    paramiko.transport                 Debug msg: b'/root/.ssh/authorized_keys:3: key options: agent-forwarding port-forwarding pty user-rc x11-forwarding'
2022-01-22 13:46:26 DEBUG    paramiko.transport                 [chan 0] Max packet out: 32768 bytes
2022-01-22 13:46:26 DEBUG    paramiko.transport                 Secsh channel 0 opened.
2022-01-22 13:46:26 DEBUG    paramiko.transport                 [chan 0] Sesch channel 0 request ok
2022-01-22 13:46:26 DEBUG    paramiko.transport                 [chan 0] EOF received (0)
2022-01-22 13:46:26 ERROR    free_space    chdbits         Less than 512000 MB of free space in /root/docker/qbittorrent/downloads aborting task.
2022-01-22 13:46:26 WARNING  task          chdbits         Aborting task (plugin: free_space)
```
