### PR TITLE
[fix] transmission: update version check

### DIFF
--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
 
 logger = logger.bind(name='transmission')
 
-__version__ = '>=4.1.4,<5.0.0'
+__version__ = '>=7.0.0,=<7.0.3'
 __package__ = 'transmission-rpc'
 __requirement__ = packaging.specifiers.SpecifierSet(__version__)
 


### PR DESCRIPTION
### Motivation for changes:

3.11.12 update broke transmission since pip version was updated was updated but not the version check

### Detailed changes:
- update version check in transmission module


#### To Do:

- check if other areas need updating (pyproject.toml, requirements-docker.txt, etc)

