### PR TITLE
from_transmission: Strip timezone info from datetimes

### DIFF
--- a/flexget/_version.py
+++ b/flexget/_version.py
@@ -7,4 +7,4 @@ The version should always be set to the <next release version>.dev
 The jenkins release job will automatically strip the .dev for release,
 and update the version again for continued development.
 """
-__version__ = '3.2.19.dev'
+__version__ = '3.3.0.dev'

--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -232,11 +232,16 @@ class PluginTransmissionInput(TransmissionBase):
                 'torrentFile',
             ]:
                 try:
-                    entry['transmission_' + attr] = getattr(torrent, attr)
+                    value = getattr(torrent, attr)
                 except Exception:
                     logger.opt(exception=True).debug(
                         'error when requesting transmissionrpc attribute {}', attr
                     )
+                else:
+                    # transmission-rpc adds timezone info to datetimes, which makes them hard to deal with. Strip it.
+                    if isinstance(value, datetime):
+                        value = value.replace(tzinfo=None)
+                    entry['transmission_' + attr] = value
             # Availability in percent
             entry['transmission_availability'] = (
                 (torrent.desiredAvailable / torrent.leftUntilDone) if torrent.leftUntilDone else 0


### PR DESCRIPTION
### Motivation for changes:

Using the dates produced by from_transmission was annoying, because you have to compare them to `now.astimezone()` since they are timezone aware. (Here's the issue from when they flipped that on https://github.com/Flexget/Flexget/issues/3084) transmission-rpc just adds the local timezone, even though it doesn't know the timezone for the transmission server, so I don't think it actually adds any value.

Additionally, we were setting transmission_date_done ourselves in some cases to fix another issue, and weren't setting it as tz aware, so the datetimes weren't even consistently having tz info.

### Detailed changes:
- Just strips tz info in any from_transmission fields

### Config usage if relevant (new plugin or updated schema):
```
if:
  # before this PR
  - transmission_date_added > now.astimezone() - timedelta(hours=3): accept 
  # after this PR. (And also before transmission-rpc changed behavior)
  - transmission_date_added > now - timedelta(hours=3): accept 
```

#### To Do:

- [x] Bump minor version and write an upgradeaction

