### PR TITLE
Dockerfile: switch to python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/python:3.9-alpine
+FROM docker.io/python:3.10-alpine
 ENV PYTHONUNBUFFERED 1
 
 RUN apk add --no-cache --upgrade \
@@ -25,7 +25,7 @@ RUN wget https://github.com/Flexget/webui/releases/latest/download/dist.zip && \
     unzip dist.zip && \
     rm dist.zip
 
-FROM docker.io/python:3.9-alpine
+FROM docker.io/python:3.10-alpine
 ENV PYTHONUNBUFFERED 1
 
 RUN apk add --no-cache --upgrade \


### PR DESCRIPTION
### Motivation for changes:

Python 3.10 is supported by Flexget, no reason to keep using 3.9

### Detailed changes:
- change image version to use python 3.10