### PR TITLE
[fix] Telegram notify - fix distutils deprecation warning

### DIFF
--- a/flexget/components/notify/notifiers/telegram.py
+++ b/flexget/components/notify/notifiers/telegram.py
@@ -1,6 +1,5 @@
-from distutils.version import LooseVersion
-
 from loguru import logger
+from packaging import version
 from sqlalchemy import Column, Integer, String
 
 from flexget import db_schema, plugin
@@ -277,7 +276,7 @@ class TelegramNotifier:
             raise plugin.PluginWarning('missing python-telegram-bot pkg')
         elif not hasattr(telegram, str('__version__')):
             raise plugin.PluginWarning('invalid or old python-telegram-bot pkg')
-        elif LooseVersion(telegram.__version__) < _MIN_TELEGRAM_VER:
+        elif version.parse(telegram.__version__) < version.parse(_MIN_TELEGRAM_VER):
             raise plugin.PluginWarning(
                 'old python-telegram-bot ({0})'.format(telegram.__version__)
             )

--- a/requirements.in
+++ b/requirements.in
@@ -26,6 +26,7 @@ flask-login>=0.4.0
 flask-restful>=0.3.3
 flask-restx==0.5.1
 flask>=0.7
+packaging~=21.3
 pyparsing==2.4.7
 werkzeug<2.1.0  # Flask-login incompatibility https://github.com/maxcountryman/flask-login/issues/636
 zxcvbn-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,10 +30,6 @@ click==8.0.4
     # via
     #   -r requirements.in
     #   flask
-colorama==0.4.4
-    # via
-    #   click
-    #   loguru
 commonmark==0.9.1
     # via rich
 feedparser==6.0.8
@@ -56,8 +52,6 @@ flask-restful==0.3.9
     # via -r requirements.in
 flask-restx==0.5.1
     # via -r requirements.in
-greenlet==1.1.2
-    # via sqlalchemy
 guessit==3.4.3
     # via -r requirements.in
 html5lib==1.1
@@ -98,6 +92,8 @@ more-itertools==8.12.0
     #   cherrypy
     #   jaraco-classes
     #   jaraco-functools
+packaging==21.3
+    # via -r requirements.in
 plumbum==1.7.2
     # via rpyc
 portend==3.0.0
@@ -109,7 +105,9 @@ pygments==2.11.2
 pynzb==0.1.0
     # via -r requirements.in
 pyparsing==2.4.7
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   packaging
 pyrsistent==0.18.0
     # via jsonschema
 pyrss2gen==1.1
@@ -157,9 +155,7 @@ sqlalchemy==1.4.32
 tempora==4.1.2
     # via portend
 tzdata==2022.1
-    # via
-    #   pytz-deprecation-shim
-    #   tzlocal
+    # via pytz-deprecation-shim
 tzlocal==4.1
     # via apscheduler
 urllib3==1.26.9


### PR DESCRIPTION
### Motivation for changes:
When running tests/using the Telegram notify plugin, the following deprecation warning appears in python 3.10:
```
.../flexget/components/notify/notifiers/telegram.py:1: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    from distutils.version import LooseVersion
```

### Detailed changes:
- Use `packaging` modules `version` function to do version comparison.