### PR TITLE
[fix]: use existing script to generate github release changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -40,10 +40,16 @@ jobs:
     - name: Update the Changelog
       run: |
         set -x
-        python update-changelog.py wiki/ChangeLog.md
+        python update-changelog.py wiki/ChangeLog.md ChangeLog.md
         cd wiki
         git add ChangeLog.md
         if ! git diff --cached --exit-code; then
             git commit -m "Automated ChangeLog update"
             git push origin main
+        fi
+        cd ..
+        git add ChangeLog.md
+        if ! git diff --cached --exit-code; then
+            git commit -m "Automated ChangeLog update"
+            git push origin develop
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,6 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.pypi_token }}
       run: |
         ./release.sh
-    - name: Build Changelog
-      id: changelog
-      if: env.release_tag
-      uses: mikepenz/release-changelog-builder-action@v3
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Create GitHub Release
       uses: ncipollo/release-action@v1
       if: env.release_tag
@@ -53,7 +47,7 @@ jobs:
         tag: ${{ env.release_tag }}
         artifacts: "dist/*"
         token: ${{ secrets.GITHUB_TOKEN }}
-        body: ${{ steps.changelog.outputs.changelog }}
+        bodyFile: ChangeLog.md
     - name: Set Deployment Status Success
       uses: deliverybot/deployment-status@v1
       with:

--- a/update-changelog.py
+++ b/update-changelog.py
@@ -98,6 +98,7 @@ def isplit(
 if __name__ == '__main__':
     try:
         filename = sys.argv[1]
+        mainfile = sys.argv[2]
     except IndexError:
         print('No filename specified, using changelog.md')
         filename = 'changelog.md'
@@ -160,5 +161,7 @@ if __name__ == '__main__':
             for ver in released_vers:
                 logfile.writelines(ver.to_md_lines())
             logfile.writelines(post_lines)
+        with open(mainfile, 'w', encoding='utf-8') as changefile:
+            changefile.writelines(cur_ver.to_md_lines())
     else:
         print('No updates to write.')


### PR DESCRIPTION
### Motivation for changes:
Add changelog to github releases as well as the wiki

### Detailed changes:
- Dropped changelog action
- Use update-changelog.py to create additional ChangeLog.md file in main repo

#### To Do:

- verify changelog on next release

