### PR TITLE
add stopped to add_paused for qbit5

### DIFF
--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -247,7 +247,8 @@ class OutputQBitTorrent:
 
             add_paused = entry.get('add_paused', config.get('add_paused'))
             if add_paused:
-                form_data['paused'] = 'true'
+                form_data['paused'] = 'true'  # qBittorrent v4.6.7-
+                form_data['stopped'] = 'true'  # qBittorrent v5.0.0+
 
             skip_check = entry.get('skip_check', config.get('skip_check'))
             if skip_check:


### PR DESCRIPTION
### Motivation for changes:
In qbittorrent 5 the add_paused option has changed to add_stopped. To handle this I have added stopped to the form data that is entered when adding torrent to qbittorrent. form_data['paused'] is still there to handle older versions of the webapi.
This change follows the same as had been done with label/category for different versions earlier
### Detailed changes:

### Addressed issues/feature requests:
- Fixes # .

### Config usage if relevant (new plugin or updated schema):
```

```
### Log and/or tests output (preferably both):
```

```
#### To Do:

