### PR TITLE
[fix] decompress: check module exists

### DIFF
--- a/flexget/components/archives/decompress.py
+++ b/flexget/components/archives/decompress.py
@@ -195,6 +195,13 @@ class Decompress:
             archive.close()
 
     @plugin.priority(plugin.PRIORITY_FIRST)
+    def on_task_start(self, task, config):
+        try:
+            archiveutil.RarArchive.check_import()
+        except archiveutil.NeedRarFile as e:
+            raise plugin.PluginError(e)
+
+    @plugin.priority(plugin.PRIORITY_FIRST)
     def on_task_output(self, task, config):
         """Task handler for archive_extract"""
         if isinstance(config, bool) and not config:

--- a/flexget/components/archives/utils.py
+++ b/flexget/components/archives/utils.py
@@ -156,8 +156,7 @@ class RarArchive(Archive):
     """
 
     def __init__(self, path):
-        if not rarfile:
-            raise NeedRarFile('Python module rarfile needed to handle RAR archives')
+        RarArchive.check_import()
 
         try:
             super().__init__(rarfile.RarFile, path)
@@ -178,6 +177,11 @@ class RarArchive(Archive):
             return super().open(member)
         except rarfile.Error as error:
             raise ArchiveError(error)
+
+    @staticmethod
+    def check_import():
+        if not rarfile:
+            raise NeedRarFile('Python module rarfile needed to handle RAR archives')
 
 
 class ZipArchive(Archive):


### PR DESCRIPTION
### Motivation for changes:

Decompress plugin was not checking if the rarfile was installed, ignoring and keeping all entries accepted. This would accept all entries and the user would not be notified.

### Detailed changes:
- Check in task start if rarfile is installed
- Created a wrap method to do the check

### Addressed issues:

### Implemented feature requests:

### Config usage if relevant (new plugin or updated schema):

### Log and/or tests output (preferably both):

#### To Do:

- [ ] Breaking change?

