### PR TITLE
Add configurable search_delay to iptorrents search plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ pip-wheel-metadata
 flexget/ui/v1/app
 .dmypy.json
 .mypy_cache/
+.tool-versions
+.devcontainer/

--- a/flexget/components/sites/sites/iptorrents.py
+++ b/flexget/components/sites/sites/iptorrents.py
@@ -94,7 +94,7 @@ class UrlRewriteIPTorrents:
                 {'oneOf': [{'type': 'integer'}, {'type': 'string', 'enum': list(CATEGORIES)}]}
             ),
             'free': {'type': 'boolean', 'default': False},
-            'search_delay': {'type': 'string', 'default': '1 seconds'}
+            'search_delay': {'type': 'string', 'default': '1 seconds'},
         },
         'required': ['rss_key', 'uid', 'password'],
         'additionalProperties': False,

--- a/flexget/components/sites/sites/iptorrents.py
+++ b/flexget/components/sites/sites/iptorrents.py
@@ -57,6 +57,7 @@ DOMAIN = "iptorrents.com"
 BASE_URL = f"https://{DOMAIN}"
 SEARCH_URL = f"https://{DOMAIN}/t?"
 FREE_SEARCH_URL = f"https://{DOMAIN}/t?free=on"
+DELAY = "2 seconds"
 
 
 class UrlRewriteIPTorrents:
@@ -94,7 +95,6 @@ class UrlRewriteIPTorrents:
                 {'oneOf': [{'type': 'integer'}, {'type': 'string', 'enum': list(CATEGORIES)}]}
             ),
             'free': {'type': 'boolean', 'default': False},
-            'search_delay': {'type': 'string', 'default': '1 seconds'},
         },
         'required': ['rss_key', 'uid', 'password'],
         'additionalProperties': False,
@@ -147,9 +147,8 @@ class UrlRewriteIPTorrents:
         entries = set()
 
         if task.requests.domain_limiters.get(DOMAIN, None) is None:
-            delay = config.get('search_delay')
-            logger.debug('limiting requests with a delay of {}', delay)
-            rate_limiter = requests.TimedLimiter(DOMAIN, delay)
+            logger.debug('limiting requests with a delay of {}', DELAY)
+            rate_limiter = requests.TokenBucketLimiter(DOMAIN, 1, DELAY, True)
             task.requests.add_domain_limiter(rate_limiter)
 
         for search_string in entry.get('search_strings', [entry['title']]):

--- a/flexget/components/sites/sites/iptorrents.py
+++ b/flexget/components/sites/sites/iptorrents.py
@@ -146,10 +146,11 @@ class UrlRewriteIPTorrents:
 
         entries = set()
 
-        delay = config.get('search_delay')
-        logger.debug('limiting requests with a delay of {}', delay)
-        rate_limiter = requests.TimedLimiter(DOMAIN, delay)
-        task.requests.add_domain_limiter(rate_limiter)
+        if task.requests.domain_limiters.get(DOMAIN, None) is None:
+            delay = config.get('search_delay')
+            logger.debug('limiting requests with a delay of {}', delay)
+            rate_limiter = requests.TimedLimiter(DOMAIN, delay)
+            task.requests.add_domain_limiter(rate_limiter)
 
         for search_string in entry.get('search_strings', [entry['title']]):
             search_params = {key: value for (key, value) in category_params.items()}

--- a/flexget/components/sites/sites/iptorrents.py
+++ b/flexget/components/sites/sites/iptorrents.py
@@ -53,9 +53,10 @@ CATEGORIES = {
     'TV-Web-DL': 22,
 }
 
-BASE_URL = 'https://iptorrents.com'
-SEARCH_URL = 'https://iptorrents.com/t?'
-FREE_SEARCH_URL = 'https://iptorrents.com/t?free=on'
+DOMAIN = "iptorrents.com"
+BASE_URL = f"https://{DOMAIN}"
+SEARCH_URL = f"https://{DOMAIN}/t?"
+FREE_SEARCH_URL = f"https://{DOMAIN}/t?free=on"
 
 
 class UrlRewriteIPTorrents:
