### PR TITLE
[add] Flood plugin

### DIFF
--- a/flexget/plugins/clients/flood.py
+++ b/flexget/plugins/clients/flood.py
@@ -218,9 +218,9 @@ class InputFlood:
 
     Example:
         from_flood:
-            url: http://localhost:3000
-            username: username
-            password: password
+            url: http://localhost:3000  # Required. Url for Flexget to connect to Flood.
+            username: flexget           # Required. Username for authentication with Flood.
+            password: password          # Required. Password for authentication with Flood.
     """
 
     schema = {
@@ -231,7 +231,7 @@ class InputFlood:
             'password': {'type': 'string'},
         },
         'additionalProperties': False,
-        'required': ['url'],
+        'required': ['url', 'username', 'password'],
     }
 
     def generate_entry(self, config: dict, torrent: dict) -> Entry:
@@ -268,12 +268,12 @@ class OutputFlood:
 
     Example:
         flood:
-            url: http://localhost:3000
-            username: username
-            password: password
-            path: /downloads/Flexget
-            tags: Flexget
-            action: add
+            url: http://localhost:3000  # Required. Url for Flexget to connect to Flood. 
+            username: flexget           # Required. Username for authentication with Flood.
+            password: password          # Required. Password for authentication with Flood.
+            action: add                 # Required. The action to perform. Can be 'add', 'remove', 'delete', 'start', or 'stop'.
+            path: /downloads            # If the action is set to 'add', the path is relative to the Flood download directory.
+            tags: [ 'Flexget' ]         # If the action is set to 'add', the tags to add to the torrent.
     """
 
     schema = {
@@ -287,7 +287,7 @@ class OutputFlood:
             'tags': {'type': 'array', 'items': {'type': 'string'}},
         },
         'additionalProperties': False,
-        'required': ['url', 'action'],
+        'required': ['url', 'username', 'password', 'action'],
     }
 
     def _add_entry_file(

--- a/flexget/plugins/clients/flood.py
+++ b/flexget/plugins/clients/flood.py
@@ -27,9 +27,7 @@ class FloodClient:
     success_list = [200, 202]
 
     @staticmethod
-    def request(
-        task: Task, config: dict, method: str, url: str, **kwargs
-    ) -> Response:
+    def request(task: Task, config: dict, method: str, url: str, **kwargs) -> Response:
         """
         Send a request to Flood.
         Returns None if the response status_code is not in the success_list.
@@ -151,9 +149,7 @@ class FloodClient:
             data["tags"] = tags
 
         # Attempt to add the torrent URLs to Flood.
-        response = FloodClient.request(
-            task, config, "post", "api/torrents/add-urls", json=data
-        )
+        response = FloodClient.request(task, config, "post", "api/torrents/add-urls", json=data)
 
         # Check if the number of hashes returned by Flood matches the number of URLs.
         if len(response.json()) != len(urls):
@@ -191,9 +187,7 @@ class FloodClient:
             data["tags"] = tags
 
         # Attempt to add the torrent files to Flood.
-        response = FloodClient.request(
-            task, config, "post", "api/torrents/add-files", json=data
-        )
+        response = FloodClient.request(task, config, "post", "api/torrents/add-files", json=data)
 
         # Check if the number of hashes returned by Flood matches the number of files.
         if len(response.json()) != len(files):
@@ -214,9 +208,7 @@ class FloodClient:
             raise PluginError("Not authenticated with Flood.")
 
         # Attempt to list the torrent contents in Flood.
-        response = FloodClient.request(
-            task, config, "get", f"api/torrents/{hash}/contents"
-        )
+        response = FloodClient.request(task, config, "get", f"api/torrents/{hash}/contents")
 
         data = response.json()
 
@@ -259,9 +251,7 @@ class FloodClient:
         if FloodClient.is_jwt_invalid(task):
             raise PluginError("Not authenticated with Flood.")
 
-        FloodClient.request(
-            task, config, "post", "api/torrents/start", json={"hashes": hashes}
-        )
+        FloodClient.request(task, config, "post", "api/torrents/start", json={"hashes": hashes})
         logger.debug(f"Successfully started torrents in Flood.")
 
     @staticmethod
@@ -276,9 +266,7 @@ class FloodClient:
         if FloodClient.is_jwt_invalid(task):
             raise PluginError("Not authenticated with Flood.")
 
-        FloodClient.request(
-            task, config, "post", "api/torrents/stop", json={"hashes": hashes}
-        )
+        FloodClient.request(task, config, "post", "api/torrents/stop", json={"hashes": hashes})
         logger.debug(f"Successfully stopped torrents in Flood.")
 
     @staticmethod
@@ -497,7 +485,7 @@ class OutputFlood:
 
         if not path:
             return entry.fail('No path found for entry or config')
-        
+
         try:
             FloodClient.download_torrent_contents(task, config, entry['flood_hash'], path)
         except PluginError as e:

--- a/flexget/plugins/clients/flood.py
+++ b/flexget/plugins/clients/flood.py
@@ -330,7 +330,12 @@ class InputFlood:
         Generate a task entry from a torrent in Flood.
         """
 
-        entry = Entry(url=urllib.parse.urljoin(config['url'], f"api/torrents/{torrent['hash']}/contents/all/data"), title=torrent['name'])
+        entry = Entry(
+            url=urllib.parse.urljoin(
+                config['url'], f"api/torrents/{torrent['hash']}/contents/all/data"
+            ),
+            title=torrent['name'],
+        )
 
         for key, value in torrent.items():
             entry['flood_' + key.lower()] = value
@@ -374,7 +379,10 @@ class OutputFlood:
             'url': {'type': 'string'},
             'username': {'type': 'string'},
             'password': {'type': 'string'},
-            'action': {'type': 'string', 'enum': ['add', 'remove', 'delete', 'download', 'start', 'stop']},
+            'action': {
+                'type': 'string',
+                'enum': ['add', 'remove', 'delete', 'download', 'start', 'stop'],
+            },
             'path': {'type': 'string'},
             'tags': {'type': 'array', 'items': {'type': 'string'}},
         },

