### PR TITLE
If a sftp_download entry represents a symlink and delete_origin is true, only remove the symlink.

### DIFF
--- a/flexget/tests/test_sftp_download.py
+++ b/flexget/tests/test_sftp_download.py
@@ -65,7 +65,30 @@ class TestSftpDownload:
               <<: *base_sftp_download
               delete_origin: True
 
+          sftp_download_file_and_delete_symlink:
+            mock: 
+              - {'title': 'file.mkv', 'url': 'sftp://test_user:test_pass@127.0.0.1:40022/home/test_user/file.mkv', 'host_key': {
+                  'key_type': 'ssh-rsa',
+                  'public_key': 'AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hn9BizDY6wI1oNYUBoVHAVioXzOJkZDPB+QsUHDBOqVIcdL/glfMtgIO1E5khoBYql8DSSI+EyrxaC+mfeJ7Ax5qZnimOFvZsJvwvO5h7LI4W1KkoJrYUfMLFfHkDy5EbPIuXeAQGdF/JzOXoIqMcCmKQDS56WRDnga91CGQeXAuzINiviZ63R55b8ynN2JFqKW5V6WZiYZBSmTia68s2ZefkFMiv7E6gmD4WYj6hitz8FGPUoyFAGIR+NVqZ5i9l/8CDuNcZ8E8G7AmNFQhChAeQdEOPO0f2vdH6aRb8Cn0EAy6zpBllxQO8EuLjiEfH01n4/VlGeQEiXlyCLqj'
+                }}
+            accept_all: True
+            sftp_download:
+              <<: *base_sftp_download
+              delete_origin: True
+
           sftp_download_dir_delete_origin:
+            mock: 
+              - {'title': 'dir', 'url': 'sftp://test_user:test_pass@127.0.0.1:40022/home/test_user/dir', 'host_key': {
+                  'key_type': 'ssh-rsa',
+                  'public_key': 'AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hn9BizDY6wI1oNYUBoVHAVioXzOJkZDPB+QsUHDBOqVIcdL/glfMtgIO1E5khoBYql8DSSI+EyrxaC+mfeJ7Ax5qZnimOFvZsJvwvO5h7LI4W1KkoJrYUfMLFfHkDy5EbPIuXeAQGdF/JzOXoIqMcCmKQDS56WRDnga91CGQeXAuzINiviZ63R55b8ynN2JFqKW5V6WZiYZBSmTia68s2ZefkFMiv7E6gmD4WYj6hitz8FGPUoyFAGIR+NVqZ5i9l/8CDuNcZ8E8G7AmNFQhChAeQdEOPO0f2vdH6aRb8Cn0EAy6zpBllxQO8EuLjiEfH01n4/VlGeQEiXlyCLqj'
+                }}
+            accept_all: True
+            sftp_download:
+              <<: *base_sftp_download
+              delete_origin: True
+              recursive: True
+
+          sftp_download_dir_delete_symlink:
             mock: 
               - {'title': 'dir', 'url': 'sftp://test_user:test_pass@127.0.0.1:40022/home/test_user/dir', 'host_key': {
                   'key_type': 'ssh-rsa',
@@ -139,4 +162,26 @@ class TestSftpDownload:
         sftp_fs.create_file('dir/nested/file.mkv', 100)
 
         execute_task('sftp_download_dir_delete_origin')
+        assert not remote_dir.exists()
+
+    def test_sftp_download_file_only_entry_symlink_is_removed(
+        self, execute_task, sftp_fs: TestSFTPFileSystem
+    ):
+        remote_target: Path = sftp_fs.create_file('target.mkv', 100)
+        remote_file: Path = sftp_fs.create_symlink('file.mkv', remote_target)
+
+        execute_task('sftp_download_file_and_delete_symlink')
+        assert remote_target.exists()
+        assert not remote_file.exists()
+
+    def test_sftp_download_dir_only_entry_symlink_is_removed(
+        self, execute_task, sftp_fs: TestSFTPFileSystem
+    ):
+        remote_target: Path = sftp_fs.create_dir('target')
+        remote_target_file: Path = sftp_fs.create_file('target/file.mkv', 100)
+        remote_dir: Path = sftp_fs.create_symlink('dir', remote_target)
+
+        execute_task('sftp_download_dir_delete_symlink')
+        assert remote_target.exists()
+        assert remote_target_file.exists()
         assert not remote_dir.exists()

--- a/flexget/tests/test_sftp_server.py
+++ b/flexget/tests/test_sftp_server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import socket
+import stat
 import threading
 import time
 from logging import Logger
@@ -178,9 +179,9 @@ class TestSFTPFileSystem:
         canonicalized: Path
         if Path(path).is_absolute():
             path = path[1:]
-            canonicalized = (self.__root / path).resolve()
+            canonicalized = (self.__root / path).absolute()
         else:
-            canonicalized = ((self.__cwd or self.__home) / path).resolve()
+            canonicalized = ((self.__cwd or self.__home) / path).absolute()
 
         if self.__root == canonicalized or self.__root in canonicalized.parents:
             return canonicalized


### PR DESCRIPTION
### Motivation for changes:
Currently if a entry represents a symlink and delete_origin is true, the target of the symlink gets removed, but not the symlink itself. This changes the behaviour such that if an entry represents a symlink, only the symlink is removed.

### Detailed changes:
If a sftp_download entry represents a symlink and delete_origin is true, only remove the symlink.

Currently is a entry represents a symlink, the target of the symlink gets removed rather than the symlink itself. This change corrects that and ensure that in the case of a symlink entry, only the symlink itself gets removed.

This also contains a fix for the test_sftp_server to use absolute() rather than resolve() when canonizing paths. Without this change lstat (which shouldn't follow symlinks which resolve does) fails to work correctly.