@@ -67,15 +68,20 @@ class UrlRewriteIPTorrents:
       uid: xxxxxxxx  (required)
       password: xxxxxxxx  (required)
       category: HD
+      free: False
+      search_delay: "1 seconds"
 
       Category is any combination of: Movie-all, Movie-3D, Movie-480p,
       Movie-4K, Movie-BD-R, Movie-BD-Rip, Movie-Cam, Movie-DVD-R,
       Movie-HD-Bluray, Movie-Kids, Movie-MP4, Movie-Non-English,
       Movie-Packs, Movie-Web-DL, Movie-x265, Movie-XviD,
-
       TV-all, TV-Documentaries, TV-Sports, TV-480p, TV-BD, TV-DVD-R,
       TV-DVD-Rip, TV-MP4, TV-Mobile, TV-Non-English, TV-Packs,
       TV-Packs-Non-English, TV-SD-x264, TV-x264, TV-x265, TV-XVID, TV-Web-DL
+
+      free is a boolean to control search result filtering for freeleach torrents only.
+
+      search_delay is a timedelta string that configures rate limit for requests to iptorrents.com.
     """
 
     schema = {
@@ -88,6 +94,7 @@ class UrlRewriteIPTorrents:
                 {'oneOf': [{'type': 'integer'}, {'type': 'string', 'enum': list(CATEGORIES)}]}
             ),
             'free': {'type': 'boolean', 'default': False},
+            'search_delay': {'type': 'string', 'default': '1 seconds'}
         },
         'required': ['rss_key', 'uid', 'password'],
         'additionalProperties': False,
@@ -95,6 +102,9 @@ class UrlRewriteIPTorrents:
 
     # urlrewriter API
     def url_rewritable(self, task, entry):
+        """
+        Determines if the entry's URL is rewriteable (not pointing at a downloadable torrent).
+        """
         url = entry['url']
         if url.startswith(BASE_URL + '/download.php/'):
             return False
@@ -104,6 +114,9 @@ class UrlRewriteIPTorrents:
 
     # urlrewriter API
     def url_rewrite(self, task, entry):
+        """
+        Resets the entry's url to one pointing directly at a torrent.
+        """
         if 'url' not in entry:
             logger.error("Didn't actually get a URL...")
         else:
@@ -119,7 +132,7 @@ class UrlRewriteIPTorrents:
     @plugin.internet(logger)
     def search(self, task, entry, config=None):
         """
