### PR TITLE
[add] docker: tzdata for timezone support via env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ ENV PYTHONUNBUFFERED 1
 
 RUN apk add --no-cache --upgrade \
         ca-certificates \
-        nodejs && \
+        nodejs \
+        tzdata && \
     rm -rf /var/cache/apk/*
 
 COPY --from=0 /wheels /wheels


### PR DESCRIPTION
### Motivation for changes:

allow setting timezone for docker via environment variable

### Detailed changes:
- add tzdata package to image
- defaults to UTC

### Config usage if relevant (new plugin or updated schema):

#### compose
```
environment:
  - TZ={TIMEZONE}
```
#### docker cli
```
docker run -e TZ={TIMEZONE}
```

Use name from tz database name [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
