### PR TITLE
[fix] skip all test_decompress tests if rarfile module missing

### DIFF
--- a/flexget/tests/test_decompress.py
+++ b/flexget/tests/test_decompress.py
@@ -8,6 +8,7 @@ except ImportError:
     rarfile = None
 
 
+@pytest.mark.skipif(rarfile is None, reason='rarfile module required')
 @pytest.mark.usefixtures('tmpdir')
 class TestExtract:
     config = """
@@ -93,7 +94,6 @@ class TestExtract:
     error_not_local = 'Entry does not appear to represent a local file.'
     error_not_exists = 'File no longer exists:'
 
-    @pytest.mark.skipif(rarfile is None, reason='rarfile module required')
     @pytest.mark.filecopy(rar_path, '__tmp__')
     def test_rar(self, execute_task, tmpdir):
         """Test basic RAR extraction"""
@@ -104,7 +104,6 @@ class TestExtract:
         ).exists(), 'Output file does not exist at the correct path.'
         assert tmpdir.join(self.rar_name).exists(), 'RAR archive should still exist.'
 
-    @pytest.mark.skipif(rarfile is None, reason='rarfile module required')
     @pytest.mark.filecopy(rar_path, '__tmp__')
     def test_delete_rar(self, execute_task, tmpdir):
         """Test RAR deletion after extraction"""


### PR DESCRIPTION
### Motivation for changes:
Running tests against a clean virtualenv (Python 3.10.4) results in failed tests in `flexget/tests/test_decompress.py` due to missing `rarfile` dep.  Virtualenv was setup (following the docs) by running:

```
pip install -e .
pip install -r dev-requirements.txt
```

### Detailed changes:
- Some tests in `test_decompress.py` are skipped if `rarfile` is missing, but some haven't been configured to use the `pytest.mark.skipif` decorator.  
- This change adds the decorator to the whole test suite, as all uses of `decompress` require the `rarfile` module.

### Log and/or tests output (preferably both):
```
=== 1349 passed, 34 skipped, 4 xfailed, 5 xpassed, 543 warnings in 32.60s ===
```
