### PR TITLE
[fix] medusa - use correct header for bearer token

### DIFF
--- a/flexget/plugins/input/medusa.py
+++ b/flexget/plugins/input/medusa.py
@@ -73,7 +73,7 @@ class Medusa:
             'token'
         ]
 
-        headers = {'authorization': 'Bearer ' + api_key}
+        headers = {'x-auth': 'Bearer ' + api_key}
 
         params = {'limit': 1000}
 


### PR DESCRIPTION
### Motivation for changes:
#3490 - medusa plugin unable to authenticate to service due to change in HTTP header used to send bearer token.

### Detailed changes:
It looks like pymedusa have changed the header used for the Bearer token from `authorization` to `x-auth`.  This updates the Flexget medusa plugin to match.

### Addressed issues:
- Fixes #3490