### PR TITLE
Replace status index with something smaller

### DIFF
--- a/flexget/components/status/db.py
+++ b/flexget/components/status/db.py
@@ -107,10 +107,7 @@ class TaskExecution(Base):
         }
 
 
-Index(
-    'ix_status_execution_task_id',
-    TaskExecution.task_id
-)
+Index('ix_status_execution_task_id', TaskExecution.task_id)
 
 
 @event('manager.db_cleanup')

--- a/flexget/components/status/db.py
+++ b/flexget/components/status/db.py
@@ -67,7 +67,7 @@ class StatusTask(Base):
 class TaskExecution(Base):
     __tablename__ = 'status_execution'
     id = Column(Integer, primary_key=True)
-    task_id = Column(Integer, ForeignKey('status_task.id'))
+    task_id = Column(Integer, ForeignKey('status_task.id'), index=True)
 
     start = Column(DateTime)
     end = Column(DateTime)
@@ -105,9 +105,6 @@ class TaskExecution(Base):
             'failed': self.failed,
             'abort_reason': self.abort_reason,
         }
-
-
-Index('ix_status_execution_task_id', TaskExecution.task_id)
 
 
 @event('manager.db_cleanup')

--- a/flexget/components/status/db.py
+++ b/flexget/components/status/db.py
@@ -10,7 +10,7 @@ from sqlalchemy.schema import ForeignKey
 from flexget import db_schema
 from flexget.event import event
 from flexget.utils.database import with_session
-from flexget.utils.sqlalchemy_utils import create_index
+from flexget.utils.sqlalchemy_utils import create_index, index_exists, drop_index
 
 logger = logger.bind(name='status.db')
 Base = db_schema.versioned_base('status', 2)
@@ -18,10 +18,14 @@ Base = db_schema.versioned_base('status', 2)
 
 @db_schema.upgrade('status')
 def upgrade(ver, session):
-    if ver < 2:
+    if ver < 3:
+        table_name = 'status_execution'
+        old_index_name = 'ix_status_execution_task_id_start_end_succeeded'
+        if index_exists(table_name, old_index_name, session):
+            drop_index(table_name, old_index_name, session)
         # Creates the executions table index
-        create_index('status_execution', session, 'task_id', 'start', 'end', 'succeeded')
-        ver = 2
+        create_index(table_name, session, 'task_id')
+        ver = 3
     return ver
 
 

--- a/flexget/components/status/db.py
+++ b/flexget/components/status/db.py
@@ -108,11 +108,8 @@ class TaskExecution(Base):
 
 
 Index(
-    'ix_status_execution_task_id_start_end_succeeded',
-    TaskExecution.task_id,
-    TaskExecution.start,
-    TaskExecution.end,
-    TaskExecution.succeeded,
+    'ix_status_execution_task_id',
+    TaskExecution.task_id
 )
 
 

--- a/flexget/components/status/db.py
+++ b/flexget/components/status/db.py
@@ -2,7 +2,7 @@ import datetime
 from datetime import timedelta
 
 from loguru import logger
-from sqlalchemy import Boolean, Column, DateTime, Index, Integer, String, func, select
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, func, select
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import ForeignKey

--- a/flexget/components/status/db.py
+++ b/flexget/components/status/db.py
@@ -13,7 +13,7 @@ from flexget.utils.database import with_session
 from flexget.utils.sqlalchemy_utils import create_index, drop_index, index_exists
 
 logger = logger.bind(name='status.db')
-Base = db_schema.versioned_base('status', 2)
+Base = db_schema.versioned_base('status', 3)
 
 
 @db_schema.upgrade('status')

--- a/flexget/components/status/db.py
+++ b/flexget/components/status/db.py
@@ -10,7 +10,7 @@ from sqlalchemy.schema import ForeignKey
 from flexget import db_schema
 from flexget.event import event
 from flexget.utils.database import with_session
