### PR TITLE
[fix] Memory leak when there is no sys.stderr

### DIFF
--- a/flexget/__init__.py
+++ b/flexget/__init__.py
@@ -22,6 +22,8 @@ def main(args: Sequence[str] = None):
         try:
             manager = Manager(args)
         except (OSError, ValueError) as e:
+            options = Manager.parse_initial_options(args)
+            log.start(level=options.loglevel, to_file=False)
             if _is_debug():
                 import traceback
 
@@ -36,10 +38,6 @@ def main(args: Sequence[str] = None):
                 to_file=manager.check_ipc_info() is None,
                 to_console=not manager.options.cron,
             )
-        finally:
-            # If we already ran due to no errors, the extra call to log.start won't do anything
-            options = Manager.parse_initial_options(args)
-            log.start(level=options.loglevel, to_file=False)
 
         try:
             if manager.options.profile:

--- a/flexget/__init__.py
+++ b/flexget/__init__.py
@@ -22,8 +22,6 @@ def main(args: Sequence[str] = None):
         try:
             manager = Manager(args)
         except (OSError, ValueError) as e:
-            options = Manager.parse_initial_options(args)
-            log.start(level=options.loglevel, to_file=False)
             if _is_debug():
                 import traceback
 
@@ -35,9 +33,13 @@ def main(args: Sequence[str] = None):
             log.start(
                 manager.log_filename,
                 manager.options.loglevel,
-                to_file=manager.check_ipc_info() is not None,
+                to_file=manager.check_ipc_info() is None,
                 to_console=not manager.options.cron,
             )
+        finally:
+            # If we already ran due to no errors, the extra call to log.start won't do anything
+            options = Manager.parse_initial_options(args)
+            log.start(level=options.loglevel, to_file=False)
 
         try:
             if manager.options.profile:

--- a/flexget/__init__.py
+++ b/flexget/__init__.py
@@ -11,15 +11,19 @@ from flexget import log  # noqa
 from flexget.manager import Manager  # noqa
 
 
-def main(args: Sequence = None):
+def main(args: Sequence[str] = None):
     """Main entry point for Command Line Interface"""
 
+    if args is None:
+        args = sys.argv[1:]
     try:
         log.initialize()
 
         try:
             manager = Manager(args)
         except (OSError, ValueError) as e:
+            options = Manager.parse_initial_options(args)
+            log.start(level=options.loglevel, to_file=False)
             if _is_debug():
                 import traceback
 
@@ -27,6 +31,13 @@ def main(args: Sequence = None):
             else:
                 print('Could not instantiate manager: %s' % e, file=sys.stderr)
             sys.exit(1)
+        else:
+            log.start(
+                manager.log_filename,
+                manager.options.loglevel,
+                to_file=manager.check_ipc_info() is not None,
+                to_console=not manager.options.cron,
+            )
 
         try:
             if manager.options.profile:

--- a/flexget/log.py
+++ b/flexget/log.py
@@ -116,15 +116,6 @@ def remove_filter(func: Callable[['loguru.Record'], bool]):
     _log_filters.remove(func)
 
 
-@event("manager.initialize")
-@event("manager.execute.started")
-def logging_stats(*args):
-    print(
-        f"startup_buffer_id={_startup_buffer_id} logging_started={_logging_started} logging_configured={_logging_configured}"
-    )
-    print(f"startup buffer len: {len(_startup_buffer) if _startup_buffer else _startup_buffer}")
-
-
 def initialize(unit_test: bool = False) -> None:
     """Prepare logging."""
     # Remove default loguru sinks
@@ -155,7 +146,6 @@ def initialize(unit_test: bool = False) -> None:
     _startup_buffer_id = logger.add(
         lambda message: _startup_buffer.append(message.record), level='DEBUG', format=LOG_FORMAT
     )
