### PR TITLE
Fix HDR quality order

### DIFF
--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -164,8 +164,8 @@ _codecs = [
 _color_ranges = [
     QualityComponent('color_range', 10, '8bit', r'8[^\w]?bits?|hi8p?'),
     QualityComponent('color_range', 20, '10bit', r'10[^\w]?bits?|hi10p?'),
-    QualityComponent('color_range', 40, 'hdrplus', r'hdr(10)?[^\w]?(\+|p|plus)'),
     QualityComponent('color_range', 30, 'hdr', r'hdr([^\w]?10)?'),
+    QualityComponent('color_range', 40, 'hdrplus', r'hdr(10)?[^\w]?(\+|p|plus)'),
     QualityComponent('color_range', 50, 'dolbyvision', r'(dolby[^\w]?vision|dv|dovi)'),
 ]
 


### PR DESCRIPTION
### Motivation for changes:
`<hdr` was not working as intended in the `quality` plugin
### Detailed changes:
- Changed the order of a single item in the `color_ranges` list
  - I'd assume the order would be irrelevant given the numeric value but that doesn't seem to be the case

### Addressed issues/feature requests:
- Fixes #3952

### Config usage if relevant (new plugin or updated schema):
N/A
### Log and/or tests output (preferably both):
Simple task for test, `Too Good` should not be accepted since it does not meet either of the criteria defined in `quality`:
```yaml
tasks:
  test:
    mock:
      - title: Bland 4k 8-bit.mkv
      - title: Small 1080p HDR.mkv
      - title: Too Good 4k HDR.mkv
    quality:
      - <2160p
      - <hdr
    accept_all: yes
```

Output before:
```
VERBOSE  details       test            Produced 3 entries.                                       
VERBOSE  task          test            ACCEPTED: `Bland 4k 8-bit.mkv` by accept_all plugin       
VERBOSE  task          test            ACCEPTED: `Small 1080p HDR.mkv` by accept_all plugin      
VERBOSE  task          test            ACCEPTED: `Too Good 4k HDR.mkv` by accept_all plugin      
VERBOSE  details       test            Summary - Accepted: 3 (Rejected: 0 Undecided: 0 Failed: 0)
```

Output after:
```
VERBOSE  details       test            Produced 3 entries.                                                                                                               
VERBOSE  task          test            REJECTED: `Too Good 4k HDR.mkv` by quality plugin because `2160p hdr` does not match any of quality requirements: `<2160p`, `<hdr`
VERBOSE  task          test            ACCEPTED: `Bland 4k 8-bit.mkv` by accept_all plugin                                                                               
VERBOSE  task          test            ACCEPTED: `Small 1080p HDR.mkv` by accept_all plugin                                                                              
VERBOSE  details       test            Summary - Accepted: 2 (Rejected: 1 Undecided: 0 Failed: 0)                                                                        
```

