### PR TITLE
rTorrent purge action

### DIFF
--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -483,7 +483,7 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
             'mkdir': {'type': 'boolean', 'default': True},
             'action': {
                 'type': 'string',
-                'emun': ['update', 'delete', 'add', 'purge'],
+                'enum': ['update', 'delete', 'add', 'purge'],
                 'default': 'add',
             },
             # properties to set on rtorrent download object

--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -481,7 +481,11 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
             'digest_auth': {'type': 'boolean', 'default': False},
             'start': {'type': 'boolean', 'default': True},
             'mkdir': {'type': 'boolean', 'default': True},
-            'action': {'type': 'string', 'emun': ['update', 'delete', 'add', 'purge'], 'default': 'add'},
+            'action': {
+                'type': 'string',
+                'emun': ['update', 'delete', 'add', 'purge'],
+                'default': 'add',
+            },
             # properties to set on rtorrent download object
             'message': {'type': 'string'},
             'priority': {'type': 'string'},

--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -379,7 +379,7 @@ class RTorrent:
         self.stop(info_hash)
 
         try:
-            self._server.execute.throw('', 'rm', '-drfa', base_path)
+            self._server.execute.throw('', 'rm', '-drf', base_path)
         except xmlrpc_client.Error:
             raise xmlrpc_client.Error(f'Unable to delete data at "{base_path}"')
 

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -169,7 +169,7 @@ class TestRTorrentClient:
 
         assert resp == 0
 
-        print('JMLTEST: {}'.format(mocked_proxy.mock_calls))
+        print(f'JMLTEST: {mocked_proxy.mock_calls}')
 
         mocked_proxy.execute.throw.assert_has_calls(
             [

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -169,8 +169,6 @@ class TestRTorrentClient:
 
         assert resp == 0
 
-        print(f'JMLTEST: {mocked_proxy.mock_calls}')
-
         mocked_proxy.execute.throw.assert_has_calls(
             [
                 mock.call('', 'rm', '-drf', '/data/downloads/ubuntu-9.04-desktop-amd64.iso'),

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -150,6 +150,33 @@ class TestRTorrentClient:
         assert resp == 0
         assert mocked_proxy.d.erase.called_with((torrent_info_hash,))
 
+    def test_purge_torrent(self, mocked_proxy):
+        mocked_proxy = mocked_proxy()
+
+        mocked_proxy.system.multicall.return_value = [
+            ['ubuntu-9.04-desktop-amd64.iso'],
+            [torrent_info_hash],
+            ['/data/downloads/ubuntu-9.04-desktop-amd64.iso'],
+        ]
+
+        mocked_proxy.d.stop.return_value = 0
+        mocked_proxy.d.close.return_value = 0
+        mocked_proxy.d.erase.return_value = 0
+        mocked_proxy.execute.throw.return_value = 0
+
+        client = RTorrent('http://localhost/RPC2')
+        resp = client.purge_torrent(torrent_info_hash)
+
+        assert resp == 0
+
+        print('JMLTEST: {}'.format(mocked_proxy.mock_calls))
+
+        mocked_proxy.execute.throw.assert_has_calls(
+            [
+                mock.call('', 'rm', '-drf', '/data/downloads/ubuntu-9.04-desktop-amd64.iso'),
+            ]
+        )
+
     def test_move(self, mocked_proxy):
         mocked_proxy = mocked_proxy()
         mocked_proxy.system.multicall.return_value = [
@@ -286,6 +313,15 @@ class TestRTorrentOutputPlugin:
               action: delete
               uri: http://localhost/SCGI
               custom1: test_custom1
+          test_purge:
+            accept_all: yes
+            mock:
+              - {title: 'test', url: '"""
+        + torrent_url
+        + """', 'torrent_info_hash': '09977FE761B8D293AD8A929CCAF2E9322D525A6C'}
+            rtorrent:
+              action: purge
+              uri: http://localhost/SCGI
     """
     )
 
@@ -386,6 +422,16 @@ class TestRTorrentOutputPlugin:
         execute_task('test_delete')
 
         mocked_client.delete.assert_called_with(torrent_info_hash)
+
+    def test_purge(self, mocked_client, execute_task):
+        mocked_client = mocked_client()
+        mocked_client.load.return_value = 0
+        mocked_client.version = [0, 9, 4]
+        mocked_client.purge_torrent.return_value = 0
+
+        execute_task('test_purge')
+
+        mocked_client.purge_torrent.assert_called_with(torrent_info_hash)
 
 
 @mock.patch('flexget.plugins.clients.rtorrent.RTorrent')


### PR DESCRIPTION
### Motivation for changes:

rTorrent currently supports adding, updating, and removing a torrent from rTorrent. However, it does not support removing the torrent and the torrent data. This PR adds the ability to specify a `purge` action for the rTorrent plugin that will both remove the torrent data and remove the torrent from rTorrent

### Detailed changes:
- `RTorrent` class
  - Add `purge_torrent` method
- 'RTorrentOutputPlugin' class
  - Update the `action` schema enumeration to include `purge`
  - Add a purge action handler to the `on_task_output` method
  - Add a `purge_entry` method for the purge action handler to call that handles the call to the `RTorrent` class' purge_torrent method
- Add tests for the rTorrent purge functionality

### Config usage if relevant (new plugin or updated schema):
```
tasks:
   rtorrent_purge:
    from_rtorrent:
      uri: scgi://localhost:5000
    accept_all: yes
    rtorrent:
      uri: scgi://localhost:5000
      action: 'purge'
```

### Log and/or tests output (preferably both):
```
2023-08-03 16:07:29 VERBOSE  details       rtd             Produced 2 entries.
2023-08-03 16:07:29 VERBOSE  task          rtd             ACCEPTED: `ubuntu-23.04-live-server-amd64.iso` by if plugin because matched requirement: custom1 == 'ubuntu'
2023-08-03 16:07:29 VERBOSE  task          rtd             ACCEPTED: `ubuntu-23.04-desktop-amd64.iso` by if plugin because matched requirement: custom1 == 'ubuntu'
2023-08-03 16:07:29 VERBOSE  details       rtd             Summary - Accepted: 2 (Rejected: 0 Undecided: 0 Failed: 0)
2023-08-03 16:07:30 VERBOSE  rtorrent      rtd             Purged ubuntu-23.04-live-server-amd64.iso (D6B4535BA8F2B34012BC633569F113E77017E032) in rtorrent
2023-08-03 16:07:30 VERBOSE  rtorrent      rtd             Purged ubuntu-23.04-desktop-amd64.iso (443C7602B4FDE83D1154D6D9DA48808418B181B6) in rtorrent
```
