### PR TITLE
[feature] movie_list - add strip_non_alphanum flag to remove non alphanum chars from title

### DIFF
--- a/flexget/components/managed_lists/lists/movie_list/db.py
+++ b/flexget/components/managed_lists/lists/movie_list/db.py
@@ -8,6 +8,7 @@ from sqlalchemy.sql.elements import and_
 from flexget import plugin
 from flexget.db_schema import versioned_base, with_session
 from flexget.entry import Entry
+from flexget.utils.tools import strip_non_alphanum as strip_non_alphanum_fn
 
 try:
     # NOTE: Importing other plugins is discouraged!
@@ -65,7 +66,7 @@ class MovieListMovie(Base):
             self.list_id,
         )
 
-    def to_entry(self, strip_year=False):
+    def to_entry(self, strip_year=False, strip_non_alphanum=False):
         entry = Entry()
         entry['title'] = entry['movie_name'] = self.title
         entry['url'] = 'mock://localhost/movie_list/%d' % self.id
@@ -76,6 +77,8 @@ class MovieListMovie(Base):
             entry['movie_year'] = self.year
         for movie_list_id in self.ids:
             entry[movie_list_id.id_name] = movie_list_id.id_value
+        if strip_non_alphanum:
+            entry['title'] = strip_non_alphanum_fn(entry['title'])
         return entry
 
     def to_dict(self):

--- a/flexget/components/managed_lists/lists/movie_list/movie_list.py
+++ b/flexget/components/managed_lists/lists/movie_list/movie_list.py
@@ -50,8 +50,10 @@ class MovieList(MutableSet):
         if not isinstance(config, dict):
             config = {'list_name': config}
         config.setdefault('strip_year', False)
+        config.setdefault('strip_non_alphanum', False)
         self.list_name = config.get('list_name')
         self.strip_year = config.get('strip_year')
+        self.strip_non_alphanum = config.get('strip_non_alphanum')
 
         db_list = self._db_list(session)
         if not db_list:
@@ -60,7 +62,10 @@ class MovieList(MutableSet):
     def __iter__(self):
         with Session() as session:
             return iter(
-                [movie.to_entry(self.strip_year) for movie in self._db_list(session).movies]
+                [
+                    movie.to_entry(self.strip_year, self.strip_non_alphanum)
+                    for movie in self._db_list(session).movies
+                ]
             )
 
     def __len__(self):
@@ -174,7 +179,11 @@ class PluginMovieList:
             {'type': 'string'},
             {
                 'type': 'object',
-                'properties': {'list_name': {'type': 'string'}, 'strip_year': {'type': 'boolean'}},
+                'properties': {
+                    'list_name': {'type': 'string'},
+                    'strip_year': {'type': 'boolean'},
+                    'strip_non_alphanum': {'type': 'boolean'},
+                },
                 'required': ['list_name'],
                 'additionalProperties': False,
             },

--- a/flexget/tests/test_movie_list.py
+++ b/flexget/tests/test_movie_list.py
@@ -318,3 +318,68 @@ class TestMovieListStripYearInterface:
         task = execute_task('test_list_get_strip_year_negative')
         assert len(task.entries) == 1
         assert task.find_entry(title='The Matrix (1999)')
