### PR TITLE
Fix jaraco lib names in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -66,18 +66,18 @@ idna==3.3
     # via requests
 itsdangerous==2.0.1
     # via flask
-jaraco-classes==3.2.1
+jaraco.classes==3.2.1
     # via jaraco-collections
-jaraco-collections==3.4.0
+jaraco.collections==3.4.0
     # via cherrypy
-jaraco-context==4.1.1
+jaraco.context==4.1.1
     # via jaraco-text
-jaraco-functools==3.4.0
+jaraco.functools==3.4.0
     # via
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==3.7.0
+jaraco.text==3.7.0
     # via jaraco-collections
 jinja2==3.0.3
     # via


### PR DESCRIPTION
### Motivation for changes:
I was unable to do a clean install from `master` due to some changes in #3401.  After running `bin/pip install -e .` and trying to run `bin/flexget -V` the error was:

```
pkg_resources.DistributionNotFound: The 'jaraco-text==3.7.0' distribution was not found and is required by FlexGet
```

Changing the `jaraco-*` dependency naming back to `jaraco.*` looks to fix this issue.

### Detailed changes:
- This is a similar change/revert like in 1604012738f1c011e50313b1605cfd029670d5d6
