### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,8 +10,14 @@ on:
     branches:
       - "*"
 
+permissions: {}
+
 jobs:
   build:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      packages: write # to push to ghcr.io
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,8 +5,14 @@ on:
     - cron: 0 15 * * *
   workflow_dispatch: {}
 
+permissions: {}
+
 jobs:
   deploy:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      deployments: write # to create deployment
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,13 @@
 name: Build and release to PyPI
 on:
   deployment: {}
+permissions: {}
 jobs:
   release:
+    permissions:
+      contents: write # for git push
+      deployments: write # to create a deployment status
+
     runs-on: ubuntu-latest
     env:
       PYTHON_VERSION: "3.7"


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.