### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,8 +5,13 @@ on:
     branches:
     - develop
 
+permissions:
+  contents: read
+
 jobs:
   update-changelog:
+    permissions:
+      contents: write  # for Git to git push
     name: Update Changelog
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
     - "*"
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Run Tests

--- a/.github/workflows/no-prs-to-master.yml
+++ b/.github/workflows/no-prs-to-master.yml
@@ -5,8 +5,13 @@ on:
     branches:
       - 'master'
 
+permissions:
+  contents: read
+
 jobs:
   fail:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     name: Please make them to develop
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,8 +7,14 @@ env:
   DAYS_BEFORE_ISSUE_CLOSE: 30
   DAYS_BEFORE_PR_STALE: 150
   DAYS_BEFORE_PR_CLOSE: 60
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v3


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
