### PR TITLE
[fix] use datetime to detect running systems tzinfo

### DIFF
--- a/flexget/components/scheduler/scheduler.py
+++ b/flexget/components/scheduler/scheduler.py
@@ -1,9 +1,9 @@
+import datetime
 import hashlib
 import logging
 import os
 import struct
 
-import datetime
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger

--- a/flexget/components/scheduler/scheduler.py
+++ b/flexget/components/scheduler/scheduler.py
@@ -3,8 +3,7 @@ import logging
 import os
 import struct
 
-import pytz
-import tzlocal
+import datetime
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -124,27 +123,10 @@ def setup_scheduler(manager):
     jobstores = {'default': SQLAlchemyJobStore(url=database_uri)}
     # If job was meant to run within last day while daemon was shutdown, run it once when continuing
     job_defaults = {'coalesce': True, 'misfire_grace_time': 60 * 60 * 24}
-    try:
-        timezone = tzlocal.get_localzone()
-        if timezone.zone == 'local':
-            timezone = None
-    except pytz.UnknownTimeZoneError:
-        timezone = None
-    except struct.error as e:
-        # Hiding exception that may occur in tzfile.py seen in entware
-        logger.warning('Hiding exception from tzlocal: {}', e)
-        timezone = None
-    if not timezone:
-        # The default sqlalchemy jobstore does not work when there isn't a name for the local timezone.
-        # Just fall back to utc in this case
-        # FlexGet #2741, upstream ticket https://github.com/agronholm/apscheduler/issues/59
-        logger.info(
-            'Local timezone name could not be determined. Scheduler will display times in UTC for any log'
-            'messages. To resolve this set up /etc/timezone with correct time zone name.'
-        )
-        timezone = pytz.utc
     scheduler = BackgroundScheduler(
-        jobstores=jobstores, job_defaults=job_defaults, timezone=timezone
+        jobstores=jobstores,
+        job_defaults=job_defaults,
+        timezone=datetime.datetime.now().astimezone().tzinfo,
     )
     setup_jobs(manager)
 


### PR DESCRIPTION
### Motivation for changes:
Attempting to address the issue raised in #3444.  The tldr is that `pytz` is being deprecated and there is now a more 'supported' way to get local `tzinfo`.
```
PytzUsageWarning: The zone attribute is specific to pytz's interface; please migrate to a new time zone provider. For more details on how to do so, see https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html
```

### Detailed changes:
- Use `datetime` to determine the running systems `tzinfo`.
- According to the `datetime` [docs](https://docs.python.org/3.6/library/datetime.html#datetime.datetime.astimezone) this method might only be reliable in Python >= 3.6.  I've tested this using 3.10 locally and it seems to be working.  I'll let the CI builds kick off to test the other versions.

### Addressed issues:
- #3444

#### Comments
- Turns our time zones in general are a bit of a rabbit hole in python.  [This](https://blog.ganssle.io/articles/2018/03/pytz-fastest-footgun.html) was an interesting read that provided a bit of context on why certain methods are being deprecated.
