### PR TITLE
Add series pack support for guessit parser

### DIFF
--- a/flexget/components/parsing/parsers/parser_guessit.py
+++ b/flexget/components/parsing/parsers/parser_guessit.py
@@ -313,7 +313,11 @@ class ParserGuessit:
 
                 if country != serie_country:
                     valid = False
-                elif not serie_country and allowed_countries and country.lower() not in allowed_countries:
+                elif (
+                    not serie_country
+                    and allowed_countries
+                    and country.lower() not in allowed_countries
+                ):
                     valid = False
             except GuessitException:
                 logger.warning('Parsing {} serie with guessit failed.', name)

--- a/flexget/tests/test_metainfo.py
+++ b/flexget/tests/test_metainfo.py
@@ -185,7 +185,7 @@ class TestMetainfoSeries:
             quality='1080p',
             media_id='something s04e00',
         ), 'Failed to parse series pack info'
-       
+
     def test_false_positives(self, execute_task):
         """Metainfo series: check for false positives"""
         task = execute_task('false_positives')

--- a/flexget/tests/test_metainfo.py
+++ b/flexget/tests/test_metainfo.py
@@ -104,6 +104,7 @@ class TestMetainfoSeries:
               - {title: 'Something.Season.2.1of4.Ep.Title.HDTV.torrent'}
               - {title: 'Show-A (US) - Episode Title S02E09 hdtv'}
               - {title: "Jack's.Show.S03E01.blah.1080p"}
+              - {title: 'Something S04 1080p'}
           false_positives:
             mock:
               - {title: 'FlexGet.epic'}
@@ -112,7 +113,7 @@ class TestMetainfoSeries:
               - {title: 'FlexGet.Step1'}
               - {title: 'Something.1x0.Complete.Season-FlexGet'}
               - {title: 'Something Seasons 1 & 2 - Complete'}
