### PR TITLE
[add] gotify: add support for setting content_type

### DIFF
--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -33,7 +33,11 @@ class GotifyNotifier(object):
             'url': {'format': 'url'},
             'token': {'type': 'string'},
             'priority': {'type': 'integer', 'default': 4},
-            'content_type': {'type': 'string', 'enum': ['text/plain', 'text/markdown'], 'default': 'text/plain'},
+            'content_type': {
+                'type': 'string',
+                'enum': ['text/plain', 'text/markdown'],
+                'default': 'text/plain',
+            },
         },
         'required': ['token', 'url'],
         'additionalProperties': False,

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -33,6 +33,7 @@ class GotifyNotifier(object):
             'url': {'format': 'url'},
             'token': {'type': 'string'},
             'priority': {'type': 'integer', 'default': 4},
+            'content_type': {'type': 'string', 'default': 'text/plain'},
         },
         'required': ['token', 'url'],
         'additionalProperties': False,
@@ -48,8 +49,14 @@ class GotifyNotifier(object):
         params = {'token': config['token']}
 
         priority = config['priority']
+        content_type = config['content_type']
 
-        notification = {'title': title, 'message': message, 'priority': priority}
+        notification = {
+            'title': title,
+            'message': message,
+            'priority': priority,
+            'extras': {'client::display': {'contentType': content_type}},
+        }
         # Make the request
         try:
             response = requests.post(url, params=params, json=notification)

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -33,7 +33,7 @@ class GotifyNotifier(object):
             'url': {'format': 'url'},
             'token': {'type': 'string'},
             'priority': {'type': 'integer', 'default': 4},
-            'content_type': {'type': 'string', 'default': 'text/plain'},
+            'content_type': {'type': 'string', 'enum': ['text/plain', 'text/markdown'], 'default': 'text/plain'},
         },
         'required': ['token', 'url'],
         'additionalProperties': False,


### PR DESCRIPTION
### Motivation for changes:
Gotify notifications are plain text by default but [they support markdown](https://gotify.net/docs/msgextras#clientdisplay).  With markdown support, notifications can be enriched with images, bold text, etc which make them easier to read/highlight important information.

### Detailed changes:
- Add option `content_type` to gotify notifier.
- Default value is `text/plain` for backwards compatibility 

### Config usage if relevant (new plugin or updated schema):
```
notify:
  task:
    always_send: yes
    title: "test!"
    template: gotify.template
    via:
      - gotify:
          url: "https://redacted-site.net/"
          token: "nope"
          priority: 1
          content_type: "text/markdown"
```
