### PR TITLE
[add] ntfy.sh notification support

### DIFF
--- a/flexget/components/notify/notifiers/ntfysh.py
+++ b/flexget/components/notify/notifiers/ntfysh.py
@@ -1,0 +1,84 @@
+from http import HTTPStatus
+from urllib.parse import urljoin
+
+from requests.exceptions import RequestException
+from requests.auth import HTTPBasicAuth
+
+from flexget import plugin
+from flexget.event import event
+from flexget.plugin import PluginWarning
+from flexget.utils.requests import Session as RequestSession
+
+plugin_name = 'ntfysh'
+
+requests = RequestSession(max_retries=3)
+
+
+class NtfyshNotifier(object):
+    """
+    Example::
+
+    notify:
+      entries:
+        via:
+          - ntfysh:
+              url: <NTFY_SERVER_URL>
+              topic: <NTFY_TOPIC>
+              priority: <PRIORITY>
+
+    Configuration parameters are also supported from entries (eg. through set).
+    """
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'url': {'format': 'url'},
+            'topic': {'type': 'string'},
+            'priority': {'type': 'integer', 'default': 3},
+            'delay': {'type': 'string'},
+            'tags': {'type': 'string'},
+            'username': {'type': 'string'},
+            'password': {'type': 'string'},
+        },
+        'required': ['topic', 'url'],
+        'additionalProperties': False,
+    }
+
+    def notify(self, title, message, config):
+        """
+        Send a Ntfy.sh notification
+        """
+        base_url = config['url']
+        topic = config['topic']
+        url = urljoin(base_url, topic)
+
+        req = {
+            'url': url,
+            'data': message,
+            'params': {'title': title, 'priority': config['priority']},
+        }
+
+        if 'username' in config or 'password' in config:
+            req['auth'] = HTTPBasicAuth(config.get('username', ''), config.get('password', ''))
+
+        if 'delay' in config:
+            req['params']['delay'] = config['delay']
+        if 'tags' in config:
+            req['params']['tags'] = config['tags']
+
+        try:
+            response = requests.post(**req)
+        except RequestException as e:
+            if e.response is not None:
+                if e.response.status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
+                    message = 'Invalid username and password'
+                else:
+                    message = e.response.text()
+            else:
+                message = str(e)
+            raise PluginWarning(message)
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(NtfyshNotifier, plugin_name, api_ver=2, interfaces=['notifiers'])

--- a/flexget/components/notify/notifiers/ntfysh.py
+++ b/flexget/components/notify/notifiers/ntfysh.py
@@ -22,9 +22,7 @@ class NtfyshNotifier(object):
       entries:
         via:
           - ntfysh:
-              url: <NTFY_SERVER_URL>
               topic: <NTFY_TOPIC>
-              priority: <PRIORITY>
 
     Configuration parameters are also supported from entries (eg. through set).
     """
@@ -32,7 +30,7 @@ class NtfyshNotifier(object):
     schema = {
         'type': 'object',
         'properties': {
-            'url': {'format': 'url'},
+            'url': {'format': 'url', 'default': 'https://ntfy.sh/'},
             'topic': {'type': 'string'},
             'priority': {'type': 'integer', 'default': 3},
             'delay': {'type': 'string'},

--- a/flexget/components/notify/notifiers/ntfysh.py
+++ b/flexget/components/notify/notifiers/ntfysh.py
@@ -1,8 +1,8 @@
 from http import HTTPStatus
 from urllib.parse import urljoin
 
-from requests.exceptions import RequestException
 from requests.auth import HTTPBasicAuth
+from requests.exceptions import RequestException
 
 from flexget import plugin
 from flexget.event import event


### PR DESCRIPTION
### Motivation for changes:
User in #3445 requested support for ntfy.sh - it seems like a decent zero-config notification option for people wanting a simple solution.

### Detailed changes:
- Add support for ntfy.sh notifications.  

### Implemented feature requests:
- #3445 

### Config usage if relevant (new plugin or updated schema):
```
tasks:
  seen1:
    mock:
      - { "title": "Big.Buck.Bunny.1080p.BluRay.x264-GRP", "url": "mock://local1" }
    accept_all: yes
    notify:
      entries:
        title: Download from task {{task}}
        template: message.template
        via:
          - ntfysh:
              url: "https://ntfy.sh/"
              topic: "flexget-test-topic"
              priority: 5
              delay: 30s
              tags: poop,train
```

#### Questions
Some of the notification implementations have this line in the example:
```
Configuration parameters are also supported from entries (eg. through set).
```
I couldn't find an example of how this is done.  Can provider specific configuration options be set via the entry somehow?

