### PR TITLE
Update seen CLI for consistency

### DIFF
--- a/flexget/components/seen/cli.py
+++ b/flexget/components/seen/cli.py
@@ -1,3 +1,5 @@
+from rich.markup import escape
+
 from flexget import options, plugin
 from flexget.event import event
 from flexget.manager import Manager
@@ -105,7 +107,7 @@ def seen_search(manager: Manager, options, session=None):
     seen_entries = db.search(value=search_term, status=None, tasks=tasks, session=session)
     table = TerminalTable('Field', 'Value', table_type=options.table_type)
     for se in seen_entries.all():
-        table.add_row('Title', se.title)
+        table.add_row('Title', escape(se.title))
         for sf in se.fields:
             if sf.field.lower() == 'title':
                 continue


### PR DESCRIPTION
### Motivation for changes:
Clean up some ambiguity and problems with seen CLI

### Detailed changes:
- `--tasks` could take multiple arguments, which meant the positional value parameter could be consumed by this if it was placed before the value. It has been replaced by `--task` which only takes one task name, but can be specified multiple times.
  old: `seen forget valuetoforget --tasks taska taskb` new: `seen forget --task taska --task taskb valuetoforget`
- The value before could be a task name which would delete all the seen entries for that task. I didn't like the ambiguity of this, so you now must specify the task name with the `--task` parameter, along with a wildcard for the value.
  old: `seen forget sometaskname` new: `seen forget --task sometaskname *`
- Allows multiple tasks to be specified for `seen add` (only one could be done at a time before)
- Also fixes a crash if there were things that looked like rich markup in entry titles for `seen search`

### Addressed issues/feature requests:
- Fixes #3442

### CLI Usage
```
# Add a seen value to 2 tasks
flexget seen add --task task1 --task task2 "the seen thing"
# Forget everything from one task
flexget seen forget --task task1 *
# Forget everything from tasks matching a glob
flexget seen forget --task movie-* *
```
#### To Do:

- [ ] Bump version to indicate breaking change
- [ ] Write upgradeactions

