### PR TITLE
Handle `ReadTimeout` exception in `DiscordNotifier`

### DIFF
--- a/flexget/components/notify/notifiers/discord.py
+++ b/flexget/components/notify/notifiers/discord.py
@@ -7,7 +7,7 @@ from loguru import logger
 from flexget import plugin
 from flexget.event import event
 from flexget.plugin import PluginWarning
-from flexget.utils.requests import RequestException, Session, TokenBucketLimiter
+from flexget.utils.requests import ReadTimeout, RequestException, Session, TokenBucketLimiter
 
 plugin_name = 'discord'
 
@@ -176,6 +176,9 @@ class DiscordNotifier:
                 session.add_domain_limiter(
                     TokenBucketLimiter('discord.com', tokens=tokens, rate=tokens_reset)
                 )
+            except ReadTimeout:
+                logger.info(f'Request timed out')
+                continue
             except RequestException as e:
                 if e.response.status_code == 429:
                     timeout = int(

--- a/flexget/components/notify/notifiers/discord.py
+++ b/flexget/components/notify/notifiers/discord.py
@@ -3,11 +3,12 @@ from time import sleep as wait
 
 from dateutil.parser import ParserError, isoparse
 from loguru import logger
+from requests.exceptions import ReadTimeout
 
 from flexget import plugin
 from flexget.event import event
 from flexget.plugin import PluginWarning
-from flexget.utils.requests import ReadTimeout, RequestException, Session, TokenBucketLimiter
+from flexget.utils.requests import RequestException, Session, TokenBucketLimiter
 
 plugin_name = 'discord'
 
@@ -177,7 +178,7 @@ class DiscordNotifier:
                     TokenBucketLimiter('discord.com', tokens=tokens, rate=tokens_reset)
                 )
             except ReadTimeout:
-                logger.info(f'Request timed out')
+                logger.info('Request timed out')
                 continue
             except RequestException as e:
                 if e.response.status_code == 429:

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -11,7 +11,7 @@ from urllib.request import urlopen
 
 import requests
 from loguru import logger
-from requests import RequestException, ReadTimeout
+from requests import RequestException
 
 from flexget import __version__ as version
 from flexget.utils.tools import TimedDict, parse_timedelta

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -11,7 +11,7 @@ from urllib.request import urlopen
 
 import requests
 from loguru import logger
-from requests import RequestException
+from requests import RequestException, ReadTimeout
 
 from flexget import __version__ as version
 from flexget.utils.tools import TimedDict, parse_timedelta


### PR DESCRIPTION
`ReadTimeout` has no response attribute and has to be handled separately

### Motivation for changes:
`ReadTimeout` has no response attribute and will therefore crash the plugin instead of logging and exiting gracefully.

### Detailed changes:
Added separate `except`-block for `ReadTimeout` in `DiscordNotifier`

### Addressed issues/feature requests:
- Fixes #3909 

### Log and/or tests output (preferably both):
Output of `pytest tests/notifiers`
```
============================= test session starts ==============================
platform darwin -- Python 3.10.12, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/axel/Documents/Projects/forks/Flexget
configfile: pyproject.toml
plugins: cov-4.1.0, xdist-3.5.0
collected 7 items

tests/notifiers/test_notify_abort.py ..                                  [ 28%]
tests/notifiers/test_notify_entry.py .                                   [ 42%]
tests/notifiers/test_notify_task.py ...                                  [ 85%]
tests/notifiers/test_pushover.py .                                       [100%]

=============================== warnings summary ===============================
config_schema.py:198
  /Users/axel/Documents/Projects/forks/Flexget/flexget/config_schema.py:198: DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the https://github.com/python-jsonschema/referencing library, which provides more compliant referencing behavior as well as more flexible APIs for customization. A future release will remove RefResolver. Please file a feature request (on referencing) if you are missing an API for the kind of customization you need.
    class RefResolver(jsonschema.RefResolver):

../../../../../Library/Caches/pypoetry/virtualenvs/flexget-RUFUP9mE-py3.10/lib/python3.10/site-packages/flask_restx/api.py:19
../../../../../Library/Caches/pypoetry/virtualenvs/flexget-RUFUP9mE-py3.10/lib/python3.10/site-packages/flask_restx/api.py:19
  /Users/axel/Library/Caches/pypoetry/virtualenvs/flexget-RUFUP9mE-py3.10/lib/python3.10/site-packages/flask_restx/api.py:19: DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the https://github.com/python-jsonschema/referencing library, which provides more compliant referencing behavior as well as more flexible APIs for customization. A future release will remove RefResolver. Please file a feature request (on referencing) if you are missing an API for the kind of customization you need.
    from jsonschema import RefResolver

api/app.py:15
api/app.py:15
  /Users/axel/Documents/Projects/forks/Flexget/flexget/api/app.py:15: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    from jsonschema import RefResolutionError

../../../../../Library/Caches/pypoetry/virtualenvs/flexget-RUFUP9mE-py3.10/lib/python3.10/site-packages/cherrypy/__init__.py:60
  /Users/axel/Library/Caches/pypoetry/virtualenvs/flexget-RUFUP9mE-py3.10/lib/python3.10/site-packages/cherrypy/__init__.py:60: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

../../../../../Library/Caches/pypoetry/virtualenvs/flexget-RUFUP9mE-py3.10/lib/python3.10/site-packages/pkg_resources/__init__.py:2868
../../../../../Library/Caches/pypoetry/virtualenvs/flexget-RUFUP9mE-py3.10/lib/python3.10/site-packages/pkg_resources/__init__.py:2868
../../../../../Library/Caches/pypoetry/virtualenvs/flexget-RUFUP9mE-py3.10/lib/python3.10/site-packages/pkg_resources/__init__.py:2868
../../../../../Library/Caches/pypoetry/virtualenvs/flexget-RUFUP9mE-py3.10/lib/python3.10/site-packages/pkg_resources/__init__.py:2868
  /Users/axel/Library/Caches/pypoetry/virtualenvs/flexget-RUFUP9mE-py3.10/lib/python3.10/site-packages/pkg_resources/__init__.py:2868: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('sphinxcontrib')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

../../../../../Library/Caches/pypoetry/virtualenvs/flexget-RUFUP9mE-py3.10/lib/python3.10/site-packages/pkg_resources/__init__.py:2868
  /Users/axel/Library/Caches/pypoetry/virtualenvs/flexget-RUFUP9mE-py3.10/lib/python3.10/site-packages/pkg_resources/__init__.py:2868: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zc')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

api/core/schema.py:2
api/core/schema.py:2
  /Users/axel/Documents/Projects/forks/Flexget/flexget/api/core/schema.py:2: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    from jsonschema import RefResolutionError

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 7 passed, 13 warnings in 1.30s ========================
```
#### To Do:
 - [ ] The same exception could be ovelooked elsewhere (I have not investigated if this is the case)
