### PR TITLE
Change the configuration format of the notifier Bark

### DIFF
--- a/flexget/components/notify/notifiers/bark.py
+++ b/flexget/components/notify/notifiers/bark.py
@@ -30,17 +30,9 @@ class BarkNotifier:
             webpost:
               server: <string>
               device_key: <string>
-              [level: <string>]
-              [badge: <integer>]
-              [automaticallyCopy: <string>]
-              [copy: <string>]
-              [sound: <string>]
-              [icon: <string>]
-              [group: <string>]
-              [isArchive: <string>]
-              [url: <string>]
-
-    # https://github.com/Finb/bark-server/blob/master/docs/API_V2.md
+              options:
+                key: value
+              # https://github.com/Finb/bark-server/blob/master/docs/API_V2.md
 
     """
 
@@ -49,15 +41,12 @@ class BarkNotifier:
         'properties': {
             'server': {'type': 'string'},
             'device_key': {'type': 'string'},
-            'level': {'type': 'string'},
-            'badge': {'type': 'integer'},
-            'automaticallyCopy': {'type': 'string'},
-            'copy': {'type': 'string'},
-            'sound': {'type': 'string'},
-            'icon': {'type': 'string'},
-            'group': {'type': 'string'},
-            'isArchive': {'type': 'string'},
-            'url': {'type': 'string'},
+            'options': {
+                'type': 'object',
+                'additionalProperties': {
+                    'oneOf': [{'type': 'string'}, {'type': 'integer'}]
+                },
+            },
         },
         'required': ['server', 'device_key'],
         'additionalProperties': False,
@@ -71,9 +60,9 @@ class BarkNotifier:
             'title': title,
             'body': message,
         }
-        options = config.copy()
-        server = options.pop('server')
-        notification.update(options)
+        server = config.get('server')
+        notification['device_key'] = config.get('device_key')
+        notification.update(config.get('options', {}))
         try:
             requests.post(server, json=notification)
         except RequestException as e:

--- a/flexget/components/notify/notifiers/bark.py
+++ b/flexget/components/notify/notifiers/bark.py
@@ -49,10 +49,7 @@ class BarkNotifier:
         'properties': {
             'server': {'type': 'string'},
             'device_key': {'type': 'string'},
-            'level': {
-                'type': 'string',
-                'enum': ['active', 'timeSensitive', 'passive']
-            },
+            'level': {'type': 'string', 'enum': ['active', 'timeSensitive', 'passive']},
             'badge': {'type': 'integer'},
             'automatically_copy': {'type': 'boolean'},
             'copy': {'type': 'string'},
@@ -69,9 +66,9 @@ class BarkNotifier:
     def prepare_config(self, config):
         options = config.copy()
         server = options.pop('server')
-        if (options.pop('automatically_copy', False)):
+        if options.pop('automatically_copy', False):
             options['automaticallyCopy'] = '1'
-        if (options.pop('is_archive', False)):
+        if options.pop('is_archive', False):
             options['isArchive'] = '1'
         return server, options
 

--- a/flexget/components/notify/notifiers/bark.py
+++ b/flexget/components/notify/notifiers/bark.py
@@ -30,9 +30,17 @@ class BarkNotifier:
             webpost:
               server: <string>
               device_key: <string>
-              options:
-                key: value
-              # https://github.com/Finb/bark-server/blob/master/docs/API_V2.md
+              [level: <string>]
+              [badge: <integer>]
+              [automaticallyCopy: <string>]
+              [copy: <string>]
+              [sound: <string>]
+              [icon: <string>]
+              [group: <string>]
+              [isArchive: <string>]
+              [url: <string>]
+
+    # https://github.com/Finb/bark-server/blob/master/docs/API_V2.md
 
     """
 
