### PR TITLE
[fix] Parse IMDB plot

### DIFF
--- a/flexget/components/imdb/utils.py
+++ b/flexget/components/imdb/utils.py
@@ -407,15 +407,9 @@ class ImdbParser:
         # Storyline section
         # NOTE: We cannot use the get default approach here .(get(x, {}))
         # as the data returned in imdb has all fields with null values if they do not exist.
-        summaries = main_column_data.get('summaries') or {}
-        summary_edges = summaries.get('edges') or []
-        if len(summary_edges) > 0:
-            edge_node = summary_edges[0].get('node') or {}
-            plot_text = edge_node.get('plotText') or {}
-            # Strip out html
-            plot_html = get_soup(plot_text.get('plaidHtml'))
-            if plot_html:
-                self.plot_outline = plot_html.text
+        plot = above_the_fold_data.get('plot') or {}
+        plot_text = plot.get('plotText') or {}
+        self.plot_outline = plot_text.get('plainText')
         if not self.plot_outline:
             logger.debug('No storyline found for {}', self.imdb_id)
 


### PR DESCRIPTION
### Motivation for changes:
`imdb_plot_outline` from `imdb_lookup` is returning empty values
### Detailed changes:
- Updated JSON path for the plot field

### Addressed issues:
- Fixes #3527 .

### Config usage if relevant (new plugin or updated schema):
Unchanged

### Log and/or tests output (preferably both):
`$ flexget --test execute --dump`
Before:
```
...
imdb_photo        : https://m.media-amazon.com/images/M/MV5BOTQ0MzAyODM0MF5BMl5BanBnXkFtZTcwNDA1MTA4OQ@@._V1_.jpg
imdb_plot_keywords: []
imdb_plot_outline : None
imdb_score        : 7.1
imdb_url          : https://www.imdb.com/title/tt2231208/
...
```
After:
```
...
imdb_photo        : https://m.media-amazon.com/images/M/MV5BOTQ0MzAyODM0MF5BMl5BanBnXkFtZTcwNDA1MTA4OQ@@._V1_.jpg
imdb_plot_keywords: []
imdb_plot_outline : Revolves around the love between an immortal hero and Janaína, the woman he has been in love with for 600 years, through Brazil's colonization, slavery, military regime and the future, in 2096, in the midst of wars
                    for water.
imdb_score        : 7.1
imdb_url          : https://www.imdb.com/title/tt2231208/
...
```