-        Search for name from iptorrents
+        Search for name from iptorrents.
         """
 
         categories = config.get('category', 'All')
@@ -133,6 +146,11 @@ class UrlRewriteIPTorrents:
 
         entries = set()
 
+        delay = config.get('search_delay')
+        logger.debug('limiting requests with a delay of {}', delay)
+        rate_limiter = requests.TimedLimiter(DOMAIN, delay)
+        task.requests.add_domain_limiter(rate_limiter)
+
         for search_string in entry.get('search_strings', [entry['title']]):
             search_params = {key: value for (key, value) in category_params.items()}
 
@@ -141,13 +159,13 @@ class UrlRewriteIPTorrents:
 
             logger.debug('searching with params: {}', search_params)
             if config.get('free'):
-                req = requests.get(
+                req = task.requests.get(
                     FREE_SEARCH_URL,
                     params=search_params,
                     cookies={'uid': str(config['uid']), 'pass': config['password']},
                 )
             else:
-                req = requests.get(
+                req = task.requests.get(
                     SEARCH_URL,
                     params=search_params,
                     cookies={'uid': str(config['uid']), 'pass': config['password']},
@@ -168,7 +186,6 @@ class UrlRewriteIPTorrents:
                 if 'leechers' in header_text:
                     leechers_idx = idx
 
-            results = torrents.findAll('tr')
             for torrent in torrents.tbody.findAll('tr', recursive=False):
                 if torrent.th and 'ac' in torrent.th.get('class'):
                     # Header column
@@ -202,6 +219,9 @@ class UrlRewriteIPTorrents:
 
 @event('plugin.register')
 def register_plugin():
+    """
+    Registers the plugin with FlexGet's plugin system.
+    """
     plugin.register(
         UrlRewriteIPTorrents, 'iptorrents', interfaces=['urlrewriter', 'search'], api_ver=2
     )

--- a/flexget/components/sites/sites/iptorrents.py
+++ b/flexget/components/sites/sites/iptorrents.py
@@ -146,7 +146,7 @@ class UrlRewriteIPTorrents:
 
         entries = set()
 
-        if task.requests.domain_limiters.get(DOMAIN, None) is None:
+        if not task.requests.domain_limiters.get(DOMAIN, None):
             logger.debug('limiting requests with a delay of {}', DELAY)
             rate_limiter = requests.TokenBucketLimiter(DOMAIN, 1, DELAY, True)
             task.requests.add_domain_limiter(rate_limiter)


### PR DESCRIPTION
### Motivation for changes:
As detailed in #3624 IPTorrents has been observed returning `429 Client Error: Too Many Requests for url` errors for long lists of series with `alternate_name` configurations.

### Detailed changes:
- Adds a configurable `search_delay` parameter to the `iptorrents` search plugin. This takes a `timedelta` string which is then used to create a `requests.TimedLimiter` to add to the task's `requests.Session` instance. It will default to `"1 seconds"`.
- Modifies the `requests.get` calls to use `task.requests.get` instead, so that any additional modifications made to the task outside of this plugin are respected.
- Adds some additional docstring documentation.
- Updates the `.gitignore` to exclude asdf's `.tool-versions` file and VS Code's `.devcontainer` directory.

### Addressed issues/feature requests:
- Fixes #3624 

### Config usage if relevant (new plugin or updated schema):
```
discover:
  what:
    - next_series_episodes: yes
  from:
    - iptorrents:
        rss_key: *****
        uid: *****
        password: *****
        free: False
        search_delay: "1 seconds"
```

### Log and/or tests output (preferably both):
With default delay of `"1 seconds"`:
```
2022-12-03 12:19:25 VERBOSE  discover      SEARCH_MOVIES   Searching for `Schindler's List (1993)` with plugin `iptorrents` (1 of 355)
2022-12-03 12:19:25 DEBUG    iptorrents    SEARCH_MOVIES   limiting requests with a delay of 1 seconds
2022-12-03 12:19:25 DEBUG    iptorrents    SEARCH_MOVIES   searching with params: {'q': "Schindler's List (1993)", 'qf': ''}
2022-12-03 12:19:25 DEBUG    utils.requests SEARCH_MOVIES   GETing URL https://iptorrents.com/t? with args () and kwargs {'params': {'q': "Schindler's List (1993)", 'qf': ''}, 'cookies': {'uid': '*****', 'pass': '*****'}, 'allow_redirects': True, 'timeout': 30}
2022-12-03 12:19:25 DEBUG    iptorrents    SEARCH_MOVIES   full search URL: https://iptorrents.com/t?q=Schindler%27s+List+%281993%29&qf=
*****
2022-12-03 12:19:25 DEBUG    discover      SEARCH_MOVIES   Discovered 13 entries from iptorrents
2022-12-03 12:19:25 VERBOSE  discover      SEARCH_MOVIES   Searching for `Capone (2020)` with plugin `iptorrents` (2 of 355)
2022-12-03 12:19:25 DEBUG    iptorrents    SEARCH_MOVIES   searching with params: {'q': 'Capone (2020)', 'qf': ''}
2022-12-03 12:19:25 DEBUG    utils.requests SEARCH_MOVIES   Waiting 0.64 seconds until next request to iptorrents.com
2022-12-03 12:19:26 DEBUG    utils.requests SEARCH_MOVIES   GETing URL https://iptorrents.com/t? with args () and kwargs {'params': {'q': 'Capone (2020)', 'qf': ''}, 'cookies': {'uid': '*****', 'pass': '*****'}, 'allow_redirects': True, 'timeout': 30}
2022-12-03 12:19:26 DEBUG    iptorrents    SEARCH_MOVIES   full search URL: https://iptorrents.com/t?q=Capone+%282020%29&qf=
*****
2022-12-03 12:19:26 DEBUG    discover      SEARCH_MOVIES   Discovered 20 entries from iptorrents
2022-12-03 12:19:26 VERBOSE  discover      SEARCH_MOVIES   Searching for `Saving Private Ryan (1998)` with plugin `iptorrents` (3 of 355)
2022-12-03 12:19:26 DEBUG    iptorrents    SEARCH_MOVIES   searching with params: {'q': 'Saving Private Ryan (1998)', 'qf': ''}
2022-12-03 12:19:26 DEBUG    utils.requests SEARCH_MOVIES   Waiting 0.53 seconds until next request to iptorrents.com
```

With delay of `"5 seconds"`:
```
2022-12-03 12:34:59 VERBOSE  discover      SEARCH_MOVIES   Searching for `Schindler's List (1993)` with plugin `iptorrents` (1 of 355)
2022-12-03 12:34:59 DEBUG    iptorrents    SEARCH_MOVIES   limiting requests with a delay of 5 seconds
2022-12-03 12:34:59 DEBUG    iptorrents    SEARCH_MOVIES   searching with params: {'q': "Schindler's List (1993)", 'qf': ''}
2022-12-03 12:34:59 DEBUG    utils.requests SEARCH_MOVIES   GETing URL https://iptorrents.com/t? with args () and kwargs {'params': {'q': "Schindler's List (1993)", 'qf': ''}, 'cookies': {'uid': '*****', 'pass': '*****'}, 'allow_redirects': True, 'timeout': 30}
2022-12-03 12:34:59 DEBUG    iptorrents    SEARCH_MOVIES   full search URL: https://iptorrents.com/t?q=Schindler%27s+List+%281993%29&qf=
*****
2022-12-03 12:34:59 DEBUG    discover      SEARCH_MOVIES   Discovered 13 entries from iptorrents
2022-12-03 12:34:59 VERBOSE  discover      SEARCH_MOVIES   Searching for `Capone (2020)` with plugin `iptorrents` (2 of 355)
2022-12-03 12:34:59 DEBUG    iptorrents    SEARCH_MOVIES   searching with params: {'q': 'Capone (2020)', 'qf': ''}
2022-12-03 12:34:59 VERBOSE  utils.requests SEARCH_MOVIES   Waiting 4.67 seconds until next request to iptorrents.com
2022-12-03 12:35:04 DEBUG    utils.requests SEARCH_MOVIES   GETing URL https://iptorrents.com/t? with args () and kwargs {'params': {'q': 'Capone (2020)', 'qf': ''}, 'cookies': {'uid': '*****', 'pass': '*****'}, 'allow_redirects': True, 'timeout': 30}
2022-12-03 12:35:04 DEBUG    iptorrents    SEARCH_MOVIES   full search URL: https://iptorrents.com/t?q=Capone+%282020%29&qf=
*****
2022-12-03 12:35:04 DEBUG    discover      SEARCH_MOVIES   Discovered 20 entries from iptorrents
2022-12-03 12:35:04 VERBOSE  discover      SEARCH_MOVIES   Searching for `Saving Private Ryan (1998)` with plugin `iptorrents` (3 of 355)
2022-12-03 12:35:04 DEBUG    iptorrents    SEARCH_MOVIES   searching with params: {'q': 'Saving Private Ryan (1998)', 'qf': ''}
2022-12-03 12:35:04 VERBOSE  utils.requests SEARCH_MOVIES   Waiting 4.69 seconds until next request to iptorrents.com
```

#### To Do:
- [X] Test locally and gather example log output
