### PR TITLE
Lostfilm fix

### DIFF
--- a/flexget/components/sites/sites/lostfilm.py
+++ b/flexget/components/sites/sites/lostfilm.py
@@ -166,6 +166,7 @@ class LostFilm:
 
         site_urls = config['site_urls']
         tried_urls = []
+        rss = None
 
         while site_urls:
             rss_url = site_urls[0] + "rss.xml"  # If RSS url changes, update it here
@@ -191,7 +192,9 @@ class LostFilm:
             tried_urls.append(site_urls.pop(0))
 
         if not rss:
-            raise PluginError('Cannot get the RSS feed')
+            logger.error('Failed to get the RSS feed')
+            return None
+
         # Use failed site locations as the last resot option for the redirect page
         site_urls.extend(tried_urls)
 

--- a/flexget/components/sites/sites/lostfilm.py
+++ b/flexget/components/sites/sites/lostfilm.py
@@ -51,6 +51,9 @@ quality_map = {
 
 # All URLs must have '/' at the end
 SITE_URLS = [
+    'https://www.lostfilmtv2.site/',
+    'https://www.lostfilm.top/',
+    'https://www.lostfilm.tw/',
     'https://www.lostfilmtv.site/',
     'https://www.lostfilmtv.uno/',
     'https://www.lostfilm.run/',


### PR DESCRIPTION
### Motivation for changes:
When plugin is aborted by exception, then next scheduled run of plugin is not clean.
As the lostfilm site could be unavailable for one or another reason, it makes sense to just log error and return `None` instead of raising exception.

### Detailed changes:
Replaced exception with error in log.
Also updated the list of site mirrors.