### PR TITLE
Issue 3806 - Add ability to work with rTorrent named custom fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ local
 *.iml
 flexget.log
 flexget.log.*
+crash_report.*.log
 received/
 share/
 dist/

--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -305,7 +305,7 @@ class RTorrent:
             fields = list(self.default_fields)
 
         if not custom_fields:
-            custom_fields = list()
+            custom_fields = []
 
         fields = self._clean_fields(fields)
 
@@ -329,7 +329,7 @@ class RTorrent:
         fields = self._clean_fields(fields)
 
         if not custom_fields:
-            custom_fields = list()
+            custom_fields = []
 
         params = ['d.%s=' % field for field in fields]
 
@@ -343,7 +343,10 @@ class RTorrent:
         resp = self._server.d.multicall2('', params)
 
         # Response is formatted as a list of lists, with just the values
-        return [dict(list(zip(self._clean_fields(fields, reverse=True) + custom_fields, val))) for val in resp]
+        return [
+            dict(list(zip(self._clean_fields(fields, reverse=True) + custom_fields, val)))
+            for val in resp
+        ]
 
     def update(self, info_hash, fields, custom_fields=None):
         if not fields:
@@ -708,7 +711,9 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
             custom_fields = {}
 
         try:
-            resp = client.load(torrent_raw, fields=options, custom_fields=custom_fields, start=start, mkdir=mkdir)
+            resp = client.load(
+                torrent_raw, fields=options, custom_fields=custom_fields, start=start, mkdir=mkdir
+            )
             if resp != 0:
                 entry.fail('Failed to add to rTorrent invalid return value %s' % resp)
         except xmlrpc_client.Error as e:

--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -251,9 +251,13 @@ class RTorrent:
 
         return fields
 
-    def load(self, raw_torrent, fields=None, start=False, mkdir=True):
+    def load(self, raw_torrent, fields=None, custom_fields=None, start=False, mkdir=True):
         if fields is None:
             fields = {}
+
+        if custom_fields is None:
+            custom_fields = {}
+
         # First param is empty 'target'
         params = ['', xmlrpc_client.Binary(raw_torrent)]
 
@@ -262,6 +266,11 @@ class RTorrent:
             # Values must be escaped if within params
             # TODO: What are the escaping requirements? re.escape works differently on python 3.7+
             params.append(f'd.{key}.set={re.escape(str(val))}')
+
+        # Set custom fields
+        for key, val in custom_fields.items():
+            # Values must be escaped if within params
+            params.append(f'd.custom.set={re.escape(str(key))},{re.escape(str(val))}')
 
         if mkdir and 'directory' in fields:
             result = self._server.execute.throw('', 'mkdir', '-p', fields['directory'])
@@ -290,10 +299,13 @@ class RTorrent:
     def get_directory(self):
         return self._server.get_directory()
 
-    def torrent(self, info_hash, fields=None):
+    def torrent(self, info_hash, fields=None, custom_fields=None):
         """Get the details of a torrent"""
         if not fields:
             fields = list(self.default_fields)
+
+        if not custom_fields:
+            custom_fields = list()
 
         fields = self._clean_fields(fields)
 
@@ -303,29 +315,52 @@ class RTorrent:
             method_name = 'd.%s' % field
             getattr(multi_call, method_name)(info_hash)
 
+        for custom_field in custom_fields:
+            method_name = 'd.custom%s' % re.escape(str(custom_field))
+            getattr(multi_call, method_name)(info_hash)
+
         resp = multi_call()
         # TODO: Maybe we should return a named tuple or a Torrent class?
         return dict(list(zip(self._clean_fields(fields, reverse=True), list(resp))))
 
-    def torrents(self, view='main', fields=None):
+    def torrents(self, view='main', fields=None, custom_fields=None):
         if not fields:
             fields = list(self.default_fields)
         fields = self._clean_fields(fields)
 
+        if not custom_fields:
+            custom_fields = list()
+
         params = ['d.%s=' % field for field in fields]
+
+        # Set custom fields
+        for custom_field in custom_fields:
+            # Values must be escaped if within params
+            params.append(f'd.custom={re.escape(str(custom_field))}')
+
         params.insert(0, view)
 
         resp = self._server.d.multicall2('', params)
 
         # Response is formatted as a list of lists, with just the values
-        return [dict(list(zip(self._clean_fields(fields, reverse=True), val))) for val in resp]
+        return [dict(list(zip(self._clean_fields(fields, reverse=True) + custom_fields, val))) for val in resp]
 
-    def update(self, info_hash, fields):
+    def update(self, info_hash, fields, custom_fields=None):
+        if not fields:
+            fields = {}
+
+        if not custom_fields:
+            custom_fields = {}
+
         multi_call = xmlrpc_client.MultiCall(self._server)
 
         for key, val in fields.items():
             method_name = 'd.%s.set' % key
             getattr(multi_call, method_name)(info_hash, val)
