### PR TITLE
Fix for empty lazy field

### DIFF
--- a/flexget/plugins/output/rss.py
+++ b/flexget/plugins/output/rss.py
@@ -198,7 +198,7 @@ class OutputRSS:
                 )
                 rss.title = entry['title']
             for field in config['link']:
-                if field in entry and entry[field] is not None:
+                if entry.get(field) is not None:
                     rss.link = entry[field]
                     break
 

--- a/flexget/plugins/output/rss.py
+++ b/flexget/plugins/output/rss.py
@@ -198,7 +198,7 @@ class OutputRSS:
                 )
                 rss.title = entry['title']
             for field in config['link']:
-                if field in entry:
+                if field in entry and entry[field] is not None:
                     rss.link = entry[field]
                     break
 


### PR DESCRIPTION
### Motivation for changes:
make_rss throws error when evaluating links for entries where lookup fails

### Detailed changes:
- Not only check for existance of a field, but also check, whether it's filled

### Log and/or tests output (preferably both):
```
  File "/home/stefan/arbeit/privat/flexget/flexget/plugins/output/rss.py", line 258, in on_task_exit
    hasher.update(db_item.link.encode('utf8'))
    │      │      │       └ <sqlalchemy.orm.attributes.InstrumentedAttribute object at 0x7f0083be8ef0>
    │      │      └ <flexget.plugins.output.rss.RSSEntry object at 0x7f008144b950>
    │      └ <method 'update' of '_hashlib.HASH' objects>
    └ <sha1 _hashlib.HASH object @ 0x7f0082650a90>
```
after:
```
2023-02-12 22:30:49 TRACE    make_rss      offer_series    Adding Top Gun into rss flexget.rss
2023-02-12 22:30:49 VERBOSE  make_rss      offer_series    Writing output rss to flexget.rss
```


