### PR TITLE
Fix deprecated use of jsonschema library

### DIFF
--- a/flexget/api/app.py
+++ b/flexget/api/app.py
@@ -12,9 +12,9 @@ from flask_cors import CORS
 from flask_restx import Api as RestxAPI
 from flask_restx import Model, Resource
 from flask_restx.reqparse import RequestParser
-from jsonschema import RefResolutionError
 from jsonschema.exceptions import ValidationError as SchemaValidationError
 from loguru import logger
+from referencing.exceptions import Unresolvable
 from sqlalchemy.orm import Session
 from werkzeug.http import generate_etag
 
@@ -137,7 +137,7 @@ class API(RestxAPI):
 
                     if errors:
                         raise ValidationError(errors)
-                except RefResolutionError as e:
+                except Unresolvable as e:
                     raise APIError(str(e))
                 return func(*args, **kwargs)
 

--- a/flexget/api/core/schema.py
+++ b/flexget/api/core/schema.py
@@ -1,5 +1,5 @@
 from flask import Response, jsonify, request
-from jsonschema import RefResolutionError
+from referencing.exceptions import Unresolvable
 from sqlalchemy.orm import Session
 
 from flexget.api import APIResource, api
@@ -59,7 +59,7 @@ class SchemaAPI(APIResource):
         """Get schema definition"""
         try:
             schema = resolve_ref(request.full_path)
-        except RefResolutionError:
+        except Unresolvable:
             raise NotFoundError('invalid schema path')
         schema['id'] = request.url
         return jsonify(rewrite_refs(schema, request.url_root))

--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -4,6 +4,7 @@ import re
 from collections import defaultdict
 from json import JSONDecodeError
 from json import loads as json_loads
+from referencing.exceptions import Unresolvable
 from typing import Any, Callable, Dict, List, Match, Optional, Pattern, Union
 from urllib.parse import parse_qsl, urlparse
 
@@ -118,7 +119,7 @@ def resolve_ref(uri: str) -> JsonSchema:
             schema = schema(**dict(parse_qsl(parsed.query)))
         schema = {'$schema': BASE_SCHEMA_URI, **schema}
         return schema
-    raise jsonschema.RefResolutionError("%s could not be resolved" % uri)
+    raise Unresolvable("%s could not be resolved" % uri)
 
 
 def process_config(

--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -4,13 +4,13 @@ import re
 from collections import defaultdict
 from json import JSONDecodeError
 from json import loads as json_loads
-from referencing.exceptions import Unresolvable
 from typing import Any, Callable, Dict, List, Match, Optional, Pattern, Union
 from urllib.parse import parse_qsl, urlparse
 
 import jsonschema
 from jsonschema import ValidationError
 from loguru import logger
+from referencing.exceptions import Unresolvable
 
 from flexget.event import fire_event
 from flexget.utils import qualities, template

--- a/flexget/tests/test_config_schema.py
+++ b/flexget/tests/test_config_schema.py
@@ -2,6 +2,8 @@ from datetime import timedelta
 
 import jsonschema
 
+from referencing.exceptions import Unresolvable
+
 from flexget import config_schema
 
 
@@ -43,7 +45,7 @@ class TestSchemaValidator:
                 try:
                     with resolver.resolving(ref):
                         pass
-                except jsonschema.RefResolutionError:
+                except Unresolvable:
                     raise AssertionError(f'$ref {ref} in schema {path} is invalid')
 
     def test_resolves_local_refs(self):

--- a/flexget/tests/test_config_schema.py
+++ b/flexget/tests/test_config_schema.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 import jsonschema
-
 from referencing.exceptions import Unresolvable
 
 from flexget import config_schema

--- a/flexget/tests/test_config_schema.py
+++ b/flexget/tests/test_config_schema.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 import jsonschema
-from referencing.exceptions import Unresolvable
 
 from flexget import config_schema
 
@@ -38,14 +37,11 @@ class TestSchemaValidator:
                 for i in item:
                     yield from refs_in(i)
 
+        registry = config_schema.Registry()
         for path, schema in iter_registered_schemas():
-            resolver = config_schema.RefResolver.from_schema(schema)
+            resolver = registry.resolver(base_uri=path)
             for ref in refs_in(schema):
-                try:
-                    with resolver.resolving(ref):
-                        pass
-                except Unresolvable:
-                    raise AssertionError(f'$ref {ref} in schema {path} is invalid')
+                assert resolver.lookup(ref)
 
     def test_resolves_local_refs(self):
         schema = {'$ref': '/schema/plugin/accept_all'}


### PR DESCRIPTION
### Motivation for changes:

As of jsonschema version 4.18.0 `jsonschema.exceptions.RefResolutionError` is deprecated and we should catch/raise `referencing.exceptions.Unresolvable` instead

RefResolver usage was also switched to use the new referencing.Registry

### Detailed changes:

Simple 1-for-1 replacements