### PR TITLE
Convert plugins to using a base class

### DIFF
--- a/flexget/components/archive/archive.py
+++ b/flexget/components/archive/archive.py
@@ -12,7 +12,7 @@ from . import db
 logger = logger.bind(name='archive')
 
 
-class Archive:
+class Archive(plugin.PluginBase):
     """
     Archives all new items into database where they can be later searched and injected.
     Stores the entries in the state as they are at the exit phase, this way task cleanup for title
@@ -88,7 +88,7 @@ class Archive:
             self.on_task_learn(task, config)
 
 
-class UrlrewriteArchive:
+class UrlrewriteArchive(plugin.PluginBase):
     """
     Provides capability to rewrite urls from archive or make searches with discover.
     """

--- a/flexget/components/archives/archives.py
+++ b/flexget/components/archives/archives.py
@@ -7,7 +7,7 @@ from flexget.event import event
 logger = logger.bind(name='archives')
 
 
-class FilterArchives:
+class FilterArchives(plugin.PluginBase):
     """
     Accepts entries that are valid Zip or RAR archives
 

--- a/flexget/components/archives/decompress.py
+++ b/flexget/components/archives/decompress.py
@@ -93,7 +93,7 @@ def is_match(info, pattern):
     return is_match
 
 
-class Decompress:
+class Decompress(plugin.PluginBase):
     r"""
     Extracts files from Zip or RAR archives. By default this plugin will extract to the same
     directory as the source archive, preserving directory structure from the archive.

--- a/flexget/components/backlog/backlog.py
+++ b/flexget/components/backlog/backlog.py
@@ -13,7 +13,7 @@ from flexget.utils.tools import parse_timedelta
 logger = logger.bind(name='backlog')
 
 
-class InputBacklog:
+class InputBacklog(plugin.PluginBase):
     """
     Keeps task history for given amount of time.
 

--- a/flexget/components/bittorrent/convert_magnet.py
+++ b/flexget/components/bittorrent/convert_magnet.py
@@ -12,7 +12,7 @@ from flexget.utils.tools import parse_timedelta
 logger = logger.bind(name='convert_magnet')
 
 
-class ConvertMagnet:
+class ConvertMagnet(plugin.PluginBase):
     """Convert magnet only entries to a torrent file"""
 
     schema = {

--- a/flexget/components/bittorrent/magnet_info_hash.py
+++ b/flexget/components/bittorrent/magnet_info_hash.py
@@ -9,7 +9,7 @@ from flexget.event import event
 logger = logger.bind(name='magnet_btih')
 
 
-class MagnetBtih:
+class MagnetBtih(plugin.PluginBase):
     """Sets torrent_info_hash from magnet url."""
 
     schema = {'type': 'boolean'}

--- a/flexget/components/bittorrent/private_torrents.py
+++ b/flexget/components/bittorrent/private_torrents.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='priv_torrents')
 
 
-class FilterPrivateTorrents:
+class FilterPrivateTorrents(plugin.PluginBase):
     """How to handle private torrents.
 
     private_torrents: yes|no

--- a/flexget/components/bittorrent/torrent.py
+++ b/flexget/components/bittorrent/torrent.py
@@ -9,7 +9,7 @@ from flexget.utils.bittorrent import Torrent, is_torrent_file
 logger = logger.bind(name='modif_torrent')
 
 
-class TorrentFilename:
+class TorrentFilename(plugin.PluginBase):
     """
     Makes sure that entries containing torrent-file have .torrent
     extension. This is enabled always by default (builtins).

--- a/flexget/components/bittorrent/torrent_alive.py
+++ b/flexget/components/bittorrent/torrent_alive.py
@@ -168,7 +168,7 @@ def get_tracker_seeds(url, info_hash):
         return 0
 
 