--- a/flexget/plugins/clients/flood.py
+++ b/flexget/plugins/clients/flood.py
@@ -62,8 +62,7 @@ class FloodClient:
             return False
 
         try:
-            decoded_jwt = decode(jwt, algorithms="HS256", options={
-                                 "verify_signature": False})
+            decoded_jwt = decode(jwt, algorithms="HS256", options={"verify_signature": False})
         except:
             return False
 
@@ -81,14 +80,12 @@ class FloodClient:
             config,
             "post",
             "api/auth/authenticate",
-            json={"username": config["username"],
-                  "password": config["password"]},
+            json={"username": config["username"], "password": config["password"]},
         )
 
         # Check if the JWT token is expired or unset.
         if not FloodClient.is_jwt_valid(task):
-            raise PluginError(
-                "Failed to authenticate with Flood. No valid JWT was found.")
+            raise PluginError("Failed to authenticate with Flood. No valid JWT was found.")
 
         logger.debug("Successfully authenticated with Flood.")
 
@@ -152,8 +149,7 @@ class FloodClient:
             data["tags"] = tags
 
         # Attempt to add the torrent URLs to Flood.
-        response = FloodClient.request(
-            task, config, "post", "api/torrents/add-urls", json=data)
+        response = FloodClient.request(task, config, "post", "api/torrents/add-urls", json=data)
 
         # Check if the number of hashes returned by Flood matches the number of URLs.
         if len(response.json()) != len(urls):
@@ -191,8 +187,7 @@ class FloodClient:
             data["tags"] = tags
 
         # Attempt to add the torrent files to Flood.
-        response = FloodClient.request(
-            task, config, "post", "api/torrents/add-files", json=data)
+        response = FloodClient.request(task, config, "post", "api/torrents/add-files", json=data)
 
         # Check if the number of hashes returned by Flood matches the number of files.
         if len(response.json()) != len(files):
@@ -213,8 +208,7 @@ class FloodClient:
             raise PluginError("Not authenticated with Flood.")
 
         # Attempt to list the torrent contents in Flood.
-        response = FloodClient.request(
-            task, config, "get", f"api/torrents/{hash}/contents")
+        response = FloodClient.request(task, config, "get", f"api/torrents/{hash}/contents")
 
         data = response.json()
 
@@ -257,8 +251,7 @@ class FloodClient:
         if not FloodClient.is_jwt_valid(task):
             raise PluginError("Not authenticated with Flood.")
 
-        FloodClient.request(task, config, "post",
-                            "api/torrents/start", json={"hashes": hashes})
+        FloodClient.request(task, config, "post", "api/torrents/start", json={"hashes": hashes})
         logger.debug(f"Successfully started torrents in Flood.")
 
     @staticmethod
