### PR TITLE
[fix] docker: typo on tags and labels

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -58,7 +58,7 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.output.labels }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
 
@@ -73,7 +73,7 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: ghcr.io/flexget/flexget:develop
-          labels: ${{ steps.meta.output.labels }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -53,10 +53,11 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
           context: ./
+          file: ./Dockerfile
           builder: ${{ steps.buildx.output.name }}
           push: true
           platforms: linux/amd64
-          tags: ${{ steps.meta.output.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.output.labels }}
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
@@ -67,6 +68,7 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/develop')
         with:
           context: ./
+          file: ./Dockerfile
           builder: ${{ steps.buildx.output.name }}
           push: true
           platforms: linux/amd64


### PR DESCRIPTION
### Motivation for changes:

output variable typo fails docker build since tags and labels are not read correctly

### Detailed changes:
- output->outputs

