### PR TITLE
[add] docker: run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ ENV PYTHONUNBUFFERED 1
 
 RUN apk add --no-cache --upgrade \
         ca-certificates \
-        nodejs && \
+        nodejs \
+        tzdata && \
     rm -rf /var/cache/apk/*
 
 COPY --from=0 /wheels /wheels

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN pip install -U pip && \
 
 COPY --from=0 /flexget-ui-v2 /usr/local/lib/python3.9/site-packages/flexget/ui/v2/
 
-RUN mkdir /root/.flexget
-VOLUME /root/.flexget
+VOLUME /config
+WORKDIR /config
 
 ENTRYPOINT ["flexget"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,7 @@ ENV PYTHONUNBUFFERED 1
 
 RUN apk add --no-cache --upgrade \
         ca-certificates \
-        nodejs \
-        tzdata && \
+        nodejs && \
     rm -rf /var/cache/apk/*
 
 COPY --from=0 /wheels /wheels


### PR DESCRIPTION
### Motivation for changes:

allow running image as non-root user by using non protected folder /config. WORKDIR set to /config so the current directory is detected first for config location

~~add tzdata to support timezones via env~~

### Detailed changes:
- change config folder location from /root/.flexget to /config
~~- install tzdata to allow timezone setting~~