@@ -273,8 +266,7 @@ class FloodClient:
         if not FloodClient.is_jwt_valid(task):
             raise PluginError("Not authenticated with Flood.")
 
-        FloodClient.request(task, config, "post",
-                            "api/torrents/stop", json={"hashes": hashes})
+        FloodClient.request(task, config, "post", "api/torrents/stop", json={"hashes": hashes})
         logger.debug(f"Successfully stopped torrents in Flood.")
 
     @staticmethod
@@ -339,8 +331,7 @@ class InputFlood:
 
     def on_task_input(self, task: Task, config: dict):
         if not FloodClient.is_jwt_valid(task):
-            logger.debug(
-                "'jwt' cookie is invalid. Re-authenticating with Flood.")
+            logger.debug("'jwt' cookie is invalid. Re-authenticating with Flood.")
             FloodClient.authenticate(task, config)
 
         entries = []
@@ -394,11 +385,9 @@ class OutputFlood:
             self._add_entry(task, config, entry)
         elif 'flood_hash' in entry:
             if config['action'] == 'remove':
-                FloodClient.delete_torrents(
-                    task, config, [entry['flood_hash']], False)
+                FloodClient.delete_torrents(task, config, [entry['flood_hash']], False)
             elif config['action'] == 'delete':
-                FloodClient.delete_torrents(
-                    task, config, [entry['flood_hash']], True)
+                FloodClient.delete_torrents(task, config, [entry['flood_hash']], True)
             elif config['action'] == 'start':
                 FloodClient.start_torrents(task, config, [entry['flood_hash']])
             elif config['action'] == 'stop':
@@ -436,8 +425,7 @@ class OutputFlood:
         """
 
         try:
-            FloodClient.add_torrent_urls(
-                task, config, [entry['url']], destination, tags, start)
+            FloodClient.add_torrent_urls(task, config, [entry['url']], destination, tags, start)
         except PluginError as e:
             return entry.fail(e)
 
@@ -450,8 +438,7 @@ class OutputFlood:
         if not FloodClient.is_jwt_valid(task):
             raise PluginError("Not authenticated with Flood.")
 
-        destination: str = entry.render(
-            entry.get('path', config.get('path', '')))
+        destination: str = entry.render(entry.get('path', config.get('path', '')))
         # Combines the tags from the entry and the config.
         # The tags from the entry will be prioritized.
         tags: list = entry.get('tags', []) + [
@@ -499,8 +486,7 @@ class OutputFlood:
             return entry.fail('No path found for entry or config')
 
         try:
-            FloodClient.download_torrent_contents(
-                task, config, entry['flood_hash'], path)
+            FloodClient.download_torrent_contents(task, config, entry['flood_hash'], path)
         except PluginError as e:
             entry.fail(e)
 
@@ -523,8 +509,7 @@ class OutputFlood:
         """
 
         if not imported:
-            raise DependencyError(
-                'pyjwt', 'pyjwt', 'pyjwt is required for this plugin')
+            raise DependencyError('pyjwt', 'pyjwt', 'pyjwt is required for this plugin')
 
         # Don't do anything if no config provided
         if not isinstance(config, dict):
@@ -532,8 +517,7 @@ class OutputFlood:
 
         # Authenticate with Flood if not already authenticated.
         if not FloodClient.is_jwt_valid(task):
-            logger.debug(
-                "'jwt' cookie is invalid. Re-authenticating with Flood.")
+            logger.debug("'jwt' cookie is invalid. Re-authenticating with Flood.")
             FloodClient.authenticate(task, config)
 
         # Process entries

--- a/flexget/plugins/clients/flood.py
+++ b/flexget/plugins/clients/flood.py
@@ -494,6 +494,7 @@ class OutputFlood:
     def on_task_download(self, task: Task, config: dict):
         """
         Use the download plugin to get temp files for entry URLs.
+        Priority is lower than the on_task_output method so that the temp files are available for the add action
         """
 
         if config['action'] == 'add' and 'download' not in task.config:
@@ -502,6 +503,11 @@ class OutputFlood:
 
     @plugin.priority(135)
     def on_task_output(self, task: Task, config: dict):
