### PR TITLE
FIX PTP plugin to use apiuser and apikey authentication and some improvements to search and match

### DIFF
--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -79,7 +79,9 @@ RELEASE_TYPES = {'non-scene': 0, 'scene': 1, 'golden popcorn': 2}
 
 @db_schema.upgrade('passthepopcorn')
 def upgrade(ver, session):
-    if ver is None or ver < 2:
+    if ver is None:
+        ver = 0
+    if ver < 2:
         if table_exists('passthepopcorn_cookie', session):
             logger.info('Removing old Cookie Tracking Table')
             drop_tables(['passthepopcorn_cookie'], session)

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -79,14 +79,12 @@ RELEASE_TYPES = {'non-scene': 0, 'scene': 1, 'golden popcorn': 2}
 @db_schema.upgrade('passthepopcorn')
 def upgrade(ver, session):
     if ver is None:
-        ver = 0
-    if ver == 0:
+        raise db_schema.UpgradeImpossible
+    else:
         if table_exists('passthepopcorn_cookie', session):
             logger.info('Removing old Cookie Tracking Table')
             # Drop the deprecated data
             drop_tables(['passthepopcorn_cookie'], session)
-        logger.info('DB Schema is now v1')
-        ver = 1
     return ver
 
 

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -201,7 +201,7 @@ class SearchPassThePopcorn:
                     release_res = torrent['Resolution']
                     release_res = release_res.replace("PAL", "576p") #Common PAL DVD vertial resolution
                     release_res = release_res.replace("NTSC", "480p") #Common PAL DVD vertial resolution
-                    # many older realses have a resolution defined as 624x480 for example this will split the value at take the hight
+                    # many older releases have a resolution defined as 624x480 for example this will split the value at take the hight
                     tsplit = release_res.split("x", 1)                    
                     if len(tsplit)>1:
                         release_res = tsplit[1] + 'p' 

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -8,6 +8,10 @@ from flexget.event import event
 from flexget.utils.requests import RequestException, TimedLimiter
 from flexget.utils.requests import Session as RequestSession
 from flexget.utils.tools import parse_filesize
+from flexget.utils.sqlalchemy_utils import (
+    drop_tables,
+    table_exists
+)
 
 logger = logger.bind(name='passthepopcorn')
 Base = db_schema.versioned_base('passthepopcorn', 1)

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -205,7 +205,9 @@ class SearchPassThePopcorn:
                     release_name = torrent['ReleaseName'].replace(
                         "4K", ""
                     )  # Remove 4K from release name as that is often the source not the torrent resolution it confuses the quality plugin
-                    e['title'] = f"{release_name} [{release_res} {torrent['Source']} {torrent['Codec']} {torrent['Container']}]"
+                    e[
+                        'title'
+                    ] = f"{release_name} [{release_res} {torrent['Source']} {torrent['Codec']} {torrent['Container']}]"
 
                     e['imdb_id'] = entry.get('imdb_id')
 

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -132,7 +132,7 @@ class SearchPassThePopcorn:
 
         if config.get('freeleech'):
             params['freetorrent'] = int(config['freeleech'])
-
+        
         ordering = 'desc' if config['order_desc'] else 'asc'
 
         grouping = int(config['grouping'])
@@ -156,6 +156,10 @@ class SearchPassThePopcorn:
         # searching with imdb id is much more precise
         if entry.get('imdb_id'):
             search_strings = [entry['imdb_id']]
+        else:
+            # use the movie year if available to improve search results.
+            if 'movie_year' in entry:
+                params['year'] = int(entry['movie_year'])
 
         for search_string in search_strings:
             params['searchstr'] = search_string
@@ -239,7 +243,7 @@ class SearchPassThePopcorn:
                             e['torrent_id'], authkey, passkey
                         )
                     )
-                    logger.debug('Add Entry: {} S:{}', e['title'],e['torrent_seeds'])
+                    logger.debug('Add Entry: {} Seeds:{}', e['title'],e['torrent_seeds'])
                     entries.add(e)
 
         return entries

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -7,11 +7,8 @@ from flexget.entry import Entry
 from flexget.event import event
 from flexget.utils.requests import RequestException, TimedLimiter
 from flexget.utils.requests import Session as RequestSession
+from flexget.utils.sqlalchemy_utils import drop_tables, table_exists
 from flexget.utils.tools import parse_filesize
