### PR TITLE
Handle additional SSH Key types

### DIFF
--- a/flexget/components/ftp/sftp_client.py
+++ b/flexget/components/ftp/sftp_client.py
@@ -1,5 +1,6 @@
 import importlib
 import logging
+import os
 import time
 from base64 import b64decode
 from dataclasses import dataclass
@@ -7,7 +8,6 @@ from functools import partial
 from pathlib import Path, PurePath, PurePosixPath
 from typing import Callable, List, Optional
 from urllib.parse import quote, urljoin
-import os
 
 from loguru import logger
 
@@ -24,8 +24,8 @@ HOST_KEY_TYPES: dict = {
 }
 
 try:
-    import pysftp
     import paramiko
+    import pysftp
 
     logging.getLogger("paramiko").setLevel(logging.ERROR)
 except ImportError:
@@ -34,6 +34,7 @@ except ImportError:
 NodeHandler = Callable[[str], None]
 
 logger = logger.bind(name='sftp_client')
+
 
 def _set_authentication_patch(self, password, private_key, private_key_pass):
     """
@@ -61,11 +62,13 @@ def _set_authentication_patch(self, password, private_key, private_key_pass):
             for key in [paramiko.RSAKey, paramiko.DSSKey, paramiko.Ed25519Key, paramiko.ECDSAKey]:
                 try:  # try all the keys
                     self._tconnect['pkey'] = key.from_private_key_file(
-                        private_key_file, private_key_pass)
+                        private_key_file, private_key_pass
+                    )
                     return
-                except paramiko.SSHException:   # if it fails, try dss
+                except paramiko.SSHException:  # if it fails, try dss
                     pass
             raise paramiko.SSHException(f'Unknown key type: {private_key}')
+
 
 @dataclass
 class HostKey:

--- a/flexget/components/ftp/sftp_client.py
+++ b/flexget/components/ftp/sftp_client.py
@@ -7,6 +7,7 @@ from functools import partial
 from pathlib import Path, PurePath, PurePosixPath
 from typing import Callable, List, Optional
 from urllib.parse import quote, urljoin
+import os
 
 from loguru import logger
 
@@ -24,6 +25,7 @@ HOST_KEY_TYPES: dict = {
 
 try:
     import pysftp
+    import paramiko
 
     logging.getLogger("paramiko").setLevel(logging.ERROR)
 except ImportError:
@@ -33,6 +35,37 @@ NodeHandler = Callable[[str], None]
 
 logger = logger.bind(name='sftp_client')
 
+def _set_authentication_patch(self, password, private_key, private_key_pass):
+    """
+    Patch pysftp.Connection._set_authentication to support additional
+    key types
+    """
+    if password is None:
+        # Use Private Key.
+        if not private_key:
+            # Try to use default key.
+            if os.path.exists(os.path.expanduser('~/.ssh/id_rsa')):
+                private_key = '~/.ssh/id_rsa'
+            elif os.path.exists(os.path.expanduser('~/.ssh/id_dsa')):
+                private_key = '~/.ssh/id_dsa'
+            else:
+                raise pysftp.exceptions.CredentialException("No password or key specified.")
+
+        if isinstance(private_key, (paramiko.AgentKey, paramiko.RSAKey)):
+            # use the paramiko agent or rsa key
+            self._tconnect['pkey'] = private_key
+        else:
+            # isn't a paramiko AgentKey or RSAKey, try to build a
+            # key from what we assume is a path to a key
+            private_key_file = os.path.expanduser(private_key)
+            for key in [paramiko.RSAKey, paramiko.DSSKey, paramiko.Ed25519Key, paramiko.ECDSAKey]:
+                try:  # try all the keys
+                    self._tconnect['pkey'] = key.from_private_key_file(
+                        private_key_file, private_key_pass)
+                    return
+                except paramiko.SSHException:   # if it fails, try dss
+                    pass
+            raise paramiko.SSHException(f'Unknown key type: {private_key}')
 
 @dataclass
 class HostKey:
@@ -256,6 +289,7 @@ class SftpClient:
 
         while not sftp:
             try:
+                pysftp.Connection._set_authentication = _set_authentication_patch
                 sftp = pysftp.Connection(
                     host=self.host,
                     username=self.username,


### PR DESCRIPTION
pysftp hasn't been updated in a while, and doesn't handle Ed25519Key and ECDSAKey key types, this monkey patches the _set_authentication method to add handling for these keys.

Ideally Flexget should move directly to using Paramiko but this in itself would be quite a large change.

Unfortunately this is a difficult change to test other than trying it locally.