### PR TITLE
[fix] convert_magnet - ensure generated url is quoted

### DIFF
--- a/flexget/components/bittorrent/convert_magnet.py
+++ b/flexget/components/bittorrent/convert_magnet.py
@@ -1,5 +1,6 @@
 import os
 import time
+from urllib.parse import quote
 
 from loguru import logger
 
@@ -114,7 +115,7 @@ class ConvertMagnet:
                 entry['url'] = torrent_file
                 entry['file'] = torrent_file
                 # make sure it's first in the list because of how download plugin works
-                entry['urls'].insert(0, 'file://{}'.format(torrent_file))
+                entry['urls'].insert(0, 'file://{}'.format(quote(torrent_file)))
 
 
 @event('plugin.register')


### PR DESCRIPTION
### Motivation for changes:
Fixes #3472 

### Detailed changes:
- Torrent names can contain characters that are not allowed in URLs.  This results in `urllib.request.urlopen` raising an exception when downloading a torrent file generated by the `convert_magnet` plugin.
- When generating the url for the entry in the `convert_magnet` plugin, ensure that it is quoted to avoid these issues by future consumers.

### Addressed issues:
- Fixes #3472 