+
+        for key, val in custom_fields.items():
+            method_name = 'd.custom.set'
+            getattr(multi_call, method_name)(info_hash, key, val)
 
         return multi_call()[0]
 
@@ -387,6 +422,29 @@ class RTorrentPluginBase:
                 elif entry_value:
                     options[opt_key] = entry.render(entry_value)
 
+        # Add custom fields on to options
+        entry_custom_fields = entry.get('custom_fields')
+        config_custom_fields = config.get('custom_fields')
+
+        if entry_custom_fields is None:
+            entry_custom_fields = {}
+
+        if config_custom_fields is None:
+            config_custom_fields = {}
+
+        merged_custom_fields = {}
+        if entry_first:
+            merged_custom_fields.update(entry_custom_fields)
+            merged_custom_fields.update(config_custom_fields)
+        else:
+            merged_custom_fields.update(config_custom_fields)
+            merged_custom_fields.update(entry_custom_fields)
+
+        if len(merged_custom_fields) > 0:
+            options['custom_fields'] = {}
+            for key, value in merged_custom_fields.items():
+                options['custom_fields'][key] = entry.render(value)
+
         # Convert priority from string to int
         priority = options.get('priority')
         if priority and priority in self.priority_map:
@@ -425,6 +483,7 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
             'custom4': {'type': 'string'},
             'custom5': {'type': 'string'},
             'fast_resume': {'type': 'boolean', 'default': False},
+            'custom_fields': {'type': 'object', 'additionalProperties': {'type': 'string'}},
         },
         'required': ['uri'],
         'additionalProperties': False,
@@ -556,8 +615,13 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
         if 'directory' in options:
             del options['directory']
 
+        if 'custom_fields' in options:
+            custom_fields = options.pop('custom_fields')
+        else:
+            custom_fields = {}
+
         try:
-            client.update(info_hash, options)
+            client.update(info_hash=info_hash, fields=options, custom_fields=custom_fields)
             logger.verbose('Updated {} ({}) in rtorrent ', entry['title'], info_hash)
         except xmlrpc_client.Error as e:
             entry.fail('Failed to update: %s' % str(e))
@@ -637,8 +701,14 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
             # No existing found
             pass
 
+        # Setup options and custom fields
+        if 'custom_fields' in options:
+            custom_fields = options.pop('custom_fields')
+        else:
+            custom_fields = {}
+
         try:
-            resp = client.load(torrent_raw, fields=options, start=start, mkdir=mkdir)
+            resp = client.load(torrent_raw, fields=options, custom_fields=custom_fields, start=start, mkdir=mkdir)
             if resp != 0:
                 entry.fail('Failed to add to rTorrent invalid return value %s' % resp)
         except xmlrpc_client.Error as e:
@@ -673,6 +743,7 @@ class RTorrentInputPlugin(RTorrentPluginBase):
             'digest_auth': {'type': 'boolean', 'default': False},
             'view': {'type': 'string', 'default': 'main'},
             'fields': one_or_more({'type': 'string', 'enum': list(RTorrent.default_fields)}),
+            'custom_fields': {'type': 'array', 'items': {'type': 'string'}},
         },
         'required': ['uri'],
         'additionalProperties': False,
@@ -688,9 +759,10 @@ class RTorrentInputPlugin(RTorrentPluginBase):
         )
 
         fields = config.get('fields')
+        custom_fields = config.get('custom_fields')
 
         try:
-            torrents = client.torrents(config['view'], fields=fields)
+            torrents = client.torrents(config['view'], fields=fields, custom_fields=custom_fields)
         except (OSError, xmlrpc_client.Error) as e:
             task.abort('Could not get torrents ({}): {}'.format(config['view'], e))
             return

--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -426,24 +426,15 @@ class RTorrentPluginBase:
                     options[opt_key] = entry.render(entry_value)
 
         # Add custom fields on to options
-        entry_custom_fields = entry.get('custom_fields')
-        config_custom_fields = config.get('custom_fields')
+        entry_custom_fields = entry.get('custom_fields', {})
+        config_custom_fields = config.get('custom_fields', {})
 
-        if entry_custom_fields is None:
-            entry_custom_fields = {}
-
-        if config_custom_fields is None:
-            config_custom_fields = {}
-
-        merged_custom_fields = {}
         if entry_first:
-            merged_custom_fields.update(entry_custom_fields)
-            merged_custom_fields.update(config_custom_fields)
+            merged_custom_fields = {**config_custom_fields, **entry_custom_fields}
         else:
-            merged_custom_fields.update(config_custom_fields)
-            merged_custom_fields.update(entry_custom_fields)
+            merged_custom_fields = {**entry_custom_fields, **config_custom_fields}
 
-        if len(merged_custom_fields) > 0:
+        if merged_custom_fields:
             options['custom_fields'] = {}
             for key, value in merged_custom_fields.items():
                 options['custom_fields'][key] = entry.render(value)
@@ -705,10 +696,7 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
             pass
 
         # Setup options and custom fields
-        if 'custom_fields' in options:
-            custom_fields = options.pop('custom_fields')
-        else:
-            custom_fields = {}
+        custom_fields = options.pop('custom_fields', {})
 
         try:
             resp = client.load(

--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -270,7 +270,9 @@ class RTorrent:
         # Set custom fields
         for key, val in custom_fields.items():
             # Values must be escaped if within params
-            params.append('d.custom.set="{}","{}"'.format(key.replace('"', '\\"'), val.replace('"', '\\"')))
+            params.append(
+                'd.custom.set="{}","{}"'.format(key.replace('"', '\\"'), val.replace('"', '\\"'))
+            )
 
         if mkdir and 'directory' in fields:
             result = self._server.execute.throw('', 'mkdir', '-p', fields['directory'])

--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -270,7 +270,7 @@ class RTorrent:
         # Set custom fields
         for key, val in custom_fields.items():
             # Values must be escaped if within params
-            params.append(f'd.custom.set={re.escape(str(key))},{re.escape(str(val))}')
+            params.append('d.custom.set="{}","{}"'.format(key.replace('"', '\\"'), val.replace('"', '\\"')))
 
         if mkdir and 'directory' in fields:
             result = self._server.execute.throw('', 'mkdir', '-p', fields['directory'])
@@ -316,7 +316,7 @@ class RTorrent:
             getattr(multi_call, method_name)(info_hash)
 
         for custom_field in custom_fields:
-            method_name = 'd.custom%s' % re.escape(str(custom_field))
+            method_name = 'd.custom={}'.format(custom_field.replace('"', '\\"'))
             getattr(multi_call, method_name)(info_hash)
 
         resp = multi_call()
@@ -336,7 +336,7 @@ class RTorrent:
         # Set custom fields
         for custom_field in custom_fields:
             # Values must be escaped if within params
-            params.append(f'd.custom={re.escape(str(custom_field))}')
+            params.append('d.custom={}'.format(custom_field.replace('"', '\\"')))
 
         params.insert(0, view)
 

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -329,7 +329,9 @@ class TestRTorrentOutputPlugin:
                 'custom1': 'test_custom1',
                 'custom2': 'test_custom2',
             },
-            custom_fields={'named_custom_field_1': 'named custom field value 1',},
+            custom_fields={
+                'named_custom_field_1': 'named custom field value 1',
+            },
             start=False,
             mkdir=False,
         )

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -231,6 +231,8 @@ class TestRTorrentOutputPlugin:
               custom1: test_custom1
               priority: low
               custom2: test_custom2
+              custom_fields:
+                named_custom_field_1: named custom field value 1
             mock:
               - {title: 'test', url: '"""
         + torrent_url
@@ -313,7 +315,7 @@ class TestRTorrentOutputPlugin:
                 'custom1': 'test_custom1',
                 'custom2': 'test_custom2',
             },
-            custom_fields={},
+            custom_fields={'named_custom_field_1': 'named custom field value 1',},
             start=False,
             mkdir=False,
         )

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -365,8 +365,8 @@ class TestRTorrentOutputPlugin:
             info_hash=torrent_info_hash,
             fields={'custom1': 'test_custom1'},
             custom_fields={
-                'named_custom_field_1': 'named custom field value 1 update again'
-                'named_custom_field_update_2': 'some value again'
+                'named_custom_field_1': 'named custom field value 1 update again',
+                'named_custom_field_update_2': 'some value again',
             },
         )
 

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -278,7 +278,7 @@ class TestRTorrentOutputPlugin:
         mocked_client.load.assert_called_with(
             torrent_raw,
             fields={'priority': 3, 'directory': '/data/downloads', 'custom1': 'test_custom1'},
-            custom_fields={}
+            custom_fields={},
             start=True,
             mkdir=True,
         )

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -384,7 +384,9 @@ class TestRTorrentInputPlugin:
         task = execute_task('test_input')
 
         mocked_client.torrents.assert_called_with(
-            'complete', fields=['custom1', 'custom3', 'down_rate']
+            'complete',
+            fields=['custom1', 'custom3', 'down_rate'],
+            custom_fields=None,
         )
 
         assert len(task.all_entries) == 2

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -335,8 +335,8 @@ class TestRTorrentOutputPlugin:
         )
 
         mocked_client.move.assert_called_with(
-            info_hash=torrent_info_hash,
-            dst_path='/new/path',
+            torrent_info_hash,
+            '/new/path',
         )
 
     def test_delete(self, mocked_client, execute_task):
