### PR TITLE
Remove deprecated use of cgi module

### DIFF
--- a/flexget/api/core/tasks.py
+++ b/flexget/api/core/tasks.py
@@ -1,7 +1,7 @@
 import argparse
-import cgi
 import copy
 from datetime import datetime, timedelta
+from email.message import EmailMessage
 from json import JSONEncoder
 from queue import Empty, Queue
 from typing import TYPE_CHECKING, Any, Dict
@@ -464,10 +464,13 @@ class TaskExecutionAPI(APIResource):
                 entry = Entry()
                 entry['url'] = item['url']
                 if not item.get('title'):
+                    # Apparently email module is the only place in stdlib that parses headers
+                    msg = EmailMessage()
                     try:
-                        value, params = cgi.parse_header(
-                            requests.head(item['url']).headers['Content-Disposition']
-                        )
+                        msg['content-type'] = requests.head(item['url']).headers[
+                            'Content-Disposition'
+                        ]
+                        params = msg['content-type'].params
                         entry['title'] = params['filename']
                     except KeyError:
                         raise BadRequest(

--- a/flexget/options.py
+++ b/flexget/options.py
@@ -278,9 +278,6 @@ class ArgumentParser(ArgParser):
         :param nested_namespace_name: When used as a subparser, options from this parser will be stored nested under
             this attribute name in the root parser's namespace
         """
-        # Do this early, so even option processing stuff is caught
-        if '--bugreport' in sys.argv:
-            self._debug_tb_callback()
 
         self.subparsers = None
         self.raise_errors = None
@@ -425,11 +422,6 @@ class ArgumentParser(ArgParser):
                     arg_strings[0] = matches[0]
         return super()._get_values(action, arg_strings)
 
-    def _debug_tb_callback(self, *dummy):
-        import cgitb
-
-        cgitb.enable(format="text")
-
 
 # This will hold just the arguments directly for Manager.
 manager_parser = ArgumentParser(add_help=False)
@@ -469,14 +461,6 @@ manager_parser.add_argument(
     type=str.upper,
 )
 manager_parser.set_post_defaults(loglevel='VERBOSE')
-# This option is already handled above.
-manager_parser.add_argument(
-    '--bugreport',
-    action='store_true',
-    dest='debug_tb',
-    help='Use this option to create a detailed bug report, '
-    'note that the output might contain PRIVATE data, so edit that out',
-)
 manager_parser.add_argument(
     '--profile',
     metavar='OUTFILE',


### PR DESCRIPTION
### Motivation for changes:
cgi and cgitb modules were deprecated, and removed in python 3.13

### Detailed changes:
- Changes to use `email` module to parse content-disposition header in download plugin
- Removes `--bugreport` cli flag. This was using cgitb module, but is not needed now, because loguru shows the extra information in tracebacks by default.

### Addressed issues/feature requests:
- Fixes #3939 
