### PR TITLE
[fix] Added AVC as an alias for h264

### DIFF
--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -154,6 +154,7 @@ _codecs = [
     QualityComponent('codec', 20, 'xvid'),
     QualityComponent('codec', 25, 'nvenc'),
     QualityComponent('codec', 30, 'h264', '[hx].?264'),
+    QualityComponent('codec', 30, 'h264', 'avc'),
     QualityComponent('codec', 35, 'vp9'),
     QualityComponent('codec', 40, 'h265', '[hx].?265'),
     QualityComponent('codec', 40, 'h265', 'hevc'),


### PR DESCRIPTION
### Motivation for changes:
Releases using only AVC to identify h264
### Detailed changes:
- Added a new alias to also account for cases where both are used simultaneously (e.g. 1080p AVC h264 AAC)

### Addressed issues/feature requests:
- Fixes [Issue brought up on Discord](https://discord.com/channels/536690097056120833/536690097496784906/1195774164183818291)

### Config usage if relevant (new plugin or updated schema):
N/A
### Log and/or tests output (preferably both):
N/A

