### PR TITLE
Fix small typos in documentation

### DIFF
--- a/flexget/tests/test_sftp_server.py
+++ b/flexget/tests/test_sftp_server.py
@@ -152,7 +152,7 @@ class TestSFTPFileSystem:
 
     def create_symlink(self, path: str, target: Path) -> Path:
         """
-        Creata a symlink on the :class:`StubSFTPServer` instance, if the
+        Create a symlink on the :class:`StubSFTPServer` instance, if the
         path or target is relative, it will be done so in relation to the
         users home directory.
 

--- a/flexget/tray_icon.py
+++ b/flexget/tray_icon.py
@@ -60,7 +60,7 @@ class TrayIcon:
         **kwargs,
     ):
         """
-        Add a menu item byt passing its text and function, or pass a created MenuItem. Force position by sending index
+        Add a menu item by passing its text and function, or pass a created MenuItem. Force position by sending index
         """
         if not any(v for v in (menu_item, text)):
             raise ValueError("Either 'text' or 'menu_item' are required")


### PR DESCRIPTION
This fixes two small typos in a couple of method docstrings.

Background: I'm doing a research study on function comments that may be incorrect. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).
 
Thanks for reviewing!
