### PR TITLE
[nfo_lookup] Fallback to movie.nfo if same name .nfo not found

### DIFF
--- a/flexget/plugins/metainfo/nfo_lookup.py
+++ b/flexget/plugins/metainfo/nfo_lookup.py
@@ -125,6 +125,10 @@ class NfoLookup:
         if os.path.isfile(nfo_full_filename):
             return nfo_full_filename
 
+        movie_nfo_filename = os.path.join(os.path.dirname(location), 'movie' + self.nfo_file_extension)
+        if os.path.isfile(movie_nfo_filename):
+            return movie_nfo_filename
+
 
 class BadXmlFile(Exception):
     """

--- a/flexget/plugins/metainfo/nfo_lookup.py
+++ b/flexget/plugins/metainfo/nfo_lookup.py
@@ -125,7 +125,9 @@ class NfoLookup:
         if os.path.isfile(nfo_full_filename):
             return nfo_full_filename
 
-        movie_nfo_filename = os.path.join(os.path.dirname(location), 'movie' + self.nfo_file_extension)
+        movie_nfo_filename = os.path.join(
+            os.path.dirname(location), 'movie' + self.nfo_file_extension
+        )
         if os.path.isfile(movie_nfo_filename):
             return movie_nfo_filename
 


### PR DESCRIPTION
### Motivation for changes:
Latest version of jellyfin stopped generating .nfo with same name of movies, and is using movie.nfo instead.

### Detailed changes:
Added a fallback to search for movie.nfo if same name .nfo not found.
