### PR TITLE
[fix]: Wrap telegram imports to avoid runtime crashes

### DIFF
--- a/flexget/components/notify/notifiers/telegram.py
+++ b/flexget/components/notify/notifiers/telegram.py
@@ -1,13 +1,18 @@
-import telegram
 from loguru import logger
 from packaging import version
 from sqlalchemy import Column, Integer, String
-from telegram.error import ChatMigrated, NetworkError, TelegramError
 
 from flexget import db_schema, plugin
 from flexget.event import event
 from flexget.manager import Session
 from flexget.plugin import PluginError, PluginWarning
+
+try:
+    import telegram
+    from telegram.error import ChatMigrated, NetworkError, TelegramError
+except ImportError:
+    telegram = None
+
 
 _MIN_TELEGRAM_VER = '3.4'
 


### PR DESCRIPTION
### Motivation for changes:
Flexget is crashing when `python-telegram-bot` package is not installed, per https://github.com/Flexget/Flexget/pull/4003#issuecomment-2179346431

### Detailed changes:
- Revert part of the changes introduced in https://github.com/Flexget/Flexget/pull/4003

