### PR TITLE
[bump] actions versions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,10 +17,10 @@ jobs:
     env:
       PYTHON_VERSION: 3.7
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: Flexget/wiki
         path: wiki

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,7 +20,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Docker metadata
         id: meta
@@ -49,7 +49,7 @@ jobs:
 
       - name: Build Base Docker Image
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
           context: ./
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build Base Docker Image develop
         id: docker_build_develop
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/develop')
         with:
           context: ./

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         operating-system: [ubuntu-latest] # TODO: Fix a couple tests and enable windows. windows-latest
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # Can we cache the apt-get stuff somehow?
     - name: Install unrar  # used by some flexget tests
       if: matrix.operating-system == 'ubuntu-latest'
@@ -28,7 +28,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -qy unrar
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,8 +15,8 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/github-script@0.9.0
+      - uses: actions/checkout@v3
+      - uses: actions/github-script@v6
         name: Create Deployment
         with:
           github-token: ${{ secrets.flexgetbot_pat }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       PYTHON_VERSION: "3.7"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         token: ${{ secrets.flexgetbot_pat }}
         fetch-depth: 0
@@ -21,7 +21,7 @@ jobs:
         git config user.email ${{ secrets.git_email }}
         git config user.name ${{ secrets.git_user }}
     - name: Set up Python ${{ env.PYTHON_VERSION }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ env.PYTHON_VERSION }}
         cache: 'pip'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v6
         with:
           stale-issue-message: 'This issue is stale because it has been open ${{ env.DAYS_BEFORE_ISSUE_STALE }} days with no activity. Remove stale label or comment or this will be closed in ${{ env.DAYS_BEFORE_ISSUE_CLOSE }} days.'
           close-issue-message: 'This issue has been stale for ${{ env.DAYS_BEFORE_ISSUE_CLOSE }} days and is being closed.'


### PR DESCRIPTION
### Motivation for changes:
clear out warnings of deprecated action versions (node 12->16) on various workflows

### Detailed changes:
- checkout v2->v3
- setup-python v2->v4
- github-script v0.9.0->v6
- stale v3->v6
- build-push v2->v3

### Addressed issues:
- warnings of deprecated node 12. various dependency updates
