### PR TITLE
[add] Discord Notifier: silent notification property

### DIFF
--- a/flexget/components/notify/notifiers/discord.py
+++ b/flexget/components/notify/notifiers/discord.py
@@ -26,6 +26,7 @@ class DiscordNotifier:
           via:
             - discord:
                 web_hook_url: <string>
+                [silent: <boolean>] (suppress notification)
                 [username: <string>] (override the default username of the webhook)
                 [avatar_url: <string>] (override the default avatar of the webhook)
                 [embeds: <arrays>[<object>]] (override embeds)
@@ -37,6 +38,7 @@ class DiscordNotifier:
             'web_hook_url': {'type': 'string', 'format': 'uri'},
             'username': {'type': 'string', 'default': 'Flexget'},
             'avatar_url': {'type': 'string', 'format': 'uri'},
+            'silent': {'type': 'boolean', 'default': False},
             'embeds': {
                 'type': 'array',
                 'items': {
@@ -164,6 +166,9 @@ class DiscordNotifier:
             'avatar_url': config.get('avatar_url'),
             'embeds': config.get('embeds'),
         }
+
+        if config.get('silent'):
+            web_hook['flags'] = 4096 # Suppress notification bitfield
 
         # Send the request and handle the rate-limit response.
         for i in range(3):

--- a/flexget/components/notify/notifiers/discord.py
+++ b/flexget/components/notify/notifiers/discord.py
@@ -168,7 +168,7 @@ class DiscordNotifier:
         }
 
         if config.get('silent'):
-            web_hook['flags'] = 4096 # Suppress notification bitfield
+            web_hook['flags'] = 4096  # Suppress notification bitfield
 
         # Send the request and handle the rate-limit response.
         for i in range(3):


### PR DESCRIPTION
### Motivation for changes:
Wanted to have a notification go out when something is grabbed and another go out when it's available, but didn't want to be notified that it was grabbed, only that it was available; without creating two separate channels.

### Detailed changes:
- Added new property called `silent` onto discord notifier plugin.
- Check if `silent` is true, set property `flags` onto web_hook object with the suppress notification bitfield set.

### Config usage if relevant (new plugin or updated schema):
```
notify:
  task:
    message: <message>
    via:
      - discord:
          web_hook_url: <web_hook_url>
          silent: true
```

https://discord.com/developers/docs/resources/webhook#execute-webhook-jsonform-params