@@ -347,7 +347,7 @@ class TestRTorrentOutputPlugin:
 
         execute_task('test_delete')
 
-        mocked_client.delete.assert_called_with(info_hash=torrent_info_hash)
+        mocked_client.delete.assert_called_with(torrent_info_hash)
 
 
 @mock.patch('flexget.plugins.clients.rtorrent.RTorrent')

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -278,6 +278,7 @@ class TestRTorrentOutputPlugin:
         mocked_client.load.assert_called_with(
             torrent_raw,
             fields={'priority': 3, 'directory': '/data/downloads', 'custom1': 'test_custom1'},
+            custom_fields={}
             start=True,
             mkdir=True,
         )

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -259,6 +259,9 @@ class TestRTorrentOutputPlugin:
               action: update
               uri: http://localhost/SCGI
               custom1: test_custom1
+              custom_fields:
+                named_custom_field_1: named custom field value 1 update
+                named_custom_field_update_1: some value
           test_update_path:
             accept_all: yes
             mock:
@@ -270,6 +273,9 @@ class TestRTorrentOutputPlugin:
               custom1: test_custom1
               uri: http://localhost/SCGI
               path: /new/path
+              custom_fields:
+                named_custom_field_1: named custom field value 1 update again
+                named_custom_field_update_2: some value again
           test_delete:
             accept_all: yes
             mock:
@@ -340,7 +346,10 @@ class TestRTorrentOutputPlugin:
         mocked_client.update.assert_called_with(
             info_hash=torrent_info_hash,
             fields={'priority': 1, 'custom1': 'test_custom1'},
-            custom_fields={},
+            custom_fields={
+                'named_custom_field_1': 'named custom field value 1 update',
+                'named_custom_field_update_1': 'some value',
+            },
         )
 
     def test_update_path(self, mocked_client, execute_task):