-class TorrentAlive:
+class TorrentAlive(plugin.PluginBase):
     schema = {
         'oneOf': [
             {'type': 'boolean'},

--- a/flexget/components/bittorrent/torrent_files.py
+++ b/flexget/components/bittorrent/torrent_files.py
@@ -8,7 +8,7 @@ from flexget.event import event
 logger = logger.bind(name='torrent_files')
 
 
-class TorrentFiles:
+class TorrentFiles(plugin.PluginBase):
     """Provides content files information when dealing with torrents."""
 
     @plugin.priority(200)

--- a/flexget/components/bittorrent/torrent_match.py
+++ b/flexget/components/bittorrent/torrent_match.py
@@ -18,7 +18,7 @@ class TorrentMatchFile:
         return f"{self.__class__.__name__}(path={self.path!s}, size={self.size})"
 
 
-class TorrentMatch:
+class TorrentMatch(plugin.PluginBase):
     """Plugin that attempts to match .torrents to local files"""
 
     schema = {

--- a/flexget/components/bittorrent/torrent_scrub.py
+++ b/flexget/components/bittorrent/torrent_scrub.py
@@ -13,7 +13,7 @@ except ImportError:
 logger = logger.bind(name='torrent_scrub')
 
 
-class TorrentScrub:
+class TorrentScrub(plugin.PluginBase):
     """Scrubs torrents from unwanted keys.
 
     Example:

--- a/flexget/components/bittorrent/torrent_size.py
+++ b/flexget/components/bittorrent/torrent_size.py
@@ -7,7 +7,7 @@ from flexget.utils.tools import format_filesize
 logger = logger.bind(name='torrent_size')
 
 
-class TorrentSize:
+class TorrentSize(plugin.PluginBase):
     """
     Provides file size information when dealing with torrents
     """

--- a/flexget/components/bittorrent/trackers.py
+++ b/flexget/components/bittorrent/trackers.py
@@ -8,7 +8,7 @@ from flexget.event import event
 logger = logger.bind(name='modify_torrents')
 
 
-class AddTrackers:
+class AddTrackers(plugin.PluginBase):
     """
     Adds tracker URL to torrent files.
 
@@ -34,7 +34,7 @@ class AddTrackers:
                 entry['url'] += ''.join(['&tr=' + url for url in config])
 
 
-class RemoveTrackers:
+class RemoveTrackers(plugin.PluginBase):
     """
     Removes trackers from torrent files using regexp matching.
 
@@ -68,7 +68,7 @@ class RemoveTrackers:
                     entry['url'] = re.sub(tr_search, '', entry['url'], re.IGNORECASE | re.UNICODE)
 
 
-class ModifyTrackers:
+class ModifyTrackers(plugin.PluginBase):
     """
     Modify tracker URL to torrent files.
 

--- a/flexget/components/emby/emby_list.py
+++ b/flexget/components/emby/emby_list.py
@@ -8,7 +8,7 @@ from flexget.event import event
 logger = logger.bind(name='emby_list')
 
 
-class PluginEmbyList:
+class PluginEmbyList(plugin.PluginBase):
     """
     Returns Emby Lists
 

--- a/flexget/components/emby/emby_refresh.py
+++ b/flexget/components/emby/emby_refresh.py
@@ -9,7 +9,7 @@ from flexget.event import event
 logger = logger.bind(name='emby_reload')
 
 
-class EmbyRefreshLibrary:
+class EmbyRefreshLibrary(plugin.PluginBase):
     """
     Refresh Emby Library
 

--- a/flexget/components/emby/from_emby.py
+++ b/flexget/components/emby/from_emby.py
@@ -9,7 +9,7 @@ from flexget.event import event
 logger = logger.bind(name='from_emby')
 
 
-class EmbyInput:
+class EmbyInput(plugin.PluginBase):
     """
     Returns Emby Inputs
 

--- a/flexget/components/estimate_release/estimate_release.py
+++ b/flexget/components/estimate_release/estimate_release.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='est_released')
 
 
-class EstimateRelease:
+class EstimateRelease(plugin.PluginBase):
     """
     Front-end for estimator plugins that estimate release times
     for various things (series, movies).

--- a/flexget/components/failed/retry_failed.py
+++ b/flexget/components/failed/retry_failed.py
@@ -15,7 +15,7 @@ FAIL_LIMIT = 100
 logger = logger.bind(name='failed')
 
 
-class PluginFailed:
+class PluginFailed(plugin.PluginBase):
     """
     Records entry failures and stores them for trying again after a certain interval.
     Rejects them after they have failed too many times.

--- a/flexget/components/ftp/ftp_download.py
+++ b/flexget/components/ftp/ftp_download.py
@@ -13,7 +13,7 @@ from flexget.utils.template import RenderError
 logger = logger.bind(name='ftp')
 
 
-class OutputFtp:
+class OutputFtp(plugin.PluginBase):
     """
     Ftp Download plugin
 

--- a/flexget/components/ftp/ftp_list.py
+++ b/flexget/components/ftp/ftp_list.py
@@ -20,7 +20,7 @@ except ImportError:
 logger = logger.bind(name='ftp_list')
 
 
-class FTPList:
+class FTPList(plugin.PluginBase):
     def __init__(self):
         self.username = None
         self.password = None

--- a/flexget/components/ftp/sftp.py
+++ b/flexget/components/ftp/sftp.py
@@ -28,7 +28,7 @@ SftpConfig = namedtuple(
 )
 
 
-class SftpList:
+class SftpList(plugin.PluginBase):
     """
     Generate entries from SFTP. This plugin requires the pysftp Python module and its dependencies.
 
@@ -144,7 +144,7 @@ class SftpList:
         return entries
 
 
-class SftpDownload:
+class SftpDownload(plugin.PluginBase):
     """
     Download files from a SFTP server. This plugin requires the pysftp Python module and its
     dependencies.
@@ -269,7 +269,7 @@ class SftpDownload:
         return config
 
 
-class SftpUpload:
+class SftpUpload(plugin.PluginBase):
     """
     Upload files to a SFTP server. This plugin requires the pysftp Python module and its
     dependencies.

--- a/flexget/components/history/history.py
+++ b/flexget/components/history/history.py
@@ -8,7 +8,7 @@ from . import db
 logger = logger.bind(name='history')
 
 
-class PluginHistory:
+class PluginHistory(plugin.PluginBase):
     """Records all accepted entries for later lookup"""
 
     schema = {'type': 'boolean'}

--- a/flexget/components/imdb/from_imdb.py
+++ b/flexget/components/imdb/from_imdb.py
@@ -11,7 +11,7 @@ from flexget.utils.cached_input import cached
 logger = logger.bind(name='from_imdb')
 
 
-class FromIMDB:
+class FromIMDB(plugin.PluginBase):
     """
     This plugin enables generating entries based on an entity, an entity being a person, character or company.
     It's based on IMDBpy which is required (pip install imdbpy). The basic config required just an IMDB ID of the

--- a/flexget/components/imdb/imdb.py
+++ b/flexget/components/imdb/imdb.py
@@ -7,7 +7,7 @@ from flexget.utils.log import log_once
 logger = logger.bind(name='imdb')
 
 
-class FilterImdb:
+class FilterImdb(plugin.PluginBase):
     """
     This plugin allows filtering based on IMDB score, votes and genres etc.
 

--- a/flexget/components/imdb/imdb_lookup.py
+++ b/flexget/components/imdb/imdb_lookup.py
@@ -14,7 +14,7 @@ from . import db
 logger = logger.bind(name='imdb_lookup')
 
 
-class ImdbLookup:
+class ImdbLookup(plugin.PluginBase):
     """
     Retrieves imdb information for entries.
     Also provides imdb lookup functionality to all other imdb related plugins.

--- a/flexget/components/imdb/imdb_url.py
+++ b/flexget/components/imdb/imdb_url.py
@@ -9,7 +9,7 @@ from flexget.event import event
 logger = logger.bind(name='metainfo_imdb_url')
 
 
-class MetainfoImdbUrl:
+class MetainfoImdbUrl(plugin.PluginBase):
     """
     Scan entry information for imdb url.
     """

--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -29,7 +29,7 @@ TITLE_TYPE_MAP = {
 }
 
 
-class ImdbWatchlist:
+class ImdbWatchlist(plugin.PluginBase):
     """ "Creates an entry for each movie in your imdb list."""
 
     schema = {

--- a/flexget/components/managed_lists/list_add.py
+++ b/flexget/components/managed_lists/list_add.py
@@ -7,7 +7,7 @@ from flexget.plugin import PluginError
 logger = logger.bind(name='list_add')
 
 
-class ListAdd:
+class ListAdd(plugin.PluginBase):
     schema = {
         'type': 'array',
         'items': {

--- a/flexget/components/managed_lists/list_clear.py
+++ b/flexget/components/managed_lists/list_clear.py
@@ -7,7 +7,7 @@ from flexget.plugin import PluginError
 logger = logger.bind(name='list_clear')
 
 
-class ListClear:
+class ListClear(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/components/managed_lists/list_match.py
+++ b/flexget/components/managed_lists/list_match.py
@@ -7,7 +7,7 @@ from flexget.plugin import PluginError
 logger = logger.bind(name='list_match')
 
 
-class ListMatch:
+class ListMatch(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/components/managed_lists/list_remove.py
+++ b/flexget/components/managed_lists/list_remove.py
@@ -7,7 +7,7 @@ from flexget.plugin import PluginError
 logger = logger.bind(name='list_remove')
 
 
-class ListRemove:
+class ListRemove(plugin.PluginBase):
     schema = {
         'type': 'array',
         'items': {

--- a/flexget/components/managed_lists/lists/couchpotato_list.py
+++ b/flexget/components/managed_lists/lists/couchpotato_list.py
@@ -272,7 +272,7 @@ class CouchPotatoSet(MutableSet):
         return self._find_entry(entry)
 
 
-class CouchPotatoList:
+class CouchPotatoList(plugin.PluginBase):
     schema = CouchPotatoSet.schema
 
     @staticmethod

--- a/flexget/components/managed_lists/lists/entry_list/entry_list.py
+++ b/flexget/components/managed_lists/lists/entry_list/entry_list.py
@@ -10,7 +10,7 @@ from . import db
 logger = logger.bind(name=__name__)
 
 
-class EntryList:
+class EntryList(plugin.PluginBase):
     schema = {'type': 'string'}
 
     @staticmethod

--- a/flexget/components/managed_lists/lists/imdb_list.py
+++ b/flexget/components/managed_lists/lists/imdb_list.py
@@ -485,7 +485,7 @@ class ImdbEntrySet(MutableSet):
         return None
 
 
-class ImdbList:
+class ImdbList(plugin.PluginBase):
     schema = ImdbEntrySet.schema
 
     @staticmethod

--- a/flexget/components/managed_lists/lists/movie_list/movie_list.py
+++ b/flexget/components/managed_lists/lists/movie_list/movie_list.py
@@ -166,7 +166,7 @@ class MovieList(MutableSet):
         return match.to_entry() if match else None
 
 
-class PluginMovieList:
+class PluginMovieList(plugin.PluginBase):
     """Remove all accepted elements from your trakt.tv watchlist/library/seen or custom list."""
 
     schema = {

--- a/flexget/components/managed_lists/lists/pending_list/pending_list.py
+++ b/flexget/components/managed_lists/lists/pending_list/pending_list.py
@@ -115,7 +115,7 @@ class PendingListSet(MutableSet):
             return Entry(match.entry) if match else None
 
 
-class PendingList:
+class PendingList(plugin.PluginBase):
     schema = {
         'oneOf': [
             {'type': 'string'},

--- a/flexget/components/managed_lists/lists/plex_watchlist.py
+++ b/flexget/components/managed_lists/lists/plex_watchlist.py
@@ -174,7 +174,7 @@ class PlexManagedWatchlist(MutableSet):
                 return item
 
 
-class PlexWatchlist:
+class PlexWatchlist(plugin.PluginBase):
     schema = {
         'properties': {
             'username': {'type': 'string'},

--- a/flexget/components/managed_lists/lists/radarr_list.py
+++ b/flexget/components/managed_lists/lists/radarr_list.py
@@ -607,7 +607,7 @@ class RadarrSet(MutableSet):
                 logger.error('Radarr search term lookup failed: {}', ex)
 
 
-class RadarrList:
+class RadarrList(plugin.PluginBase):
     """List plugin for Radarr that also works as an input plugin"""
 
     schema = {

--- a/flexget/components/managed_lists/lists/regexp_list/regexp_list.py
+++ b/flexget/components/managed_lists/lists/regexp_list/regexp_list.py
@@ -97,7 +97,7 @@ class RegexpList(MutableSet):
         return match.to_entry() if match else None
 
 
-class PluginRegexpList:
+class PluginRegexpList(plugin.PluginBase):
     """Subtitle list"""
 
     schema = RegexpList.schema

--- a/flexget/components/managed_lists/lists/sonarr_list.py
+++ b/flexget/components/managed_lists/lists/sonarr_list.py
@@ -286,7 +286,7 @@ class SonarrSet(MutableSet):
         return self._find_entry(entry)
 
 
-class SonarrList:
+class SonarrList(plugin.PluginBase):
     schema = SonarrSet.schema
 
     @staticmethod

--- a/flexget/components/managed_lists/lists/subtitle_list.py
+++ b/flexget/components/managed_lists/lists/subtitle_list.py
@@ -324,7 +324,7 @@ class SubtitleList(MutableSet):
         return match.to_entry() if match else None
 
 
-class PluginSubtitleList:
+class PluginSubtitleList(plugin.PluginBase):
     """Subtitle list"""
 
     schema = SubtitleList.schema

--- a/flexget/components/managed_lists/lists/thetvdb_list.py
+++ b/flexget/components/managed_lists/lists/thetvdb_list.py
@@ -140,7 +140,7 @@ class TheTVDBSet(MutableSet):
         return True
 
 
-class TheTVDBList:
+class TheTVDBList(plugin.PluginBase):
     schema = TheTVDBSet.schema
 
     def get_list(self, config):

--- a/flexget/components/managed_lists/lists/yaml_list.py
+++ b/flexget/components/managed_lists/lists/yaml_list.py
@@ -152,7 +152,7 @@ class YamlManagedList(MutableSet):
         return False
 
 
-class YamlList:
+class YamlList(plugin.PluginBase):
     schema = {
         'oneOf': [
             {'type': 'string'},

--- a/flexget/components/notify/notification_framework.py
+++ b/flexget/components/notify/notification_framework.py
@@ -83,7 +83,7 @@ def render_config(config, template_renderer, notifier_name, _path=''):
         return config
 
 
-class NotificationFramework:
+class NotificationFramework(plugin.PluginBase):
     def send_notification(self, title, message, notifiers, template_renderer=None):
         """
         Send a notification out to the given `notifiers` with a given `title` and `message`.

--- a/flexget/components/notify/notifiers/bark.py
+++ b/flexget/components/notify/notifiers/bark.py
@@ -13,7 +13,7 @@ plugin_name = 'bark'
 logger = logger.bind(name=plugin_name)
 
 
-class BarkNotifier:
+class BarkNotifier(plugin.PluginBase):
     """
     Example::
 

--- a/flexget/components/notify/notifiers/cronitor.py
+++ b/flexget/components/notify/notifiers/cronitor.py
@@ -15,7 +15,7 @@ plugin_name = "cronitor"
 logger = logger.bind(name=plugin_name)
 
 
-class Cronitor:
+class Cronitor(plugin.PluginBase):
     """
     Example::
       cronitor: ABC123

--- a/flexget/components/notify/notifiers/discord.py
+++ b/flexget/components/notify/notifiers/discord.py
@@ -16,7 +16,7 @@ session = Session()
 session.add_domain_limiter(TokenBucketLimiter('discord.com', 6, '3 seconds'))
 
 
-class DiscordNotifier:
+class DiscordNotifier(plugin.PluginBase):
     """
     Example::
 

--- a/flexget/components/notify/notifiers/email.py
+++ b/flexget/components/notify/notifiers/email.py
@@ -17,7 +17,7 @@ plugin_name = 'email'
 logger = logger.bind(name=plugin_name)
 
 
-class EmailNotifier:
+class EmailNotifier(plugin.PluginBase):
     """
     Send an e-mail with the list of all succeeded (downloaded) entries.
 

--- a/flexget/components/notify/notifiers/gotify.py
+++ b/flexget/components/notify/notifiers/gotify.py
@@ -13,7 +13,7 @@ plugin_name = 'gotify'
 requests = RequestSession(max_retries=3)
 
 
-class GotifyNotifier:
+class GotifyNotifier(plugin.PluginBase):
     """
     Example::
 

--- a/flexget/components/notify/notifiers/ifttt.py
+++ b/flexget/components/notify/notifiers/ifttt.py
@@ -11,7 +11,7 @@ plugin_name = 'ifttt'
 logger = logger.bind(name=plugin_name)
 
 
-class IFTTTNotifier:
+class IFTTTNotifier(plugin.PluginBase):
     """
     Push the notification to an IFTTT webhook.
 

--- a/flexget/components/notify/notifiers/join.py
+++ b/flexget/components/notify/notifiers/join.py
@@ -17,7 +17,7 @@ requests.add_domain_limiter(TimedLimiter('appspot.com', '5 seconds'))
 JOIN_URL = 'https://joinjoaomgcd.appspot.com/_ah/api/messaging/v1/sendPush'
 
 
-class JoinNotifier:
+class JoinNotifier(plugin.PluginBase):
     """
     Example::
 

--- a/flexget/components/notify/notifiers/matrix.py
+++ b/flexget/components/notify/notifiers/matrix.py
@@ -22,7 +22,7 @@ def urljoin(*args):
     return "/".join(str(x).rstrip('/') for x in args)
 
 
-class MatrixNotifier:
+class MatrixNotifier(plugin.PluginBase):
     """
     Sends messages via Matrix. The MatrixHttpApi library is required to be installed.
     Install it with: `pip install matrix_client`

--- a/flexget/components/notify/notifiers/microsoftteams.py
+++ b/flexget/components/notify/notifiers/microsoftteams.py
@@ -13,7 +13,7 @@ plugin_name = 'ms_teams'
 logger = logger.bind(name=plugin_name)
 
 
-class MsTeamsNotifier:
+class MsTeamsNotifier(plugin.PluginBase):
     """
     Example::
 

--- a/flexget/components/notify/notifiers/mqtt.py
+++ b/flexget/components/notify/notifiers/mqtt.py
@@ -11,7 +11,7 @@ plugin_name = 'mqtt'
 logger = logger.bind(name=plugin_name)
 
 
-class MQTTNotifier:
+class MQTTNotifier(plugin.PluginBase):
     """
     Example::
       notify:

--- a/flexget/components/notify/notifiers/notifymyandroid.py
+++ b/flexget/components/notify/notifiers/notifymyandroid.py
@@ -15,7 +15,7 @@ logger = logger.bind(name=plugin_name)
 NOTIFYMYANDROID_URL = 'https://www.notifymyandroid.com/publicapi/notify'
 
 
-class NotifyMyAndroidNotifier:
+class NotifyMyAndroidNotifier(plugin.PluginBase):
     """
     Example::
 

--- a/flexget/components/notify/notifiers/ntfysh.py
+++ b/flexget/components/notify/notifiers/ntfysh.py
@@ -14,7 +14,7 @@ plugin_name = 'ntfysh'
 requests = RequestSession(max_retries=3)
 
 
-class NtfyshNotifier:
+class NtfyshNotifier(plugin.PluginBase):
     """
     Example::
 

--- a/flexget/components/notify/notifiers/prowl.py
+++ b/flexget/components/notify/notifiers/prowl.py
@@ -19,7 +19,7 @@ requests = RequestSession(max_retries=3)
 requests.add_domain_limiter(TimedLimiter('prowlapp.com', '5 seconds'))
 
 
-class ProwlNotifier:
+class ProwlNotifier(plugin.PluginBase):
     """
     Send prowl notifications
 

--- a/flexget/components/notify/notifiers/pushalot.py
+++ b/flexget/components/notify/notifiers/pushalot.py
@@ -17,7 +17,7 @@ requests = RequestSession(max_retries=3)
 requests.add_domain_limiter(TimedLimiter('pushalot.com', '5 seconds'))
 
 
-class PushalotNotifier:
+class PushalotNotifier(plugin.PluginBase):
     """
     Example::
 

--- a/flexget/components/notify/notifiers/pushbullet.py
+++ b/flexget/components/notify/notifiers/pushbullet.py
@@ -20,7 +20,7 @@ requests = RequestSession(max_retries=3)
 requests.add_domain_limiter(TimedLimiter('pushbullet.com', '5 seconds'))
 
 
-class PushbulletNotifier:
+class PushbulletNotifier(plugin.PluginBase):
     """
     Example::
 

--- a/flexget/components/notify/notifiers/pushover.py
+++ b/flexget/components/notify/notifiers/pushover.py
@@ -19,7 +19,7 @@ requests = RequestSession(max_retries=3)
 requests.add_domain_limiter(TimedLimiter('pushover.net', '5 seconds'))
 
 
-class PushoverNotifier:
+class PushoverNotifier(plugin.PluginBase):
     """
     Example::
 

--- a/flexget/components/notify/notifiers/pushsafer.py
+++ b/flexget/components/notify/notifiers/pushsafer.py
@@ -17,7 +17,7 @@ requests = RequestSession(max_retries=3)
 requests.add_domain_limiter(TimedLimiter('pushsafer.com', '5 seconds'))
 
 
-class PushsaferNotifier:
+class PushsaferNotifier(plugin.PluginBase):
     """
     Example::
 

--- a/flexget/components/notify/notifiers/rapidpush.py
+++ b/flexget/components/notify/notifiers/rapidpush.py
@@ -19,7 +19,7 @@ requests = RequestSession(max_retries=3)
 requests.add_domain_limiter(TimedLimiter('rapidpush.net', '5 seconds'))
 
 
-class RapidpushNotifier:
+class RapidpushNotifier(plugin.PluginBase):
     """
     Example::
 

--- a/flexget/components/notify/notifiers/slack.py
+++ b/flexget/components/notify/notifiers/slack.py
@@ -13,7 +13,7 @@ plugin_name = 'slack'
 logger = logger.bind(name=plugin_name)
 
 
-class SlackNotifier:
+class SlackNotifier(plugin.PluginBase):
     """
     Example:
 

--- a/flexget/components/notify/notifiers/sms_ru.py
+++ b/flexget/components/notify/notifiers/sms_ru.py
@@ -19,7 +19,7 @@ requests = RequestSession(max_retries=3)
 requests.add_domain_limiter(TimedLimiter('sms.ru', '5 seconds'))
 
 
-class SMSRuNotifier:
+class SMSRuNotifier(plugin.PluginBase):
     """
     Sends SMS notification through sms.ru http api sms/send.
     Phone number is a login assigned to sms.ru account.

--- a/flexget/components/notify/notifiers/telegram.py
+++ b/flexget/components/notify/notifiers/telegram.py
@@ -61,7 +61,7 @@ class ChatIdEntry(ChatIdsBase):
         return ' '.join(x)
 
 
-class TelegramNotifier:
+class TelegramNotifier(plugin.PluginBase):
     """Send a message to one or more Telegram users or groups upon accepting a download.
 
 

--- a/flexget/components/notify/notifiers/toast.py
+++ b/flexget/components/notify/notifiers/toast.py
@@ -12,7 +12,7 @@ plugin_name = 'toast'
 logger = logger.bind(name=plugin_name)
 
 
-class NotifyToast:
+class NotifyToast(plugin.PluginBase):
     """
     Sends messages via local notification system. You must have a notification system like dbus for Linux.
     Preliminary support for Windows notifications. Not heavily tested yet.

--- a/flexget/components/notify/notifiers/xmpp.py
+++ b/flexget/components/notify/notifiers/xmpp.py
@@ -12,7 +12,7 @@ plugin_name = 'xmpp'
 logger = logger.bind(name=plugin_name)
 
 
-class XMPPNotifier:
+class XMPPNotifier(plugin.PluginBase):
     """
     Sends messages via XMPP. The sleekxmpp library is required to be installed.
     Install it with: `pip install sleekxmpp`

--- a/flexget/components/notify/notify.py
+++ b/flexget/components/notify/notify.py
@@ -27,7 +27,7 @@ VIA_SCHEMA = {
 }
 
 
-class Notify:
+class Notify(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/components/parsing/plugin_parsing.py
+++ b/flexget/components/parsing/plugin_parsing.py
@@ -35,7 +35,7 @@ def init_parsers(manager):
         )
 
 
-class PluginParsing:
+class PluginParsing(plugin.PluginBase):
     """Provides parsing framework"""
 
     @property

--- a/flexget/components/pending_approval/pending_approval.py
+++ b/flexget/components/pending_approval/pending_approval.py
@@ -9,7 +9,7 @@ from . import db
 logger = logger.bind(name='pending_approval')
 
 
-class PendingApproval:
+class PendingApproval(plugin.PluginBase):
     schema = {
         'type': 'boolean',
         'deprecated': 'pending_approval is deprecated, switch to using pending_list',

--- a/flexget/components/rejected/remember_rejected.py
+++ b/flexget/components/rejected/remember_rejected.py
@@ -13,7 +13,7 @@ from . import db
 logger = logger.bind(name='remember_rej')
 
 
-class FilterRememberRejected:
+class FilterRememberRejected(plugin.PluginBase):
     """Internal.
     Rejects entries which have been rejected in the past.
 

--- a/flexget/components/seen/seen.py
+++ b/flexget/components/seen/seen.py
@@ -8,7 +8,7 @@ from . import db
 logger = logger.bind(name='seen')
 
 
-class FilterSeen:
+class FilterSeen(plugin.PluginBase):
     """
     Remembers previously downloaded content and rejects them in
     subsequent executions. Without this plugin FlexGet would

--- a/flexget/components/seen/seen_info_hash.py
+++ b/flexget/components/seen/seen_info_hash.py
@@ -4,7 +4,7 @@ from flexget.event import event
 from . import seen as plugin_seen
 
 
-class FilterSeenInfoHash(plugin_seen.FilterSeen):
+class FilterSeenInfoHash(plugin_seen.FilterSeen, plugin.PluginBase):
     """Prevents the same torrent from being downloaded twice by remembering the infohash of all downloaded torrents."""
 
     schema = {'oneOf': [{'type': 'boolean'}, {'type': 'string', 'enum': ['global', 'local']}]}

--- a/flexget/components/seen/seen_movies.py
+++ b/flexget/components/seen/seen_movies.py
@@ -10,7 +10,7 @@ from . import seen as plugin_seen
 logger = logger.bind(name='seen_movies')
 
 
-class FilterSeenMovies(plugin_seen.FilterSeen):
+class FilterSeenMovies(plugin_seen.FilterSeen, plugin.PluginBase):
     """
     Prevents movies being downloaded twice.
     Works only on entries which have imdb url available.

--- a/flexget/components/series/all_series.py
+++ b/flexget/components/series/all_series.py
@@ -4,7 +4,7 @@ from flexget.event import event
 from . import series as plugin_series
 
 
-class FilterAllSeries(plugin_series.FilterSeriesBase):
+class FilterAllSeries(plugin_series.FilterSeriesBase, plugin.PluginBase):
     """
     Grabs all entries that appear to be series episodes in a task.
 

--- a/flexget/components/series/configure_series.py
+++ b/flexget/components/series/configure_series.py
@@ -10,7 +10,7 @@ from . import series as plugin_series
 logger = logger.bind(name='configure_series')
 
 
-class ConfigureSeries(plugin_series.FilterSeriesBase):
+class ConfigureSeries(plugin_series.FilterSeriesBase, plugin.PluginBase):
     """Generates series configuration from any input (supporting API version 2, soon all)
 
     Configuration::

--- a/flexget/components/series/gen_series.py
+++ b/flexget/components/series/gen_series.py
@@ -12,7 +12,7 @@ logger = logger.bind(name='gen_series')
 PER_RUN = 50
 
 
-class GenSeries:
+class GenSeries(plugin.PluginBase):
     """
     Purely for debugging purposes. Not great quality :)
 

--- a/flexget/components/series/metainfo_series.py
+++ b/flexget/components/series/metainfo_series.py
@@ -14,7 +14,7 @@ except ImportError:
 logger = logger.bind(name='metainfo_series')
 
 
-class MetainfoSeries:
+class MetainfoSeries(plugin.PluginBase):
     """
     Check if entry appears to be a series, and populate series info if so.
     """

--- a/flexget/components/series/next_series_episodes.py
+++ b/flexget/components/series/next_series_episodes.py
@@ -13,7 +13,7 @@ from . import db
 logger = logger.bind(name='next_series_episodes')
 
 
-class NextSeriesEpisodes:
+class NextSeriesEpisodes(plugin.PluginBase):
     """
     Emit next episode number from all series configured in this task.
 

--- a/flexget/components/series/next_series_seasons.py
+++ b/flexget/components/series/next_series_seasons.py
@@ -16,7 +16,7 @@ MAX_SEASON_DIFF_WITHOUT_BEGIN = 15
 MAX_SEASON_DIFF_WITH_BEGIN = 30
 
 
-class NextSeriesSeasons:
+class NextSeriesSeasons(plugin.PluginBase):
     """
     Emit next season number from all series configured in this task.
 

--- a/flexget/components/series/series.py
+++ b/flexget/components/series/series.py
@@ -327,7 +327,7 @@ class FilterSeriesBase:
         return task.config['series']
 
 
-class FilterSeries(FilterSeriesBase):
+class FilterSeries(FilterSeriesBase, plugin.PluginBase):
     """
     Intelligent filter for tv-series.
 

--- a/flexget/components/series/series_begin.py
+++ b/flexget/components/series/series_begin.py
@@ -8,7 +8,7 @@ from . import db
 logger = logger.bind(name='set_series_begin')
 
 
-class SetSeriesBegin:
+class SetSeriesBegin(plugin.PluginBase):
     """
     Set the first episode for series. Uses series_name and series_id.
 

--- a/flexget/components/series/series_premiere.py
+++ b/flexget/components/series/series_premiere.py
@@ -5,7 +5,7 @@ from . import db
 from . import series as plugin_series
 
 
-class FilterSeriesPremiere(plugin_series.FilterSeriesBase):
+class FilterSeriesPremiere(plugin_series.FilterSeriesBase, plugin.PluginBase):
     """
     Accept an entry that appears to be the first episode of any series.
 

--- a/flexget/components/series/series_remove.py
+++ b/flexget/components/series/series_remove.py
@@ -8,7 +8,7 @@ from . import db
 logger = logger.bind(name='series_remove')
 
 
-class OutputSeriesRemove:
+class OutputSeriesRemove(plugin.PluginBase):
     schema = {
         'oneOf': [
             {'type': 'boolean'},

--- a/flexget/components/sites/sites/allyoulike.py
+++ b/flexget/components/sites/sites/allyoulike.py
@@ -21,7 +21,7 @@ except ImportError:
 logger = logger.bind(name='allyoulike')
 
 
-class UrlRewriteAllyoulike:
+class UrlRewriteAllyoulike(plugin.PluginBase):
     r"""
     allyoulike.com urlrewriter
     Version 0.1

--- a/flexget/components/sites/sites/alpharatio.py
+++ b/flexget/components/sites/sites/alpharatio.py
@@ -68,7 +68,7 @@ class AlphaRatioCookie(Base):
     expires = Column(DateTime)
 
 
-class SearchAlphaRatio:
+class SearchAlphaRatio(plugin.PluginBase):
     """
     AlphaRatio search plugin.
     """

--- a/flexget/components/sites/sites/animeindex.py
+++ b/flexget/components/sites/sites/animeindex.py
@@ -12,7 +12,7 @@ logger = logger.bind(name='animeindex')
 # http://tracker.anime-index.org/download.php?id=b8327fdf9003e87446c8b3601951a9a65526abb2&f=[DeadFish]%20Yowamushi%20Pedal:%20Grande%20Road%20-%2002%20[720p][AAC].mp4.torrent
 
 
-class UrlRewriteAnimeIndex:
+class UrlRewriteAnimeIndex(plugin.PluginBase):
     """AnimeIndex urlrewriter."""
 
     def url_rewritable(self, task, entry):

--- a/flexget/components/sites/sites/anirena.py
+++ b/flexget/components/sites/sites/anirena.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='anirena')
 
 
-class UrlRewriteAniRena:
+class UrlRewriteAniRena(plugin.PluginBase):
     """AniRena urlrewriter."""
 
     def url_rewritable(self, task, entry):

--- a/flexget/components/sites/sites/archetorrent.py
+++ b/flexget/components/sites/sites/archetorrent.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name="archetorrent")
 
 
-class UrlRewriteArchetorrent:
+class UrlRewriteArchetorrent(plugin.PluginBase):
     """Archetorrent urlrewriter."""
 
     # urlrewriter API

--- a/flexget/components/sites/sites/argenteam.py
+++ b/flexget/components/sites/sites/argenteam.py
@@ -9,7 +9,7 @@ from flexget.event import event
 logger = logger.bind(name='argenteam')
 
 
-class SearchArgenteam:
+class SearchArgenteam(plugin.PluginBase):
     """Argenteam
     Search plugin which gives results from www.argenteam.net, latin american (Argentina) web.
 

--- a/flexget/components/sites/sites/awesomehd.py
+++ b/flexget/components/sites/sites/awesomehd.py
@@ -13,7 +13,7 @@ from flexget.utils.tools import parse_filesize
 logger = logger.bind(name='awesomehd')
 
 
-class SearchAwesomeHD:
+class SearchAwesomeHD(plugin.PluginBase):
     """
     AwesomeHD search plugin.
     """

--- a/flexget/components/sites/sites/bakabt.py
+++ b/flexget/components/sites/sites/bakabt.py
@@ -8,7 +8,7 @@ from flexget.utils.soup import get_soup
 logger = logger.bind(name='bakabt')
 
 
-class UrlRewriteBakaBT:
+class UrlRewriteBakaBT(plugin.PluginBase):
     """BakaBT urlrewriter."""
 
     # urlrewriter API

--- a/flexget/components/sites/sites/btn.py
+++ b/flexget/components/sites/sites/btn.py
@@ -16,7 +16,7 @@ logger = logger.bind(name='search_btn')
 ORIGINS = ['None', 'Scene', 'P2P', 'User', 'Mixed', 'Internal']
 
 
-class SearchBTN:
+class SearchBTN(plugin.PluginBase):
     schema = {
         'oneOf': [
             {'type': 'string'},

--- a/flexget/components/sites/sites/cinemageddon.py
+++ b/flexget/components/sites/sites/cinemageddon.py
@@ -8,7 +8,7 @@ from flexget.event import event
 logger = logger.bind(name='cinemageddon')
 
 
-class UrlRewriteCinemageddon:
+class UrlRewriteCinemageddon(plugin.PluginBase):
     """Cinemageddon urlrewriter."""
 
     def url_rewritable(self, task, entry):

--- a/flexget/components/sites/sites/cpasbien.py
+++ b/flexget/components/sites/sites/cpasbien.py
@@ -16,7 +16,7 @@ logger = logger.bind(name='search_cpasbien')
 session = requests.Session()
 
 
-class SearchCPASBIEN:
+class SearchCPASBIEN(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/components/sites/sites/deadfrog.py
+++ b/flexget/components/sites/sites/deadfrog.py
@@ -10,7 +10,7 @@ from flexget.utils.soup import get_soup
 logger = logger.bind(name='deadfrog')
 
 
-class UrlRewriteDeadFrog:
+class UrlRewriteDeadFrog(plugin.PluginBase):
     """DeadFrog urlrewriter."""
 
     # urlrewriter API

--- a/flexget/components/sites/sites/ettv.py
+++ b/flexget/components/sites/sites/ettv.py
@@ -16,7 +16,7 @@ DOMAINS = [
 ]
 
 
-class UrlRewriteETTV:
+class UrlRewriteETTV(plugin.PluginBase):
     """ETTV urlrewriter."""
 
     # urlrewriter API

--- a/flexget/components/sites/sites/eztv.py
+++ b/flexget/components/sites/sites/eztv.py
@@ -14,7 +14,7 @@ logger = logger.bind(name='eztv')
 EZTV_MIRRORS = [('http', 'eztv.ch'), ('https', 'eztv-proxy.net'), ('http', 'eztv.come.in')]
 
 
-class UrlRewriteEztv:
+class UrlRewriteEztv(plugin.PluginBase):
     """Eztv url rewriter."""
 
     def url_rewritable(self, task, entry):

--- a/flexget/components/sites/sites/filelist.py
+++ b/flexget/components/sites/sites/filelist.py
@@ -66,7 +66,7 @@ class FileListCookie(Base):
     expires = Column(DateTime)
 
 
-class SearchFileList:
+class SearchFileList(plugin.PluginBase):
     """
     FileList.ro search plugin.
     """

--- a/flexget/components/sites/sites/filelist_api.py
+++ b/flexget/components/sites/sites/filelist_api.py
@@ -13,7 +13,7 @@ logger = logger.bind(name='filelist')
 requests = RequestSession()
 
 
-class SearchFileList:
+class SearchFileList(plugin.PluginBase):
     """
     FileList search plugin w/ API w00t.
     """

--- a/flexget/components/sites/sites/frenchtorrentdb.py
+++ b/flexget/components/sites/sites/frenchtorrentdb.py
@@ -10,7 +10,7 @@ from flexget.utils.soup import get_soup
 logger = logger.bind(name='FTDB')
 
 
-class UrlRewriteFTDB:
+class UrlRewriteFTDB(plugin.PluginBase):
     """FTDB RSS url_rewrite"""
 
     def url_rewritable(self, task, entry):

--- a/flexget/components/sites/sites/fuzer.py
+++ b/flexget/components/sites/sites/fuzer.py
@@ -41,7 +41,7 @@ CATEGORIES = {
 }
 
 
-class UrlRewriteFuzer:
+class UrlRewriteFuzer(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/components/sites/sites/google_cse.py
+++ b/flexget/components/sites/sites/google_cse.py
@@ -16,7 +16,7 @@ requests.headers.update({'User-Agent': 'Mozilla/4.0 (compatible; MSIE 5.5; Windo
 requests.add_domain_limiter(TimedLimiter('imdb.com', '2 seconds'))
 
 
-class UrlRewriteGoogleCse:
+class UrlRewriteGoogleCse(plugin.PluginBase):
     """Google custom query urlrewriter."""
 
     # urlrewriter API
@@ -51,7 +51,7 @@ class UrlRewriteGoogleCse:
             raise UrlRewritingError(e)
 
 
-class UrlRewriteGoogle:
+class UrlRewriteGoogle(plugin.PluginBase):
     # urlrewriter API
 
     def url_rewritable(self, task, entry):

--- a/flexget/components/sites/sites/hebits.py
+++ b/flexget/components/sites/sites/hebits.py
@@ -40,7 +40,7 @@ class HeBitsSort(Enum):
     random = 7
 
 
-class SearchHeBits:
+class SearchHeBits(plugin.PluginBase):
     """
     HeBits search plugin.
     """

--- a/flexget/components/sites/sites/hliang.py
+++ b/flexget/components/sites/sites/hliang.py
@@ -10,7 +10,7 @@ from flexget.utils.soup import get_soup
 logger = logger.bind(name='hliang')
 
 
-class UrlRewriteHliang:
+class UrlRewriteHliang(plugin.PluginBase):
     """Hliang urlrewriter."""
 
     # urlrewriter API

--- a/flexget/components/sites/sites/horriblesubs.py
+++ b/flexget/components/sites/sites/horriblesubs.py
@@ -12,7 +12,7 @@ from flexget.utils.soup import get_soup
 logger = logger.bind(name='horriblesubs')
 
 
-class HorribleSubs:
+class HorribleSubs(plugin.PluginBase):
     """
     Give latest horriblesubs releases
     """

--- a/flexget/components/sites/sites/koreus.py
+++ b/flexget/components/sites/sites/koreus.py
@@ -10,7 +10,7 @@ from flexget.utils.soup import get_soup
 logger = logger.bind(name='koreus')
 
 
-class UrlRewriteKoreus:
+class UrlRewriteKoreus(plugin.PluginBase):
     """Koreus urlrewriter."""
 
     # urlrewriter API

--- a/flexget/components/sites/sites/limetorrents.py
+++ b/flexget/components/sites/sites/limetorrents.py
@@ -26,7 +26,7 @@ def clean_symbols(text):
     return result
 
 
-class Limetorrents:
+class Limetorrents(plugin.PluginBase):
     """
     Limetorrents search plugin.
     """

--- a/flexget/components/sites/sites/lostfilm.py
+++ b/flexget/components/sites/sites/lostfilm.py
@@ -81,7 +81,7 @@ class TextProcessingError(Exception):
         return repr(self.value)
 
 
-class LostFilm:
+class LostFilm(plugin.PluginBase):
     """
     Grab new torrents from lostfilm RSS feed
 

--- a/flexget/components/sites/sites/magnetdl.py
+++ b/flexget/components/sites/sites/magnetdl.py
@@ -21,7 +21,7 @@ class Page404Error(Exception):
     pass
 
 
-class MagnetDL:
+class MagnetDL(plugin.PluginBase):
     """Creates entries from magnetdl categories"""
 
     url = 'https://www.magnetdl.com'

--- a/flexget/components/sites/sites/morethantv.py
+++ b/flexget/components/sites/sites/morethantv.py
@@ -112,7 +112,7 @@ class MoreThanTVCookie(Base):
     expires = Column(DateTime)
 
 
-class SearchMoreThanTV:
+class SearchMoreThanTV(plugin.PluginBase):
     """
     MorethanTV search plugin.
     """

--- a/flexget/components/sites/sites/ncore.py
+++ b/flexget/components/sites/sites/ncore.py
@@ -45,7 +45,7 @@ SORT = {
 }
 
 
-class UrlRewriteNcore:
+class UrlRewriteNcore(plugin.PluginBase):
     """nCore urlrewriter."""
 
     schema = {

--- a/flexget/components/sites/sites/newtorrents.py
+++ b/flexget/components/sites/sites/newtorrents.py
@@ -14,7 +14,7 @@ from flexget.utils.soup import get_soup
 logger = logger.bind(name='newtorrents')
 
 
-class NewTorrents:
+class NewTorrents(plugin.PluginBase):
     """NewTorrents urlrewriter and search plugin."""
 
     def __init__(self):

--- a/flexget/components/sites/sites/newznab.py
+++ b/flexget/components/sites/sites/newznab.py
@@ -11,7 +11,7 @@ __author__ = 'deksan'
 logger = logger.bind(name='newznab')
 
 
-class Newznab:
+class Newznab(plugin.PluginBase):
     """
     Newznab search plugin
     Provide a url or your website + apikey and a category.

--- a/flexget/components/sites/sites/nnmclub.py
+++ b/flexget/components/sites/sites/nnmclub.py
@@ -8,7 +8,7 @@ from flexget.utils import requests
 logger = logger.bind(name='nnm-club')
 
 
-class UrlRewriteNnmClub:
+class UrlRewriteNnmClub(plugin.PluginBase):
     """Nnm-club.me urlrewriter."""
 
     def url_rewritable(self, task, entry):

--- a/flexget/components/sites/sites/nyaa.py
+++ b/flexget/components/sites/sites/nyaa.py
@@ -46,7 +46,7 @@ CATEGORIES = {
 FILTERS = ['all', 'filter remakes', 'trusted only']
 
 
-class UrlRewriteNyaa:
+class UrlRewriteNyaa(plugin.PluginBase):
     """Nyaa urlrewriter and search plugin."""
 
     schema = {

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -100,7 +100,7 @@ class PassThePopcornCookie(Base):
     expires = Column(DateTime)
 
 
-class SearchPassThePopcorn:
+class SearchPassThePopcorn(plugin.PluginBase):
     """
     PassThePopcorn search plugin.
     """

--- a/flexget/components/sites/sites/ptn.py
+++ b/flexget/components/sites/sites/ptn.py
@@ -53,7 +53,7 @@ default_search_params = {
 }
 
 
-class SearchPTN:
+class SearchPTN(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/components/sites/sites/rarbg.py
+++ b/flexget/components/sites/sites/rarbg.py
@@ -39,7 +39,7 @@ CATEGORIES = {
 }
 
 
-class SearchRarBG:
+class SearchRarBG(plugin.PluginBase):
     """
     RarBG search plugin. Implements https://torrentapi.org/apidocs_v2.txt
 

--- a/flexget/components/sites/sites/redirect.py
+++ b/flexget/components/sites/sites/redirect.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='redirect_url')
 
 
-class UrlRewriteRedirect:
+class UrlRewriteRedirect(plugin.PluginBase):
     """Rewrites urls which actually redirect somewhere else."""
 
     def __init__(self):

--- a/flexget/components/sites/sites/rlsbb.py
+++ b/flexget/components/sites/sites/rlsbb.py
@@ -12,7 +12,7 @@ from flexget.utils.soup import get_soup
 logger = logger.bind(name='rlsbb')
 
 
-class UrlRewriteRlsbb:
+class UrlRewriteRlsbb(plugin.PluginBase):
     r"""
     rlsbb.ru urlrewriter
     Version 0.1

--- a/flexget/components/sites/sites/rmz.py
+++ b/flexget/components/sites/sites/rmz.py
@@ -12,7 +12,7 @@ from flexget.utils.soup import get_soup
 logger = logger.bind(name='rmz')
 
 
-class UrlRewriteRmz:
+class UrlRewriteRmz(plugin.PluginBase):
     r"""
     rmz.cr (rapidmoviez.com) urlrewriter
     Version 0.1

--- a/flexget/components/sites/sites/rss.py
+++ b/flexget/components/sites/sites/rss.py
@@ -10,7 +10,7 @@ from flexget.event import event
 logger = logger.bind(name='search_rss')
 
 
-class SearchRSS:
+class SearchRSS(plugin.PluginBase):
     """A generic search plugin that can use rss based search feeds. Configure it like rss
     plugin, but include {{{search_term}}} in the url where the search term should go."""
 

--- a/flexget/components/sites/sites/rutracker.py
+++ b/flexget/components/sites/sites/rutracker.py
@@ -126,7 +126,7 @@ class RutrackerAuth(AuthBase):
         return r
 
 
-class RutrackerUrlrewrite:
+class RutrackerUrlrewrite(plugin.PluginBase):
     """Usage:
 
     rutracker_auth:

--- a/flexget/components/sites/sites/shortened.py
+++ b/flexget/components/sites/sites/shortened.py
@@ -8,7 +8,7 @@ from flexget.event import event
 logger = logger.bind(name='shortened')
 
 
-class UrlRewriteShortened:
+class UrlRewriteShortened(plugin.PluginBase):
     """Shortened url rewriter."""
 
     def url_rewritable(self, task, entry):

--- a/flexget/components/sites/sites/site_1337x.py
+++ b/flexget/components/sites/sites/site_1337x.py
@@ -15,7 +15,7 @@ from flexget.utils.tools import parse_filesize
 logger = logger.bind(name='1337x')
 
 
-class Site1337x:
+class Site1337x(plugin.PluginBase):
     """
     1337x search plugin.
     """

--- a/flexget/components/sites/sites/site_rutracker.py
+++ b/flexget/components/sites/sites/site_rutracker.py
@@ -10,7 +10,7 @@ from flexget.event import event
 logger = logger.bind(name='rutracker')
 
 
-class SiteRutracker:
+class SiteRutracker(plugin.PluginBase):
     schema = {'type': 'boolean'}
 
     base_url = 'https://api.t-ru.org'

--- a/flexget/components/sites/sites/torrent_cache.py
+++ b/flexget/components/sites/sites/torrent_cache.py
@@ -16,7 +16,7 @@ MIRRORS = [
 ]
 
 
-class TorrentCache:
+class TorrentCache(plugin.PluginBase):
     """Adds urls to torrent cache sites to the urls list."""
 
     def infohash_urls(self, info_hash):

--- a/flexget/components/sites/sites/torrentz.py
+++ b/flexget/components/sites/sites/torrentz.py
@@ -21,7 +21,7 @@ REPUTATIONS = {  # Maps reputation name to feed address
 }
 
 
-class Torrentz:
+class Torrentz(plugin.PluginBase):
     """Torrentz search and urlrewriter"""
 
     schema = {

--- a/flexget/components/sites/sites/wordpress.py
+++ b/flexget/components/sites/sites/wordpress.py
@@ -46,7 +46,7 @@ def get_valid_cookies(cookies):
     return cookiejar_from_dict(valid_cookies)
 
 
-class PluginWordPress:
+class PluginWordPress(plugin.PluginBase):
     """
     Supports accessing feeds and media that require wordpress account credentials
     Usage:

--- a/flexget/components/sites/sites/yts.py
+++ b/flexget/components/sites/sites/yts.py
@@ -13,7 +13,7 @@ from flexget.utils.tools import parse_filesize
 logger = logger.bind(name='yts')
 
 
-class UrlRewriteYTS:
+class UrlRewriteYTS(plugin.PluginBase):
     """YTS search"""
 
     schema = {'type': 'boolean'}

--- a/flexget/components/sites/urlrewrite.py
+++ b/flexget/components/sites/urlrewrite.py
@@ -9,7 +9,7 @@ from flexget.event import event
 logger = logger.bind(name='urlrewrite')
 
 
-class UrlRewrite:
+class UrlRewrite(plugin.PluginBase):
     r"""
     Generic configurable urlrewriter.
 

--- a/flexget/components/sites/urlrewrite_search.py
+++ b/flexget/components/sites/urlrewrite_search.py
@@ -8,7 +8,7 @@ from flexget.event import event
 logger = logger.bind(name='urlrewrite_search')
 
 
-class PluginSearch:
+class PluginSearch(plugin.PluginBase):
     """
     Search entry from sites. Accepts list of known search plugins, list is in priority order.
     Once hit has been found no more searches are performed. Should be used only when

--- a/flexget/components/sites/urlrewriting.py
+++ b/flexget/components/sites/urlrewriting.py
@@ -14,7 +14,7 @@ class UrlRewritingError(Exception):
         return repr(self.value)
 
 
-class PluginUrlRewriting:
+class PluginUrlRewriting(plugin.PluginBase):
     """
     Provides URL rewriting framework
     """
@@ -89,7 +89,7 @@ class PluginUrlRewriting:
                     )
 
 
-class DisableUrlRewriter:
+class DisableUrlRewriter(plugin.PluginBase):
     """Disable certain urlrewriters."""
 
     schema = {'type': 'array', 'items': {'type': 'string'}}

--- a/flexget/components/status/status.py
+++ b/flexget/components/status/status.py
@@ -11,7 +11,7 @@ from . import db
 logger = logger.bind(name='status')
 
 
-class Status:
+class Status(plugin.PluginBase):
     """Track health status of tasks"""
 
     schema = {'type': 'boolean'}

--- a/flexget/components/tmdb/api_tmdb.py
+++ b/flexget/components/tmdb/api_tmdb.py
@@ -276,7 +276,7 @@ class TMDBSearchResult(Base):
             self.movie = movie
 
 
-class ApiTmdb:
+class ApiTmdb(plugin.PluginBase):
     """Does lookups to TMDb and provides movie information. Caches lookups."""
 
     @staticmethod

--- a/flexget/components/trakt/api_trakt.py
+++ b/flexget/components/trakt/api_trakt.py
@@ -118,7 +118,7 @@ class TraktUserCache(TimedDict):
 user_cache = TraktUserCache(cache_time=USER_CACHE_DURATION)
 
 
-class ApiTrakt:
+class ApiTrakt(plugin.PluginBase):
     def __init__(self, username=None, account=None):
         self.account = account
         self.username = db.get_username(username, account)

--- a/flexget/components/trakt/next_trakt_episodes.py
+++ b/flexget/components/trakt/next_trakt_episodes.py
@@ -12,7 +12,7 @@ from . import db
 logger = logger.bind(name='next_trakt_episodes')
 
 
-class NextTraktEpisodes:
+class NextTraktEpisodes(plugin.PluginBase):
     """
     Creates an entry for the latest or the next item in your watched or collected
     episodes in your trakt account.

--- a/flexget/components/trakt/trakt_calendar.py
+++ b/flexget/components/trakt/trakt_calendar.py
@@ -15,7 +15,7 @@ logger = logger.bind(name='trakt_calendar')
 max_number_of_days = 31
 
 
-class TraktCalendar:
+class TraktCalendar(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/components/trakt/trakt_list.py
+++ b/flexget/components/trakt/trakt_list.py
@@ -497,7 +497,7 @@ class TraktSet(MutableSet):
         return True
 
 
-class TraktList:
+class TraktList(plugin.PluginBase):
     schema = TraktSet.schema
 
     def get_list(self, config):

--- a/flexget/components/tvmaze/api_tvmaze.py
+++ b/flexget/components/tvmaze/api_tvmaze.py
@@ -435,7 +435,7 @@ def prepare_lookup_for_tvmaze(**lookup_params):
     return prepared_params
 
 
-class APITVMaze:
+class APITVMaze(plugin.PluginBase):
     @staticmethod
     @with_session
     def series_lookup(session=None, only_cached=False, **lookup_params):

--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -1,6 +1,7 @@
 import os
 import re
 import time
+import typing
 from functools import total_ordering
 from http.client import BadStatusLine
 from importlib import import_module
@@ -18,11 +19,18 @@ from flexget import plugins as plugins_pkg
 from flexget.event import Event, event, fire_event, remove_event_handlers
 from flexget.event import add_event_handler as add_phase_handler
 
+if typing.TYPE_CHECKING:
+    pass
+
 logger = loguru.logger.bind(name='plugin')
 
 PRIORITY_DEFAULT = 128
 PRIORITY_LAST = -255
 PRIORITY_FIRST = 255
+
+
+class PluginBase:
+    pass
 
 
 class DependencyError(Exception):

--- a/flexget/plugins/cli/try_regexp.py
+++ b/flexget/plugins/cli/try_regexp.py
@@ -9,7 +9,7 @@ from flexget.terminal import console
 logger = logger.bind(name='try_regexp')
 
 
-class PluginTryRegexp:
+class PluginTryRegexp(plugin.PluginBase):
     """
     This plugin allows user to test regexps for a task.
     """

--- a/flexget/plugins/clients/aria2.py
+++ b/flexget/plugins/clients/aria2.py
@@ -142,7 +142,7 @@ class XmlRpcClient(RpcClient):
 RPC_CLIENTS = {'xml': XmlRpcClient, 'json': JsonRpcClient}
 
 
-class OutputAria2:
+class OutputAria2(plugin.PluginBase):
     """
     Simple Aria2 output
 

--- a/flexget/plugins/clients/deluge.py
+++ b/flexget/plugins/clients/deluge.py
@@ -85,7 +85,7 @@ class DelugePlugin:
                     return username, password
 
 
-class InputDeluge(DelugePlugin):
+class InputDeluge(DelugePlugin, plugin.PluginBase):
     """Create entries for torrents in the deluge session."""
 
     # Fields we provide outside of the deluge_ prefixed namespace

--- a/flexget/plugins/clients/nzbget.py
+++ b/flexget/plugins/clients/nzbget.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='nzbget')
 
 
-class OutputNzbget:
+class OutputNzbget(plugin.PluginBase):
     """
     Example::
 

--- a/flexget/plugins/clients/pyload.py
+++ b/flexget/plugins/clients/pyload.py
@@ -49,7 +49,7 @@ class PyloadApi:
             raise
 
 
-class PluginPyLoad:
+class PluginPyLoad(plugin.PluginBase):
     """
     Parse task content or url for hoster links and adds them to pyLoad.
 

--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -13,7 +13,7 @@ from flexget.utils.template import RenderError
 logger = logger.bind(name='qbittorrent')
 
 
-class OutputQBitTorrent:
+class OutputQBitTorrent(plugin.PluginBase):
     """
     Example:
 
@@ -322,7 +322,7 @@ class OutputQBitTorrent:
             self.add_entries(task, config)
 
 
-class FromQBitTorrent:
+class FromQBitTorrent(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -470,7 +470,7 @@ class RTorrentPluginBase:
         return options
 
 
-class RTorrentOutputPlugin(RTorrentPluginBase):
+class RTorrentOutputPlugin(RTorrentPluginBase, plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -177,7 +177,7 @@ class TransmissionBase:
                     logger.error('It looks like there was a problem connecting to transmission.')
 
 
-class PluginTransmissionInput(TransmissionBase):
+class PluginTransmissionInput(TransmissionBase, plugin.PluginBase):
     schema = {
         'anyOf': [
             {'type': 'boolean'},

--- a/flexget/plugins/filter/abort_if_exists.py
+++ b/flexget/plugins/filter/abort_if_exists.py
@@ -8,7 +8,7 @@ from flexget.event import event
 logger = logger.bind(name='abort_if_exists')
 
 
-class PluginAbortIfExists:
+class PluginAbortIfExists(plugin.PluginBase):
     """Aborts a task if an entry field matches the regexp"""
 
     schema = {

--- a/flexget/plugins/filter/accept_all.py
+++ b/flexget/plugins/filter/accept_all.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='accept_all')
 
 
-class FilterAcceptAll:
+class FilterAcceptAll(plugin.PluginBase):
     """
     Just accepts all entries.
 

--- a/flexget/plugins/filter/age.py
+++ b/flexget/plugins/filter/age.py
@@ -10,7 +10,7 @@ from flexget.utils.tools import parse_timedelta
 logger = logger.bind(name='age')
 
 
-class Age:
+class Age(plugin.PluginBase):
     """
     Rejects/accepts entries based on date in specified entry field
 

--- a/flexget/plugins/filter/best_quality.py
+++ b/flexget/plugins/filter/best_quality.py
@@ -10,7 +10,7 @@ logger = logger.bind(name='best_quality')
 entry_actions = {'accept': Entry.accept, 'reject': Entry.reject}
 
 
-class FilterBestQuality:
+class FilterBestQuality(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/plugins/filter/content_filter.py
+++ b/flexget/plugins/filter/content_filter.py
@@ -9,7 +9,7 @@ from flexget.event import event
 logger = logger.bind(name='content_filter')
 
 
-class FilterContentFilter:
+class FilterContentFilter(plugin.PluginBase):
     """
     Rejects entries based on the filenames in the content. Torrent files only right now.
 

--- a/flexget/plugins/filter/content_size.py
+++ b/flexget/plugins/filter/content_size.py
@@ -10,7 +10,7 @@ from flexget.utils.tools import format_filesize, parse_filesize
 logger = logger.bind(name='content_size')
 
 
-class FilterContentSize:
+class FilterContentSize(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/plugins/filter/crossmatch.py
+++ b/flexget/plugins/filter/crossmatch.py
@@ -7,7 +7,7 @@ from flexget.utils.tools import aggregate_inputs
 logger = logger.bind(name='crossmatch')
 
 
-class CrossMatch:
+class CrossMatch(plugin.PluginBase):
     """
     Perform action based on item on current task and other inputs.
 

--- a/flexget/plugins/filter/delay.py
+++ b/flexget/plugins/filter/delay.py
@@ -81,7 +81,7 @@ def upgrade(ver, session):
     return ver
 
 
-class FilterDelay:
+class FilterDelay(plugin.PluginBase):
     """
     Add delay to a task. This is useful for de-prioritizing expensive / bad-quality tasks.
 

--- a/flexget/plugins/filter/duplicates.py
+++ b/flexget/plugins/filter/duplicates.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='duplicates')
 
 
-class Duplicates:
+class Duplicates(plugin.PluginBase):
     """
     Take action on entries with duplicate field values
 

--- a/flexget/plugins/filter/exists.py
+++ b/flexget/plugins/filter/exists.py
@@ -10,7 +10,7 @@ from flexget.event import event
 logger = logger.bind(name='exists')
 
 
-class FilterExists:
+class FilterExists(plugin.PluginBase):
     """
     Reject entries that already exist in given path.
 

--- a/flexget/plugins/filter/exists_movie.py
+++ b/flexget/plugins/filter/exists_movie.py
@@ -18,7 +18,7 @@ def merge_found_qualities(existing_qualities: Dict[str, set], new_qualities: Dic
         existing_qualities.setdefault(movie_id, set()).update(quals)
 
 
-class FilterExistsMovie:
+class FilterExistsMovie(plugin.PluginBase):
     """
     Reject existing movies.
 

--- a/flexget/plugins/filter/exists_series.py
+++ b/flexget/plugins/filter/exists_series.py
@@ -17,7 +17,7 @@ except ImportError:
 logger = logger.bind(name='exists_series')
 
 
-class FilterExistsSeries:
+class FilterExistsSeries(plugin.PluginBase):
     """
     Intelligent series aware exists rejecting.
 

--- a/flexget/plugins/filter/if_condition.py
+++ b/flexget/plugins/filter/if_condition.py
@@ -12,7 +12,7 @@ from flexget.utils.template import evaluate_expression
 logger = logger.bind(name='if')
 
 
-class FilterIf:
+class FilterIf(plugin.PluginBase):
     """Can run actions on entries that satisfy a given condition.
 
     Actions include accept, reject, and fail, as well as the ability to run other filter plugins on the entries.

--- a/flexget/plugins/filter/limit_new.py
+++ b/flexget/plugins/filter/limit_new.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='limit_new')
 
 
-class FilterLimitNew:
+class FilterLimitNew(plugin.PluginBase):
     """
     Limit number of new items.
 

--- a/flexget/plugins/filter/magnets.py
+++ b/flexget/plugins/filter/magnets.py
@@ -2,7 +2,7 @@ from flexget import plugin
 from flexget.event import event
 
 
-class Magnets:
+class Magnets(plugin.PluginBase):
     """Removes magnet urls form the urls list. Rejects entries that have nothing but magnet urls."""
 
     schema = {'type': 'boolean'}

--- a/flexget/plugins/filter/only_new.py
+++ b/flexget/plugins/filter/only_new.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='only_new')
 
 
-class FilterOnlyNew:
+class FilterOnlyNew(plugin.PluginBase):
     """Causes input plugins to only emit entries that haven't been seen on previous runs."""
 
     schema = {'type': 'boolean'}

--- a/flexget/plugins/filter/proper_movies.py
+++ b/flexget/plugins/filter/proper_movies.py
@@ -46,7 +46,7 @@ Index(
 )
 
 
-class FilterProperMovies:
+class FilterProperMovies(plugin.PluginBase):
     """
     Automatically download proper movies.
 

--- a/flexget/plugins/filter/quality.py
+++ b/flexget/plugins/filter/quality.py
@@ -8,7 +8,7 @@ from flexget.utils import qualities
 logger = logger.bind(name='quality')
 
 
-class FilterQuality:
+class FilterQuality(plugin.PluginBase):
     """
     Rejects all entries that don't have one of the specified qualities
 

--- a/flexget/plugins/filter/regexp.py
+++ b/flexget/plugins/filter/regexp.py
@@ -11,7 +11,7 @@ from flexget.event import event
 logger = logger.bind(name='regexp')
 
 
-class FilterRegexp:
+class FilterRegexp(plugin.PluginBase):
     """
     All possible forms.
 

--- a/flexget/plugins/filter/require_field.py
+++ b/flexget/plugins/filter/require_field.py
@@ -7,7 +7,7 @@ from flexget.event import event
 logger = logger.bind(name='require_field')
 
 
-class FilterRequireField:
+class FilterRequireField(plugin.PluginBase):
     """
     Rejects entries without defined field.
 

--- a/flexget/plugins/filter/rottentomatoes.py
+++ b/flexget/plugins/filter/rottentomatoes.py
@@ -7,7 +7,7 @@ from flexget.utils.log import log_once
 logger = logger.bind(name='rt')
 
 
-class FilterRottenTomatoes:
+class FilterRottenTomatoes(plugin.PluginBase):
     """
     This plugin allows filtering based on Rotten Tomatoes score, votes and genres etc.
 

--- a/flexget/plugins/filter/thetvdb.py
+++ b/flexget/plugins/filter/thetvdb.py
@@ -7,7 +7,7 @@ from flexget.utils.log import log_once
 logger = logger.bind(name='thetvdb')
 
 
-class FilterTvdb:
+class FilterTvdb(plugin.PluginBase):
     """
     This plugin allows filtering based on thetvdb series rating,
     episode rating, status, genres, runtime, content-rating,

--- a/flexget/plugins/filter/timeframe.py
+++ b/flexget/plugins/filter/timeframe.py
@@ -33,7 +33,7 @@ class EntryTimeFrame(Base):
         return f'<Timeframe(id={self.id},added={self.added},quality={self.quality})>'
 
 
-class FilterTimeFrame:
+class FilterTimeFrame(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/plugins/filter/unique.py
+++ b/flexget/plugins/filter/unique.py
@@ -7,7 +7,7 @@ from flexget.event import event
 logger = logger.bind(name='unique')
 
 
-class Unique:
+class Unique(plugin.PluginBase):
     """
     Take action on entries with duplicate fields, except for the first item
 

--- a/flexget/plugins/filter/upgrade.py
+++ b/flexget/plugins/filter/upgrade.py
@@ -33,7 +33,7 @@ class EntryUpgrade(Base):
         return f'<Upgrade(id={self.id},added={self.added},quality={self.quality})>'
 
 
-class FilterUpgrade:
+class FilterUpgrade(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/plugins/generic/urlfix.py
+++ b/flexget/plugins/generic/urlfix.py
@@ -7,7 +7,7 @@ from flexget.utils.log import log_once
 logger = logger.bind(name='urlfix')
 
 
-class UrlFix:
+class UrlFix(plugin.PluginBase):
     """
     Automatically fix broken urls.
     """

--- a/flexget/plugins/input/anidb_list.py
+++ b/flexget/plugins/input/anidb_list.py
@@ -13,7 +13,7 @@ logger = logger.bind(name='anidb_list')
 USER_ID_RE = r'^\d{1,6}$'
 
 
-class AnidbList:
+class AnidbList(plugin.PluginBase):
     """ "Creates an entry for each movie or series in your AniDB wishlist."""
 
     anidb_url = 'http://anidb.net/perl-bin/'

--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -23,7 +23,7 @@ TRAILER_SOURCE = {
 }
 
 
-class AniList:
+class AniList(plugin.PluginBase):
     """ " Creates entries for series and movies from your AniList list
 
     Syntax:

--- a/flexget/plugins/input/apple_trailers.py
+++ b/flexget/plugins/input/apple_trailers.py
@@ -13,7 +13,7 @@ from flexget.utils.requests import RequestException
 logger = logger.bind(name='apple_trailers')
 
 
-class AppleTrailers:
+class AppleTrailers(plugin.PluginBase):
     """
     Adds support for Apple.com movie trailers.
 

--- a/flexget/plugins/input/betaseries_list.py
+++ b/flexget/plugins/input/betaseries_list.py
@@ -14,7 +14,7 @@ logger = logger.bind(name='betaseries_list')
 API_URL_PREFIX = 'https://api.betaseries.com/'
 
 
-class BetaSeriesList:
+class BetaSeriesList(plugin.PluginBase):
     """
     Emits an entry for each serie followed by one or more BetaSeries account.
     See https://www.betaseries.com/

--- a/flexget/plugins/input/discover.py
+++ b/flexget/plugins/input/discover.py
@@ -44,7 +44,7 @@ def db_cleanup(manager, session):
         session.delete(discover_entry)
 
 
-class Discover:
+class Discover(plugin.PluginBase):
     """
     Discover content based on other inputs material.
 

--- a/flexget/plugins/input/filesystem.py
+++ b/flexget/plugins/input/filesystem.py
@@ -13,7 +13,7 @@ from flexget.event import event
 logger = logger.bind(name='filesystem')
 
 
-class Filesystem:
+class Filesystem(plugin.PluginBase):
     """
     Uses local path content as an input. Can use recursion if configured.
     Recursion is False by default. Can be configured to true or get integer that will specify max depth in relation to

--- a/flexget/plugins/input/filmweb_watchlist.py
+++ b/flexget/plugins/input/filmweb_watchlist.py
@@ -21,7 +21,7 @@ def translate_type(type):
     return {'shows': 'serial', 'movies': 'film'}[type]
 
 
-class FilmwebWatchlist:
+class FilmwebWatchlist(plugin.PluginBase):
     """ "Creates an entry for each movie in your Filmweb list."""
 
     schema = {

--- a/flexget/plugins/input/from_piratebay.py
+++ b/flexget/plugins/input/from_piratebay.py
@@ -83,7 +83,7 @@ TRACKERS = [
 ]
 
 
-class FromPirateBay:
+class FromPirateBay(plugin.PluginBase):
     """
     Return torrent listing from piratebay api.
 

--- a/flexget/plugins/input/from_task.py
+++ b/flexget/plugins/input/from_task.py
@@ -8,7 +8,7 @@ from flexget.task import Task
 logger = logger.bind(name='from_task')
 
 
-class FromTask:
+class FromTask(plugin.PluginBase):
     """An input plugin which returns accepted entries from another task."""
 
     schema = {'type': 'string'}

--- a/flexget/plugins/input/from_telegram.py
+++ b/flexget/plugins/input/from_telegram.py
@@ -14,7 +14,7 @@ logger = logger.bind(name='from_telegram')
 _TELEGRAM_API_URL = "https://api.telegram.org/"
 
 
-class TelegramInput:
+class TelegramInput(plugin.PluginBase):
     """
     Parse any messages from Telegram and fills fields with regex
 

--- a/flexget/plugins/input/gazelle.py
+++ b/flexget/plugins/input/gazelle.py
@@ -32,7 +32,7 @@ class GazelleSession(Base):
     expires = Column(DateTime)
 
 
-class InputGazelle:
+class InputGazelle(plugin.PluginBase):
     """A generic plugin that searches a Gazelle-based website
 
     Limited functionality but should work for almost all of them.
@@ -311,7 +311,7 @@ class InputGazelle:
         return self.get_entries(self.search_results(params))
 
 
-class InputGazelleMusic(InputGazelle):
+class InputGazelleMusic(InputGazelle, plugin.PluginBase):
     """A plugin that searches a Gazelle-based music website
 
     Based on https://github.com/WhatCD/Gazelle since it's the starting point of

--- a/flexget/plugins/input/generate.py
+++ b/flexget/plugins/input/generate.py
@@ -7,7 +7,7 @@ from flexget.event import event
 logger = logger.bind(name='generate')
 
 
-class Generate:
+class Generate(plugin.PluginBase):
     """Generates n number of random entries. Used for debugging purposes."""
 
     schema = {'type': 'integer'}

--- a/flexget/plugins/input/html.py
+++ b/flexget/plugins/input/html.py
@@ -16,7 +16,7 @@ from flexget.utils.soup import get_soup
 logger = logger.bind(name='html')
 
 
-class InputHtml:
+class InputHtml(plugin.PluginBase):
     """
     Parses urls from html page. Usefull on sites which have direct download
     links of any type (mp3, jpg, torrent, ...).

--- a/flexget/plugins/input/input_csv.py
+++ b/flexget/plugins/input/input_csv.py
@@ -11,7 +11,7 @@ from flexget.utils.cached_input import cached
 logger = logger.bind(name='csv')
 
 
-class InputCSV:
+class InputCSV(plugin.PluginBase):
     """
     Adds support for CSV format. Configuration may seem a bit complex,
     but this has advantage of being universal solution regardless of CSV

--- a/flexget/plugins/input/inputs.py
+++ b/flexget/plugins/input/inputs.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='inputs')
 
 
-class PluginInputs:
+class PluginInputs(plugin.PluginBase):
     """
     Allows the same input plugin to be configured multiple times in a task.
 

--- a/flexget/plugins/input/json.py
+++ b/flexget/plugins/input/json.py
@@ -12,7 +12,7 @@ from flexget.utils import json
 logger = logger.bind(name='json')
 
 
-class Json:
+class Json(plugin.PluginBase):
     """
     Return entries from a json file.
 

--- a/flexget/plugins/input/kitsu.py
+++ b/flexget/plugins/input/kitsu.py
@@ -10,7 +10,7 @@ from flexget.utils.requests import RequestException
 logger = logger.bind(name='kitsu')
 
 
-class KitsuAnime:
+class KitsuAnime(plugin.PluginBase):
     """
     Creates an entry for each item in your kitsu.io list.
 

--- a/flexget/plugins/input/letterboxd.py
+++ b/flexget/plugins/input/letterboxd.py
@@ -36,7 +36,7 @@ SORT_BY = {
 }
 
 
-class Letterboxd:
+class Letterboxd(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/plugins/input/limit.py
+++ b/flexget/plugins/input/limit.py
@@ -8,7 +8,7 @@ from flexget.event import event
 logger = logger.bind(name='limit')
 
 
-class PluginLimit:
+class PluginLimit(plugin.PluginBase):
     """
     Limits the number of entries an input plugin can produce.
     """

--- a/flexget/plugins/input/medusa.py
+++ b/flexget/plugins/input/medusa.py
@@ -9,7 +9,7 @@ from flexget.event import event
 logger = logger.bind(name='medusa')
 
 
-class Medusa:
+class Medusa(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/plugins/input/mock.py
+++ b/flexget/plugins/input/mock.py
@@ -8,7 +8,7 @@ from flexget.event import event
 logger = logger.bind(name='mock')
 
 
-class Mock:
+class Mock(plugin.PluginBase):
     """
     Allows adding mock input entries.
 

--- a/flexget/plugins/input/my_anime_list.py
+++ b/flexget/plugins/input/my_anime_list.py
@@ -16,7 +16,7 @@ AIRING_STATUS = {'airing': 1, 'finished': 2, 'planned': 3, 'all': 6}
 ANIME_TYPE = ['all', 'tv', 'ova', 'movie', 'special', 'ona', 'music', 'unknown']
 
 
-class MyAnimeList:
+class MyAnimeList(plugin.PluginBase):
     """ " Creates entries for series and movies from MyAnimeList list
 
     Syntax:

--- a/flexget/plugins/input/myepisodes_list.py
+++ b/flexget/plugins/input/myepisodes_list.py
@@ -15,7 +15,7 @@ logger = logger.bind(name='myepisodes_list')
 URL = 'http://www.myepisodes.com/'
 
 
-class MyEpisodesList:
+class MyEpisodesList(plugin.PluginBase):
     """Creates an entry for each item in your myepisodes.com show list.
 
     Syntax:

--- a/flexget/plugins/input/next_sonarr_episodes.py
+++ b/flexget/plugins/input/next_sonarr_episodes.py
@@ -11,7 +11,7 @@ from flexget.event import event
 logger = logger.bind(name='next_sonarr_episodes')
 
 
-class NextSonarrEpisodes:
+class NextSonarrEpisodes(plugin.PluginBase):
     """
     This plugin return the 1st missing episode of every show configures in Sonarr.
     This can be used with the discover plugin or set_series_begin plugin to

--- a/flexget/plugins/input/npo_watchlist.py
+++ b/flexget/plugins/input/npo_watchlist.py
@@ -19,7 +19,7 @@ requests.add_domain_limiter(TimedLimiter('npostart.nl', '6 seconds'))
 requests.add_domain_limiter(TimedLimiter('npo.nl', '6 seconds'))
 
 
-class NPOWatchlist:
+class NPOWatchlist(plugin.PluginBase):
     """
     Produces entries for every episode on the user's npostart.nl watchlist (Dutch public television).
     Entries can be downloaded using http://arp242.net/code/download-npo

--- a/flexget/plugins/input/parameterize.py
+++ b/flexget/plugins/input/parameterize.py
@@ -7,7 +7,7 @@ from flexget.utils.template import RenderError, render_from_entry
 log = logging.getLogger('parameterize')
 
 
-class Parameterize:
+class Parameterize(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/plugins/input/plex.py
+++ b/flexget/plugins/input/plex.py
@@ -16,7 +16,7 @@ from flexget.utils import requests
 logger = logger.bind(name='plex')
 
 
-class InputPlex:
+class InputPlex(plugin.PluginBase):
     """
     Uses a plex media server (www.plexapp.com) tv section as an input.
 

--- a/flexget/plugins/input/pogcal.py
+++ b/flexget/plugins/input/pogcal.py
@@ -9,7 +9,7 @@ from flexget.utils.soup import get_soup
 logger = logger.bind(name='pogcal')
 
 
-class InputPogDesign:
+class InputPogDesign(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {'username': {'type': 'string'}, 'password': {'type': 'string'}},

--- a/flexget/plugins/input/regexp_parse.py
+++ b/flexget/plugins/input/regexp_parse.py
@@ -12,7 +12,7 @@ from flexget.utils.cached_input import cached
 logger = logger.bind(name='regexp_parse')
 
 
-class RegexpParse:
+class RegexpParse(plugin.PluginBase):
     r"""This plugin is designed to take input from a web resource or a file.
     It then parses the text via regexps supplied in the config file.
 

--- a/flexget/plugins/input/rlslog.py
+++ b/flexget/plugins/input/rlslog.py
@@ -21,7 +21,7 @@ except ImportError:
 logger = logger.bind(name='rlslog')
 
 
-class RlsLog:
+class RlsLog(plugin.PluginBase):
     """
     Adds support for rlslog.net as a feed.
     """

--- a/flexget/plugins/input/rottentomatoes_list.py
+++ b/flexget/plugins/input/rottentomatoes_list.py
@@ -14,7 +14,7 @@ except ImportError:
 logger = logger.bind(name='rottentomatoes_list')
 
 
-class RottenTomatoesList:
+class RottenTomatoesList(plugin.PluginBase):
     """
     Emits an entry for each movie in a Rotten Tomatoes list.
 

--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -28,7 +28,7 @@ def fp_field_name(name):
     return name.replace(':', '_').lower()
 
 
-class InputRSS:
+class InputRSS(plugin.PluginBase):
     """
     Parses RSS feed.
 

--- a/flexget/plugins/input/sceper.py
+++ b/flexget/plugins/input/sceper.py
@@ -17,7 +17,7 @@ except ImportError:
 logger = logger.bind(name='sceper')
 
 
-class InputSceper:
+class InputSceper(plugin.PluginBase):
     """
     Uses sceper.ws category url as input.
 

--- a/flexget/plugins/input/sickbeard.py
+++ b/flexget/plugins/input/sickbeard.py
@@ -10,7 +10,7 @@ from flexget.event import event
 logger = logger.bind(name='sickbeard')
 
 
-class Sickbeard:
+class Sickbeard(plugin.PluginBase):
     """
     This plugin returns ALL of the shows monitored by Sickbeard.
     This includes both ongoing and ended.

--- a/flexget/plugins/input/tail.py
+++ b/flexget/plugins/input/tail.py
@@ -22,7 +22,7 @@ class TailPosition(Base):
     position = Column(Integer)
 
 
-class InputTail:
+class InputTail(plugin.PluginBase):
     """
     Parse any text for entries using regular expression.
 

--- a/flexget/plugins/input/text.py
+++ b/flexget/plugins/input/text.py
@@ -12,7 +12,7 @@ from flexget.utils.cached_input import cached
 logger = logger.bind(name='text')
 
 
-class Text:
+class Text(plugin.PluginBase):
     """
     Parse any text for entries using regular expression.
 

--- a/flexget/plugins/input/torznab.py
+++ b/flexget/plugins/input/torznab.py
@@ -14,7 +14,7 @@ from flexget.utils.tools import parse_timedelta
 logger = logger.bind(name='torznab')
 
 
-class Torznab:
+class Torznab(plugin.PluginBase):
     """Torznab search plugin
 
     Handles searching for tv shows and movies, with fallback to simple query strings if these are not available.

--- a/flexget/plugins/input/twitterfeed.py
+++ b/flexget/plugins/input/twitterfeed.py
@@ -16,7 +16,7 @@ CHUNK_SIZE = 200
 MAX_TWEETS = 1000
 
 
-class TwitterFeed:
+class TwitterFeed(plugin.PluginBase):
     """Parses a twitter feed
 
     Example::

--- a/flexget/plugins/internal/api_bluray.py
+++ b/flexget/plugins/internal/api_bluray.py
@@ -200,7 +200,7 @@ class BluraySearchResult(Base):
             self.movie = movie
 
 
-class ApiBluray:
+class ApiBluray(plugin.PluginBase):
     """Does lookups to Blu-ray.com and provides movie information. Caches lookups."""
 
     @staticmethod

--- a/flexget/plugins/internal/change_warn.py
+++ b/flexget/plugins/internal/change_warn.py
@@ -9,7 +9,7 @@ logger = logger.bind(name='change')
 found_deprecated = False
 
 
-class ChangeWarn:
+class ChangeWarn(plugin.PluginBase):
     """
     Gives warning if user has deprecated / changed configuration in the root level.
 

--- a/flexget/plugins/metainfo/assume_quality.py
+++ b/flexget/plugins/metainfo/assume_quality.py
@@ -9,7 +9,7 @@ from flexget.event import event
 logger = logger.bind(name='assume_quality')
 
 
-class AssumeQuality:
+class AssumeQuality(plugin.PluginBase):
     """
     Applies quality components to entries that match specified quality requirements.
     When a quality is applied, any components which are unknown in the entry are filled from the applied quality.

--- a/flexget/plugins/metainfo/content_size.py
+++ b/flexget/plugins/metainfo/content_size.py
@@ -13,7 +13,7 @@ logger = logger.bind(name='metanfo_csize')
 SIZE_RE = re.compile(r'Size[^\d]{0,7}(\d*\.?\d+).{0,5}(MB|GB)', re.IGNORECASE | re.UNICODE)
 
 
-class MetainfoContentSize:
+class MetainfoContentSize(plugin.PluginBase):
     """
     Utility:
 

--- a/flexget/plugins/metainfo/media_id.py
+++ b/flexget/plugins/metainfo/media_id.py
@@ -7,7 +7,7 @@ from flexget.event import event
 logger = logger.bind(name='metainfo_media_id')
 
 
-class MetainfoMediaId:
+class MetainfoMediaId(plugin.PluginBase):
     """
     Populate media_id field based on media type etc.
     """

--- a/flexget/plugins/metainfo/metainfo_movie.py
+++ b/flexget/plugins/metainfo/metainfo_movie.py
@@ -12,7 +12,7 @@ except ImportError:
 logger = logger.bind(name='metainfo_movie')
 
 
-class MetainfoMovie:
+class MetainfoMovie(plugin.PluginBase):
     """
     Check if entry appears to be a movie, and populate movie info if so.
     """

--- a/flexget/plugins/metainfo/nfo_lookup.py
+++ b/flexget/plugins/metainfo/nfo_lookup.py
@@ -16,7 +16,7 @@ except ImportError:
 logger = logger.bind(name='nfo_lookup')
 
 
-class NfoLookup:
+class NfoLookup(plugin.PluginBase):
     """
     Retrieves information from a local '.nfo' info file.
 

--- a/flexget/plugins/metainfo/nzb_size.py
+++ b/flexget/plugins/metainfo/nzb_size.py
@@ -12,7 +12,7 @@ logger = logger.bind(name='nzb_size')
 mimetypes.add_type('application/x-nzb', '.nzb')
 
 
-class NzbSize:
+class NzbSize(plugin.PluginBase):
     """
     Provides entry size information when dealing with nzb files
     """

--- a/flexget/plugins/metainfo/quality.py
+++ b/flexget/plugins/metainfo/quality.py
@@ -8,7 +8,7 @@ from flexget.utils import qualities
 logger = logger.bind(name='metainfo_quality')
 
 
-class MetainfoQuality:
+class MetainfoQuality(plugin.PluginBase):
     """
     Utility:
 

--- a/flexget/plugins/metainfo/subtitles_check.py
+++ b/flexget/plugins/metainfo/subtitles_check.py
@@ -11,7 +11,7 @@ from flexget.event import event
 logger = logger.bind(name='check_subtitles')
 
 
-class MetainfoSubs:
+class MetainfoSubs(plugin.PluginBase):
     """
     Set 'subtitles' field for entries, if they are local video files with subs.
     The field is a list of language codes (3-letter ISO-639-3) for each subtitles

--- a/flexget/plugins/metainfo/task.py
+++ b/flexget/plugins/metainfo/task.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='metainfo_task')
 
 
-class MetainfoTask:
+class MetainfoTask(plugin.PluginBase):
     """
     Set 'task' field for entries.
     """

--- a/flexget/plugins/modify/extension.py
+++ b/flexget/plugins/modify/extension.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='extension')
 
 
-class ModifyExtension:
+class ModifyExtension(plugin.PluginBase):
     """
     Allows specifying file extension explicitly when all other built-in detection mechanisms fail.
 

--- a/flexget/plugins/modify/headers.py
+++ b/flexget/plugins/modify/headers.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='headers')
 
 
-class PluginHeaders:
+class PluginHeaders(plugin.PluginBase):
     """Allow setting up any headers in all requests (which use urllib2)
 
     Example:

--- a/flexget/plugins/modify/manipulate.py
+++ b/flexget/plugins/modify/manipulate.py
@@ -8,7 +8,7 @@ from flexget.event import event
 logger = logger.bind(name='manipulate')
 
 
-class Manipulate:
+class Manipulate(plugin.PluginBase):
     r"""
     Usage:
 

--- a/flexget/plugins/modify/path_by_ext.py
+++ b/flexget/plugins/modify/path_by_ext.py
@@ -8,7 +8,7 @@ from flexget.event import event
 logger = logger.bind(name='path_by_ext')
 
 
-class PluginPathByExt:
+class PluginPathByExt(plugin.PluginBase):
     """
     Allows specifying path based on content-type
 

--- a/flexget/plugins/modify/path_by_space.py
+++ b/flexget/plugins/modify/path_by_space.py
@@ -89,7 +89,7 @@ selector_map = {
 }
 
 
-class PluginPathBySpace:
+class PluginPathBySpace(plugin.PluginBase):
     """Allows setting a field to a folder based on it's space
 
     Path will be selected at random if multiple paths match the within

--- a/flexget/plugins/modify/plugin_priority.py
+++ b/flexget/plugins/modify/plugin_priority.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='p_priority')
 
 
-class PluginPriority:
+class PluginPriority(plugin.PluginBase):
     """
     Allows modifying plugin priorities from default values.
 

--- a/flexget/plugins/modify/regex_extract.py
+++ b/flexget/plugins/modify/regex_extract.py
@@ -10,7 +10,7 @@ from flexget.utils.tools import ReList
 logger = logger.bind(name='regex_extract')
 
 
-class RegexExtract:
+class RegexExtract(plugin.PluginBase):
     r"""
     Updates an entry with the values of regex matched named groups
 

--- a/flexget/plugins/modify/reorder_quality.py
+++ b/flexget/plugins/modify/reorder_quality.py
@@ -7,7 +7,7 @@ from flexget.utils import qualities
 logger = logger.bind(name='reorder_quality')
 
 
-class ReorderQuality:
+class ReorderQuality(plugin.PluginBase):
     """
     Allows modifying quality priorities from default ordering.
 

--- a/flexget/plugins/modify/set_field.py
+++ b/flexget/plugins/modify/set_field.py
@@ -11,7 +11,7 @@ logger = logger.bind(name='set')
 UNSET = '__unset__'
 
 
-class ModifySet:
+class ModifySet(plugin.PluginBase):
     """Allows adding information to a task entry for use later.
 
     Example:

--- a/flexget/plugins/modify/sort_by.py
+++ b/flexget/plugins/modify/sort_by.py
@@ -12,7 +12,7 @@ logger = logger.bind(name='sort_by')
 RE_ARTICLES = r'^(the|a|an)\s'
 
 
-class PluginSortBy:
+class PluginSortBy(plugin.PluginBase):
     """
     Sort task entries based on a field
 

--- a/flexget/plugins/modify/sort_by_weight.py
+++ b/flexget/plugins/modify/sort_by_weight.py
@@ -17,7 +17,7 @@ DEFAULT_STRIDE = (
 )
 
 
-class PluginSortByWeight:
+class PluginSortByWeight(plugin.PluginBase):
     """
     Sort task entries based on multiple fields using a sort weight per field.
     Result per entry is stored in 'sort_by_weight_sum'.

--- a/flexget/plugins/operate/abort.py
+++ b/flexget/plugins/operate/abort.py
@@ -2,7 +2,7 @@ from flexget import plugin
 from flexget.event import event
 
 
-class AbortPlugin:
+class AbortPlugin(plugin.PluginBase):
     """
     abort plugin for debug purposes.
 

--- a/flexget/plugins/operate/cfscraper.py
+++ b/flexget/plugins/operate/cfscraper.py
@@ -9,7 +9,7 @@ from flexget.utils.requests import Session
 logger = logger.bind(name='cfscraper')
 
 
-class CFScraper:
+class CFScraper(plugin.PluginBase):
     """
     Plugin that enables scraping of cloudflare protected sites.
 

--- a/flexget/plugins/operate/cookies.py
+++ b/flexget/plugins/operate/cookies.py
@@ -9,7 +9,7 @@ from flexget.utils.tools import TimedDict
 logger = logger.bind(name='cookies')
 
 
-class PluginCookies:
+class PluginCookies(plugin.PluginBase):
     """
     Adds cookie to all requests (rss, resolvers, download). Anything
     that uses urllib2 to be exact.

--- a/flexget/plugins/operate/digest.py
+++ b/flexget/plugins/operate/digest.py
@@ -66,7 +66,7 @@ class DigestEntry(Base):
     entry = entry_synonym('_json')
 
 
-class OutputDigest:
+class OutputDigest(plugin.PluginBase):
     schema = {
         'oneOf': [
             {'type': 'string'},
@@ -104,7 +104,7 @@ class OutputDigest:
                 session.add(DigestEntry(list=config['list'], entry=entry))
 
 
-class FromDigest:
+class FromDigest(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/plugins/operate/disable.py
+++ b/flexget/plugins/operate/disable.py
@@ -12,7 +12,7 @@ def all_builtins():
     return (p for p in plugin.plugins.values() if p.builtin)
 
 
-class DisablePlugin:
+class DisablePlugin(plugin.PluginBase):
     """
     Allows disabling built-ins, or plugins referenced by template/include plugin.
 

--- a/flexget/plugins/operate/disable_phases.py
+++ b/flexget/plugins/operate/disable_phases.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='disable_phases')
 
 
-class PluginDisablePhases:
+class PluginDisablePhases(plugin.PluginBase):
     """Disables phases from task execution.
 
     Mainly meant for advanced users and development.

--- a/flexget/plugins/operate/domain_delay.py
+++ b/flexget/plugins/operate/domain_delay.py
@@ -7,7 +7,7 @@ from flexget.utils.requests import TimedLimiter
 logger = logger.bind(name='domain_delay')
 
 
-class DomainDelay:
+class DomainDelay(plugin.PluginBase):
     """
     Sets a minimum interval between requests to specific domains.
 

--- a/flexget/plugins/operate/entry_trace.py
+++ b/flexget/plugins/operate/entry_trace.py
@@ -13,7 +13,7 @@ def on_entry_action(entry, act=None, task=None, reason=None, **kwargs):
         entry['reason'] = reason
 
 
-class EntryOperations:
+class EntryOperations(plugin.PluginBase):
     """
     Records accept, reject and fail metainfo into entries.
 

--- a/flexget/plugins/operate/formlogin.py
+++ b/flexget/plugins/operate/formlogin.py
@@ -16,7 +16,7 @@ except ImportError:
 logger = logger.bind(name='formlogin')
 
 
-class FormLogin:
+class FormLogin(plugin.PluginBase):
     """
     Login on form
     """

--- a/flexget/plugins/operate/free_space.py
+++ b/flexget/plugins/operate/free_space.py
@@ -62,7 +62,7 @@ def get_free_space(config, task):
         return (stats.f_bavail * stats.f_frsize) / (1024 * 1024)
 
 
-class PluginFreeSpace:
+class PluginFreeSpace(plugin.PluginBase):
     """Aborts a task if an entry is accepted and there is less than a certain amount of space free on a drive."""
 
     schema = {

--- a/flexget/plugins/operate/include.py
+++ b/flexget/plugins/operate/include.py
@@ -12,7 +12,7 @@ plugin_name = 'include'
 logger = logger.bind(name=plugin_name)
 
 
-class PluginInclude:
+class PluginInclude(plugin.PluginBase):
     """
     Include configuration from another yaml file.
 

--- a/flexget/plugins/operate/interval.py
+++ b/flexget/plugins/operate/interval.py
@@ -9,7 +9,7 @@ from flexget.event import event
 logger = logger.bind(name='interval')
 
 
-class PluginInterval:
+class PluginInterval(plugin.PluginBase):
     """
     Allows specifying minimum interval for task execution.
 

--- a/flexget/plugins/operate/log_filter.py
+++ b/flexget/plugins/operate/log_filter.py
@@ -55,7 +55,7 @@ SCHEMA = {
 }
 
 
-class LogFilter:
+class LogFilter(plugin.PluginBase):
     """
     Prevent entries with specific text from being logged.
 

--- a/flexget/plugins/operate/manual.py
+++ b/flexget/plugins/operate/manual.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='manual')
 
 
-class ManualTask:
+class ManualTask(plugin.PluginBase):
     """Only execute task when specified with --tasks"""
 
     schema = {'type': 'boolean'}

--- a/flexget/plugins/operate/max_reruns.py
+++ b/flexget/plugins/operate/max_reruns.py
@@ -7,7 +7,7 @@ from flexget.task import Task
 logger = logger.bind(name='max_reruns')
 
 
-class MaxReRuns:
+class MaxReRuns(plugin.PluginBase):
     """Overrides the maximum amount of re-runs allowed by a task."""
 
     schema = {'type': 'integer'}

--- a/flexget/plugins/operate/pathscrub.py
+++ b/flexget/plugins/operate/pathscrub.py
@@ -3,7 +3,7 @@ from flexget.event import event
 from flexget.utils import pathscrub
 
 
-class PathScrub:
+class PathScrub(plugin.PluginBase):
     """
     Plugin that will clear illegal characters from paths. Other plugins should use this if available when
     creating paths. User can specify what os if filenames must be compatible with an os other than current.

--- a/flexget/plugins/operate/priority.py
+++ b/flexget/plugins/operate/priority.py
@@ -10,7 +10,7 @@ logger = logger.bind(name='priority')
 # Currently the manager reads this value directly out of the config when the 'execute' command is run, and this plugin
 # does nothing but make the config key valid.
 # In daemon mode, schedules should be made which run tasks in the proper order instead of using this.
-class TaskPriority:
+class TaskPriority(plugin.PluginBase):
     """Set task priorities"""
 
     schema = {'type': 'integer'}

--- a/flexget/plugins/operate/proxy.py
+++ b/flexget/plugins/operate/proxy.py
@@ -10,7 +10,7 @@ logger = logger.bind(name='proxy')
 PROTOCOLS = ['http', 'https']
 
 
-class Proxy:
+class Proxy(plugin.PluginBase):
     """Adds a proxy to the requests session."""
 
     schema = {

--- a/flexget/plugins/operate/rerun.py
+++ b/flexget/plugins/operate/rerun.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='rerun')
 
 
-class Rerun:
+class Rerun(plugin.PluginBase):
     """
     Force a task to rerun for debugging purposes.
     Configured value will set max_rerun value and enables a lock

--- a/flexget/plugins/operate/run_task.py
+++ b/flexget/plugins/operate/run_task.py
@@ -9,7 +9,7 @@ from flexget.event import event
 logger = logger.bind(name='run_task')
 
 
-class RunTask:
+class RunTask(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/plugins/operate/sequence.py
+++ b/flexget/plugins/operate/sequence.py
@@ -8,7 +8,7 @@ from flexget.event import event
 logger = logger.bind(name='sequence')
 
 
-class PluginSequence:
+class PluginSequence(plugin.PluginBase):
     """Allows the same plugin to be configured multiple times in a task.
 
     Example:

--- a/flexget/plugins/operate/sleep.py
+++ b/flexget/plugins/operate/sleep.py
@@ -8,7 +8,7 @@ from flexget.event import event
 logger = logger.bind(name='sleep')
 
 
-class PluginSleep:
+class PluginSleep(plugin.PluginBase):
     """
     Causes a pause in execution to occur at the beginning of the specified phase of a task.
     The point at which the pause occurs can be adjusted using the `plugin_priority` plugin.

--- a/flexget/plugins/operate/spy_headers.py
+++ b/flexget/plugins/operate/spy_headers.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='spy_headers')
 
 
-class PluginSpyHeaders:
+class PluginSpyHeaders(plugin.PluginBase):
     """
     Logs all headers sent in http requests. Useful for resolving issues.
 

--- a/flexget/plugins/operate/template.py
+++ b/flexget/plugins/operate/template.py
@@ -9,7 +9,7 @@ plugin_name = 'template'
 logger = logger.bind(name=plugin_name)
 
 
-class PluginTemplate:
+class PluginTemplate(plugin.PluginBase):
     """
     Appyly templates with preconfigured plugins to a task config.
 

--- a/flexget/plugins/operate/verbose.py
+++ b/flexget/plugins/operate/verbose.py
@@ -9,7 +9,7 @@ from flexget.utils.log import log_once
 logger = logger.bind(name='verbose')
 
 
-class Verbose:
+class Verbose(plugin.PluginBase):
     """
     Verbose entry accept, reject and failure
     """

--- a/flexget/plugins/operate/verbose_details.py
+++ b/flexget/plugins/operate/verbose_details.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='details')
 
 
-class PluginDetails:
+class PluginDetails(plugin.PluginBase):
     def on_task_start(self, task, config):
         # Make a flag for tasks to declare if it is ok not to produce entries
         task.no_entries_ok = False
@@ -37,7 +37,7 @@ class PluginDetails:
         )
 
 
-class NoEntriesOk:
+class NoEntriesOk(plugin.PluginBase):
     """Allows manually silencing the warning message for tasks that regularly produce no entries."""
 
     schema = {'type': 'boolean'}

--- a/flexget/plugins/operate/verify_ssl_certificates.py
+++ b/flexget/plugins/operate/verify_ssl_certificates.py
@@ -7,7 +7,7 @@ from flexget.event import event
 logger = logger.bind(name='verify_ssl')
 
 
-class VerifySSLCertificates:
+class VerifySSLCertificates(plugin.PluginBase):
     """
     Plugin that can off SSL certificate verification.
 

--- a/flexget/plugins/operate/version_checker.py
+++ b/flexget/plugins/operate/version_checker.py
@@ -41,7 +41,7 @@ schema = {
 }
 
 
-class VersionChecker:
+class VersionChecker(plugin.PluginBase):
     """
     A plugin that checks whether user is running the latest flexget version and place a log warning if not.
     Checks via interval to avoid hammering, default is 1 day.

--- a/flexget/plugins/output/download.py
+++ b/flexget/plugins/output/download.py
@@ -21,7 +21,7 @@ from flexget.utils.tools import decode_html
 logger = logger.bind(name='download')
 
 
-class PluginDownload:
+class PluginDownload(plugin.PluginBase):
     """
     Downloads content from entry url and writes it into a file.
 

--- a/flexget/plugins/output/download_auth.py
+++ b/flexget/plugins/output/download_auth.py
@@ -11,7 +11,7 @@ PLUGIN_NAME = 'download_auth'
 logger = logger.bind(name=PLUGIN_NAME)
 
 
-class DownloadAuth:
+class DownloadAuth(plugin.PluginBase):
     host_schema = {
         'additionalProperties': {
             'type': 'object',

--- a/flexget/plugins/output/dump.py
+++ b/flexget/plugins/output/dump.py
@@ -98,7 +98,7 @@ def dump(entries, debug=False, eval_lazy=False, trace=False, title_only=False):
             console('')
 
 
-class OutputDump:
+class OutputDump(plugin.PluginBase):
     """
     Outputs all entries to console
     """

--- a/flexget/plugins/output/dump_config.py
+++ b/flexget/plugins/output/dump_config.py
@@ -11,7 +11,7 @@ from flexget.terminal import console
 logger = logger.bind(name='dump_config')
 
 
-class OutputDumpConfig:
+class OutputDumpConfig(plugin.PluginBase):
     """
     Dumps task config in STDOUT in yaml at exit or abort event.
     """

--- a/flexget/plugins/output/exec.py
+++ b/flexget/plugins/output/exec.py
@@ -26,7 +26,7 @@ class EscapingEntry(Entry):
         return value
 
 
-class PluginExec:
+class PluginExec(plugin.PluginBase):
     """
     Execute commands
 

--- a/flexget/plugins/output/file_operations.py
+++ b/flexget/plugins/output/file_operations.py
@@ -165,7 +165,7 @@ class BaseFileOps:
         raise NotImplementedError()
 
 
-class DeleteFiles(BaseFileOps):
+class DeleteFiles(BaseFileOps, plugin.PluginBase):
     """Delete all accepted files."""
 
     schema = {

--- a/flexget/plugins/output/html.py
+++ b/flexget/plugins/output/html.py
@@ -11,7 +11,7 @@ PLUGIN_NAME = 'make_html'
 logger = logger.bind(name=PLUGIN_NAME)
 
 
-class OutputHtml:
+class OutputHtml(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {'template': {'type': 'string'}, 'file': {'type': 'string'}},

--- a/flexget/plugins/output/mock_output.py
+++ b/flexget/plugins/output/mock_output.py
@@ -6,7 +6,7 @@ from flexget.event import event
 logger = logger.bind(name='mock_output')
 
 
-class MockOutput:
+class MockOutput(plugin.PluginBase):
     """
     Debugging plugin which records a copy of all accepted entries into a list stored in `mock_output` attribute
     of the task.

--- a/flexget/plugins/output/rss.py
+++ b/flexget/plugins/output/rss.py
@@ -46,7 +46,7 @@ class RSSEntry(Base):
     enc_type = Column(String)
 
 
-class OutputRSS:
+class OutputRSS(plugin.PluginBase):
     """
     Write RSS containing succeeded (downloaded) entries.
 

--- a/flexget/plugins/output/rtorrent_magnet.py
+++ b/flexget/plugins/output/rtorrent_magnet.py
@@ -10,7 +10,7 @@ logger = logger.bind(name='rtorrent_magnet')
 pat = re.compile('xt=urn:btih:([^&/]+)')
 
 
-class PluginRtorrentMagnet:
+class PluginRtorrentMagnet(plugin.PluginBase):
     """
     Process Magnet URI's into rtorrent compatible torrent files
 

--- a/flexget/plugins/output/sabnzbd.py
+++ b/flexget/plugins/output/sabnzbd.py
@@ -9,7 +9,7 @@ from flexget.event import event
 logger = logger.bind(name='sabnzbd')
 
 
-class OutputSabnzbd:
+class OutputSabnzbd(plugin.PluginBase):
     """
     Example::
 

--- a/flexget/plugins/output/sns.py
+++ b/flexget/plugins/output/sns.py
@@ -21,7 +21,7 @@ DEFAULT_TEMPLATE_VALUE = json.dumps(
 )
 
 
-class SNSNotification:
+class SNSNotification(plugin.PluginBase):
     """
     Emits SNS notifications of entries
 

--- a/flexget/plugins/output/subtitles.py
+++ b/flexget/plugins/output/subtitles.py
@@ -18,7 +18,7 @@ logger = logger.bind(name='subtitles')
 # http://trac.opensubtitles.org/projects/opensubtitles/wiki/XMLRPC
 
 
-class Subtitles:
+class Subtitles(plugin.PluginBase):
     """
     Fetch subtitles from opensubtitles.org
     """

--- a/flexget/plugins/output/subtitles_periscope.py
+++ b/flexget/plugins/output/subtitles_periscope.py
@@ -10,7 +10,7 @@ from flexget.event import event
 logger = logger.bind(name='subtitles')
 
 
-class PluginPeriscope:
+class PluginPeriscope(plugin.PluginBase):
     r"""
     Search and download subtitles using Periscope by Patrick Dessalle
     (http://code.google.com/p/periscope/).

--- a/flexget/plugins/output/subtitles_subliminal.py
+++ b/flexget/plugins/output/subtitles_subliminal.py
@@ -30,7 +30,7 @@ except ImportError:
 AUTHENTICATION_SCHEMA = {provider: {'type': 'object'} for provider in PROVIDERS}
 
 
-class PluginSubliminal:
+class PluginSubliminal(plugin.PluginBase):
     r"""
     Search and download subtitles using Subliminal by Antoine Bertin
     (https://pypi.python.org/pypi/subliminal).

--- a/flexget/plugins/output/symlink.py
+++ b/flexget/plugins/output/symlink.py
@@ -10,7 +10,7 @@ from flexget.utils.template import RenderError
 logger = logger.bind(name='symlink')
 
 
-class Symlink:
+class Symlink(plugin.PluginBase):
     schema = {
         'oneOf': [
             {

--- a/flexget/plugins/output/utorrent.py
+++ b/flexget/plugins/output/utorrent.py
@@ -11,7 +11,7 @@ from flexget.utils.template import RenderError
 logger = logger.bind(name='utorrent')
 
 
-class PluginUtorrent:
+class PluginUtorrent(plugin.PluginBase):
     """
     Parse task content or url for hoster links and adds them to utorrent.
 

--- a/flexget/plugins/services/kodi_library.py
+++ b/flexget/plugins/services/kodi_library.py
@@ -11,7 +11,7 @@ logger = logger.bind(name='kodi_library')
 JSON_URI = '/jsonrpc'
 
 
-class KodiLibrary:
+class KodiLibrary(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {

--- a/flexget/plugins/services/myepisodes.py
+++ b/flexget/plugins/services/myepisodes.py
@@ -33,7 +33,7 @@ class MyEpisodesInfo(Base):
         )
 
 
-class MyEpisodes:
+class MyEpisodes(plugin.PluginBase):
     """
     Marks a series episode as acquired in your myepisodes.com account.
 

--- a/flexget/plugins/services/pogcal_acquired.py
+++ b/flexget/plugins/services/pogcal_acquired.py
@@ -22,7 +22,7 @@ class PogcalShow(Base):
     name = Column(Unicode)
 
 
-class PogcalAcquired:
+class PogcalAcquired(plugin.PluginBase):
     schema = {
         'type': 'object',
         'properties': {'username': {'type': 'string'}, 'password': {'type': 'string'}},

--- a/flexget/tests/conftest.py
+++ b/flexget/tests/conftest.py
@@ -398,7 +398,7 @@ class MockManager(Manager):
 # Perhaps this bit should go somewhere else... The way reruns work can be complicated, and was causing issues in
 # some cases. This plugin should run on all tests in the suite, to make sure certain phases aren't getting
 # called twice. https://github.com/Flexget/Flexget/issues/3254
-class DoublePhaseChecker:
+class DoublePhaseChecker(plugin.PluginBase):
     @staticmethod
     def on_phase(task, phase):
         if getattr(task, f'did_{phase}', None):

--- a/flexget/tests/external_plugins/external_plugin.py
+++ b/flexget/tests/external_plugins/external_plugin.py
@@ -3,7 +3,7 @@ from flexget.entry import Entry
 from flexget.event import event
 
 
-class ExternalPlugin:
+class ExternalPlugin(plugin.PluginBase):
     schema = {'type': 'boolean'}
 
     def on_task_input(self, task, config):

--- a/flexget/tests/test_cached_input.py
+++ b/flexget/tests/test_cached_input.py
@@ -7,7 +7,7 @@ from flexget.entry import Entry
 from flexget.utils.cached_input import cached
 
 
-class InputPersist:
+class InputPersist(plugin.PluginBase):
     """Fake input plugin to test db cache. Only emits an entry the first time it is run."""
 
     hasrun = False

--- a/flexget/tests/test_discover.py
+++ b/flexget/tests/test_discover.py
@@ -4,7 +4,7 @@ from flexget import plugin
 from flexget.entry import Entry
 
 
-class SearchPlugin:
+class SearchPlugin(plugin.PluginBase):
     """
     Fake search plugin. Result differs depending on config value:
       `'fail'`: raises a PluginError
@@ -29,7 +29,7 @@ class SearchPlugin:
 plugin.register(SearchPlugin, 'test_search', interfaces=['search'], api_ver=2)
 
 
-class EstRelease:
+class EstRelease(plugin.PluginBase):
     """Fake release estimate plugin. Just returns 'est_release' entry field."""
 
     def estimate(self, entry):

--- a/flexget/tests/test_limit.py
+++ b/flexget/tests/test_limit.py
@@ -2,7 +2,7 @@ from flexget import plugin
 from flexget.entry import Entry
 
 
-class OneEntryInput:
+class OneEntryInput(plugin.PluginBase):
     """Fake input plugin, fails if second entry is grabbed."""
 
     def on_task_input(self, task, config):

--- a/flexget/tests/test_pluginapi.py
+++ b/flexget/tests/test_pluginapi.py
@@ -39,13 +39,13 @@ class TestPluginApi:
         # assert len(plugin.plugins) >= len(plugin_modules) - 1, "Less plugins than plugin modules"
 
     def test_register_by_class(self, execute_task):
-        class TestPlugin:
+        class TestPlugin(plugin.PluginBase):
             pass
 
-        class Oneword:
+        class Oneword(plugin.PluginBase):
             pass
 
-        class TestHTML:
+        class TestHTML(plugin.PluginBase):
             pass
 
         assert 'test_plugin' not in plugin.plugins

--- a/flexget/tests/test_remember_rejected.py
+++ b/flexget/tests/test_remember_rejected.py
@@ -3,7 +3,7 @@ from flexget.event import event
 from flexget.utils.tools import parse_timedelta
 
 
-class RejectRememberPlugin:
+class RejectRememberPlugin(plugin.PluginBase):
     def on_task_filter(self, task, config):
         for entry in task.all_entries:
             if isinstance(config, str):


### PR DESCRIPTION
### Motivation for changes:
Thought maybe this was useful, but then after doing it I became less sure. I think maybe if we go this route we should ditch the PluginInfo class completely and just use the instance of the plugin. Just putting this up here in case anyone (cough @paranoidi) is inspired to do some experimentation on top of this change.

### Detailed changes:
- 

### Addressed issues/feature requests:
- Fixes # .

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
```
paste output here
```
#### To Do:

- [ ] Stuff..

