### PR TITLE
Fix Kitsu.io plugin failures

### DIFF
--- a/flexget/plugins/input/kitsu.py
+++ b/flexget/plugins/input/kitsu.py
@@ -46,10 +46,7 @@ class KitsuAnime:
             'latest': {'type': 'boolean', 'default': False},
             'status': {'type': 'string', 'enum': ['airing', 'finished']},
         },
-        'oneOf': [
-            {'required': ['username']},
-            {'required': ['user_id']}
-        ],
+        'oneOf': [{'required': ['username']}, {'required': ['user_id']}],
         'additionalProperties': False,
     }
 
@@ -80,7 +77,11 @@ class KitsuAnime:
         json_data = response.json()
 
         while json_data:
-            anime_dict = {relation['id']: relation for relation in json_data['included'] if relation['type'] == 'anime'}
+            anime_dict = {
+                relation['id']: relation
+                for relation in json_data['included']
+                if relation['type'] == 'anime'
+            }
 
             for item in json_data['data']:
                 if item['relationships']['anime']['data'] is None:
@@ -160,6 +161,7 @@ class KitsuAnime:
             user_id = user['data'][0]['id']
 
         return user_id
+
 
 @event('plugin.register')
 def register_plugin():


### PR DESCRIPTION
### Motivation for changes:
Kitsu.io API returns 500 when including `media`. The app uses `anime` relationship instead, which works fine.
This breaks Kitsu input plugin, making it unable to configure series plugin.

### Detailed changes:
- Update API call to load less data and use new filter defitinions
- Allow use of `user_id` directly instead of name lookup. Lookup call likes to fail a lot
- Fetch only used fields from the API

### Addressed issues:
- Fixes #3483 

### Config usage if relevant (new plugin or updated schema):

```
kitsu: 
  lists: 
    - current
    - planned
  user_id: "107833"
```
