### PR TITLE
[fix] docker: typo on develop caching, extra latest tag on releases tag

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -31,7 +31,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            latest
       
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
@@ -73,6 +72,6 @@ jobs:
           platforms: linux/amd64
           tags: ghcr.io/flexget/flexget:develop
           labels: ${{ steps.meta.output.labels }}
-          cache-form: type=gha, scope=${{ github.workflow }}
+          cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
 


### PR DESCRIPTION
### Motivation for changes:

fix docker release build workflow

### Detailed changes:
- typo on dev build caching
- metadata action already includes latest tag when using semver, remove explicit latest tag

