### PR TITLE
Don't crash when writing markup like text to console

### DIFF
--- a/flexget/terminal.py
+++ b/flexget/terminal.py
@@ -21,6 +21,7 @@ class _Console(rich.console.Console):
     def __init__(self, *args, **kwargs):
         if "PYCHARM_HOSTED" in os.environ:
             kwargs.setdefault('color_system', 'truecolor')
+        kwargs.setdefault("markup", True)
         super().__init__(*args, **kwargs)
 
     def __call__(self, text: Any, *args, **kwargs) -> None:


### PR DESCRIPTION
Make colorizing markup when writing to console opt-in, rather than opt out. fix #3469

### Motivation for changes:
The new `rich` based console could crash when we were printing unsatitized text that looked like rich markup. Make it so the markup flag has to be set explicitly when markup behavior is desired, and the caller will be responsible for escaping user input.

e.g. `console("[red]my text[/red]", markup=True)`

To protect against problems in unknown text:
```python
from rich.console import escape
console(f"[bold]remember to escape unsafe text {escape(entry['title'])}[/bold]", markup=True)
```
#### To Do:

- [ ] Figure out if there were any places that were relying on markup being enabled by default, and fix them.
- [ ] Add some tests for the colored output?
