### PR TITLE
Fix handling of empty `url` in *toast* on macOS

### DIFF
--- a/flexget/components/notify/notifiers/toast.py
+++ b/flexget/components/notify/notifiers/toast.py
@@ -77,10 +77,7 @@ class NotifyToast:
         if config.get('url'):
             notify_kwargs['open'] = config.get('url')
         try:
-            Notifier.notify(
-                message,
-                **notify_kwargs
-            )
+            Notifier.notify(message, **notify_kwargs)
         except Exception as e:
             raise PluginWarning('Cannot send a notification: %s' % e)
 

--- a/flexget/components/notify/notifiers/toast.py
+++ b/flexget/components/notify/notifiers/toast.py
@@ -68,14 +68,18 @@ class NotifyToast:
         except Exception as e:
             logger.debug('Error trying to get flexget icon from webui folder: {}', e)
 
+        notify_kwargs = {
+            'subtitle': title,
+            'title': 'FlexGet Notification',
+            'appIcon': icon_path,
+            'timeout': config['timeout'],
+        }
+        if config.get('url'):
+            notify_kwargs['open'] = config.get('url')
         try:
             Notifier.notify(
                 message,
-                subtitle=title,
-                title='FlexGet Notification',
-                appIcon=icon_path,
-                timeout=config['timeout'],
-                open=config.get('url'),
+                **notify_kwargs
             )
         except Exception as e:
             raise PluginWarning('Cannot send a notification: %s' % e)


### PR DESCRIPTION
### Motivation for changes:
`pync` package cannot handle empty string as an argument for `open`, so is `url` isn't configured for *toast*, no notification was displayed.