### PR TITLE
Identify `(Season 1)` as season_pack

### DIFF
--- a/flexget/utils/parsers/series.py
+++ b/flexget/utils/parsers/series.py
@@ -58,7 +58,7 @@ class SeriesParser(TitleParser):
     season_pack_regexps = ReList(
         [
             # S01 or Season 1 but not Season 1 Episode|Part 2
-            r'(?:season\s?|s)(\d{1,})(?:\s|$)(?!(?:(?:.*?\s)?(?:episode|e|ep|part|pt)\s?(?:\d{1,3}|%s)|(?:\d{1,3})\s?of\s?(?:\d{1,3})))'
+            r'(?:season\s?|s)(\d{1,}\b)(?!(?:(?:.*?\s)?(?:episode|e|ep|part|pt)\s?(?:\d{1,3}|%s)|(?:\d{1,3})\s?of\s?(?:\d{1,3})))'
             % roman_numeral_re,
             r'(\d{1,3})\s?x\s?all',  # 1xAll
         ]

--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -152,9 +152,12 @@ _sources = [
 _codecs = [
     QualityComponent('codec', 10, 'divx'),
     QualityComponent('codec', 20, 'xvid'),
+    QualityComponent('codec', 25, 'nvenc'),
     QualityComponent('codec', 30, 'h264', '[hx].?264'),
     QualityComponent('codec', 35, 'vp9'),
-    QualityComponent('codec', 40, 'h265', '[hx].?265|hevc'),
+    QualityComponent('codec', 40, 'h265', '[hx].?265'),
+    QualityComponent('codec', 40, 'h265', 'hevc'),
+    QualityComponent('codec', 50, 'av1', 'av-?1'),
 ]
 
 _color_ranges = [


### PR DESCRIPTION
### Motivation for changes:
Entries with `(Season 1) ... [HEVC x265]` in the title being misidentified as s1e265 instead of a Season Pack
### Detailed changes:
- Replaced Space or EOL character with Word Boundary in the Season Pack RegEx
- Split `HEVC` and `[hx].?265` into separate entities so if an entry uses both they get properly cleaned up. That fixes leaving a stray `x265` to be misidentified as episode 265 later.
- Added `NVENC` as a lower quality codec. Although it's not strictly its own codec, the encoder renders with lower quality h264+ in exchange for speed.
- Added `AV-1` as a codec above `H265`. "The future is now, old man"

### Addressed issues/feature requests:
- Fixes #3901

