### PR TITLE
[fix] Use "string" type for Aria2 options

### DIFF
--- a/flexget/plugins/clients/aria2.py
+++ b/flexget/plugins/clients/aria2.py
@@ -42,7 +42,9 @@ class OutputAria2:
             },
             'options': {
                 'type': 'object',
-                'additionalProperties': {'oneOf': [{'type': 'string'}, {'type': 'number'}, {'type': 'boolean'}]},
+                'additionalProperties': {
+                    'oneOf': [{'type': 'string'}, {'type': 'number'}, {'type': 'boolean'}]
+                },
             },
         },
         'required': ['path'],

--- a/flexget/plugins/clients/aria2.py
+++ b/flexget/plugins/clients/aria2.py
@@ -1,6 +1,5 @@
 import os
 import re
-import ssl
 import xmlrpc.client
 from socket import error as socket_error
 
@@ -29,7 +28,6 @@ class OutputAria2:
         'properties': {
             'server': {'type': 'string', 'default': 'localhost'},
             'port': {'type': 'integer', 'default': 6800},
-            'use_ssl': {'type': 'boolean', 'default': False},
             'secret': {'type': 'string', 'default': ''},
             'username': {'type': 'string', 'default': ''},  # NOTE: To be deprecated by aria2
             'password': {'type': 'string', 'default': ''},
@@ -51,18 +49,16 @@ class OutputAria2:
         'additionalProperties': False,
     }
 
-    def aria2_connection(self, server, port, use_ssl, username=None, password=None):
+    def aria2_connection(self, server, port, username=None, password=None):
         if username and password:
             userpass = '%s:%s@' % (username, password)
         else:
             userpass = ''
-        scheme = 'https' if use_ssl else 'http'
-        context = ssl.SSLContext() if scheme == 'https' else None
-        url = '%s://%s%s:%s/rpc' % (scheme, userpass, server, port)
+        url = 'http://%s%s:%s/rpc' % (userpass, server, port)
         logger.debug('aria2 url: {}', url)
         logger.info('Connecting to daemon at {}', url)
         try:
-            return xmlrpc.client.ServerProxy(url, context=context).aria2
+            return xmlrpc.client.ServerProxy(url).aria2
         except xmlrpc.client.ProtocolError as err:
             raise plugin.PluginError(
                 'Could not connect to aria2 at %s. Protocol error %s: %s'
@@ -101,11 +97,7 @@ class OutputAria2:
             return
         config = self.prepare_config(config)
         aria2 = self.aria2_connection(
-            config['server'],
-            config['port'],
-            config['use_ssl'],
-            config['username'],
-            config['password'],
+            config['server'], config['port'], config['username'], config['password']
         )
         for entry in task.accepted:
             if task.options.test:

--- a/flexget/plugins/clients/aria2.py
+++ b/flexget/plugins/clients/aria2.py
@@ -44,7 +44,7 @@ class OutputAria2:
             },
             'options': {
                 'type': 'object',
-                'additionalProperties': {'oneOf': [{'type': 'string'}, {'type': 'integer'}]},
+                'additionalProperties': {'oneOf': [{'type': 'string'}]},
             },
         },
         'required': ['path'],

--- a/flexget/plugins/clients/aria2.py
+++ b/flexget/plugins/clients/aria2.py
@@ -42,7 +42,7 @@ class OutputAria2:
             },
             'options': {
                 'type': 'object',
-                'additionalProperties': {'oneOf': [{'type': 'string'}]},
+                'additionalProperties': {'oneOf': [{'type': 'string'}, {'type': 'number'}, {'type': 'boolean'}]},
             },
         },
         'required': ['path'],
@@ -89,6 +89,12 @@ class OutputAria2:
         config.setdefault('secret', '')
         config.setdefault('options', {})
         config.setdefault('add_extension', False)
+        options = config['options']
+        for key in options:
+            if isinstance(options[key], bool):
+                options[key] = str(options[key]).lower()
+            elif not isinstance(options[key], str):
+                options[key] = str(options[key])
         return config
 
     def on_task_output(self, task, config):

--- a/flexget/plugins/clients/aria2.py
+++ b/flexget/plugins/clients/aria2.py
@@ -101,7 +101,11 @@ class OutputAria2:
             return
         config = self.prepare_config(config)
         aria2 = self.aria2_connection(
-            config['server'], config['port'], config['use_ssl'], config['username'], config['password']
+            config['server'],
+            config['port'],
+            config['use_ssl'],
+            config['username'],
+            config['password'],
         )
         for entry in task.accepted:
             if task.options.test:


### PR DESCRIPTION
### Motivation for changes:
The value of option must be a `string`, not `integer`.

### Detailed changes:
- allow `string` `number` `boolean` type for `options`
- auto convert non-string type to string for options before sending to aria2

> In the option struct, the name element is the option name (without the preceding `--`) and the value element is the argument as a **string**.    ——[Options - aria2 documentation](https://aria2.github.io/manual/en/html/aria2c.html#id3)

As document says, option value should be a string. If other types are used such as integer, the option will not take effect (already tested in aria2 v1.36.0).

Now option can be a boolean or number directly. Writing option as a string is also allowed. See the config below.


### Addressed issues:


### Implemented feature requests:


### Config usage if relevant (new plugin or updated schema):
```yaml
    aria2:
      path: "/downloads"
      options:
        max-upload-limit: 0
        bt-stop-timeout: "2400"
        seed-time: 66
        seed-ratio: 4.4
        bt-remove-unselected-file: true
        allow-overwrite: "false"
```

### Log and/or tests output (preferably both):

#### To Do:

