### PR TITLE
Newznab support more ids

### DIFF
--- a/flexget/components/sites/sites/newznab.py
+++ b/flexget/components/sites/sites/newznab.py
@@ -113,7 +113,17 @@ class Newznab:
             or 'series_episode' not in arg_entry
         ):
             return []
-        if arg_entry.get('tvrage_id'):
+        if arg_entry.get('tvdb_id'):
+            config['params']['tvdbid'] = arg_entry.get('tvdb_id')
+        elif arg_entry.get('trakt_id'):
+            config['params']['traktid'] = arg_entry.get('trakt_id')
+        elif arg_entry.get('tvmaze_series_id'):
+            config['params']['tvmazeid'] = arg_entry.get('tvmaze_series_id')
+        elif arg_entry.get('tmdb_id'):
+            config['params']['tmdbid'] = arg_entry.get('tmdb_id')
+        elif arg_entry.get('imdb_id'):
+            config['params']['imdbid'] = arg_entry.get('imdb_id')
+        elif arg_entry.get('tvrage_id'):
             config['params']['rid'] = arg_entry.get('tvrage_id')
         else:
             config['params']['q'] = arg_entry['series_name']

--- a/flexget/components/sites/sites/newznab.py
+++ b/flexget/components/sites/sites/newznab.py
@@ -73,7 +73,7 @@ class Newznab:
             rss = feedparser.parse(r.content)
             logger.debug('Raw RSS: {}', rss)
 
-            if rss.entries:
+            if not rss.entries:
                 logger.info('No results returned')
 
             for rss_entry in rss.entries:


### PR DESCRIPTION
### Motivation for changes:

Some newznab sites provide other id searches than tvrage. Use those too and prefer them.

### Detailed changes:
- check if tvdb_id is set and search using the `&tvdbid=${tvdb_id}` parameters
- if not set, try with `trakt_id`
- if not set, try with `tmdb_id`
- and so on

Additionally a small fix to the logging has been added, it used to log "no results" if there were any results. :exploding_head: 

### Addressed issues:
- N/A

### Config usage if relevant (new plugin or updated schema):
N/A,

#### To Do:

- [ ] Verify `?t&caps` api to check if those ids are supported
- [ ] There's a larger project of merging *x*znab like plugins together, i.e. torznab and newznab
