### PR TITLE
Fix URL for Web-UI instructions

### DIFF
--- a/flexget/ui/v1/__init__.py
+++ b/flexget/ui/v1/__init__.py
@@ -76,7 +76,7 @@ def register_web_ui(mgr):
         if not os.path.exists(app_base):
             logger.warning(
                 'Unable to start web ui in debug mode. To enable debug mode please run the debug build, '
-                'see http://flexget.com/wiki/Web-UI for instructions'
+                'see https://flexget.com/Web-UI for instructions'
             )
             logger.warning('Attempting to serve web ui from complied directory')
             app_base = None
@@ -87,7 +87,7 @@ def register_web_ui(mgr):
             logger.critical(
                 'Failed to start web ui,'
                 ' this can happen if you are running from GitHub version and forgot to run the web ui build, '
-                'see http://flexget.com/wiki/Web-UI for instructions'
+                'see https://flexget.com/Web-UI for instructions'
             )
             app_base = None
 

--- a/flexget/ui/v1/load.failure.html
+++ b/flexget/ui/v1/load.failure.html
@@ -8,7 +8,7 @@
 <h1>Failed to load Flexget Web UI</h1>
 
 <p>It looks like you are running flexget from the GitHub source. If you want to use the webui you'll have to run the build steps by following
-    <a href="http://flexget.com/wiki/Web-UI">http://flexget.com/wiki/Web-UI</a></p>
+    <a href="https://flexget.com/Web-UI">https://flexget.com/Web-UI</a></p>
 <p>Hint: Read the section "Using GIT Version"</p>
 </body>
 </html>

--- a/flexget/ui/v1/src/components/home/home.tmpl.html
+++ b/flexget/ui/v1/src/components/home/home.tmpl.html
@@ -24,7 +24,7 @@
                     There is a functional API with documentation available at <a href="api">/api</a>
                 </p>
 
-                <p>More information: <a href="http://flexget.com/wiki/Web-UI" target="_blank">http://flexget.com/wiki/Web-UI</a></p>
+                <p>More information: <a href="https://flexget.com/Web-UI" target="_blank">https://flexget.com/Web-UI</a></p>
                 <p>Gitter Chat: <a href="https://gitter.im/Flexget/Flexget" target="_blank">https://gitter.im/Flexget/Flexget</a></p>
                 <div layout="row" layout-align="center center">
                     <md-button class="md-icon-button" aria-label="GitHub" href="http://github.com/Flexget/Flexget" target="_blank">


### PR DESCRIPTION
### Motivation for changes:
Error message for Web-UI had a broken URL

### Detailed changes:
- Find http://flexget.com/wiki/Web-UI and Replace for https://flexget.com/Web-UI
