### PR TITLE
[Change] Add simpler string-only format to mock plugin's schema

### DIFF
--- a/flexget/plugins/input/mock.py
+++ b/flexget/plugins/input/mock.py
@@ -18,6 +18,7 @@ class Mock:
       mock:
         - {title: foobar, url: http://some.com }
         - {title: mock, url: http://another.com }
+        - Title Only
 
     If url is not given a random url pointing to localhost will be generated.
     """
@@ -25,16 +26,21 @@ class Mock:
     schema = {
         'type': 'array',
         'items': {
-            'type': 'object',
-            'properties': {'title': {'type': 'string'}, 'url': {'type': 'string'}},
-            'required': ['title'],
+            'oneOf': [
+                {'type': 'string'},
+                {
+                    'type': 'object',
+                    'properties': {'title': {'type': 'string'}, 'url': {'type': 'string'}},
+                    'required': ['title'],
+                },
+            ],
         },
     }
 
     def on_task_input(self, task, config):
         entries = []
         for line in config:
-            entry = Entry(line)
+            entry = Entry(line) if isinstance(line, dict) else Entry(title=line)
             # no url specified, add random one based on title (ie. test)
             if 'url' not in entry:
                 entry['url'] = 'mock://localhost/mock/{}'.format(hash(entry['title']))


### PR DESCRIPTION
### Motivation for changes:
Having to type the Dict-structure for every entry is kind of annoying, especially pasting the titles from elsewhere

### Detailed changes:
- Added a simple `string` option to the accepted formats for each of the  list's entries and assume it's the title

### Addressed issues/feature requests:
- None, just indulging my own laziness

### Config usage if relevant (new plugin or updated schema):
```diff
mock:
        - {title: foobar, url: http://some.com }
        - {title: mock}
+       - MockTitle
```
### Log and/or tests output (preferably both):
```
VERBOSE  details       test            Produced 3 entries.
VERBOSE  task          test            ACCEPTED: `foobar` by accept_all plugin
VERBOSE  task          test            ACCEPTED: `mock` by accept_all plugin
VERBOSE  task          test            ACCEPTED: `MockTitle` by accept_all plugin
```
