### PR TITLE
[add] Python 3.12 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         operating-system: [ubuntu-latest] # TODO: Fix a couple tests and enable windows. windows-latest
       fail-fast: false
     env:

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -74,7 +74,7 @@ class TestRTorrentClient:
         assert torrent.get('name') == 'private.torrent'
         assert torrent.get('down_rate') == 123456
 
-        assert mocked_proxy.system.multicall.called_with(
+        mocked_proxy.system.multicall.assert_called_with(
             [
                 {'params': (torrent_info_hash,), 'methodName': 'd.base_path'},
                 {'params': (torrent_info_hash,), 'methodName': 'd.name'},
@@ -110,7 +110,7 @@ class TestRTorrentClient:
             else:
                 raise AssertionError('Invalid hash returned')
 
-        assert mocked_proxy.system.multicall.called_with(
+        mocked_proxy.system.multicall.assert_called_with(
             (['main', 'd.directory_base=', 'd.name=', 'd.hash=', 'd.custom1='],)
         )
 
@@ -129,7 +129,7 @@ class TestRTorrentClient:
         resp = client.update(torrent_info_hash, fields=update_fields)
         assert resp == 0
 
-        assert mocked_proxy.system.multicall.called_with(
+        mocked_proxy.system.multicall.assert_called_with(
             [
                 {
                     'params': (torrent_info_hash, '/data/downloads'),
@@ -148,7 +148,7 @@ class TestRTorrentClient:
         resp = client.delete(torrent_info_hash)
 
         assert resp == 0
-        assert mocked_proxy.d.erase.called_with((torrent_info_hash,))
+        mocked_proxy.d.erase.assert_called_with((torrent_info_hash,))
 
     def test_purge_torrent(self, mocked_proxy):
         mocked_proxy = mocked_proxy()
@@ -205,7 +205,7 @@ class TestRTorrentClient:
         resp = client.start(torrent_info_hash)
 
         assert resp == 0
-        assert mocked_proxy.d.start.called_with((torrent_info_hash,))
+        mocked_proxy.d.start.assert_called_with((torrent_info_hash,))
 
     def test_stop(self, mocked_proxy):
         mocked_proxy = mocked_proxy()
@@ -216,8 +216,8 @@ class TestRTorrentClient:
         resp = client.stop(torrent_info_hash)
 
         assert resp == 0
-        assert mocked_proxy.d.stop.called_with((torrent_info_hash,))
-        assert mocked_proxy.d.close.called_with((torrent_info_hash,))
+        mocked_proxy.d.stop.assert_called_with((torrent_info_hash,))
+        mocked_proxy.d.close.assert_called_with((torrent_info_hash,))
 
 
 @mock.patch('flexget.plugins.clients.rtorrent.RTorrent')

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -89,7 +89,7 @@ class TestRTorrentClient:
         hash1 = '09977FE761AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
         hash2 = '09977FE761BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
 
-        mocked_proxy.d.multicall.return_value = (
+        mocked_proxy.d.multicall2.return_value = (
             ['/data/downloads', 'private.torrent', hash1, 'test_custom1'],
             ['/data/downloads', 'private.torrent', hash2, 'test_custom2'],
         )
@@ -98,6 +98,7 @@ class TestRTorrentClient:
         torrents = client.torrents(fields=['custom1'])  # Required fields should be added
 
         assert isinstance(torrents, list)
+        assert len(torrents) == 2
 
         for torrent in torrents:
             assert torrent.get('base_path') == '/data/downloads'
@@ -110,8 +111,8 @@ class TestRTorrentClient:
             else:
                 raise AssertionError('Invalid hash returned')
 
-        mocked_proxy.system.multicall.assert_called_with(
-            (['main', 'd.directory_base=', 'd.name=', 'd.hash=', 'd.custom1='],)
+        mocked_proxy.d.multicall2.assert_called_with(
+            '', ['main', 'd.base_path=', 'd.name=', 'd.hash=', 'd.custom1=']
         )
 
     def test_update(self, mocked_proxy):
@@ -131,12 +132,12 @@ class TestRTorrentClient:
 
         mocked_proxy.system.multicall.assert_called_with(
             [
+                {'params': (torrent_info_hash, 'test_custom1'), 'methodName': 'd.custom1.set'},
                 {
                     'params': (torrent_info_hash, '/data/downloads'),
-                    'methodName': 'd.directory_base',
+                    'methodName': 'd.directory_base.set',
                 },
-                {'params': (torrent_info_hash, 'test_custom1'), 'methodName': 'd.custom1'},
-                {'params': (torrent_info_hash, '/data/downloads'), 'methodName': 'd.custom1'},
+                {'params': (torrent_info_hash, 3), 'methodName': 'd.priority.set'},
             ]
         )
 
@@ -148,7 +149,7 @@ class TestRTorrentClient:
         resp = client.delete(torrent_info_hash)
 
         assert resp == 0
-        mocked_proxy.d.erase.assert_called_with((torrent_info_hash,))
+        mocked_proxy.d.erase.assert_called_with(torrent_info_hash)
 
     def test_purge_torrent(self, mocked_proxy):
         mocked_proxy = mocked_proxy()
@@ -205,7 +206,7 @@ class TestRTorrentClient:
         resp = client.start(torrent_info_hash)
 
         assert resp == 0
-        mocked_proxy.d.start.assert_called_with((torrent_info_hash,))
+        mocked_proxy.d.start.assert_called_with(torrent_info_hash)
 
     def test_stop(self, mocked_proxy):
         mocked_proxy = mocked_proxy()
@@ -216,8 +217,8 @@ class TestRTorrentClient:
         resp = client.stop(torrent_info_hash)
 
         assert resp == 0
-        mocked_proxy.d.stop.assert_called_with((torrent_info_hash,))
-        mocked_proxy.d.close.assert_called_with((torrent_info_hash,))
+        mocked_proxy.d.stop.assert_called_with(torrent_info_hash)
+        mocked_proxy.d.close.assert_called_with(torrent_info_hash)
 
 
 @mock.patch('flexget.plugins.clients.rtorrent.RTorrent')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ testpaths = ["flexget/tests"]
 [tool.black]
 line-length = 99
 skip-string-normalization = true
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
 # Only include files in /flexget/, or directly in project root
 include = '^/(flexget/.*)?[^/]*\.pyi?$'
 exclude = '''


### PR DESCRIPTION
### Motivation for changes:
Support python 3.12

### Detailed changes:
- Start testing against python 3.12
- Fix rtorrent tests:
  - they weren't actually calling asserts properly
  - they were asserting the wrong things in some cases
