### PR TITLE
[fix] release: add changelog to release body with changelog-builder-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,14 +40,12 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.pypi_token }}
       run: |
         ./release.sh
-    - name: Prep Changelog
+    - name: Build Changelog
       id: changelog
       if: env.release_tag
-      run: |
-        version=$(echo ${{ env.release_tag }} | sed -e 's/v//' -e 's/\.//g')
-        date=$(date +%Y-%m-%d)
-        link="${{ env.release_tag }} [Changelog](https://flexget.com/ChangeLog#${version}-${date})"
-        echo ::set-output name=changeloglink::$link
+      uses: mikepenz/release-changelog-builder-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Create GitHub Release
       uses: ncipollo/release-action@v1
       if: env.release_tag
@@ -55,7 +53,7 @@ jobs:
         tag: ${{ env.release_tag }}
         artifacts: "dist/*"
         token: ${{ secrets.GITHUB_TOKEN }}
-        body: ${{ steps.changelog.output.changeloglink }}
+        body: ${{ steps.changelog.outputs.changelog }}
     - name: Set Deployment Status Success
       uses: deliverybot/deployment-status@v1
       with:


### PR DESCRIPTION
### Motivation for changes:
github releases have empty body with no notes or changelog on new versions

### Detailed changes:
- replace run step with changelog builder action

#### To Do:

- verify github release notes
- test changelog workflow for wiki changelog

