### PR TITLE
[Fix] magnetdl error 404 when search string contains a special character

### DIFF
--- a/flexget/components/sites/sites/magnetdl.py
+++ b/flexget/components/sites/sites/magnetdl.py
@@ -153,8 +153,11 @@ class MagnetDL:
         entries = []
         for search_string in entry.get('search_strings', [entry['title']]):
             logger.debug('Searching `{}`', search_string)
-            try:
-                term = search_string.lower().replace(' ', '-')
+            try:                
+                # magnetdl.com search path accepts only [a-z0-9] and dashes/-
+                normalized_string = ''.join(c for c in unicodedata.normalize('NFD', search_string) if unicodedata.category(c) != 'Mn')
+                term = re.sub('[^a-z0-9]', '-', normalized_string.lower())
+                term = re.sub('-+', '-', term).strip('-')
                 # note: weird url convention, uses first letter of search term
                 slash = term[0]
                 url = 'https://www.magnetdl.com/{}/{}/'.format(slash, term)

--- a/flexget/components/sites/sites/magnetdl.py
+++ b/flexget/components/sites/sites/magnetdl.py
@@ -153,9 +153,13 @@ class MagnetDL:
         entries = []
         for search_string in entry.get('search_strings', [entry['title']]):
             logger.debug('Searching `{}`', search_string)
-            try:                
+            try:
                 # magnetdl.com search path accepts only [a-z0-9] and dashes/-
-                normalized_string = ''.join(c for c in unicodedata.normalize('NFD', search_string) if unicodedata.category(c) != 'Mn')
+                normalized_string = ''.join(
+                    c
+                    for c in unicodedata.normalize('NFD', search_string)
+                    if unicodedata.category(c) != 'Mn'
+                )
                 term = re.sub('[^a-z0-9]', '-', normalized_string.lower())
                 term = re.sub('-+', '-', term).strip('-')
                 # note: weird url convention, uses first letter of search term


### PR DESCRIPTION
### Motivation for changes:
magnetdl search returns error 404 every time the search term contains a special character because magnetdl.com search path can only contains [a-z0-9] and slashes/-. Current implementation is not good enough.

### Detailed changes:
- Unicode characters are normalized to ASCII first before all invalid chars are stripped to construct a valid search URL
- For example, search term "Pépé le Moko (1937)" should now be constructed as https://www.magnetdl.com/p/pepe-le-moko-1937

### Log and/or tests output (preferably both):
Magnetdl.com should return 200 even when there is no matches but it returns error 404 due to malform URLs
```
2022-12-27 12:44:24 WARNING  magnetdl      download-movie-queue Url https://www.magnetdl.com/s/sample-movie-(2001)/ returned 404
2022-12-27 12:44:23 WARNING  magnetdl      download-movie-queue Url https://www.magnetdl.com/p/p<C3><A9>p<C3><A9>-le-moko-(1937)/ returned 404
2022-12-27 12:44:20 WARNING  magnetdl      download-movie-queue Url https://www.magnetdl.com/y/you-&-i/ returned 404
```


