### PR TITLE
Add template filter to parse human-readable file size to bytes

### DIFF
--- a/flexget/tests/test_jinja_filters.py
+++ b/flexget/tests/test_jinja_filters.py
@@ -37,6 +37,7 @@ class TestJinjaFilters:
         'to_date',
         'strip_year',
         'get_year',
+        'parse_size',
         'asciify',
         'strip_symbols',
     ]

--- a/flexget/tests/test_jinja_filters.py
+++ b/flexget/tests/test_jinja_filters.py
@@ -25,12 +25,14 @@ class TestJinjaFilters:
               - {"title": "The Matrix [13.84 GB]", "actual": 13.84 }
               - {"title": "The Matrix [13.84 GiB]", "actual": 13.84 }
               - {"title": "The Matrix [13 GB]", "actual": 13 }
+              - {"title": "The Matrix [WebRip 6mbps][13.84GB]", "actual": 13.84 }
             
             accept_all: yes
 
             set:
               size: "{{title|parse_size}}"
               size_si: "{{title|parse_size(si=True)}}"
+              size_case: "{{title|parse_size(case=False)}}"
     """
 
     custom_filters = [
@@ -79,7 +81,7 @@ class TestJinjaFilters:
     def test_parse_size(self, execute_task):
         task = execute_task('parse_size')
 
-        assert len(task.accepted) == 4
+        assert len(task.accepted) == 5
 
         assert task.accepted[0]['size'] == int(task.accepted[0]['actual'] * 1024**3)
         assert task.accepted[0]['size_si'] == int(task.accepted[0]['actual'] * 1000**3)
@@ -93,6 +95,10 @@ class TestJinjaFilters:
 
         assert task.accepted[3]['size'] == int(task.accepted[3]['actual'] * 1024**3)
         assert task.accepted[3]['size_si'] == int(task.accepted[3]['actual'] * 1000**3)
+
+        assert task.accepted[4]['size'] == int(task.accepted[4]['actual'] * 1024**3)
+        assert task.accepted[4]['size_si'] == int(task.accepted[4]['actual'] * 1000**3)
+        assert task.accepted[4]['size_case'] == 6 * 1024**2  # a case that parsed wrong size
 
     @pytest.mark.parametrize('test_filter', custom_filters)
     def test_undefined_preserved(self, test_filter):

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -187,7 +187,9 @@ def filter_get_year(name: str) -> str:
     return split_title_year(name).year
 
 
-def filter_parse_size(val: str, match_re: Optional[str] = None, si: bool = False) -> int:
+def filter_parse_size(
+    val: str, match_re: Optional[str] = None, si: bool = False, case: bool = True
+) -> int:
     """Parse human-readable file size to bytes"""
     if not isinstance(val, str):
         return val
@@ -208,16 +210,17 @@ def filter_parse_size(val: str, match_re: Optional[str] = None, si: bool = False
         'PiB': 1024**5,
         'EiB': 1024**6,
     }
+    size_map = {k.casefold(): v for k, v in size_map.items()}
 
     match_re = match_re or r'(?P<digit>\d+(?:\.\d+)?)\s*(?P<unit>[KMGTPE]?i?B)'
-    matched_size = re.search(match_re, val)
+    matched_size = re.search(match_re, val, flags=0 if case else re.IGNORECASE)
 
     if matched_size:
-        unit = matched_size['unit']
-
-        if unit in size_map:
+        unit = matched_size['unit'].casefold()
+        unit_base = size_map.get(unit)
+        if unit_base is not None:
             size = float(matched_size['digit'])
-            return int(size * size_map[unit])
+            return int(size * unit_base)
     return 0
 
 

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -187,29 +187,34 @@ def filter_get_year(name: str) -> str:
     return split_title_year(name).year
 
 
-def filter_parse_size(val: str, match_re: Optional[str] = None) -> int:
+def filter_parse_size(val: str, match_re: Optional[str] = None, si: bool = False) -> int:
     """Parse human-readable file size to bytes"""
     if not isinstance(val, str):
         return val
 
-    match_re = match_re or r'^(?P<digit>\d+(?:\.\d+)?)\s*(?P<unit>[a-zA-Z]+B)$'
-    matched_size = re.match(match_re, val)
+    carry = 1000 if si else 1024
+    size_map = {
+        'B': 1,
+        'KB': carry,
+        'MB': carry**2,
+        'GB': carry**3,
+        'TB': carry**4,
+        'PB': carry**5,
+        'EB': carry**6,
+        'KiB': 1024,
+        'MiB': 1024**2,
+        'GiB': 1024**3,
+        'TiB': 1024**4,
+        'PiB': 1024**5,
+        'EiB': 1024**6,
+    }
+
+    match_re = match_re or r'(?P<digit>\d+(?:\.\d+)?)\s*(?P<unit>[A-Z]?i?B)'
+    matched_size = re.search(match_re, val)
 
     if matched_size:
         unit = matched_size['unit']
-        size_map = {
-            'B': 1,
-            'KB': 1024,
-            'KiB': 1024,
-            'MB': 1024**2,
-            'MiB': 1024**2,
-            'GB': 1024**3,
-            'GiB': 1024**3,
-            'TB': 1024**4,
-            'TiB': 1024**4,
-            'PB': 1024**5,
-            'PiB': 1024**5,
-        }
+
         if unit in size_map:
             size = float(matched_size['digit'])
             return int(size * size_map[unit])

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -187,6 +187,32 @@ def filter_get_year(name: str) -> str:
     return split_title_year(name).year
 
 
+def filter_parse_size(val: str, match_re: Optional[str] = None) -> int:
+    """Parse human-readable file size to bytes"""
+    match_re = match_re or r'^(?P<digit>\d+(?:\.\d+)?)\s*(?P<unit>[a-zA-Z]+B)$'
+    matched_size = re.match(match_re, val)
+
+    if matched_size:
+        unit = matched_size['unit']
+        size_map = {
+            'B': 1,
+            'KB': 1024,
+            'KiB': 1024,
+            'MB': 1024**2,
+            'MiB': 1024**2,
+            'GB': 1024**3,
+            'GiB': 1024**3,
+            'TB': 1024**4,
+            'TiB': 1024**4,
+            'PB': 1024**5,
+            'PiB': 1024**5,
+        }
+        if unit in size_map:
+            size = float(matched_size['digit'])
+            return int(size * size_map[unit])
+    return 0
+
+
 def is_fs_file(pathname: Union[str, os.PathLike]) -> bool:
     """Test whether item is existing file in filesystem"""
     return os.path.isfile(pathname)

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -192,15 +192,15 @@ def filter_parse_size(val: str, match_re: Optional[str] = None, si: bool = False
     if not isinstance(val, str):
         return val
 
-    carry = 1000 if si else 1024
+    base = 1000 if si else 1024
     size_map = {
         'B': 1,
-        'KB': carry,
-        'MB': carry**2,
-        'GB': carry**3,
-        'TB': carry**4,
-        'PB': carry**5,
-        'EB': carry**6,
+        'KB': base,
+        'MB': base**2,
+        'GB': base**3,
+        'TB': base**4,
+        'PB': base**5,
+        'EB': base**6,
         'KiB': 1024,
         'MiB': 1024**2,
         'GiB': 1024**3,
@@ -209,7 +209,7 @@ def filter_parse_size(val: str, match_re: Optional[str] = None, si: bool = False
         'EiB': 1024**6,
     }
 
-    match_re = match_re or r'(?P<digit>\d+(?:\.\d+)?)\s*(?P<unit>[A-Z]?i?B)'
+    match_re = match_re or r'(?P<digit>\d+(?:\.\d+)?)\s*(?P<unit>[KMGTPE]?i?B)'
     matched_size = re.search(match_re, val)
 
     if matched_size:

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -189,6 +189,9 @@ def filter_get_year(name: str) -> str:
 
 def filter_parse_size(val: str, match_re: Optional[str] = None) -> int:
     """Parse human-readable file size to bytes"""
+    if not isinstance(val, str):
+        return val
+    
     match_re = match_re or r'^(?P<digit>\d+(?:\.\d+)?)\s*(?P<unit>[a-zA-Z]+B)$'
     matched_size = re.match(match_re, val)
 

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -191,7 +191,7 @@ def filter_parse_size(val: str, match_re: Optional[str] = None) -> int:
     """Parse human-readable file size to bytes"""
     if not isinstance(val, str):
         return val
-    
+
     match_re = match_re or r'^(?P<digit>\d+(?:\.\d+)?)\s*(?P<unit>[a-zA-Z]+B)$'
     matched_size = re.match(match_re, val)
 


### PR DESCRIPTION
### Motivation for changes:

Some of the plugin, for example `rss` does not produce the `torrent_size` entry field, but for some sites, it actually contains human-readable size like `114.5MB`, `14GB`, or `1.91TB` in the torrent title.
In some cases, we need to filter out the torrents that are larger or smaller than we expected size. In this case, a filter to parse human-readable string to actual bytes number is necessary.

### Detailed changes:
- Added a jinja filter `parse_size`  to support parse the string like `114.5GB` to `122943438848` bytes int

### Config usage if relevant (new plugin or updated schema):

```yaml
tasks:
  download_filtered_size:
    rss: https://example.com/?token=xxxx
    accept_all: yes
    no_entries_ok: yes
    if: # rejects torrents size which are larger than 100GB
      - "title|re_search('\d+(\.\d+)?\s*\w+B')|parse_size > 100 * (1024**3)": reject
```

#### To Do:

Current PR is a proof of concept, if you have any ideas about it, welcome comment.

- [ ] tests
- [ ] document 

