### PR TITLE
Aria2 jsonrpc support

### DIFF
--- a/flexget/plugins/clients/aria2.py
+++ b/flexget/plugins/clients/aria2.py
@@ -29,7 +29,7 @@ class JSONRPC(object):
         if token:
             self._token = 'token:' + token
         else:
-            self._token = token
+            self._token = ''
         if username and password:
             userpass = '%s:%s@' % (username, password)
         else:
@@ -90,7 +90,7 @@ class XMLRPC(object):
         if token:
             self._token = 'token:' + token
         else:
-            self._token = token
+            self._token = ''
         if username and password:
             userpass = '%s:%s@' % (username, password)
         else:

--- a/flexget/plugins/clients/aria2.py
+++ b/flexget/plugins/clients/aria2.py
@@ -101,7 +101,7 @@ class XmlRpcClient(RpcClient):
         _schemes = {'http': None, 'https': ssl.SSLContext()}
         if scheme not in _schemes:
             raise plugin.PluginError('Unknown scheme: %s' % (scheme), logger)
-        super(JsonRpcClient, self).__init__(
+        super(XmlRpcClient, self).__init__(
             server, port, scheme, rpc_path, username, password, token
         )
         try:

--- a/flexget/plugins/clients/aria2.py
+++ b/flexget/plugins/clients/aria2.py
@@ -15,7 +15,7 @@ from flexget.utils.template import RenderError
 logger = logger.bind(name='aria2')
 
 
-class RpcClient():
+class RpcClient:
     def __init__(self, server, port, scheme, rpc_path, username, password, token):
         if token:
             self._token = 'token:' + token
@@ -45,8 +45,9 @@ class JsonRpcClient(RpcClient):
     ADDMETALINK_METHOD = 'aria2.addMetalink'
 
     def __init__(self, server, port, scheme, rpc_path, username=None, password=None, token=None):
-        super(JsonRpcClient, self).__init__(server, port,
-              scheme, rpc_path, username, password, token)
+        super(JsonRpcClient, self).__init__(
+            server, port, scheme, rpc_path, username, password, token
+        )
         # trigger _default_error_handle on failure
         self.get_global_stat()
 
@@ -100,8 +101,9 @@ class XmlRpcClient(RpcClient):
         _schemes = {'http': None, 'https': ssl.SSLContext()}
         if scheme not in _schemes:
             raise plugin.PluginError('Unknown scheme: %s' % (scheme), logger)
-        super(JsonRpcClient, self).__init__(server, port,
-              scheme, rpc_path, username, password, token)
+        super(JsonRpcClient, self).__init__(
+            server, port, scheme, rpc_path, username, password, token
+        )
         try:
             self._aria2 = xmlrpc.client.ServerProxy(self._url, context=_schemes[scheme]).aria2
         except xmlrpc.client.ProtocolError as err:

--- a/flexget/plugins/clients/aria2.py
+++ b/flexget/plugins/clients/aria2.py
@@ -102,7 +102,7 @@ class XMLRPC(object):
         logger.debug('aria2 url: {}', url)
         logger.info('Connecting to daemon at {}', url)
         try:
-            self._aria2 = xmlrpc.client.ServerProxy(url, context=_schemes(scheme)).aria2
+            self._aria2 = xmlrpc.client.ServerProxy(url, context=_schemes[scheme]).aria2
         except xmlrpc.client.ProtocolError as err:
             raise plugin.PluginError(
                 'Could not connect to aria2 at %s. Protocol error %s: %s'


### PR DESCRIPTION
### Motivation for changes:
- Add support  for JSON-RPC 

### Detailed changes:
- Add configs: 
  - scheme: http(default)/https
  - rpc_mode: xml(default)/json
  - rpc_path: rpc(default)
- JSON-RPC client

### Addressed issues:
- Fixes #3460 .

### Implemented feature requests:
- N/A

### Config usage if relevant (new plugin or updated schema):
```
web_server:
  bind: 0.0.0.0
  port: 5050
  web_ui: yes

tasks:
  SPYxFAMILY:
    rss: https://******
    accept_all: yes
    aria2:
        server: ******
        port: ******
        scheme: https
        secret: ******
        rpc_mode: json
        rpc_path: jsonrpc
        path: /downloads/Flexget
schedules:
  - tasks: '*'
    interval:
      minutes: 10
```
### Log and/or tests output (preferably both):
flexget:
```
2022-07-31 03:46:43 INFO     web_server_daemon                 Running web server at IP 0.0.0.0:5050
2022-07-31 03:46:43 INFO     web_server_daemon                 Initiating API
2022-07-31 03:46:43 INFO     web_server_daemon                 Registering WebUI v2
2022-07-31 03:46:43 INFO     web_server                    Web server started at http://10.42.0.102:5050
2022-07-31 03:46:43 INFO     web_server                    API available at http://10.42.0.102:5050/api
2022-07-31 03:46:43 INFO     scheduler                     Starting scheduler
2022-07-31 03:46:43 INFO     web_server                    WebUI (v2) available at http://10.42.0.102:5050/
2022-07-31 03:46:49 INFO     aria2         SPYxFAMILY      Connecting to daemon at https://******:******/jsonrpc
2022-07-31 03:49:05 INFO     aria2         SPYxFAMILY      Connecting to daemon at https://******:******/jsonrpc
2022-07-31 03:59:10 INFO     aria2         SPYxFAMILY      Connecting to daemon at https://******:******/jsonrpc
```
aria2:
```
07/31 03:46:51 [NOTICE] Serialized session to '/config/aria2.session' successfully.

07/31 03:46:51 [NOTICE] Download complete: /downloads/Flexget/[诸神字幕组][间谍过家家][Spy x Family][12][简繁日语字幕][1080P][MKV HEVC].torrent

07/31 03:46:51 [NOTICE] Download complete: /downloads/Flexget/[诸神字幕组][间谍过家家][Spy x Family][10][简繁日语字幕][1080P][MKV HEVC].torrent
07/31 03:46:51 [WARRING] Skip delete. Task status invalid: complete
07/31 03:46:51 [WARRING] Skip delete. Task status invalid: complete
07/31 03:46:51 [INFO] General download task, skipped delete .torrent file.
07/31 03:46:51 [INFO] Deleting empty directory ...
07/31 03:46:51 [INFO] General download task, skipped delete .torrent file.
07/31 03:46:51 [INFO] Deleting empty directory ...

07/31 03:46:51 [NOTICE] Download complete: /downloads/Flexget/[诸神字幕组][间谍过家家][Spy x Family][09][简繁日语字幕][1080P][MKV HEVC].torrent
07/31 03:46:51 [WARRING] Skip delete. Task status invalid: complete
07/31 03:46:51 [INFO] General download task, skipped delete .torrent file.
07/31 03:46:51 [INFO] Deleting empty directory ...
```
#### To Do:

- [x] ~~Testing requirements: XML-RPC client (I am using a custom version of Aria2, which prevents me from testing the XML-RPC client)~~ Tested
- [ ] WS(and WSS) protocol support

