### PR TITLE
Don't override default timezone in the scheduler

### DIFF
--- a/flexget/components/scheduler/scheduler.py
+++ b/flexget/components/scheduler/scheduler.py
@@ -1,4 +1,3 @@
-import datetime
 import hashlib
 import logging
 import os
@@ -126,7 +125,6 @@ def setup_scheduler(manager):
     scheduler = BackgroundScheduler(
         jobstores=jobstores,
         job_defaults=job_defaults,
-        timezone=datetime.datetime.now().astimezone().tzinfo,
     )
     setup_jobs(manager)
 


### PR DESCRIPTION
### Motivation for changes:

Fix #3603.

### Detailed changes:

Since the change in #3453, the code was passing a non-pytz timezone, causing #3603.

All we want to do is to tell appscheduler to use the local timezone, and as seen in the documentation for [appscheduler.schedulers.base][1], the local timezone is already the default value, so there is no need to pass this option.

[1]: https://apscheduler.readthedocs.io/en/3.x/modules/schedulers/base.html#module-apscheduler.schedulers.base

### Addressed issues/feature requests:
- Fixes #3603.