### PR TITLE
Tweak some of the new pendulum behavior

### DIFF
--- a/flexget/entry.py
+++ b/flexget/entry.py
@@ -5,6 +5,7 @@ from datetime import date, datetime
 from enum import Enum
 from typing import Callable, Iterable, Mapping, Optional, Sequence, Union
 
+import pendulum
 from loguru import logger
 
 from flexget import plugin
@@ -239,8 +240,7 @@ class Entry(LazyDict, Serializer):
                     f"{key} was set to a naive datetime. Plugin should be updated to provide a timezone aware datetime"
                 )
         elif isinstance(value, date):
-            # Dates become datetimes at midnight. This allows the user to compare with 'now' and other datetimes
-            value = CoercingDateTime.create(value.year, value.month, value.day, tz='local')
+            value = pendulum.instance(value)
 
         # url and original_url handling
         if key == 'url':

--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -164,21 +164,19 @@ class AniList:
                         entry['al_banner'] = anime.get('bannerImage')
                         entry['al_cover'] = anime.get('coverImage', {}).get('large')
                         entry['al_date_end'] = (
-                            pendulum.datetime(
+                            pendulum.date(
                                 year=anime.get('endDate').get('year'),
                                 month=(anime.get('endDate').get('month') or 1),
                                 day=(anime.get('endDate').get('day') or 1),
-                                tz='Asia/Tokyo',
                             )
                             if anime.get('endDate').get('year')
                             else None
                         )
                         entry['al_date_start'] = (
-                            pendulum.datetime(
+                            pendulum.date(
                                 year=anime.get('startDate').get('year'),
                                 month=(anime.get('startDate').get('month') or 1),
                                 day=(anime.get('startDate').get('day') or 1),
-                                tz='Asia/Tokyo',
                             )
                             if anime.get('startDate').get('year')
                             else None

--- a/flexget/tests/test_misc.py
+++ b/flexget/tests/test_misc.py
@@ -176,11 +176,7 @@ class TestEntryCoercion:
     def test_date_coercion(self):
         e = Entry('title', 'url')
         e['date'] = datetime.date(2023, 9, 3)
-        assert isinstance(e['date'], CoercingDateTime)
-        # Times should be midnight in the local timezone
-        assert e['date'].hour == 0
-        assert e['date'].minute == 0
-        assert e['date'].tzinfo == CoercingDateTime.now().tzinfo
+        assert isinstance(e['date'], pendulum.Date)
 
 
 class TestFilterRequireField:


### PR DESCRIPTION
Some of the changes to add timezone aware datetimes weren't fully backwards compatible as intended with 3.11.0. This hopefully fixes those issues and reverts a dubious decision:
- Dates are no longer cast to datetimes when added as entry fields. Instead, for convenience, the user is allowed to compare a date to a datetime, and at that point the date will be considered to be a datetime at midnight.
- Anidb reverted to set plain dates, rather than datetimes in tokyo time.
- `now` and `utcnow` template variables are now the special datetimes that allow comparison with naive datetimes and dates.