-              - {title: 'Something Seasons 4 Complete'}
+              - {title: 'Something Seasons 4-10 Complete'}
               - {title: 'Something.S01D2.DVDR-FlexGet'}
     """
 
@@ -176,7 +177,15 @@ class TestMetainfoSeries:
             quality='1080p',
             media_id='jack\'s show s03e01',
         ), 'Failed to parse series info'
-
+        # Test season pack
+        assert task.find_entry(
+            series_name='Something',
+            series_season=4,
+            season_pack=True,
+            quality='1080p',
+            media_id='something s04e00',
+        ), 'Failed to parse series pack info'
+       
     def test_false_positives(self, execute_task):
         """Metainfo series: check for false positives"""
         task = execute_task('false_positives')

--- a/flexget/tests/test_seriesparser.py
+++ b/flexget/tests/test_seriesparser.py
@@ -268,21 +268,29 @@ class TestSeriesParser:
     def test_ignore_seasonpacks_by_default(self, parse, parse_valid, parse_invalid):
         """SeriesParser: ignoring season packs by default"""
         assert parse_valid(name='The Foo', data='The.Foo.S04.1080p.FlexGet.5.1').season_pack
-        assert parse_valid(name='The Foo', data='The Foo S05 720p BluRay DTS x264-FlexGet').season_pack
-        assert parse_valid(name='The Foo', data='The Foo S05 720p BluRay DTS x264-FlexGet').season_pack
-        assert parse_valid(name='Something', data='Something S02 Pack 720p WEB-DL-FlexGet').season_pack
+        assert parse_valid(
+            name='The Foo', data='The Foo S05 720p BluRay DTS x264-FlexGet'
+        ).season_pack
+        assert parse_valid(
+            name='The Foo', data='The Foo S05 720p BluRay DTS x264-FlexGet'
+        ).season_pack
+        assert parse_valid(
+            name='Something', data='Something S02 Pack 720p WEB-DL-FlexGet'
+        ).season_pack
         assert parse_valid(name='Something', data='Something S06 AC3-CRAPL3SS').season_pack
         assert parse_valid(
             name='Something',
             data='Something SEASON 1 2010 540p BluRay QEBS AAC ANDROID IPAD MP4 FASM',
-            identified_by='ep'
+            identified_by='ep',
         ).season_pack
-        assert parse_valid(name='Something', data='Something.1xAll.Season.Complete-FlexGet').season_pack
+        assert parse_valid(
+            name='Something', data='Something.1xAll.Season.Complete-FlexGet'
+        ).season_pack
         assert parse_valid(name='Something', data='Something - Season 10 - FlexGet').season_pack
-        
+
         # Multi season and multi episode are not allowed
         parse_invalid(name='Something', data='Something S6 E1-4')
-        
+
         # Make sure no false positives
         parse_invalid(name='Something', data='Something.1x0.Complete.Season-FlexGet')
         parse_invalid(name='Something', data='Something_Season_1_Full_Season_2_EP_1-7_HD')
@@ -290,28 +298,48 @@ class TestSeriesParser:
 
     def test_allow_seasonpacks_by_ep(self, parse, parse_valid, parse_invalid):
         """SeriesParser: allowing season packs by ep"""
-        assert parse_valid(name='The Foo', data='The.Foo.S04.1080p.FlexGet.5.1', identified_by='ep').season_pack
-        assert parse_valid(name='The Foo', data='The Foo S05 720p BluRay DTS x264-FlexGet', identified_by='ep').season_pack
-        assert parse_valid(name='The Foo', data='The Foo S05 720p BluRay DTS x264-FlexGet', identified_by='ep').season_pack
-        assert parse_valid(name='Something', data='Something S02 Pack 720p WEB-DL-FlexGet', identified_by='ep').season_pack
-        assert parse_valid(name='Something', data='Something S06 AC3-CRAPL3SS', identified_by='ep').season_pack
+        assert parse_valid(
+            name='The Foo', data='The.Foo.S04.1080p.FlexGet.5.1', identified_by='ep'
+        ).season_pack
+        assert parse_valid(
+            name='The Foo', data='The Foo S05 720p BluRay DTS x264-FlexGet', identified_by='ep'
+        ).season_pack
+        assert parse_valid(
+            name='The Foo', data='The Foo S05 720p BluRay DTS x264-FlexGet', identified_by='ep'
+        ).season_pack
+        assert parse_valid(
+            name='Something', data='Something S02 Pack 720p WEB-DL-FlexGet', identified_by='ep'
+        ).season_pack
+        assert parse_valid(
+            name='Something', data='Something S06 AC3-CRAPL3SS', identified_by='ep'
+        ).season_pack
         assert parse_valid(
             name='Something',
             data='Something SEASON 1 2010 540p BluRay QEBS AAC ANDROID IPAD MP4 FASM',
-            identified_by='ep'
+            identified_by='ep',
         ).season_pack
-        assert parse_valid(name='Something', data='Something.1xAll.Season.Complete-FlexGet', identified_by='ep').season_pack
-        assert parse_valid(name='Something', data='Something - Season 10 - FlexGet', identified_by='ep').season_pack
-        
+        assert parse_valid(
+            name='Something', data='Something.1xAll.Season.Complete-FlexGet', identified_by='ep'
+        ).season_pack
+        assert parse_valid(
+            name='Something', data='Something - Season 10 - FlexGet', identified_by='ep'
+        ).season_pack
+
         # Season pack by episode group are not allowed
         parse_invalid(name='Something', data='Something S6 E1-4', identified_by='ep')
-        
-        # Make sure no false positives
-        parse_invalid(name='Something', data='Something.1x0.Complete.Season-FlexGet', identified_by='ep')
-        parse_invalid(name='Something', data='Something_Season_1_Full_Season_2_EP_1-7_HD', identified_by='ep')
-        parse_invalid(name='Something', data='Something_ S01D2 MANofKENT INVICTA RG', identified_by='ep')
 
-    @pytest.mark.parametrize( 
+        # Make sure no false positives
+        parse_invalid(
+            name='Something', data='Something.1x0.Complete.Season-FlexGet', identified_by='ep'
+        )
+        parse_invalid(
+            name='Something', data='Something_Season_1_Full_Season_2_EP_1-7_HD', identified_by='ep'
+        )
+        parse_invalid(
+            name='Something', data='Something_ S01D2 MANofKENT INVICTA RG', identified_by='ep'
+        )
+
+    @pytest.mark.parametrize(
         "parse",
         [(ParserGuessit)],
         ids=["guessit"],
@@ -319,15 +347,21 @@ class TestSeriesParser:
     )
     def test_ignore_multi_seasonpacks(self, parse, parse_valid, parse_invalid):
         """SeriesParser: ignore multi season and multi episode (only supported by guessit)"""
-        parse_invalid(name='Something', data='Something Seasons 1 & 2 - Complete', identified_by='ep')
+        parse_invalid(
+            name='Something', data='Something Seasons 1 & 2 - Complete', identified_by='ep'
+        )
         parse_invalid(name='Something', data='Something Seasons 1 2 3 4', identified_by='ep')
         parse_invalid(name='Something', data='Something S01-03 Full Throttle', identified_by='ep')
         parse_invalid(name='Something', data='Something S6 E1-4', identified_by='ep')
-        
+
         # Make sure no false positives
-        assert parse_valid(name='The Foo', data='The.Foo.S04.1080p.FlexGet.5.1', identified_by='ep').season_pack
-        assert parse_valid(name='Something', data='Something Seasons 4 Complete', identified_by='ep').season_pack
-        
+        assert parse_valid(
+            name='The Foo', data='The.Foo.S04.1080p.FlexGet.5.1', identified_by='ep'
+        ).season_pack
+        assert parse_valid(
+            name='Something', data='Something Seasons 4 Complete', identified_by='ep'
+        ).season_pack
+
     def test_similar(self, parse):
         s = parse(
             name='Foo Bar', data='Foo.Bar:Doppelganger.S02E04.HDTV.FlexGet', strict_name=True

--- a/flexget/tests/test_seriesparser.py
+++ b/flexget/tests/test_seriesparser.py
@@ -21,10 +21,21 @@ class TestSeriesParser:
     def parse_invalid(self, parse):
         def parse_invalid(name, data, **kwargs):
             """Makes sure either ParseWarning is raised, or return is invalid."""
-            r = parse(name, data, **kwargs)
+            r = parse(data, name, **kwargs)
             assert not r.valid, '{data} should not be valid'.format(data=data)
+            return r
 
         return parse_invalid
+
+    @pytest.fixture(scope='class')
+    def parse_valid(self, parse):
+        def parse_valid(name, data, **kwargs):
+            """Makes sure return is valid."""
+            r = parse(data, name, **kwargs)
+            assert r.valid, '{data} should be valid'.format(data=data)
+            return r
+
+        return parse_valid
 
     def test_proper(self, parse):
         """SeriesParser: proper"""
@@ -254,29 +265,69 @@ class TestSeriesParser:
         assert s.season == 2 and s.episode == 4, 'failed to parse %s' % s.data
         assert s.quality.name == 'hdtv xvid', 'failed to parse quality from %s' % s.data
 
-    def test_ignore_seasonpacks(self, parse, parse_invalid):
-        """SeriesParser: ignoring season packs"""
-        # parse_invalid(name='The Foo', data='The.Foo.S04.1080p.FlexGet.5.1')
-        parse_invalid(name='The Foo', data='The Foo S05 720p BluRay DTS x264-FlexGet')
-        parse_invalid(name='The Foo', data='The Foo S05 720p BluRay DTS x264-FlexGet')
-        parse_invalid(name='Something', data='Something S02 Pack 720p WEB-DL-FlexGet')
-        parse_invalid(name='Something', data='Something S06 AC3-CRAPL3SS')
-        parse_invalid(
+    def test_ignore_seasonpacks_by_default(self, parse, parse_valid, parse_invalid):
+        """SeriesParser: ignoring season packs by default"""
+        assert parse_valid(name='The Foo', data='The.Foo.S04.1080p.FlexGet.5.1').season_pack
+        assert parse_valid(name='The Foo', data='The Foo S05 720p BluRay DTS x264-FlexGet').season_pack
+        assert parse_valid(name='The Foo', data='The Foo S05 720p BluRay DTS x264-FlexGet').season_pack
+        assert parse_valid(name='Something', data='Something S02 Pack 720p WEB-DL-FlexGet').season_pack
+        assert parse_valid(name='Something', data='Something S06 AC3-CRAPL3SS').season_pack
+        assert parse_valid(
             name='Something',
             data='Something SEASON 1 2010 540p BluRay QEBS AAC ANDROID IPAD MP4 FASM',
-        )
-        parse_invalid(name='Something', data='Something.1x0.Complete.Season-FlexGet')
-        parse_invalid(name='Something', data='Something.1xAll.Season.Complete-FlexGet')
-        parse_invalid(name='Something', data='Something Seasons 1 & 2 - Complete')
-        parse_invalid(name='Something', data='Something Seasons 4 Complete')
-        parse_invalid(name='Something', data='Something Seasons 1 2 3 4')
+            identified_by='ep'
+        ).season_pack
+        assert parse_valid(name='Something', data='Something.1xAll.Season.Complete-FlexGet').season_pack
+        assert parse_valid(name='Something', data='Something - Season 10 - FlexGet').season_pack
+        
+        # Multi season and multi episode are not allowed
         parse_invalid(name='Something', data='Something S6 E1-4')
-        parse_invalid(name='Something', data='Something_Season_1_Full_Season_2_EP_1-7_HD')
-        parse_invalid(name='Something', data='Something - Season 10 - FlexGet')
-        parse_invalid(name='Something', data='Something_ DISC_1_OF_2 MANofKENT INVICTA RG')
+        
         # Make sure no false positives
-        assert parse(name='Something', data='Something S01E03 Full Throttle').valid
+        parse_invalid(name='Something', data='Something.1x0.Complete.Season-FlexGet')
+        parse_invalid(name='Something', data='Something_Season_1_Full_Season_2_EP_1-7_HD')
+        parse_invalid(name='Something', data='Something_ S01D2 MANofKENT INVICTA RG')
 
+    def test_allow_seasonpacks_by_ep(self, parse, parse_valid, parse_invalid):
+        """SeriesParser: allowing season packs by ep"""
+        assert parse_valid(name='The Foo', data='The.Foo.S04.1080p.FlexGet.5.1', identified_by='ep').season_pack
+        assert parse_valid(name='The Foo', data='The Foo S05 720p BluRay DTS x264-FlexGet', identified_by='ep').season_pack
+        assert parse_valid(name='The Foo', data='The Foo S05 720p BluRay DTS x264-FlexGet', identified_by='ep').season_pack
+        assert parse_valid(name='Something', data='Something S02 Pack 720p WEB-DL-FlexGet', identified_by='ep').season_pack
+        assert parse_valid(name='Something', data='Something S06 AC3-CRAPL3SS', identified_by='ep').season_pack
+        assert parse_valid(
+            name='Something',
+            data='Something SEASON 1 2010 540p BluRay QEBS AAC ANDROID IPAD MP4 FASM',
+            identified_by='ep'
+        ).season_pack
+        assert parse_valid(name='Something', data='Something.1xAll.Season.Complete-FlexGet', identified_by='ep').season_pack
+        assert parse_valid(name='Something', data='Something - Season 10 - FlexGet', identified_by='ep').season_pack
+        
+        # Season pack by episode group are not allowed
+        parse_invalid(name='Something', data='Something S6 E1-4', identified_by='ep')
+        
+        # Make sure no false positives
+        parse_invalid(name='Something', data='Something.1x0.Complete.Season-FlexGet', identified_by='ep')
+        parse_invalid(name='Something', data='Something_Season_1_Full_Season_2_EP_1-7_HD', identified_by='ep')
+        parse_invalid(name='Something', data='Something_ S01D2 MANofKENT INVICTA RG', identified_by='ep')
+
+    @pytest.mark.parametrize( 
+        "parse",
+        [(ParserGuessit)],
+        ids=["guessit"],
+        indirect=["parse"],
+    )
+    def test_ignore_multi_seasonpacks(self, parse, parse_valid, parse_invalid):
+        """SeriesParser: ignore multi season and multi episode (only supported by guessit)"""
+        parse_invalid(name='Something', data='Something Seasons 1 & 2 - Complete', identified_by='ep')
+        parse_invalid(name='Something', data='Something Seasons 1 2 3 4', identified_by='ep')
+        parse_invalid(name='Something', data='Something S01-03 Full Throttle', identified_by='ep')
+        parse_invalid(name='Something', data='Something S6 E1-4', identified_by='ep')
+        
+        # Make sure no false positives
+        assert parse_valid(name='The Foo', data='The.Foo.S04.1080p.FlexGet.5.1', identified_by='ep').season_pack
+        assert parse_valid(name='Something', data='Something Seasons 4 Complete', identified_by='ep').season_pack
+        
     def test_similar(self, parse):
         s = parse(
             name='Foo Bar', data='Foo.Bar:Doppelganger.S02E04.HDTV.FlexGet', strict_name=True


### PR DESCRIPTION
### Motivation for changes:

Series plugin support season pack for `identify_by ep` and Internal parsing have partial support even guessit more capabilities and support season packs in more cases than internal guessit, so this PR add support of pack for guessit in flexget 

### Detailed changes:
- Update guessit parser to support series pack
- Fix check by country that was rejecting valid cases like `Dark (2022)`

### Addressed issues:
- N/A

### Implemented feature requests:
- N/A

### Config usage if relevant (new plugin or updated schema):
```
    discover:
      what:
        - next_series_seasons:
            from_start: yes
            backfill: yes
      from:
        - 1337x:
            order_by: seeders
    configure_series:
      from:
        entry_list: watchlist_series
      settings:
        identified_by: ep
        tracking: backfill
        exact: yes
        season_packs: only
```
### Log and/or tests output (preferably both):
```
paste output here
```

