### PR TITLE
Tweak docker webui install for easier maintenance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/python:3.10-alpine
+FROM docker.io/python:3.11-alpine
 ENV PYTHONUNBUFFERED 1
 
 RUN apk add --no-cache --upgrade \
@@ -25,7 +25,7 @@ RUN wget https://github.com/Flexget/webui/releases/latest/download/dist.zip && \
     unzip dist.zip && \
     rm dist.zip
 
-FROM docker.io/python:3.10-alpine
+FROM docker.io/python:3.11-alpine
 ENV PYTHONUNBUFFERED 1
 
 RUN apk add --no-cache --upgrade \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN pip install -U pip && \
                 cloudscraper && \
     rm -rf /wheels
 
-COPY --from=0 /flexget-ui-v2 /usr/local/lib/python3.10/site-packages/flexget/ui/v2/
+COPY --from=0 /flexget-ui-v2 /usr/local/lib/python3.11/site-packages/flexget/ui/v2/
 
 VOLUME /config
 WORKDIR /config

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,12 @@ WORKDIR /wheels
 COPY . /flexget
 
 RUN pip install -U pip && \
-    pip wheel -e /flexget && \
+    pip install -r /flexget/dev-requirements.txt
+RUN python /flexget/dev_tools.py bundle-webui
+RUN pip wheel -e /flexget && \
     pip wheel 'transmission-rpc>=3.0.0,<4.0.0' && \
     pip wheel deluge-client && \
     pip wheel cloudscraper
-
-WORKDIR /flexget-ui-v2
-RUN wget https://github.com/Flexget/webui/releases/latest/download/dist.zip && \
-    unzip dist.zip && \
-    rm dist.zip
 
 FROM docker.io/python:3.11-alpine
 ENV PYTHONUNBUFFERED 1
@@ -45,8 +42,6 @@ RUN pip install -U pip && \
                 deluge-client \
                 cloudscraper && \
     rm -rf /wheels
-
-COPY --from=0 /flexget-ui-v2 /usr/local/lib/python3.11/site-packages/flexget/ui/v2/
 
 VOLUME /config
 WORKDIR /config


### PR DESCRIPTION
### Motivation for changes:
In #3595 when updating the docker to use python 3.11 it was noted that we had to update the install directory for the webui to match. Rather than have to keep this updated, it's easier if it gets bundled before the flexget wheel gets built, so that it always goes to the right place.

### Detailed changes:
- In the builder image, it installs dev-requirements, then uses our dev_tools.py script to install the webui before building the flexget wheel.
- Also updates python to 3.11
