### PR TITLE
[fix] adding save_path parameter to the convert_magnet module

### DIFF
--- a/flexget/components/bittorrent/convert_magnet.py
+++ b/flexget/components/bittorrent/convert_magnet.py
@@ -44,6 +44,7 @@ class ConvertMagnet:
             params['url'] = magnet_uri
         else:
             params.url = magnet_uri
+        params.save_path = destination_folder
         handle = session.add_torrent(params)
         logger.debug('Acquiring torrent metadata for magnet {}', magnet_uri)
         timeout_value = timeout


### PR DESCRIPTION
### Motivation for changes:
As mentioned in the Issue, the problem got introduced after the libtorrent version bump last year. Magnet links were causing an error and task crash. 

### Detailed changes:
- Adding an explicit definition of the `save_path` parameter

### Addressed issues/feature requests:
- Fixes #3781 