-from flexget.utils.sqlalchemy_utils import (
-    drop_tables,
-    table_exists
-)
 
 logger = logger.bind(name='passthepopcorn')
 Base = db_schema.versioned_base('passthepopcorn', 1)

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -80,7 +80,7 @@ RELEASE_TYPES = {'non-scene': 0, 'scene': 1, 'golden popcorn': 2}
 @db_schema.upgrade('passthepopcorn')
 def upgrade(ver, session):
     if ver is None:
-        logger.info('No Schema Found to Upgrade')
+        raise db_schema.UpgradeImpossible
     else:
         if table_exists('passthepopcorn_cookie', session):
             logger.info('Removing old Cookie Tracking Table')

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -141,8 +141,16 @@ class SearchPassThePopcorn:
         else:
             # use the movie year if available to improve search results.
             if 'movie_year' in entry:
-                params['year'] = int(entry['movie_year'])
-                
+                #the movie list plugin seems to have garbage in the year entry sometimes like a 1 for the year
+                #validate we have a useful year to filter on
+                try:
+                    if int(entry['movie_year']) > 1900:
+                        params['year'] = int(entry['movie_year'])
+                    else:
+                        logger.error(f"Searching for '{entry['title']}' ignoring invalid movie_year: '{entry['movie_year']}'")
+                except ValueError:
+                    logger.error(f"Searching for '{entry['title']}'  ignoring non numeric movie_year: '{entry['movie_year']}'")
+
         task.requests.add_domain_limiter(TimedLimiter('passthepopcorn.me', '5 seconds'))
 
         for search_string in search_strings:

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -83,7 +83,6 @@ def upgrade(ver, session):
         if table_exists('passthepopcorn_cookie', session):
             logger.info('Removing old Cookie Tracking Table')
             drop_tables(['passthepopcorn_cookie'], session)
-        ver = 2
     return ver
 
 

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -214,18 +214,7 @@ class SearchPassThePopcorn:
                     release_name = torrent['ReleaseName'].replace(
                         "4K", ""
                     )  # Remove 4K from release name as that is often the source not the torrent resolution it confuses the quality plugin
-                    e['title'] = (
-                        release_name
-                        + ' ['
-                        + release_res
-                        + ' '
-                        + torrent['Source']
-                        + ' '
-                        + torrent['Codec']
-                        + ' '
-                        + torrent['Container']
-                        + ']'
-                    )
+                    e['title'] ="{} [{} {} {} {}]".format(release_name, release_res, torrent['Source'],torrent['Codec'],torrent['Container'])
 
                     e['imdb_id'] = entry.get('imdb_id')
 

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -11,7 +11,6 @@ from flexget.utils.sqlalchemy_utils import drop_tables, table_exists
 from flexget.utils.tools import parse_filesize
 
 logger = logger.bind(name='passthepopcorn')
-Base = db_schema.versioned_base('passthepopcorn', 2)
 
 requests = RequestSession()
 requests.add_domain_limiter(TimedLimiter('passthepopcorn.me', '5 seconds'))

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -205,13 +205,7 @@ class SearchPassThePopcorn:
                     release_name = torrent['ReleaseName'].replace(
                         "4K", ""
                     )  # Remove 4K from release name as that is often the source not the torrent resolution it confuses the quality plugin