+        """
+        Process entries on task output.
+        Priority is higher than the on_task_download method so that the temp files are available for the add action
+        """
+
         if not imported:
             raise DependencyError('pyjwt', 'pyjwt', 'pyjwt is required for this plugin')
 

--- a/flexget/plugins/clients/flood.py
+++ b/flexget/plugins/clients/flood.py
@@ -394,6 +394,8 @@ class OutputFlood:
                 FloodClient.stop_torrents(task, config, [entry['flood_hash']])
             elif config['action'] == 'download':
                 self._download_entry(task, config, entry)
+        else:
+            return entry.fail('Entry does not have a flood_hash field.')
 
     def _add_entry_file(
         self, task: Task, config: dict, entry: Entry, destination: str, tags: list, start: bool
@@ -474,9 +476,6 @@ class OutputFlood:
         Requires a 'path' to be set on the config or on the entry.
         Requires a 'jwt' cookie on the tasks requests session to be valid.
         """
-
-        if not 'flood_hash' in entry:
-            entry.fail('No flood_hash found for entry.')
 
         if FloodClient.is_jwt_invalid(task):
             raise PluginError("Not authenticated with Flood.")

--- a/flexget/plugins/clients/flood.py
+++ b/flexget/plugins/clients/flood.py
@@ -445,8 +445,11 @@ class OutputFlood:
             entry.fail('No flood_hash found for entry.')
 
         path: str = entry.render(entry.get('path', config.get('path', '')))
-
-        FloodClient.download_torrent_contents(task, config, entry['flood_hash'], path)
+        
+        try:
+            FloodClient.download_torrent_contents(task, config, entry['flood_hash'], path)
+        except PluginError as e:
+            entry.fail(e)
 
     def add_entry(self, task: Task, config: dict, entry: Entry) -> None:
         """

--- a/flexget/plugins/clients/flood.py
+++ b/flexget/plugins/clients/flood.py
@@ -1,4 +1,3 @@
-
 import time, os, base64
 
 from loguru import logger
@@ -158,7 +157,7 @@ class FloodClient:
             raise PluginError("Not authenticated with Flood.")
 
         try:
-            response = post(f"{config['url']}/api/torrents/start", data={"hashes": hashes }, cookies={ "jwt": self.jwt})
+            response = post(f"{config['url']}/api/torrents/start", json={"hashes": hashes }, cookies={ "jwt": self.jwt})
 
             if response.status_code == 200:
                 logger.debug(f"Successfully started {len(hashes)} torrents in Flood.")
@@ -181,7 +180,7 @@ class FloodClient:
             raise PluginError("Not authenticated with Flood.")
 
         try:
-            response = post(f"{config['url']}/api/torrents/stop", data={"hashes": hashes }, cookies={ "jwt": self.jwt})
+            response = post(f"{config['url']}/api/torrents/stop", json={"hashes": hashes }, cookies={ "jwt": self.jwt})
 
             if response.status_code == 200:
                 logger.debug(f"Successfully stopped {len(hashes)} torrents in Flood.")
@@ -204,7 +203,7 @@ class FloodClient:
             raise PluginError("Not authenticated with Flood.")
 
         try:
-            response = post(f"{config['url']}/api/torrents/delete", data={"hashes": hashes, 'deleteData': deleteData}, cookies={"jwt": self.jwt})
+            response = post(f"{config['url']}/api/torrents/delete", json={"hashes": hashes, "deleteData": deleteData}, cookies={"jwt": self.jwt})
 
             if response.status_code == 200:
                 logger.debug(f"Successfully deleted {len(hashes)} torrents from Flood.")
@@ -214,19 +213,84 @@ class FloodClient:
             return False
         except RequestException as e:
             raise PluginError(f"An error occurred while attempting to delete torrents from Flood: {e}")
+
+class InputFlood:
+    """Creates entries from torrents in Flood based
     
-class OutputFlood:
+    Example:
+        from_flood:
+            url: http://localhost:3000
+            username: username
+            password: password
+    """
+
     schema = {
        'type': 'object',
         'properties': {
             'url': {'type': 'string'},
             'username': {'type': 'string'},
             'password': {'type': 'string'},
-            'action': {'type': 'string', 'enum': ['add', 'remove', 'delete']},
-            'path': {'type': 'string'},
-            'tags': {'type': 'array', 'items': {'type': 'string'}},
         },
         'additionalProperties': False,
+        'required': [ 'url' ]
+    }
+
+    def __init__(self) -> None:
+        self.flood = FloodClient()
+
+    def generate_entry(self, config: dict, torrent: dict) -> Entry:
+        """
+        Generate a task entry from a torrent in Flood.
+        """
+
+        entry = Entry(url='', title=torrent['name'])
+
+        for key, value in torrent.items():
+            entry['flood_' + key.lower()] = value
+
+        return entry
+
+    def on_task_input(self, task: Task, config: dict):
+        if self.flood.is_jwt_expired():
+            logger.debug("JWT token is expired. Re-authenticating with Flood.")
+            self.flood.authenticate(config)
+
+        entries = []
+        torrents = self.flood.list_torrents(config)
+
+        for hash, torrent in torrents.items():
+            entry = self.generate_entry(config, torrent)
+
+            if entry:
+                entries.append(entry)
+
+        return entries
+
+class OutputFlood:
+    """Add, remove, delete, start, or stop torrents in Flood.
+    
+    Example:
+        flood:
+            url: http://localhost:3000
+            username: username
+            password: password
+            path: /downloads/Flexget
+            tags: Flexget
+            action: add
+    """
+
+    schema = {
+       'type': 'object',
+        'properties': {
+            'url': {'type': 'string'},
+            'username': {'type': 'string'},
+            'password': {'type': 'string'},
+            'action': {'type': 'string', 'enum': ['add', 'remove', 'delete', 'start', 'stop']},
+            'path': {'type': 'string'},
+            'tags': {'type': 'array', 'items': {'type': 'string'}}
+        },
+        'additionalProperties': False,
+        'required': [ 'url', 'action' ]
     }
 
     def __init__(self) -> None:
@@ -283,7 +347,7 @@ class OutputFlood:
         Use the download plugin to get temp files for entry URLs.
         """
 
-        if 'download' not in task.config:
+        if config['action'] == 'add' and 'download' not in task.config:
             download = plugin.get('download', self)
             download.get_temp_files(task)
 
@@ -300,11 +364,21 @@ class OutputFlood:
         if self.flood.is_jwt_expired():
             logger.debug("JWT token is expired. Re-authenticating with Flood.")
             self.flood.authenticate(config)
-        
-        if config['action'] == 'add':
-            for entry in task.accepted:
+
+        for entry in task.accepted:
+            if config['action'] == 'add':
                 self.add_entry(config, task, entry)
+            elif 'flood_hash' in entry:
+                if config['action'] == 'remove':
+                    self.flood.delete_torrents(config, [ entry['flood_hash'] ], False)
+                elif config['action'] == 'delete':
+                    self.flood.delete_torrents(config, [ entry['flood_hash'] ], True)
+                elif config['action'] == 'start':
+                    self.flood.start_torrents(config, [ entry['flood_hash'] ])
+                elif config['action'] == 'stop':
+                    self.flood.stop_torrents(config, [ entry['flood_hash'] ])
 
 @event('plugin.register')
 def register_plugin():
+    plugin.register(InputFlood, 'from_flood', api_ver=2)
     plugin.register(OutputFlood, 'flood', api_ver=2)

--- a/flexget/plugins/clients/flood.py
+++ b/flexget/plugins/clients/flood.py
@@ -305,7 +305,7 @@ class OutputFlood:
 
     Example:
         flood:
-            url: http://localhost:3000  # Required. Url for Flexget to connect to Flood. 
+            url: http://localhost:3000  # Required. Url for Flexget to connect to Flood.
             username: flexget           # Required. Username for authentication with Flood.
             password: password          # Required. Password for authentication with Flood.
             action: add                 # Required. The action to perform. Can be 'add', 'remove', 'delete', 'start', or 'stop'.

--- a/flexget/plugins/clients/flood.py
+++ b/flexget/plugins/clients/flood.py
@@ -1,0 +1,221 @@
+
+import time, os, base64
+
+from loguru import logger
+from requests import post
+from requests.exceptions import RequestException
+
+from flexget import plugin
+from flexget.plugin import DependencyError, PluginError
+from flexget.event import event
+from flexget.entry import Entry
+from flexget.task import Task
+
+try:
+    from jwt import decode
+    imported = True
+except ImportError:
+    imported = False
+
+logger = logger.bind(name='flood')
+
+
+class FloodClient:
+    def __init__(self) -> None:
+        self.jwt = ""
+    
+    def is_jwt_expired(self) -> bool:
+        """
+        Check if the JWT token is expired.
+        Returns True if the JWT token is expired or if the JWT token is not set.
+        """
+
+        if not self.jwt:
+            return True
+
+        try:
+            decoded_jwt = decode(self.jwt, algorithms="HS256", options={"verify_signature": False})
+        except:
+            return True
+
+        return decoded_jwt.get("exp", 0) <= time.time()
+
+    def authenticate(self, config: dict) -> None:
+        """
+        Authenticate with Flood and obtain a JWT token.
+        """
+        
+        try:
+            response = post(f"{config['url']}/api/auth/authenticate", json={
+                "username": config["username"],
+                "password": config["password"]
+            })
+
+            if response.status_code == 200 and response.cookies.get("jwt"):
+                self.jwt = response.cookies.get("jwt")
+                logger.debug("Successfully authenticated with Flood.")
+            else:
+                raise PluginError(f"Failed to authenticate with Flood. (status={response.status_code})")
+        except RequestException as e:
+            raise PluginError(f"An error occurred while attempting to authenticate with Flood: {e}")
+    
+    def add_torrent_urls(self, config: dict, urls: list, destination: str = None, tags: list = None, start: bool = True) -> bool:
+        """
+        Add a list of torrent URLs to Flood.
+        Will only attempt to add torrents if the JWT token is not expired or unset.
+        """
+
+        if not urls:
+            raise PluginError("Parameter 'urls' cannot be empty.")
+        if self.is_jwt_expired():
+            raise PluginError("Not authenticated with Flood.")
+
+        data = {
+            "urls": urls,
+            "start": start
+        }
+
+        if destination:
+            data["destination"] = destination
+        if tags:
+            data["tags"] = tags
+
+        try:
+            response = post(f"{config['url']}/api/torrents/add-urls", json=data, cookies={"jwt": self.jwt})
+
+            if response.status_code == 200:
+                logger.debug(f"Successfully added {len(urls)} urls to Flood.")
+                return True
+
+            logger.debug(f"Failed to add {len(urls)} urls to Flood. (status={response.status_code})")
+            return False                        
+        except RequestException as e:
+            raise PluginError(f"An error occurred while attempting to add torrent urls to Flood: {e}")
+
+    def add_torrent_files(self, config: dict, files: list, destination: str = None, tags: list = None, start: bool = True) -> bool:
+        """
+        Add a list of torrent files to Flood.
+        Each file must be in base64 encoded format.
+        Will only attempt to add torrents if the JWT token is not expired or unset.
+        """
+
+        if not files:
+            raise PluginError("Parameter 'urls' cannot be empty.")
+        if self.is_jwt_expired():
+            raise PluginError("Not authenticated with Flood.")
+
+        data = {
+            "files": files,
+            "start": start
+        }
+
+        if destination:
+            data["destination"] = destination
+        if tags:
+            data["tags"] = tags
+        
+        try:
+            response = post(f"{config['url']}/api/torrents/add-files", json=data, cookies={"jwt": self.jwt})
+
+            if response.status_code == 200:
+                logger.debug(f"Successfully added {len(files)} files to Flood.")
+                return True
+
+            logger.debug(f"Failed to add {len(files)} files to Flood. (status={response.status_code})")
+            return False
+        except RequestException as e:
+            raise PluginError(f"An error occurred while attempting to add torrent files to Flood: {e}")
+    
+class OutputFlood:
+    schema = {
+       'type': 'object',
+        'properties': {
+            'url': {'type': 'string'},
+            'username': {'type': 'string'},
+            'password': {'type': 'string'},
+            'action': {'type': 'string', 'enum': ['add', 'update', 'remove', 'delete']},
+            'path': {'type': 'string'},
+            'tags': {'type': 'array', 'items': {'type': 'string'}},
+        },
+        'additionalProperties': False,
+    }
+
+    def __init__(self) -> None:
+        self.flood = FloodClient()
+
+    def add_entry(self, config: dict, task: Task, entry: Entry) -> None:
+        """
+        Add an entry to Flood.
+        Will only attempt to add torrents if the JWT token is not expired or unset.
+        """
+
+        if self.flood.is_jwt_expired():
+            raise PluginError("Not authenticated with Flood.")
+
+        destination: str = entry.render(entry.get('path', ''), config.get('path', ''))
+        # Combines the tags from the entry and the config.
+        # The tags from the entry will be prioritized.
+        tags: list = entry.get('tags', []) + [ tag for tag in config.get('tags', []) if not tag in entry.get('tags', []) ]
+        tags = [ entry.render(tag) for tag in tags ]
+        start: bool = entry.get('start', config.get('start', True))
+
+        if task.manager.options.test:
+            logger.info('Would add {} to Flood with options:', entry['title'])
+
+            if entry.get('file'):
+                logger.info('  File: {}', entry['file'])
+            elif entry.get('url'):
+                logger.info('  Url: {}', entry['url'])
+            else:
+                logger.info('  No URL or File found.')
+
+            logger.info('  Destination: {}', destination)
+            logger.info('  Tags: {}', ', '.join(tags) or 'None')
+            logger.info('  Start: {}', config.get('start', True))
+            return
+        
+        if entry.get('file'):
+            if not os.path.exists(entry['file']):
+                return entry.fail('Temp file not found.')
+
+            with open(entry['file'], 'rb') as fs:
+                encoded_file = base64.b64encode(fs.read()).decode('utf-8')
+                if not self.flood.add_torrent_files(config, files=[ encoded_file ], destination=destination, tags=tags, start=start):
+                    return entry.fail('Failed to add file(s) to Flood.')
+        elif entry.get('url'):
+            if not self.flood.add_torrent_urls(config, urls=[ entry['url'] ], destination=destination, tags=tags, start=start):
+                return entry.fail('Failed to add url(s) to Flood.')
+        else:
+            return entry.fail('No URL or File found.')
+
+    @plugin.priority(120)
+    def on_task_download(self, task: Task, config: dict):
+        """
+        Use the download plugin to get temp files for entry URLs.
+        """
+
+        if 'download' not in task.config:
+            download = plugin.get('download', self)
+            download.get_temp_files(task)
+
+    @plugin.priority(135)
+    def on_task_output(self, task: Task, config: dict):
+        if not imported:
+            raise DependencyError('pyjwt', 'pyjwt', 'pyjwt is required for this plugin')
+
+        # Don't do anything if no config provided
+        if not isinstance(config, dict):
+            return
+
+        # Authenticate with Flood if not already authenticated.
+        if self.flood.is_jwt_expired():
+            logger.debug("JWT token is expired. Re-authenticating with Flood.")
+            self.flood.authenticate(config)
+        
+        if config['action'] == 'add':
+            for entry in task.accepted:
+                self.add_entry(config, task, entry)
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(OutputFlood, 'flood', api_ver=2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,4 +74,3 @@ win32-setctime==1.1.0 ; python_version >= "3.7" and python_version < "4.0" and s
 zc-lockfile==2.0 ; python_version >= "3.7" and python_version < "4.0"
 zipp==3.11.0 ; python_version >= "3.7" and python_version < "3.10"
 zxcvbn-python==4.4.24 ; python_version >= "3.7" and python_version < "4.0"
-pyjwt==2.6.0 ; python_version >= "3.7" and python_version < "4.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,3 +74,4 @@ win32-setctime==1.1.0 ; python_version >= "3.7" and python_version < "4.0" and s
 zc-lockfile==2.0 ; python_version >= "3.7" and python_version < "4.0"
 zipp==3.11.0 ; python_version >= "3.7" and python_version < "3.10"
 zxcvbn-python==4.4.24 ; python_version >= "3.7" and python_version < "4.0"
+pyjwt==2.6.0 ; python_version >= "3.7" and python_version < "4.0"


### PR DESCRIPTION
### Motivation for changes:
Wanted to interface with [Flood](https://github.com/jesec/flood). Originally created a plugin that I've been using for 18 monthes at this point but the PR went stale. 
See #3072.

### Detailed changes:
- Adds new dependency `pyjwt`, for parsing Flood's JWT token. 
- Adds two new plugins, `flood` and `from_flood` for interfacing with Flood.

### Config
```
flood:
  url: '{? flood.url ?}'
  username: '{? flood.username ?}'
  password: '{? flood.password ?}'
  action: 'add'
  path: '/download/'
  tags:
    - Flexget
    
from_flood:
  url: '{? flood.url ?}'
  username: '{? flood.username ?}'
  password: '{? flood.password ?}'
```

#### To Do:

- [x] Download action for OutputFlood