@@ -355,7 +364,10 @@ class TestRTorrentOutputPlugin:
         mocked_client.update.assert_called_with(
             info_hash=torrent_info_hash,
             fields={'custom1': 'test_custom1'},
-            custom_fields={},
+            custom_fields={
+                'named_custom_field_1': 'named custom field value 1 update again'
+                'named_custom_field_update_2': 'some value again'
+            },
         )
 
         mocked_client.move.assert_called_with(
@@ -387,7 +399,10 @@ class TestRTorrentInputPlugin:
                 - custom1
                 - custom3
                 - down_rate
-
+              custom_fields:
+                - foo
+                - bar
+                - foobar
     """
 
     def test_input(self, mocked_client, execute_task):
@@ -410,7 +425,7 @@ class TestRTorrentInputPlugin:
         mocked_client.torrents.assert_called_with(
             'complete',
             fields=['custom1', 'custom3', 'down_rate'],
-            custom_fields=None,
+            custom_fields=['foo', 'bar', 'foobar'],
         )
 
         assert len(task.all_entries) == 2

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -197,8 +197,12 @@ class TestRTorrentClient:
 
 @mock.patch('flexget.plugins.clients.rtorrent.RTorrent')
 class TestRTorrentOutputPlugin:
+    variable_value = 'variable field jinja replacesment test value'
+    entry_field_value = 'entry field jinja replacement test value'
     config = (
         """
+        variables:
+            rtorrent_variable_test: '""" + variable_value + """'
         tasks:
           test_add_torrent:
             accept_all: yes
@@ -206,6 +210,8 @@ class TestRTorrentOutputPlugin:
               - {title: 'test', url: '"""
         + torrent_url
         + """'}
+            set:
+              rtorrent_test_add_val: '""" + entry_field_value + """'
             rtorrent:
               action: add
               start: yes
@@ -214,6 +220,10 @@ class TestRTorrentOutputPlugin:
               priority: high
               path: /data/downloads
               custom1: test_custom1
+              custom_fields:
+                named_custom_field_1: named custom field value 1
+                named_custom_field_2: Test variable substitution - '{? rtorrent_variable_test ?}'
+                named_custom_field_3: Test entry field substitution - '{{rtorrent_test_add_val}}'
           test_add_torrent_set:
             accept_all: yes
             set:
@@ -278,7 +288,11 @@ class TestRTorrentOutputPlugin:
         mocked_client.load.assert_called_with(
             torrent_raw,
             fields={'priority': 3, 'directory': '/data/downloads', 'custom1': 'test_custom1'},
-            custom_fields={},
+            custom_fields={
+                'named_custom_field_1': 'named custom field value 1',
+                'named_custom_field_2': "Test variable substitution - '" + self.variable_value + "'",
+                'named_custom_field_3': "Test entry field substitution - '" + self.entry_field_value + "'",
+            },
             start=True,
             mkdir=True,
         )

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -299,6 +299,7 @@ class TestRTorrentOutputPlugin:
                 'custom1': 'test_custom1',
                 'custom2': 'test_custom2',
             },
+            custom_fields={},
             start=False,
             mkdir=False,
         )
@@ -313,7 +314,12 @@ class TestRTorrentOutputPlugin:
         execute_task('test_update')
 
         mocked_client.update.assert_called_with(
-            torrent_info_hash, {'priority': 1, 'custom1': 'test_custom1'}
+            info_hash=torrent_info_hash,
+            fields={
+                'priority': 1,
+                'custom1': 'test_custom1'
+            },
+            custom_fields={},
         )
 
     def test_update_path(self, mocked_client, execute_task):
@@ -325,9 +331,18 @@ class TestRTorrentOutputPlugin:
 
         execute_task('test_update_path')
 
-        mocked_client.update.assert_called_with(torrent_info_hash, {'custom1': 'test_custom1'})
+        mocked_client.update.assert_called_with(
+            info_hash=torrent_info_hash,
+            fields={
+                'custom1': 'test_custom1'
+            },
+            custom_fields={},
+        )
 
-        mocked_client.move.assert_called_with(torrent_info_hash, '/new/path')
+        mocked_client.move.assert_called_with(
+            info_hash=torrent_info_hash,
+            dst_path='/new/path',
+        )
 
     def test_delete(self, mocked_client, execute_task):
         mocked_client = mocked_client()
@@ -337,7 +352,7 @@ class TestRTorrentOutputPlugin:
 
         execute_task('test_delete')
 
-        mocked_client.delete.assert_called_with(torrent_info_hash)
+        mocked_client.delete.assert_called_with(info_hash=torrent_info_hash)
 
 
 @mock.patch('flexget.plugins.clients.rtorrent.RTorrent')

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -315,10 +315,7 @@ class TestRTorrentOutputPlugin:
 
         mocked_client.update.assert_called_with(
             info_hash=torrent_info_hash,
-            fields={
-                'priority': 1,
-                'custom1': 'test_custom1'
-            },
+            fields={'priority': 1, 'custom1': 'test_custom1'},
             custom_fields={},
         )
 
@@ -333,9 +330,7 @@ class TestRTorrentOutputPlugin:
 
         mocked_client.update.assert_called_with(
             info_hash=torrent_info_hash,
-            fields={
-                'custom1': 'test_custom1'
-            },
+            fields={'custom1': 'test_custom1'},
             custom_fields={},
         )
 


### PR DESCRIPTION
### Motivation for changes:

rTorrent has the ability to work with named custom fields, but flexget only exposes the builtin custom1...custom5 fields. This PR is to expose the functionality of named custom fields to flexget for both the `rtorrent` and `from_rtorrent` plugins.

### Detailed changes:
- Modify existinf functions of rtorrent client to work with custom fields

### Addressed issues/feature requests:
Implements #3806 

### Config usage if relevant (new plugin or updated schema):
`from_rtorrent`
```
from_rtorrent:
      uri: '{? rtorrent.uri ?}'
      username: '{? rtorrent.username ?}'
      password: '{? rtorrent.password ?}'
      custom_fields:
        - foo
        - bar
        - foobar
```

`rtorrent`
```
rtorrent:
      uri: '{? rtorrent.uri ?}'
      username: '{? rtorrent.username ?}'
      password: '{? rtorrent.password ?}'
      custom1: 'ubuntu'
      custom_fields:
        foo: 'This is a test value from a variables file: {? test_set.foo ?}'
        bar: 'down total: {{down_total|default(-1)}}'
        foobar: 'foobar_value_new'
```

### Log and/or tests output (preferably both):

`config.yml`
```
variables: "variables.yml"

tasks:
  rtorrent_output_plugin_test_add:
    priority: 10
    verify_ssl_certificates: no
    disable:
      - seen
      - seen_info_hash
    mock:
      - {title: 'ubuntu-23.04-live-server-amd64.iso', url: 'https://releases.ubuntu.com/23.04/ubuntu-23.04-live-server-amd64.iso.torrent'}
      - {title: 'ubuntu-23.04-desktop-amd64.iso', url: 'https://releases.ubuntu.com/23.04/ubuntu-23.04-desktop-amd64.iso.torrent'}
    accept_all: yes
    rtorrent:
      uri: '{? rtorrent.uri ?}'
      username: '{? rtorrent.username ?}'
      password: '{? rtorrent.password ?}'
      custom1: 'ubuntu'
      custom_fields:
        foo: 'This is a test value from a variables file: {? test_set.foo ?}'
        bar: 'down total: {{down_total|default(-1)}}'
        foobar: 'foobar_value_new'

  rtorrent_input_plugin_test_after_add:
    priority: 20
    verify_ssl_certificates: no
    disable:
      - seen
      - seen_info_hash
    from_rtorrent:
      uri: '{? rtorrent.uri ?}'
      username: '{? rtorrent.username ?}'
      password: '{? rtorrent.password ?}'
      custom_fields:
        - foo
        - bar
        - foobar
        - foobar2
    accept_all: yes
    exec: |
      printf '\n'
      printf 'TEST %-16s: "%s"\n' 'title' "{{title}}"
      printf 'TEST %-16s: "%s"\n' 'hash' "{{torrent_info_hash}}"
      printf 'TEST %-16s: "%s"\n' 'custom-foo' "{{foo}}"
      printf 'TEST %-16s: "%s"\n' 'custom-bar' "{{bar}}"
      printf 'TEST %-16s: "%s"\n' 'custom-foobar' "{{foobar}}"
      printf 'TEST %-16s: "%s"\n' 'custom-foobar2' "{{foobar2}}"

  rtorrent_output_plugin_test_update:
    priority: 30
    verify_ssl_certificates: no
    disable:
      - seen
      - seen_info_hash
    from_rtorrent:
      uri: '{? rtorrent.uri ?}'
      username: '{? rtorrent.username ?}'
      password: '{? rtorrent.password ?}'
      custom_fields:
        - foo
        - bar
        - foobar
        - foobar2
    accept_all: yes
    rtorrent:
      uri: '{? rtorrent.uri ?}'
      username: '{? rtorrent.username ?}'
      password: '{? rtorrent.password ?}'
      action: update
      custom_fields:
        bar: 'down total (updated): {{down_total}}'
        foobar: 'foobar_value_updated'
        foobar2: 'foobar2_value_new'

  rtorrent_input_plugin_test_after_update:
    priority: 40
    verify_ssl_certificates: no
    disable:
      - seen
      - seen_info_hash
    from_rtorrent:
      uri: '{? rtorrent.uri ?}'
      username: '{? rtorrent.username ?}'
      password: '{? rtorrent.password ?}'
      custom_fields:
        - foo
        - bar
        - foobar
        - foobar2
    accept_all: yes
    exec: |
      printf '\n'
      printf 'TEST %-16s: "%s"\n' 'title' "{{title}}"
      printf 'TEST %-16s: "%s"\n' 'hash' "{{torrent_info_hash}}"
      printf 'TEST %-16s: "%s"\n' 'custom-foo' "{{foo}}"
      printf 'TEST %-16s: "%s"\n' 'custom-bar' "{{bar}}"
      printf 'TEST %-16s: "%s"\n' 'custom-foobar' "{{foobar}}"
      printf 'TEST %-16s: "%s"\n' 'custom-foobar2' "{{foobar2}}"

  rtorrent_input_plugin_delete_server_download:
    priority: 99
    verify_ssl_certificates: no
    disable:
      - seen
      - seen_info_hash
    from_rtorrent:
      uri: '{? rtorrent.uri ?}'
      username: '{? rtorrent.username ?}'
      password: '{? rtorrent.password ?}'
      custom_fields:
        - foo
        - bar
        - foobar
    if:
      - "custom1 == 'ubuntu'": accept
    rtorrent:
      uri: '{? rtorrent.uri ?}'
      username: '{? rtorrent.username ?}'
      password: '{? rtorrent.password ?}'
      action: 'delete'
```

Test output
```
2023-07-31 22:34:08 VERBOSE  task_queue                    There are 5 tasks to execute. Shutdown will commence when they have completed.
2023-07-31 22:34:08 VERBOSE  details       rtorrent_output_plugin_test_add Produced 2 entries.
2023-07-31 22:34:08 VERBOSE  task          rtorrent_output_plugin_test_add ACCEPTED: `ubuntu-23.04-live-server-amd64.iso` by accept_all plugin
2023-07-31 22:34:08 VERBOSE  task          rtorrent_output_plugin_test_add ACCEPTED: `ubuntu-23.04-desktop-amd64.iso` by accept_all plugin
2023-07-31 22:34:08 INFO     download      rtorrent_output_plugin_test_add Downloading: ubuntu-23.04-live-server-amd64.iso
2023-07-31 22:34:09 INFO     download      rtorrent_output_plugin_test_add Downloading: ubuntu-23.04-desktop-amd64.iso
2023-07-31 22:34:09 VERBOSE  details       rtorrent_output_plugin_test_add Summary - Accepted: 2 (Rejected: 0 Undecided: 0 Failed: 0)
2023-07-31 22:34:10 INFO     rtorrent      rtorrent_output_plugin_test_add ubuntu-23.04-live-server-amd64.iso added to rtorrent
2023-07-31 22:34:11 INFO     rtorrent      rtorrent_output_plugin_test_add ubuntu-23.04-desktop-amd64.iso added to rtorrent
2023-07-31 22:34:12 VERBOSE  details       rtorrent_input_plugin_test_after_add Produced 2 entries.
2023-07-31 22:34:12 VERBOSE  task          rtorrent_input_plugin_test_after_add ACCEPTED: `ubuntu-23.04-live-server-amd64.iso` by accept_all plugin
2023-07-31 22:34:12 VERBOSE  task          rtorrent_input_plugin_test_after_add ACCEPTED: `ubuntu-23.04-desktop-amd64.iso` by accept_all plugin
2023-07-31 22:34:12 VERBOSE  details       rtorrent_input_plugin_test_after_add Summary - Accepted: 2 (Rejected: 0 Undecided: 0 Failed: 0)
2023-07-31 22:34:12 VERBOSE  exec          rtorrent_input_plugin_test_after_add Executing: printf '\n'
printf 'TEST %-16s: "%s"\n' 'title' "ubuntu-23.04-live-server-amd64.iso"
printf 'TEST %-16s: "%s"\n' 'hash' "D6B4535BA8F2B34012BC633569F113E77017E032"
printf 'TEST %-16s: "%s"\n' 'custom-foo' "This is a test value from a variables file: a value from a variable"
printf 'TEST %-16s: "%s"\n' 'custom-bar' "down total: -1"
printf 'TEST %-16s: "%s"\n' 'custom-foobar' "foobar_value_new"
printf 'TEST %-16s: "%s"\n' 'custom-foobar2' ""
2023-07-31 22:34:12 INFO     exec          rtorrent_input_plugin_test_after_add Stdout:
TEST title           : "ubuntu-23.04-live-server-amd64.iso"
TEST hash            : "D6B4535BA8F2B34012BC633569F113E77017E032"
TEST custom-foo      : "This is a test value from a variables file: a value from a variable"
TEST custom-bar      : "down total: -1"
TEST custom-foobar   : "foobar_value_new"
TEST custom-foobar2  : ""
2023-07-31 22:34:12 VERBOSE  exec          rtorrent_input_plugin_test_after_add Executing: printf '\n'
printf 'TEST %-16s: "%s"\n' 'title' "ubuntu-23.04-desktop-amd64.iso"
printf 'TEST %-16s: "%s"\n' 'hash' "443C7602B4FDE83D1154D6D9DA48808418B181B6"
printf 'TEST %-16s: "%s"\n' 'custom-foo' "This is a test value from a variables file: a value from a variable"
printf 'TEST %-16s: "%s"\n' 'custom-bar' "down total: -1"
printf 'TEST %-16s: "%s"\n' 'custom-foobar' "foobar_value_new"
printf 'TEST %-16s: "%s"\n' 'custom-foobar2' ""
2023-07-31 22:34:12 INFO     exec          rtorrent_input_plugin_test_after_add Stdout:
TEST title           : "ubuntu-23.04-desktop-amd64.iso"
TEST hash            : "443C7602B4FDE83D1154D6D9DA48808418B181B6"
TEST custom-foo      : "This is a test value from a variables file: a value from a variable"
TEST custom-bar      : "down total: -1"
TEST custom-foobar   : "foobar_value_new"
TEST custom-foobar2  : ""
2023-07-31 22:34:12 VERBOSE  details       rtorrent_output_plugin_test_update Produced 2 entries.
2023-07-31 22:34:12 VERBOSE  task          rtorrent_output_plugin_test_update ACCEPTED: `ubuntu-23.04-live-server-amd64.iso` by accept_all plugin
2023-07-31 22:34:12 VERBOSE  task          rtorrent_output_plugin_test_update ACCEPTED: `ubuntu-23.04-desktop-amd64.iso` by accept_all plugin
2023-07-31 22:34:12 VERBOSE  details       rtorrent_output_plugin_test_update Summary - Accepted: 2 (Rejected: 0 Undecided: 0 Failed: 0)
2023-07-31 22:34:13 VERBOSE  rtorrent      rtorrent_output_plugin_test_update Updated ubuntu-23.04-live-server-amd64.iso (D6B4535BA8F2B34012BC633569F113E77017E032) in rtorrent
2023-07-31 22:34:13 VERBOSE  rtorrent      rtorrent_output_plugin_test_update Updated ubuntu-23.04-desktop-amd64.iso (443C7602B4FDE83D1154D6D9DA48808418B181B6) in rtorrent
2023-07-31 22:34:14 VERBOSE  details       rtorrent_input_plugin_test_after_update Produced 2 entries.
2023-07-31 22:34:14 VERBOSE  task          rtorrent_input_plugin_test_after_update ACCEPTED: `ubuntu-23.04-live-server-amd64.iso` by accept_all plugin
2023-07-31 22:34:14 VERBOSE  task          rtorrent_input_plugin_test_after_update ACCEPTED: `ubuntu-23.04-desktop-amd64.iso` by accept_all plugin
2023-07-31 22:34:14 VERBOSE  details       rtorrent_input_plugin_test_after_update Summary - Accepted: 2 (Rejected: 0 Undecided: 0 Failed: 0)
2023-07-31 22:34:14 VERBOSE  exec          rtorrent_input_plugin_test_after_update Executing: printf '\n'
printf 'TEST %-16s: "%s"\n' 'title' "ubuntu-23.04-live-server-amd64.iso"
printf 'TEST %-16s: "%s"\n' 'hash' "D6B4535BA8F2B34012BC633569F113E77017E032"
printf 'TEST %-16s: "%s"\n' 'custom-foo' "This is a test value from a variables file: a value from a variable"
printf 'TEST %-16s: "%s"\n' 'custom-bar' "down total (updated): 0"
printf 'TEST %-16s: "%s"\n' 'custom-foobar' "foobar_value_updated"
printf 'TEST %-16s: "%s"\n' 'custom-foobar2' "foobar2_value_new"
2023-07-31 22:34:14 INFO     exec          rtorrent_input_plugin_test_after_update Stdout:
TEST title           : "ubuntu-23.04-live-server-amd64.iso"
TEST hash            : "D6B4535BA8F2B34012BC633569F113E77017E032"
TEST custom-foo      : "This is a test value from a variables file: a value from a variable"
TEST custom-bar      : "down total (updated): 0"
TEST custom-foobar   : "foobar_value_updated"
TEST custom-foobar2  : "foobar2_value_new"
2023-07-31 22:34:14 VERBOSE  exec          rtorrent_input_plugin_test_after_update Executing: printf '\n'
printf 'TEST %-16s: "%s"\n' 'title' "ubuntu-23.04-desktop-amd64.iso"
printf 'TEST %-16s: "%s"\n' 'hash' "443C7602B4FDE83D1154D6D9DA48808418B181B6"
printf 'TEST %-16s: "%s"\n' 'custom-foo' "This is a test value from a variables file: a value from a variable"
printf 'TEST %-16s: "%s"\n' 'custom-bar' "down total (updated): 0"
printf 'TEST %-16s: "%s"\n' 'custom-foobar' "foobar_value_updated"
printf 'TEST %-16s: "%s"\n' 'custom-foobar2' "foobar2_value_new"
2023-07-31 22:34:14 INFO     exec          rtorrent_input_plugin_test_after_update Stdout:
TEST title           : "ubuntu-23.04-desktop-amd64.iso"
TEST hash            : "443C7602B4FDE83D1154D6D9DA48808418B181B6"
TEST custom-foo      : "This is a test value from a variables file: a value from a variable"
TEST custom-bar      : "down total (updated): 0"
TEST custom-foobar   : "foobar_value_updated"
TEST custom-foobar2  : "foobar2_value_new"
2023-07-31 22:34:14 VERBOSE  details       rtorrent_input_plugin_delete_server_download Produced 2 entries.
2023-07-31 22:34:14 VERBOSE  task          rtorrent_input_plugin_delete_server_download ACCEPTED: `ubuntu-23.04-live-server-amd64.iso` by if plugin because matched requirement: custom1 == 'ubuntu'
2023-07-31 22:34:14 VERBOSE  task          rtorrent_input_plugin_delete_server_download ACCEPTED: `ubuntu-23.04-desktop-amd64.iso` by if plugin because matched requirement: custom1 == 'ubuntu'
2023-07-31 22:34:14 VERBOSE  details       rtorrent_input_plugin_delete_server_download Summary - Accepted: 2 (Rejected: 0 Undecided: 0 Failed: 0)
2023-07-31 22:34:14 VERBOSE  rtorrent      rtorrent_input_plugin_delete_server_download Deleted ubuntu-23.04-live-server-amd64.iso (D6B4535BA8F2B34012BC633569F113E77017E032) in rtorrent
2023-07-31 22:34:15 VERBOSE  rtorrent      rtorrent_input_plugin_delete_server_download Deleted ubuntu-23.04-desktop-amd64.iso (443C7602B4FDE83D1154D6D9DA48808418B181B6) in rtorrent
```

