### PR TITLE
Correct hdrplus regexp

### DIFF
--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -160,7 +160,7 @@ _codecs = [
 _color_ranges = [
     QualityComponent('color_range', 10, '8bit', r'8[^\w]?bits?|hi8p?'),
     QualityComponent('color_range', 20, '10bit', r'10[^\w]?bits?|hi10p?'),
-    QualityComponent('color_range', 40, 'hdrplus', r'hdr[^\w]?(\+|p|plus)'),
+    QualityComponent('color_range', 40, 'hdrplus', r'hdr(10)?[^\w]?(\+|p|plus)'),
     QualityComponent('color_range', 30, 'hdr', r'hdr([^\w]?10)?'),
     QualityComponent('color_range', 50, 'dolbyvision', r'(dolby[^\w]?vision|dv|dovi)'),
 ]


### PR DESCRIPTION
Correct "hdrplus" regex to include "anything.HDR10Plus.anything" entries

### Motivation for changes:
hdr10plus identification was not working properly

### Detailed changes:
Just improved the regex

### Addressed issues:
- Fixes # .
Correct "hdrplus" regex to include "anything.HDR10Plus.anything" entries

