### PR TITLE
Use importlib.metadata to replace deprecated pkg_resources

### DIFF
--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -9,8 +9,14 @@ from typing import Callable, Dict, Iterable, List, Optional, Union
 from urllib.error import HTTPError, URLError
 
 import loguru
-import pkg_resources
 from requests import RequestException
+
+try:
+    # This is in our requirements for python versions older than 3.10 to get the new style selectable entry points
+    from importlib_metadata import entry_points
+except ImportError:
+    # Python 3.10 and higher has the new functionality
+    from importlib.metadata import entry_points
 
 from flexget import components as components_pkg
 from flexget import config_schema
@@ -490,7 +496,7 @@ def _load_components_from_dirs(dirs: List[str]) -> None:
 
 def _load_plugins_from_packages() -> None:
     """Load plugins installed via PIP"""
-    for entrypoint in pkg_resources.iter_entry_points('FlexGet.plugins'):
+    for entrypoint in entry_points(group='FlexGet.plugins'):
         try:
             plugin_module = entrypoint.load()
         except DependencyError as e:
@@ -517,7 +523,7 @@ def _load_plugins_from_packages() -> None:
             raise
         else:
             logger.trace(
-                'Loaded packaged module {} from {}', entrypoint.module_name, plugin_module.__file__
+                'Loaded packaged module {} from {}', entrypoint.module, plugin_module.__file__
             )
     _check_phase_queue()
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3474,4 +3474,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "61e477dc8a1a04565639455620a873d71c5eab9abaa817a68b2548ce994abecd"
+content-hash = "3b051e98195145701e3c291335d2b6035244da73fbefe34175e07cfa4424bf21"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ colorama = ">=0.4.4"
 feedparser = ">=6.0.2"
 guessit = ">=3.4,<4.0"
 html5lib = ">=0.11"
-importlib-metadata = { version = "*", python = "<3.8" }  # TODO: remove this after we drop python3.7
+importlib-metadata = { version = ">=3.6", python = "<3.10" }  # TODO: remove this after we drop python3.9
 jinja2 = ">=3.0,<4.0"
 jsonschema = ">=2.0"
 loguru = ">=0.4.1"


### PR DESCRIPTION
### Motivation for changes:
pkg_resources is deprecated. Switch to importlib_metadata (or importlib.metadata on python 3.10+ for loading plugins installed via pip)

### Detailed changes:
- Uses the entrypoint api from importlib.metadata. To avoid using deprecated interfaces in the new package, importlib_metadata >=3.6 is required for python <3.10