### PR TITLE
Fix transmission file list not getting updated

### DIFF
--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -493,6 +493,7 @@ class PluginTransmission(TransmissionBase):
                 skip_files = options['post'].get('skip_files')
                 # We need to index the files if any of the following are defined
                 if find_main_file or skip_files:
+                    torrent_info = client.get_torrent(torrent_info.id)
                     file_list = torrent_info.get_files()
 
                     if options['post'].get('magnetization_timeout', 0) > 0 and not file_list:
@@ -503,6 +504,7 @@ class PluginTransmission(TransmissionBase):
                         )
                         for _ in range(options['post']['magnetization_timeout']):
                             sleep(1)
+                            torrent_info = client.get_torrent(torrent_info.id)
                             file_list = torrent_info.get_files()
                             if file_list:
                                 total_size = client.get_torrent(


### PR DESCRIPTION
### Motivation for changes:
`content_filename` doesn't work in my config and I'm seeing multiple `{title} did not magnetize before the timeout elapsed, file list unavailable for processing` even though the torrent has been magnetized and the file list should be available.
### Detailed changes:
- update `torrent_info` before `get_files()`, because `get_files()` will not update file list automatically and will instead return the status when the torrent object is created

### Config usage if relevant (new plugin or updated schema):
```
tasks:
  test:
    text:
      url: https://archlinux.org/download/
      entry:
        url: "\"(magnet:.*)\""
        title: "(Arch Linux)"
    accept_all: yes
    transmission:
      host: localhost
      port: 9091
      magnetization_timeout: 120
      content_filename: "renamed title"
  
```
### Log and/or tests output (preferably both):
Transmission correctly rename the file