-                    e['title'] = "{} [{} {} {} {}]".format(
-                        release_name,
-                        release_res,
-                        torrent['Source'],
-                        torrent['Codec'],
-                        torrent['Container'],
-                    )
+                    e['title'] = f"{release_name} [{release_res} {torrent['Source']} {torrent['Codec']} {torrent['Container']}]"
 
                     e['imdb_id'] = entry.get('imdb_id')
 

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -75,6 +75,18 @@ ORDERING = {
 
 RELEASE_TYPES = {'non-scene': 0, 'scene': 1, 'golden popcorn': 2}
 
+@db_schema.upgrade('passthepopcorn')
+def upgrade(ver, session):
+    if ver is None:
+        ver = 0
+    if ver == 0:
+        if table_exists('passthepopcorn_cookie', session):
+            logger.info('Removing old Cookie Tracking Table')
+            # Drop the deprecated data
+            drop_tables(['passthepopcorn_cookie'], session)
+        logger.info('DB Schema is now v1')
+        ver = 1
+    return ver
 
 class SearchPassThePopcorn:
     """
@@ -151,7 +163,7 @@ class SearchPassThePopcorn:
             params['searchstr'] = search_string
             logger.debug('Using search params: {}', params)
             try:
-                siteresponse = requests.get(
+                siteresponse = task.requests.get(
                     self.base_url + 'torrents.php', headers=request_headers, params=params
                 )
                 result = siteresponse.json()

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -200,7 +200,7 @@ class SearchPassThePopcorn:
                     # Add the PTP qualities to the title so the quality plugin has a better chance
                     release_res = torrent['Resolution']
                     release_res = release_res.replace("PAL", "576p") #Common PAL DVD vertial resolution
-                    release_res = release_res.replace("NTSC", "480p") #Common PAL DVD vertial resolution
+                    release_res = release_res.replace("NTSC", "480p") #Common NTSC DVD vertial resolution
                     # many older releases have a resolution defined as 624x480 for example this will split the value at take the hight
                     tsplit = release_res.split("x", 1)                    
                     if len(tsplit)>1:

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -1,13 +1,12 @@
 from dateutil.parser import parse as dateutil_parse
 from loguru import logger
 
-from flexget import db_schema, plugin
+from flexget import plugin
 from flexget.config_schema import one_or_more
 from flexget.entry import Entry
 from flexget.event import event
 from flexget.utils.requests import RequestException, TimedLimiter
 from flexget.utils.requests import Session as RequestSession
-from flexget.utils.sqlalchemy_utils import drop_tables, table_exists
 from flexget.utils.tools import parse_filesize
 
 logger = logger.bind(name='passthepopcorn')

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -79,7 +79,7 @@ RELEASE_TYPES = {'non-scene': 0, 'scene': 1, 'golden popcorn': 2}
 @db_schema.upgrade('passthepopcorn')
 def upgrade(ver, session):
     if ver is None:
-        raise db_schema.UpgradeImpossible
+        logger.info('No Schema Found to Upgrade')
     else:
         if table_exists('passthepopcorn_cookie', session):
             logger.info('Removing old Cookie Tracking Table')

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -140,15 +140,19 @@ class SearchPassThePopcorn:
         else:
             # use the movie year if available to improve search results.
             if 'movie_year' in entry:
-                #the movie list plugin seems to have garbage in the year entry sometimes like a 1 for the year
-                #validate we have a useful year to filter on
+                # the movie list plugin seems to have garbage in the year entry sometimes like a 1 for the year
+                # validate we have a useful year to filter on
                 try:
                     if int(entry['movie_year']) > 1900:
                         params['year'] = int(entry['movie_year'])
                     else:
-                        logger.error(f"Searching for '{entry['title']}' ignoring invalid movie_year: '{entry['movie_year']}'")
+                        logger.error(
+                            f"Searching for '{entry['title']}' ignoring invalid movie_year: '{entry['movie_year']}'"
+                        )
                 except ValueError:
-                    logger.error(f"Searching for '{entry['title']}'  ignoring non numeric movie_year: '{entry['movie_year']}'")
+                    logger.error(
+                        f"Searching for '{entry['title']}'  ignoring non numeric movie_year: '{entry['movie_year']}'"
+                    )
 
         task.requests.add_domain_limiter(TimedLimiter('passthepopcorn.me', '5 seconds'))
 

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -75,6 +75,7 @@ ORDERING = {
 
 RELEASE_TYPES = {'non-scene': 0, 'scene': 1, 'golden popcorn': 2}
 
+
 @db_schema.upgrade('passthepopcorn')
 def upgrade(ver, session):
     if ver is None:
@@ -87,6 +88,7 @@ def upgrade(ver, session):
         logger.info('DB Schema is now v1')
         ver = 1
     return ver
+
 
 class SearchPassThePopcorn:
     """

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -75,6 +75,7 @@ ORDERING = {
 
 RELEASE_TYPES = {'non-scene': 0, 'scene': 1, 'golden popcorn': 2}
 
+
 class SearchPassThePopcorn:
     """
     PassThePopcorn search plugin.

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -11,7 +11,7 @@ from flexget.utils.sqlalchemy_utils import drop_tables, table_exists
 from flexget.utils.tools import parse_filesize
 
 logger = logger.bind(name='passthepopcorn')
-Base = db_schema.versioned_base('passthepopcorn', 1)
+Base = db_schema.versioned_base('passthepopcorn', 2)
 
 requests = RequestSession()
 requests.add_domain_limiter(TimedLimiter('passthepopcorn.me', '5 seconds'))
@@ -79,13 +79,11 @@ RELEASE_TYPES = {'non-scene': 0, 'scene': 1, 'golden popcorn': 2}
 
 @db_schema.upgrade('passthepopcorn')
 def upgrade(ver, session):
-    if ver is None:
-        raise db_schema.UpgradeImpossible
-    else:
+    if ver is None or ver < 2:
         if table_exists('passthepopcorn_cookie', session):
             logger.info('Removing old Cookie Tracking Table')
-            # Drop the deprecated data
             drop_tables(['passthepopcorn_cookie'], session)
+        ver = 2
     return ver
 
 

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -75,16 +75,6 @@ ORDERING = {
 
 RELEASE_TYPES = {'non-scene': 0, 'scene': 1, 'golden popcorn': 2}
 
-
-@db_schema.upgrade('passthepopcorn')
-def upgrade(ver, session):
-    if ver is None:
-        ver = 0
-    if ver == 0:
-        raise db_schema.UpgradeImpossible
-    return ver
-
-
 class SearchPassThePopcorn:
     """
     PassThePopcorn search plugin.

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -11,9 +11,6 @@ from flexget.utils.tools import parse_filesize
 
 logger = logger.bind(name='passthepopcorn')
 
-requests = RequestSession()
-requests.add_domain_limiter(TimedLimiter('passthepopcorn.me', '5 seconds'))
-
 TAGS = [
     'action',
     'adventure',
@@ -145,6 +142,8 @@ class SearchPassThePopcorn:
             # use the movie year if available to improve search results.
             if 'movie_year' in entry:
                 params['year'] = int(entry['movie_year'])
+                
+        task.requests.add_domain_limiter(TimedLimiter('passthepopcorn.me', '5 seconds'))
 
         for search_string in search_strings:
             params['searchstr'] = search_string

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -206,8 +206,8 @@ class SearchPassThePopcorn:
                     if len(tsplit)>1:
                         release_res = tsplit[1] + 'p' 
 
-                    releasname = torrent['ReleaseName'].replace("4K", "") # Remove 4K from release name as that is often the source not the torrent resolution it confuses the quality plugin
-                    e['title'] = releasname + ' [' + release_res + ' ' + torrent['Source'] + ' ' + torrent['Codec'] + ' ' + torrent['Container'] + ']'
+                    release_name = torrent['ReleaseName'].replace("4K", "") # Remove 4K from release name as that is often the source not the torrent resolution it confuses the quality plugin
+                    e['title'] = release_name + ' [' + release_res + ' ' + torrent['Source'] + ' ' + torrent['Codec'] + ' ' + torrent['Container'] + ']'
 
                     e['imdb_id'] = entry.get('imdb_id')
 

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -75,18 +75,6 @@ ORDERING = {
 
 RELEASE_TYPES = {'non-scene': 0, 'scene': 1, 'golden popcorn': 2}
 
-
-@db_schema.upgrade('passthepopcorn')
-def upgrade(ver, session):
-    if ver is None:
-        ver = 0
-    if ver < 2:
-        if table_exists('passthepopcorn_cookie', session):
-            logger.info('Removing old Cookie Tracking Table')
-            drop_tables(['passthepopcorn_cookie'], session)
-    return ver
-
-
 class SearchPassThePopcorn:
     """
     PassThePopcorn search plugin.


### PR DESCRIPTION
### Motivation for changes:

Current plugin impersonates a user with their primary credentials and uses complicated cookie refresh auth. This is in violation of current site rules and can cause an auto ban. Current site rules require all scripts to use apiuser / apikey auth generated by the user as separate credentials.

### Detailed changes:
- removed username / password / cookie auth
- added apiuser / apikey header auth
- added some mappings for odd quality values from ptp to make the quality plugin match more often
- added search parameter for year if input has a movie year and NO IMDB ID
- plugin should raise an error if search fails.
- changed the schema default for the grouping parameter as it seems to provide better matches
- schema replaced username and password with apiuser and apikey

### Addressed issues/feature requests:
- Fixes authentication / user getting banned by old cookie auth

### Config usage if relevant (new plugin or updated schema):
```
    schema = {
        'type': 'object',
        'properties': {
            'apiuser': {'type': 'string'},
            'apikey': {'type': 'string'},
            'passkey': {'type': 'string'},
            'tags': one_or_more({'type': 'string', 'enum': TAGS}, unique_items=True),
            'order_by': {'type': 'string', 'enum': list(ORDERING.keys()), 'default': 'Time added'},
            'order_desc': {'type': 'boolean', 'default': True},
            'freeleech': {'type': 'boolean'},
            'release_type': {'type': 'string', 'enum': list(RELEASE_TYPES.keys())},
            'grouping': {'type': 'boolean', 'default': False},
        },
        'required': ['apiuser', 'apikey', 'passkey'],
        'additionalProperties': False,
    }
```
