### PR TITLE
adding matrix notifier

### DIFF
--- a/flexget/components/notify/notifiers/matrix.py
+++ b/flexget/components/notify/notifiers/matrix.py
@@ -1,0 +1,76 @@
+from loguru import logger
+from requests.exceptions import RequestException
+
+from flexget import plugin
+from flexget.event import event
+from flexget.plugin import PluginWarning
+from flexget.utils.requests import Session as RequestSession
+
+requests = RequestSession(max_retries=3)
+
+plugin_name = 'matrix'
+
+logger = logger.bind(name=plugin_name)
+
+def urljoin(*args):
+    """
+    Author: Rune Kaagaard
+    Joins given arguments into an url. Trailing but not leading slashes are
+    stripped for each argument.
+    """
+    return "/".join(map(lambda x: str(x).rstrip('/'), args))
+
+class MatrixNotifier:
+    """
+    Sends messages via Matrix. The MatrixHttpApi library is required to be installed.
+    Install it with: `pip install matrix_client`
+
+    All fields are required.
+
+    token: Is available in Element under Help/About.
+    roomId: Is available in Element under room settings.
+
+    Example::
+
+      notify:
+        entries:
+          via:
+            - matrix:
+                server: "https://matrix.org"
+                token: sender's token
+                roomid: room identifier
+    """
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'server': {'type': 'string'},
+            'token': {'type': 'string'},
+            'roomid': {'type': 'string'},
+        },
+        'required': ['server', 'token', 'roomid'],
+        'additionalProperties': False,
+    }
+
+    __version__ = '0.2'
+
+    def notify(self, title, message, config):
+        """
+        Send notification to Matrix Room
+        """
+        notification = {'body': message, 
+                        'msgtype': "m.text"}
+        room = urljoin(config['server'],
+                        "_matrix/client/r0/rooms",
+                        config['roomid'],
+                        "send/m.room.message?access_token="+config['token']
+                        )                        
+        try:
+            requests.post(room, json=notification)
+        except RequestException as e:
+            raise PluginWarning(e.args[0])
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(MatrixNotifier, plugin_name, api_ver=2, interfaces=['notifiers'])

--- a/flexget/components/notify/notifiers/matrix.py
+++ b/flexget/components/notify/notifiers/matrix.py
@@ -29,8 +29,9 @@ class MatrixNotifier:
 
     All fields are required.
 
-    token: Is available in Element under Help/About.
-    roomId: Is available in Element under room settings.
+    server: Matrix hostname to integrate to (required)
+    token: Is available in Element under Help/About. (required)
+    room_id: Is available in Element under room settings. (required)
 
     Example::
 
@@ -40,7 +41,7 @@ class MatrixNotifier:
             - matrix:
                 server: "https://matrix.org"
                 token: sender's token
-                roomid: room identifier
+                room_id: room identifier
     """
 
     schema = {
@@ -48,13 +49,13 @@ class MatrixNotifier:
         'properties': {
             'server': {'type': 'string'},
             'token': {'type': 'string'},
-            'roomid': {'type': 'string'},
+            'room_id': {'type': 'string'},
         },
-        'required': ['server', 'token', 'roomid'],
+        'required': ['server', 'token', 'room_id'],
         'additionalProperties': False,
     }
 
-    __version__ = '0.2'
+    __version__ = '0.3'
 
     def notify(self, title, message, config):
         """
@@ -64,13 +65,13 @@ class MatrixNotifier:
         room = urljoin(
             config['server'],
             "_matrix/client/r0/rooms",
-            config['roomid'],
+            config['room_id'],
             "send/m.room.message?access_token=" + config['token'],
         )
         try:
             requests.post(room, json=notification)
         except RequestException as e:
-            raise PluginWarning(e.args[0])
+            raise PluginWarning(e.args[0]) from e
 
 
 @event('plugin.register')

--- a/flexget/components/notify/notifiers/matrix.py
+++ b/flexget/components/notify/notifiers/matrix.py
@@ -12,6 +12,7 @@ plugin_name = 'matrix'
 
 logger = logger.bind(name=plugin_name)
 
+
 def urljoin(*args):
     """
     Author: Rune Kaagaard
@@ -19,6 +20,7 @@ def urljoin(*args):
     stripped for each argument.
     """
     return "/".join(map(lambda x: str(x).rstrip('/'), args))
+
 
 class MatrixNotifier:
     """
@@ -58,13 +60,13 @@ class MatrixNotifier:
         """
         Send notification to Matrix Room
         """
-        notification = {'body': message, 
-                        'msgtype': "m.text"}
-        room = urljoin(config['server'],
-                        "_matrix/client/r0/rooms",
-                        config['roomid'],
-                        "send/m.room.message?access_token="+config['token']
-                        )                        
+        notification = {'body': message, 'msgtype': "m.text"}
+        room = urljoin(
+            config['server'],
+            "_matrix/client/r0/rooms",
+            config['roomid'],
+            "send/m.room.message?access_token=" + config['token'],
+        )
         try:
             requests.post(room, json=notification)
         except RequestException as e:


### PR DESCRIPTION
### Motivation for changes:
Matrix is a secure msging platform that allows for updates via a REST call

### Detailed changes:
Addition of matrix.py to the notifiers folder. 

### Addressed issues:
- Fixes # .
- Feature request.

### Implemented feature requests:
- Matrix support

### Config usage if relevant (new plugin or updated schema):
```
Sample config:
      entries:
        via:
          - matrix:
                  server: 'https://matrix.org'
                  token: 'SECRETKEY-dsarasfaFASZgo'
                  roomid: '!ufPOdHzBzMRGDSASgf:matrix.org'

```
### Log and/or tests output (preferably both):
```
2022-08-23 14:32:49 VERBOSE  notify        sort-stuff     Successfully sent a notification to `matrix`
```
#### To Do:
- [ ] Group multiple notifications to a single msg to reduce number of requests.