+
+
+class TestMovieListStripNonAlphaNumInterface:
+    config = """
+        templates:
+          global:
+            disable: [seen]
+
+        tasks:
+          test_list_add:
+            mock:
+              - {title: 'Star Wars: Episode IX - The Rise of Skywalker (2019)', imdb_url: 'http://www.imdb.com/title/tt0133093/'}
+            accept_all: yes
+            list_add:
+              - movie_list: test_list
+
+          test_list_get_simple:
+             movie_list: test_list
+
+          test_list_get_list_name:
+             movie_list:
+               list_name: test_list
+
+          test_list_get_strip_non_alphanum:
+             movie_list:
+               list_name: test_list
+               strip_non_alphanum: yes
+
+          test_list_get_strip_non_alphanum_negative:
+             movie_list:
+               list_name: test_list
+               strip_year: no
+    """
+
+    def test_strip_non_alphanum_regression_test(self, execute_task):
+        task = execute_task('test_list_add')
+        assert len(task.entries) == 1
+
+        task = execute_task('test_list_get_simple')
+        assert len(task.entries) == 1
+        assert task.find_entry(title='Star Wars Episode Ix - The Rise Of Skywalker (2019)')
+
+    def test_strip_non_alphanum_just_list_name(self, execute_task):
+        task = execute_task('test_list_add')
+        assert len(task.entries) == 1
+
+        task = execute_task('test_list_get_list_name')
+        assert len(task.entries) == 1
+        assert task.find_entry(title='Star Wars Episode Ix - The Rise Of Skywalker (2019)')
+
+    def test_strip_non_alphanum_positive(self, execute_task):
+        task = execute_task('test_list_add')
+        assert len(task.entries) == 1
+
+        task = execute_task('test_list_get_strip_non_alphanum')
+        assert len(task.entries) == 1
+        assert task.find_entry(title='Star Wars Episode Ix The Rise Of Skywalker 2019')
+
+    def test_strip_non_alphanum_negative(self, execute_task):
+        task = execute_task('test_list_add')
+        assert len(task.entries) == 1
+
+        task = execute_task('test_list_get_strip_non_alphanum_negative')
+        assert len(task.entries) == 1
+        assert task.find_entry(title='Star Wars Episode Ix - The Rise Of Skywalker (2019)')

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -397,7 +397,7 @@ def parse_filesize(text_size: str, si: bool = True) -> float:
     order = prefix_order[unit]
     amount = float(amount_str.replace(',', '').replace(' ', ''))
     base = 1000 if si else 1024
-    return (amount * (base**order)) / 1024**2
+    return (amount * (base ** order)) / 1024 ** 2
 
 
 def get_config_hash(config: Any) -> str:
@@ -536,3 +536,13 @@ def chunked(seq: Sequence, limit: int = 900) -> Iterator[Sequence]:
     """Helper to divide our expired lists into sizes sqlite can handle in a query. (<1000)"""
     for i in range(0, len(seq), limit):
         yield seq[i : i + limit]
+
+
+# This pattern matches any non-alphanumeric character (ie not a-z, A-Z, 0-9).
+nonwordrepat = re.compile(r'[\W_]+')
+
+
+def strip_non_alphanum(inp: str) -> str:
+    """Removes non-alphanumeric characters from the input string."""
+
+    return nonwordrepat.sub(' ', inp).strip()

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -397,7 +397,7 @@ def parse_filesize(text_size: str, si: bool = True) -> float:
     order = prefix_order[unit]
     amount = float(amount_str.replace(',', '').replace(' ', ''))
     base = 1000 if si else 1024
-    return (amount * (base ** order)) / 1024 ** 2
+    return (amount * (base**order)) / 1024**2
 
 
 def get_config_hash(config: Any) -> str:


### PR DESCRIPTION
### Motivation for changes:
Some search sites have very simple search implementations that can't match with non-alphanumeric characters in the movie title as these characters are often not in the entry name on the site.  Removing these characters from the search string has a higher likelihood of resulting in a search match.

An example of this is `Spider-Man: No Way Home (2021)` -> `Spider Man No Way Home 2021`.

### Detailed changes:
- Add flag to `movie_list` that replaces non-alphanumeric characters with a space.

### Config:
```
test_list_get_strip_non_alphanum:
   movie_list:
     list_name: test_list
     strip_non_alphanum: yes
```

### Test output:
```
====================================================== test session starts =======================================================
platform linux -- Python 3.8.10, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /home/aidan/Projects/Flexget, configfile: setup.cfg
plugins: cov-3.0.0, xdist-2.4.0, forked-1.3.0
collected 18 items                                                                                                               

flexget/tests/test_movie_list.py ..................                                                                        [100%]

======================================================== warnings summary ========================================================
<removed warnings>
================================================ 18 passed, 53 warnings in 5.38s =================================================
```
