### PR TITLE
[fix] pyload: Fix pyload-ng api support

### DIFF
--- a/flexget/plugins/clients/pyload.py
+++ b/flexget/plugins/clients/pyload.py
@@ -141,13 +141,17 @@ class PluginPyLoad:
         parse_urls_command = 'parseURLs'
         add_package_command = 'addPackage'
         set_package_data_command = 'setPackageData'
+        package_id_parameter = 'pid'
+        folder_key = 'folder'
 
         # pyload-ng is returning dict instead of session string on login
         if isinstance(session, dict):
             is_pyload_ng = True
             parse_urls_command = 'parse_urls'
             add_package_command = 'add_package'
-            set_package_data_command = 'set_package_date'
+            set_package_data_command = 'set_package_data'
+            package_id_parameter = 'package_id'
+            folder_key = '_folder'
 
         hoster = config.get('hoster', self.DEFAULT_HOSTER)
 
@@ -252,8 +256,8 @@ class PluginPyLoad:
                         folder = self.DEFAULT_FOLDER
                         logger.error('Error rendering jinja event: {}', e)
                     # set folder with api
-                    data = json.dumps({'folder': folder})
-                    post_data = {'pid': pid, 'data': data}
+                    data = json.dumps({folder_key: folder})
+                    post_data = {package_id_parameter: pid, 'data': data}
                     if not is_pyload_ng:
                         post_data['session'] = session
                     api.post(set_package_data_command, data=post_data)
@@ -262,7 +266,7 @@ class PluginPyLoad:
                 package_password = config.get('package_password')
                 if package_password:
                     data = json.dumps({'password': package_password})
-                    post_data = {'pid': pid, 'data': data}
+                    post_data = {package_id_parameter: pid, 'data': data}
                     if not is_pyload_ng:
                         post_data['session'] = session
                     api.post(set_package_data_command, data=post_data)


### PR DESCRIPTION
### Motivation for changes:

Adding packages to pyload-ng doesn't work. There are several issues that prevent adding packages:
- Typo in variable `set_package_data_command`
- Parameter name for package_id changed in pyload-ng
- Key for folder name changed in pyload-ng

### Detailed changes:
- Fix typo in set_package_data_command: set_package_dat**a** (instead of set_package_dat**e**)
- Different name for package_id parameter (pyload stable: `pid`, pyload-ng: `package_id`)
- Different name for folder key (pyload stable: `folder`, pyload-ng: `_folder`)

### Log and/or tests output (preferably both):
Without these changes, adding a package to pyload-ng fails with error:
```
500 Server Error: INTERNAL SERVER ERROR for url: http://x.x.x.x:8000/api/set_package_date
```

