### PR TITLE
fix: transmission-rpc deprecated base64 torrent content

### DIFF
--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -419,8 +419,7 @@ class PluginTransmission(TransmissionBase):
                 try:
                     if downloaded:
                         with open(entry['file'], 'rb') as f:
-                            filedump = base64.b64encode(f.read()).decode('utf-8')
-                        torrent_info = client.add_torrent(filedump, 30, **options['add'])
+                            torrent_info = client.add_torrent(f, 30, **options['add'])
                     else:
                         if options['post'].get('magnetization_timeout', 0) > 0:
                             options['add']['paused'] = False

--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -1,6 +1,4 @@
-import base64
 import os
-import pathlib
 import re
 from datetime import datetime, timedelta
 from fnmatch import fnmatch
@@ -420,9 +418,8 @@ class PluginTransmission(TransmissionBase):
 
                 try:
                     if downloaded:
-                        torrent_info = client.add_torrent(
-                            pathlib.Path(entry['file']).read_bytes(), **options['add']
-                        )
+                        with open(entry['file'], 'rb') as f:
+                            torrent_info = client.add_torrent(f.read(), **options['add'])
                     else:
                         if options['post'].get('magnetization_timeout', 0) > 0:
                             options['add']['paused'] = False

--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -71,6 +71,7 @@ class TransmissionBase:
                 path=path,
                 username=user,
                 password=password,
+                timeout=30,
             )
         except TransmissionError as e:
             if e.original and e.original.code == 401:
@@ -420,16 +421,12 @@ class PluginTransmission(TransmissionBase):
                 try:
                     if downloaded:
                         torrent_info = client.add_torrent(
-                            pathlib.Path(entry['file']).read_bytes(),
-                            timeout=30,
-                            **options['add'],
+                            pathlib.Path(entry['file']).read_bytes(), **options['add']
                         )
                     else:
                         if options['post'].get('magnetization_timeout', 0) > 0:
                             options['add']['paused'] = False
-                        torrent_info = client.add_torrent(
-                            entry['url'], timeout=30, **options['add']
-                        )
+                        torrent_info = client.add_torrent(entry['url'], **options['add'])
                 except TransmissionError as e:
                     logger.opt(exception=True).debug('TransmissionError')
                     logger.debug('Failed options dict: {}', options['add'])
@@ -616,7 +613,7 @@ class PluginTransmission(TransmissionBase):
 
                 # Set any changed file properties
                 if list(options['change'].keys()):
-                    client.change_torrent(torrent_info.id, 30, **options['change'])
+                    client.change_torrent(torrent_info.id, **options['change'])
 
                 start_torrent = partial(client.start_torrent, [torrent_info.id])
 

--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -1,5 +1,6 @@
 import base64
 import os
+import pathlib
 import re
 from datetime import datetime, timedelta
 from fnmatch import fnmatch
@@ -418,8 +419,11 @@ class PluginTransmission(TransmissionBase):
 
                 try:
                     if downloaded:
-                        with open(entry['file'], 'rb') as f:
-                            torrent_info = client.add_torrent(f, 30, **options['add'])
+                        torrent_info = client.add_torrent(
+                            pathlib.Path(entry['file']).read_bytes(),
+                            timeout=30,
+                            **options['add'],
+                        )
                     else:
                         if options['post'].get('magnetization_timeout', 0) > 0:
                             options['add']['paused'] = False


### PR DESCRIPTION
### Motivation for changes:

### Detailed changes:
- no need to encode torrent content to base64, removed in new transmission-rpc version

### Addressed issues/feature requests:
- Fixes # .


