### PR TITLE
Removed special characters from alpharatio.py search

### DIFF
--- a/flexget/components/sites/sites/alpharatio.py
+++ b/flexget/components/sites/sites/alpharatio.py
@@ -16,8 +16,10 @@ from flexget.utils.requests import Session as RequestSession
 from flexget.utils.soup import get_soup
 from flexget.utils.tools import parse_filesize
 
+
 def remove_special_characters(text):
     return re.sub(r'[^a-zA-Z0-9 ]', '', text)
+
 
 logger = logger.bind(name='alpharatio')
 Base = db_schema.versioned_base('alpharatio', 0)
@@ -211,8 +213,6 @@ class SearchAlphaRatio:
         raise plugin.PluginError(
             'AlphaRatio layout has changed, unable to parse correctly. Please open a Github issue'
         )
-
-
 
     @plugin.internet(logger)
     def search(self, task, entry, config):

--- a/flexget/components/sites/sites/alpharatio.py
+++ b/flexget/components/sites/sites/alpharatio.py
@@ -16,6 +16,9 @@ from flexget.utils.requests import Session as RequestSession
 from flexget.utils.soup import get_soup
 from flexget.utils.tools import parse_filesize
 
+def remove_special_characters(text):
+    return re.sub(r'[^a-zA-Z0-9 ]', '', text)
+
 logger = logger.bind(name='alpharatio')
 Base = db_schema.versioned_base('alpharatio', 0)
 
@@ -209,6 +212,8 @@ class SearchAlphaRatio:
             'AlphaRatio layout has changed, unable to parse correctly. Please open a Github issue'
         )
 
+
+
     @plugin.internet(logger)
     def search(self, task, entry, config):
         """
@@ -243,7 +248,7 @@ class SearchAlphaRatio:
         )
 
         for search_string in entry.get('search_strings', [entry['title']]):
-            params['searchstr'] = search_string
+            params['searchstr'] = remove_special_characters(search_string)
             logger.debug('Using search params: {}', params)
             try:
                 page = self.get(


### PR DESCRIPTION
the movie-list plugin that uses imdb adds certain special characters to the search, which alpharatio can't handle, like parentheses and colon. This commit makes sure that only alphanumerical characters is used.

Top Gun: Maverick (2023)
South Park: Not Suitable for Children (2023)

Will now work since this commit will strip the colon and the parentheses.

### Motivation for changes:

### Detailed changes:
- 

### Addressed issues/feature requests:
- Fixes # .

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
```
paste output here
```
#### To Do:

- [ ] Stuff..

