### PR TITLE
[fix] sftp_list - check host_key before accessing keys of dict

### DIFF
--- a/flexget/components/ftp/sftp.py
+++ b/flexget/components/ftp/sftp.py
@@ -396,7 +396,7 @@ def task_config_to_sftp_config(config: dict) -> SftpConfig:
     private_key_pass: str = config['private_key_pass']
 
     host_key: Optional[HostKey] = None
-    if 'host_key' in config:
+    if config.get('host_key') is not None:
         host_key = HostKey(config['host_key']['key_type'], config['host_key']['public_key'])
 
     return SftpConfig(host, port, username, password, private_key, private_key_pass, host_key)


### PR DESCRIPTION
### Motivation for changes:
`sftp_list` configurations that do not set `host_key` via Flexget are currently broken.

### Detailed changes:
- #3641 introduced the `host_key` configuration that allows the setting of the SFTP server host key via Flexget rather than relying on the system lookup.
- The `host_key` config key is defaulted to `None` and no check is currently done to ensure its populated before accessing sub-keys.  This causes an exception: `TypeError: 'NoneType' object is not subscriptable`.

### Addressed issues/feature requests:
- Fixes the above mentioned issue.

### Config usage if relevant (new plugin or updated schema):
n/a

### Log and/or tests output (preferably both):
This is challenging to test, which is probably the whole point of #3641 doing the refactor (and adding the new config options) to make this more testable.

#### To Do:

