### PR TITLE
[fix] transmission: invalid version specifier

### DIFF
--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
 
 logger = logger.bind(name='transmission')
 
-__version__ = '>=7.0.0,=<7.0.3'
+__version__ = '>=7.0.3,<8.0.0'
 __package__ = 'transmission-rpc'
 __requirement__ = packaging.specifiers.SpecifierSet(__version__)
 


### PR DESCRIPTION
### Motivation for changes:

transmission client version check still broken

### Detailed changes:
- fix version specifier, can't have 2 boundaries with '='
