### PR TITLE
qBittorrent: add options for ratio limit and seeding time limit

### DIFF
--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -274,7 +274,7 @@ class OutputQBitTorrent:
 
             seeding_time_limit = entry.get('seeding_time_limit', config.get('seeding_time_limit'))
             if seeding_time_limit:
-                form_data['seedingTimeLimit'] = parse_timedelta(seeding_time_limit) * 60
+                form_data['seedingTimeLimit'] = int(parse_timedelta(seeding_time_limit).total_seconds() / 60)
 
             is_magnet = entry['url'].startswith('magnet:')
 

--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -225,8 +225,6 @@ class OutputQBitTorrent:
         config.setdefault('maxupspeed', 0)
         config.setdefault('maxdownspeed', 0)
         config.setdefault('fail_html', True)
-        config.setdefault('ratio_limit', -2)
-        config.setdefault('seeding_time_limit', -1)
         return config
 
     def add_entries(self, task, config):

--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -294,7 +294,9 @@ class OutputQBitTorrent:
                 if maxdownspeed:
                     logger.info('Download Speed Limit: {}', form_data.get('dlLimit'))
                 logger.info('Ratio limit: {}', form_data.get('ratio_limit', -2))
-                logger.info('Seeding time limit: {} minutes', form_data.get('seeding_time_limit', -1))
+                logger.info(
+                    'Seeding time limit: {} minutes', form_data.get('seeding_time_limit', -1)
+                )
                 continue
 
             if self.check_torrent_exists(

--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -30,6 +30,8 @@ class OutputQBitTorrent:
         maxupspeed: <torrent upload speed limit> (default: 0)
         maxdownspeed: <torrent download speed limit> (default: 0)
         add_paused: <ADD_PAUSED> (default: False)
+        ratio_limit: <RATIO_LIMIT> (default: -2)
+        seeding_time_limit: <SEEDING_TIME_LIMIT> (default: -1)
     """
 
     schema = {
@@ -52,6 +54,8 @@ class OutputQBitTorrent:
                     'fail_html': {'type': 'boolean'},
                     'add_paused': {'type': 'boolean'},
                     'skip_check': {'type': 'boolean'},
+                    'ratio_limit': {'type': 'float'},
+                    'seeding_time_limit': {'type': 'integer'},
                 },
                 'additionalProperties': False,
             },
@@ -220,6 +224,8 @@ class OutputQBitTorrent:
         config.setdefault('maxupspeed', 0)
         config.setdefault('maxdownspeed', 0)
         config.setdefault('fail_html', True)
+        config.setdefault('ratio_limit', -2)
+        config.setdefault('seeding_time_limit', -1)
         return config
 
     def add_entries(self, task, config):
@@ -261,6 +267,14 @@ class OutputQBitTorrent:
             if maxdownspeed:
                 form_data['dlLimit'] = maxdownspeed * 1024
 
+            ratio_limit = entry.get('ratio_limit', config.get('ratio_limit'))
+            if ratio_limit:
+                form_data['ratioLimit'] = ratio_limit
+
+            seeding_time_limit = entry.get('seeding_time_limit', config.get('seeding_time_limit'))
+            if seeding_time_limit:
+                form_data['seedingTimeLimit'] = seeding_time_limit
+
             is_magnet = entry['url'].startswith('magnet:')
 
             if task.manager.options.test:
@@ -279,6 +293,8 @@ class OutputQBitTorrent:
                     logger.info('Upload Speed Limit: {}', form_data.get('upLimit'))
                 if maxdownspeed:
                     logger.info('Download Speed Limit: {}', form_data.get('dlLimit'))
+                logger.info('Ratio limit: {}', form_data.get('ratio_limit', -2)
+                logger.info('Seeding time limit: {} minutes', form_data.get('seeding_time_limit', -1)
                 continue
 
             if self.check_torrent_exists(

--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -293,8 +293,8 @@ class OutputQBitTorrent:
                     logger.info('Upload Speed Limit: {}', form_data.get('upLimit'))
                 if maxdownspeed:
                     logger.info('Download Speed Limit: {}', form_data.get('dlLimit'))
-                logger.info('Ratio limit: {}', form_data.get('ratio_limit', -2)
-                logger.info('Seeding time limit: {} minutes', form_data.get('seeding_time_limit', -1)
+                logger.info('Ratio limit: {}', form_data.get('ratio_limit', -2))
+                logger.info('Seeding time limit: {} minutes', form_data.get('seeding_time_limit', -1))
                 continue
 
             if self.check_torrent_exists(

--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -9,6 +9,7 @@ from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
 from flexget.utils.template import RenderError
+from flexget.utils.tools import parse_timedelta
 
 logger = logger.bind(name='qbittorrent')
 
@@ -55,7 +56,7 @@ class OutputQBitTorrent:
                     'add_paused': {'type': 'boolean'},
                     'skip_check': {'type': 'boolean'},
                     'ratio_limit': {'type': 'number'},
-                    'seeding_time_limit': {'type': 'integer'},
+                    'seeding_time_limit': {'type': 'string', 'format': 'interval'},
                 },
                 'additionalProperties': False,
             },
@@ -273,7 +274,7 @@ class OutputQBitTorrent:
 
             seeding_time_limit = entry.get('seeding_time_limit', config.get('seeding_time_limit'))
             if seeding_time_limit:
-                form_data['seedingTimeLimit'] = seeding_time_limit
+                form_data['seedingTimeLimit'] = parse_timedelta(seeding_time_limit) * 60
 
             is_magnet = entry['url'].startswith('magnet:')
 

--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -274,7 +274,9 @@ class OutputQBitTorrent:
 
             seeding_time_limit = entry.get('seeding_time_limit', config.get('seeding_time_limit'))
             if seeding_time_limit:
-                form_data['seedingTimeLimit'] = int(parse_timedelta(seeding_time_limit).total_seconds() / 60)
+                form_data['seedingTimeLimit'] = int(
+                    parse_timedelta(seeding_time_limit).total_seconds() / 60
+                )
 
             is_magnet = entry['url'].startswith('magnet:')
 

--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -54,7 +54,7 @@ class OutputQBitTorrent:
                     'fail_html': {'type': 'boolean'},
                     'add_paused': {'type': 'boolean'},
                     'skip_check': {'type': 'boolean'},
-                    'ratio_limit': {'type': 'float'},
+                    'ratio_limit': {'type': 'number'},
                     'seeding_time_limit': {'type': 'integer'},
                 },
                 'additionalProperties': False,


### PR DESCRIPTION
### Motivation for changes:
This adds config options for specifying ratio and seeding time limits.

### Detailed changes:
- Adds two config options: `ratio_limit`, and `seeding_time_limit`

### Addressed issues/feature requests:
None.

### Config usage if relevant (new plugin or updated schema):
```
    qbittorrent:
      label: some-label
      path: /home/user/download
      ratio_limit: 1.5
      seeding_time_limit: 10
```

`ratio_limit` is a float, and `seeding_time_limit` is in minutes.