-    print(f"Added startup buffer handler. {_startup_buffer_id}")
 
     # Add a handler that sores the last 100 debug lines to `debug_buffer` for use in crash reports
     logger.add(
@@ -207,8 +197,7 @@ def start(
             sys.stdout.reconfigure(errors='replace')
             logger.add(sys.stdout, level=level, format=LOG_FORMAT, filter=_log_filterer)
 
-    if _startup_buffer_id:
-        print(f"Removing startup buffer handler. {_startup_buffer_id}")
+    if _startup_buffer_id is not None:
         logger.remove(_startup_buffer_id)
         _startup_buffer_id = None
 

--- a/flexget/log.py
+++ b/flexget/log.py
@@ -119,12 +119,10 @@ def remove_filter(func: Callable[['loguru.Record'], bool]):
 @event("manager.initialize")
 @event("manager.execute.started")
 def logging_stats(*args):
-    logger.info(
-        f"{_startup_buffer=} {_startup_buffer_id=} {_logging_started=} {_logging_configured=}"
+    print(
+        f"startup_buffer_id={_startup_buffer_id} logging_started={_logging_started} logging_configured={_logging_configured}"
     )
-    logger.info(
-        f"startup buffer len: {len(_startup_buffer) if _startup_buffer else _startup_buffer}"
-    )
+    print(f"startup buffer len: {len(_startup_buffer) if _startup_buffer else _startup_buffer}")
 
 
 def initialize(unit_test: bool = False) -> None:
@@ -157,7 +155,7 @@ def initialize(unit_test: bool = False) -> None:
     _startup_buffer_id = logger.add(
         lambda message: _startup_buffer.append(message.record), level='DEBUG', format=LOG_FORMAT
     )
-    logger.bind(startup=True).info("Added startup buffer handler.")
+    print(f"Added startup buffer handler. {_startup_buffer_id}")
 
     # Add a handler that sores the last 100 debug lines to `debug_buffer` for use in crash reports
     logger.add(
@@ -210,7 +208,7 @@ def start(
             logger.add(sys.stdout, level=level, format=LOG_FORMAT, filter=_log_filterer)
 
     if _startup_buffer_id:
-        logger.info("Removing startup buffer handler.")
+        print(f"Removing startup buffer handler. {_startup_buffer_id}")
         logger.remove(_startup_buffer_id)
         _startup_buffer_id = None
 

--- a/flexget/log.py
+++ b/flexget/log.py
@@ -194,18 +194,8 @@ def start(
             logger.debug("No sys.stdout, can't log to console.")
         else:
             # Make sure we don't send any characters that the current terminal doesn't support printing
-            if sys.version_info >= (3, 7):
-                sys.stdout.reconfigure(errors='replace')
-                out = sys.stdout
-            else:
-                out = io.TextIOWrapper(sys.stdout.buffer, encoding=io_encoding, errors='replace')
-                # Loguru only autodetects whether we need to wrap the stream only when it's sys.__stdout__
-                # since we've already wrapped it we need to add the colorama support ourselves
-                if os.name == "nt":
-                    out = colorama.AnsiToWin32(
-                        out, convert=True, strip=False, autoreset=False
-                    ).stream
-            logger.add(out, level=level, format=LOG_FORMAT, filter=_log_filterer)
+            sys.stdout.reconfigure(errors='replace')
+            logger.add(sys.stdout, level=level, format=LOG_FORMAT, filter=_log_filterer)
 
     # flush what we have stored from the plugin initialization
     global _startup_buffer, _startup_buffer_id

--- a/flexget/log.py
+++ b/flexget/log.py
@@ -165,9 +165,14 @@ def start(
     filename: str = None, level: str = 'INFO', to_console: bool = True, to_file: bool = True
 ) -> None:
     """After initialization, start file logging."""
-    global _logging_started
+    global _logging_started, _startup_buffer, _startup_buffer_id
 
     assert _logging_configured
+
+    if _startup_buffer_id:
+        logger.remove(_startup_buffer_id)
+        _startup_buffer_id = None
+
     if _logging_started:
         return
 
@@ -198,12 +203,9 @@ def start(
             logger.add(sys.stdout, level=level, format=LOG_FORMAT, filter=_log_filterer)
 
     # flush what we have stored from the plugin initialization
-    global _startup_buffer, _startup_buffer_id
-    if _startup_buffer_id:
-        logger.remove(_startup_buffer_id)
+    if _startup_buffer:
         for record in _startup_buffer:
             level, message = record['level'].name, record['message']
             logger.patch(lambda r: r.update(record)).log(level, message)
         _startup_buffer = []
-        _startup_buffer_id = None
     _logging_started = True

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -156,6 +156,8 @@ class Manager:
             self.lockfile = os.path.join(self.config_base, f'.test-{self.config_name}-lock')
         self._init_logging()
 
+        manager = self
+
         logger.debug('sys.defaultencoding: {}', sys.getdefaultencoding())
         logger.debug('sys.getfilesystemencoding: {}', sys.getfilesystemencoding())
         logger.debug('flexget detected io encoding: {}', io_encoding)

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -46,13 +46,7 @@ import flexget.log  # noqa
 from flexget import config_schema, db_schema, plugin  # noqa
 from flexget.event import fire_event  # noqa
 from flexget.ipc import IPCClient, IPCServer  # noqa
-from flexget.options import (  # noqa
-    CoreArgumentParser,
-    ParserError,
-    get_parser,
-    manager_parser,
-    unicode_argv,
-)
+from flexget.options import CoreArgumentParser, ParserError, get_parser, manager_parser  # noqa
 from flexget.task import Task  # noqa
 from flexget.task_queue import TaskQueue  # noqa
 from flexget.terminal import console, get_console_output  # noqa
@@ -124,7 +118,7 @@ class Manager:
     unit_test = False
     options: argparse.Namespace
 
-    def __init__(self, args: Optional[List[str]]) -> None:
+    def __init__(self, args: List[str]) -> None:
         """
         :param args: CLI args
         """
@@ -134,9 +128,6 @@ class Manager:
         elif manager:
             logger.info('last manager was not torn down correctly')
 
-        if args is None:
-            # Decode all arguments to unicode before parsing
-            args = unicode_argv()[1:]
         self.args = args
         self.autoreload_config = False
         self.config_file_hash: Optional[str] = None
@@ -158,14 +149,12 @@ class Manager:
 
         self.config: Dict = {}
 
-        self.options = self._init_options(self.args)
-        try:
-            self._init_config(create=False)
-        except Exception:
-            flexget.log.start(level=self.options.loglevel, to_file=False)
-            raise
-
-        manager = self
+        self.options = self.parse_initial_options(args)
+        self._init_config(create=False)
+        # When we are in test mode, we use a different lock file and db
+        if self.options.test:
+            self.lockfile = os.path.join(self.config_base, f'.test-{self.config_name}-lock')
+        self._init_logging()
 
         logger.debug('sys.defaultencoding: {}', sys.getdefaultencoding())
         logger.debug('sys.getfilesystemencoding: {}', sys.getfilesystemencoding())
@@ -187,8 +176,8 @@ class Manager:
         tray_icon.add_menu_separator(index=4)
 
     @staticmethod
-    def _init_options(args: List[str]) -> argparse.Namespace:
-        """Initialize argument parsing"""
+    def parse_initial_options(args: List[str]) -> argparse.Namespace:
+        """Parse what we can from cli args before plugins are loaded."""
         try:
             options = CoreArgumentParser().parse_known_args(args, do_help=False)[0]
         except ParserError as exc:
@@ -202,16 +191,13 @@ class Manager:
                 sys.exit(1)
         return options
 
-    def _init_logging(self, to_file: bool = True) -> None:
-        """Initialize logging facilities"""
+    def _init_logging(self) -> None:
+        """Initialize logging variables"""
         log_file = os.path.expanduser(self.options.logfile)
         # If an absolute path is not specified, use the config directory.
         if not os.path.isabs(log_file):
             log_file = os.path.join(self.config_base, log_file)
         self.log_filename = log_file
-        flexget.log.start(
-            log_file, self.options.loglevel, to_file=to_file, to_console=not self.options.cron
-        )
 
     def initialize(self) -> None:
         """
@@ -342,14 +328,10 @@ class Manager:
         and results will be streamed back.
         If not, this will attempt to obtain a lock, initialize the manager, and run the command here.
         """
-        # When we are in test mode, we use a different lock file and db
-        if self.options.test:
-            self.lockfile = os.path.join(self.config_base, f'.test-{self.config_name}-lock')
         # If another process is started, send the execution to the running process
         ipc_info = self.check_ipc_info()
         # If we are connecting to a running daemon, we don't want to log to the log file,
         # the daemon is already handling that.
-        self._init_logging(to_file=not ipc_info)
         if ipc_info:
             console(
                 'There is a FlexGet process already running for this config, sending execution there.'

--- a/flexget/options.py
+++ b/flexget/options.py
@@ -17,16 +17,6 @@ _UNSET = object()
 core_parser: Optional['CoreArgumentParser'] = None
 
 
-def unicode_argv() -> List[str]:
-    """Like sys.argv, but decodes all arguments."""
-    args = []
-    for arg in sys.argv:
-        if isinstance(arg, bytes):
-            arg = arg.decode(sys.getfilesystemencoding())
-        args.append(arg)
-    return args
-
-
 def get_parser(command: str = None) -> 'ArgumentParser':
     global core_parser
     if not core_parser:
@@ -283,7 +273,7 @@ class ArgumentParser(ArgParser):
             this attribute name in the root parser's namespace
         """
         # Do this early, so even option processing stuff is caught
-        if '--bugreport' in unicode_argv():
+        if '--bugreport' in sys.argv:
             self._debug_tb_callback()
 
         self.subparsers = None
@@ -369,8 +359,7 @@ class ArgumentParser(ArgParser):
         do_help: bool = None,
     ):
         if args is None:
-            # Decode all arguments to unicode before parsing
-            args = unicode_argv()[1:]
+            args = sys.argv[1:]
         if namespace is None:
             namespace = ScopedNamespace()
         old_do_help = ArgumentParser.do_help

--- a/flexget/plugins/output/memusage.py
+++ b/flexget/plugins/output/memusage.py
@@ -48,14 +48,13 @@ def on_manager_shutdown(manager):
 
     try:
         import resource
+
         console(
             'Resource Module memory usage: %s (kb)'
             % resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
         )
     except ImportError:
-        console(
-            'Resource Module memory usage:'
-        )
+        console('Resource Module memory usage:')
 
     global heapy
     console('Heapy module calculating memory usage:')


### PR DESCRIPTION
### Motivation for changes:
In certain cases the startup log buffer could be left installed, and start consuming large amounts of memory.

Turns out that case was when the startup log buffer was the first log sink to be registered. (Which happened with flexget-headless, since there was no console to log to.)

### Detailed changes:
- Makes sure the startup log buffer is always uninstalled
- Cleaned up the logging init/startup logic to be all called from `__init__.py` directly, so that it's easier to reason about.
- Removed some old python 2 compatibility code `unicode_argv` since argv is always unicode on python 3.
- Moves some more of `Manager` variable initialization to actual `__init__` rather than be delayed, so that logging and lock file variables are filled earlier.

### Addressed issues/feature requests:
- Possibly related to #2781
