### PR TITLE
Fix for pyload ng

### DIFF
--- a/flexget/plugins/clients/pyload.py
+++ b/flexget/plugins/clients/pyload.py
@@ -155,11 +155,17 @@ class PluginPyLoad:
 
         for entry in task.accepted:
             # bunch of urls now going to check
-            content = entry.get('description', '') + ' ' + quote(entry['url'])
-            content = json.dumps(content)
+            contents = []
+            description = entry.get('description', '')
+            if description != '':
+                contents.append(description)
+            contents.append(quote(entry['url']))
+            content = " ".join(contents)
+
+            content = repr(content)
 
             if is_pyload_ng:
-                url = entry['url'] if config.get('parse_url', self.DEFAULT_PARSE_URL) else ''
+                url = repr(entry['url'] if config.get('parse_url', self.DEFAULT_PARSE_URL) else '')
             else:
                 url = (
                     json.dumps(entry['url'])
@@ -222,8 +228,8 @@ class PluginPyLoad:
 
                 if is_pyload_ng:
                     data = {
-                        'name': name.encode('ascii', 'ignore').decode(),
-                        'links': urls,
+                        'name': repr(name.encode('ascii', 'ignore').decode()),
+                        'links': repr(urls),
                         'dest': dest,
                     }
                 else:

--- a/flexget/plugins/clients/pyload.py
+++ b/flexget/plugins/clients/pyload.py
@@ -156,8 +156,8 @@ class PluginPyLoad:
         for entry in task.accepted:
             # bunch of urls now going to check
             contents = []
-            description = entry.get('description', '')
-            if description != '':
+            description = entry.get('description')
+            if description is not None:
                 contents.append(description)
             contents.append(quote(entry['url']))
             content = " ".join(contents)


### PR DESCRIPTION
### Motivation for changes:
pyload-ng is throwing an exception when pushing contents

### Detailed changes:
- pyload is using ast.parse_literals when parsing the inputs, so, argements have to be encoded accoringly.

### Log and/or tests output (preferably both):
before:
```
  File "/home/stefan/arbeit/privat/flexget/flexget/plugins/clients/pyload.py", line 45, in post
    return self.requests.post(self.url.rstrip("/") + "/" + method.strip("/"), data=data)
           │    │        │    │    │   │                   │      │                └ {'html': '" http%3A//some.url.com/12345"', 'url': ''}
           │    │        │    │    │   │                   │      └ <method 'strip' of 'str' objects>
           │    │        │    │    │   │                   └ 'parse_urls'
           │    │        │    │    │   └ <method 'rstrip' of 'str' objects>
           │    │        │    │    └ 'http://localhost:8000/api'
           │    │        │    └ <flexget.plugins.clients.pyload.PyloadApi object at 0x7f7ad7289550>
           │    │        └ <function Session.post at 0x7f7ae58d34c0>
           │    └ <flexget.utils.requests.Session object at 0x7f7ad5bf3ed0>
           └ <flexget.plugins.clients.pyload.PyloadApi object at 0x7f7ad7289550>

  File "/home/stefan/arbeit/privat/flexget/venv/lib/python3.11/site-packages/requests/sessions.py", line 635, in post
    return self.request("POST", url, data=data, json=json, **kwargs)
           │    │               │         │          │       └ {}
           │    │               │         │          └ None
           │    │               │         └ {'html': '" http%3A//some.url.com/12345"', 'url': ''}
           │    │               └ 'http://localhost:8000/api/parse_urls'
           │    └ <function Session.request at 0x7f7ae4751760>
           └ <flexget.utils.requests.Session object at 0x7f7ad5bf3ed0>

  File "/home/stefan/arbeit/privat/flexget/flexget/utils/requests.py", line 270, in request
    result.raise_for_status()
    │      └ <function Response.raise_for_status at 0x7f7ae58d2020>
    └ <Response [500]>

  File "/home/stefan/arbeit/privat/flexget/venv/lib/python3.11/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
          │         │                        └ <Response [500]>
          │         └ '500 Server Error: INTERNAL SERVER ERROR for url: http://localhost:8000/api/parse_urls'
          └ <class 'requests.exceptions.HTTPError'>

requests.exceptions.HTTPError: 500 Server Error: INTERNAL SERVER ERROR for url: http://localhost:8000/api/parse_urls
```
after:
```
3-02-11 22:13:17 DEBUG    utils.requests test_pyload     POSTing URL http://localhost:8000/api/parse_urls with args () and kwargs {'data': {'html': "'http%3A//some.url.com/12345'", 'url': "''"}, 'json': None, 'timeout': 30}
2023-02-11 22:13:18 DEBUG    pyload        test_pyload     Add 1 urls to pyLoad
2023-02-11 22:13:18 TRACE    entry         test_pyload     rendering: Top Gun
2023-02-11 22:13:18 DEBUG    utils.requests test_pyload     POSTing URL http://localhost:8000/api/add_package with args () and kwargs {'data': {'name': "'Top Gun'", 'links': "['http://some.url.com/12345']", 'dest': 0}, 'json': None, 'timeout': 30}
2023-02-11 22:13:18 DEBUG    pyload        test_pyload     added package pid: 39
```