@@ -41,12 +49,15 @@ class BarkNotifier:
         'properties': {
             'server': {'type': 'string'},
             'device_key': {'type': 'string'},
-            'options': {
-                'type': 'object',
-                'additionalProperties': {
-                    'oneOf': [{'type': 'string'}, {'type': 'integer'}]
-                },
-            },
+            'level': {'type': 'string'},
+            'badge': {'type': 'integer'},
+            'automaticallyCopy': {'type': 'string'},
+            'copy': {'type': 'string'},
+            'sound': {'type': 'string'},
+            'icon': {'type': 'string'},
+            'group': {'type': 'string'},
+            'isArchive': {'type': 'string'},
+            'url': {'type': 'string'},
         },
         'required': ['server', 'device_key'],
         'additionalProperties': False,
@@ -60,9 +71,9 @@ class BarkNotifier:
             'title': title,
             'body': message,
         }
-        server = config.get('server')
-        notification['device_key'] = config.get('device_key')
-        notification.update(config.get('options', {}))
+        options = config.copy()
+        server = options.pop('server')
+        notification.update(options)
         try:
             requests.post(server, json=notification)
         except RequestException as e:

--- a/flexget/components/notify/notifiers/bark.py
+++ b/flexget/components/notify/notifiers/bark.py
@@ -32,12 +32,12 @@ class BarkNotifier:
               device_key: <string>
               [level: <string>]
               [badge: <integer>]
-              [automaticallyCopy: <string>]
+              [automatically_copy: <boolean>]
               [copy: <string>]
               [sound: <string>]
               [icon: <string>]
               [group: <string>]
-              [isArchive: <string>]
+              [is_archive: <boolean>]
               [url: <string>]
 
     # https://github.com/Finb/bark-server/blob/master/docs/API_V2.md
@@ -49,19 +49,31 @@ class BarkNotifier:
         'properties': {
             'server': {'type': 'string'},
             'device_key': {'type': 'string'},
-            'level': {'type': 'string'},
+            'level': {
+                'type': 'string',
+                'enum': ['active', 'timeSensitive', 'passive']
+            },
             'badge': {'type': 'integer'},
-            'automaticallyCopy': {'type': 'string'},
+            'automatically_copy': {'type': 'boolean'},
             'copy': {'type': 'string'},
             'sound': {'type': 'string'},
             'icon': {'type': 'string'},
             'group': {'type': 'string'},
-            'isArchive': {'type': 'string'},
+            'is_archive': {'type': 'boolean'},
             'url': {'type': 'string'},
         },
         'required': ['server', 'device_key'],
         'additionalProperties': False,
     }
+
+    def prepare_config(self, config):
+        options = config.copy()
+        server = options.pop('server')
+        if (options.pop('automatically_copy', False)):
+            options['automaticallyCopy'] = '1'
+        if (options.pop('is_archive', False)):
+            options['isArchive'] = '1'
+        return server, options
 
     def notify(self, title, message, config):
         """
@@ -71,8 +83,7 @@ class BarkNotifier:
             'title': title,
             'body': message,
         }
-        options = config.copy()
-        server = options.pop('server')
+        server, options = self.prepare_config(config)
         notification.update(options)
         try:
             requests.post(server, json=notification)


### PR DESCRIPTION
### Motivation for changes:
Change to the consistent identifier naming convention with the project

### Detailed changes:
- replace options
  - automaticallyCopy: string -> automatically_copy: boolean
  - isArchive: string -> is_archive: boolean
- add enum
  - level: 'active', 'timeSensitive', 'passive'

### Addressed issues:
- Flexget/wiki#11

### Implemented feature requests:
- N/A

### Config usage if relevant (new plugin or updated schema):
```
notify:
  entries:
    what: rejected  #only for test
    title: |
          {{task}}
    message: |
          {% if series_name is defined %}{{series_name}}{% if series_id is defined %} - {{series_id}}{% endif %}{% if trakt_ep_name is defined %} - {{trakt_ep_name}}{% endif %}
          {% elif imdb_name is defined%}{{movie_name}}
          {% else %}{{title}}
          {% endif %}
    via:
      - bark:
          server:  https://******
          device_key: ******
          level: passive
          automatically_copy: true
          is_archive: true
```
### Log and/or tests output (preferably both):
```
paste output here
```
#### To Do:

- N/A