-from flexget.utils.sqlalchemy_utils import create_index, index_exists, drop_index
+from flexget.utils.sqlalchemy_utils import create_index, drop_index, index_exists
 
 logger = logger.bind(name='status.db')
 Base = db_schema.versioned_base('status', 2)

--- a/flexget/utils/sqlalchemy_utils.py
+++ b/flexget/utils/sqlalchemy_utils.py
@@ -28,6 +28,20 @@ def table_exists(name: str, session: Session) -> bool:
         return False
     return True
 
+def index_exists(table_name: str, index_name: str, session: Session) -> bool:
+    """
+    Use SQLAlchemy reflect to check index existences.
+
+    :param string table_name: Table name to check
+    :param string index_name: Index name to check
+    :param Session session: Session to use
+    :return: True if table exists, False otherwise
+    :rtype: bool
+    """
+    try:
+        return bool(table_index(table_name, index_name, session))
+    except NoSuchTableError:
+        return False
 
 def table_schema(name: str, session: Session) -> Table:
     """
@@ -51,6 +65,28 @@ def table_columns(table: Union[str, Table], session: Session) -> List[str]:
         res.append(column.name)
     return res
 
+def table_index(table_name: str, index_name: str, session: Session) -> Index:
+    """Finds an index by table name and index name
+
+    :param string table_name: Name of table
+    :param string index_name: Name of the index
+    :param Session session: SQLAlchemy Session
+    :returns: The requested index
+    """
+
+    table = table_schema(table_name, session)
+    return get_index_by_name(table, index_name)
+
+def drop_index(table_name: str, index_name: str, session: Session) -> None:
+    """Drops an index by table name and index name
+
+    :param string table_name: Name of table
+    :param string index_name: Name of the index
+    :param Session session: SQLAlchemy Session
+    """
+
+    index = table_index(table_name, index_name, session)
+    index.drop(bind=session.bind)
 
 def table_add_column(
     table: Union[Table, str],

--- a/flexget/utils/sqlalchemy_utils.py
+++ b/flexget/utils/sqlalchemy_utils.py
@@ -28,6 +28,7 @@ def table_exists(name: str, session: Session) -> bool:
         return False
     return True
 
+
 def index_exists(table_name: str, index_name: str, session: Session) -> bool:
     """
     Use SQLAlchemy reflect to check index existences.
@@ -42,6 +43,7 @@ def index_exists(table_name: str, index_name: str, session: Session) -> bool:
         return bool(table_index(table_name, index_name, session))
     except NoSuchTableError:
         return False
+
 
 def table_schema(name: str, session: Session) -> Table:
     """
@@ -65,6 +67,7 @@ def table_columns(table: Union[str, Table], session: Session) -> List[str]:
         res.append(column.name)
     return res
 
+
 def table_index(table_name: str, index_name: str, session: Session) -> Index:
     """Finds an index by table name and index name
 
@@ -77,6 +80,7 @@ def table_index(table_name: str, index_name: str, session: Session) -> Index:
     table = table_schema(table_name, session)
     return get_index_by_name(table, index_name)
 
+
 def drop_index(table_name: str, index_name: str, session: Session) -> None:
     """Drops an index by table name and index name
 
@@ -87,6 +91,7 @@ def drop_index(table_name: str, index_name: str, session: Session) -> None:
 
     index = table_index(table_name, index_name, session)
     index.drop(bind=session.bind)
+
 
 def table_add_column(
     table: Union[Table, str],


### PR DESCRIPTION
### Motivation for changes:
The index `ix_status_execution_task_id_start_end_succeeded` is almost 93% the size of the actual table. An index on just `task_id` should be similarly performant but much smaller.

### Detailed changes:
- Add DB util functions to manage indexes
- Update DB migration to drop `ix_status_execution_task_id_start_end_succeeded` if it exists and then create the new index

### Addressed issues/feature requests:
- Fixes # .

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
```
paste output here
```
#### To Do:

- [ ] Stuff..

