### PR TITLE
[Change] Accept Input Plugins in `content_filter`

### DIFF
--- a/flexget/plugins/filter/content_filter.py
+++ b/flexget/plugins/filter/content_filter.py
@@ -98,10 +98,10 @@ class FilterContentFilter:
                     any(matching_mask(file, mask) for file in files) for mask in config['require']
                 ):
                     logger.info(
-                        'Entry {} does not have any of the required filetypes, rejecting',
+                        'Entry {} does not have any of the required files, rejecting',
                         entry['title'],
                     )
-                    entry.reject('does not have any of the required filetypes', remember=True)
+                    entry.reject('does not have any of the required files', remember=True)
                     return True
             if config.get('require_all'):
                 # Make sure each mask matches at least one of the contained files
@@ -110,10 +110,10 @@ class FilterContentFilter:
                     for mask in config['require_all']
                 ):
                     logger.info(
-                        'Entry {} does not have all of the required filetypes, rejecting',
+                        'Entry {} does not have all of the required files, rejecting',
                         entry['title'],
                     )
-                    entry.reject('does not have all of the required filetypes', remember=True)
+                    entry.reject('does not have all of the required files', remember=True)
                     return True
             if config.get('reject'):
                 mask = any(

--- a/flexget/plugins/filter/content_filter.py
+++ b/flexget/plugins/filter/content_filter.py
@@ -116,13 +116,11 @@ class FilterContentFilter:
                     entry.reject('does not have all of the required files', remember=True)
                     return True
             if config.get('reject'):
-                mask = any(
-                    any(matching_mask(file, mask) for file in files) for mask in config['reject']
-                )
-                if mask:
-                    logger.info('Entry {} has banned file {}, rejecting', entry['title'], mask)
-                    entry.reject(f'has banned file {mask}', remember=True)
-                    return True
+                for mask in config['reject']:
+                    if any(matching_mask(file, mask) for file in files):
+                        logger.info('Entry {} has banned file {}, rejecting', entry['title'], mask)
+                        entry.reject(f'has banned file {mask}', remember=True)
+                        return True
             if config.get('require_mainfile') and len(files) > 1:
                 best = None
                 for f in entry['torrent'].get_filelist():

--- a/flexget/tests/test_content_filter.py
+++ b/flexget/tests/test_content_filter.py
@@ -90,14 +90,14 @@ class TestContentFilter:
 
           test_list_populate_a:
             mock:
-              - ubuntu
+              - ubuntu*
             accept_all: yes
             list_add:
               - entry_list: accept-list
 
           test_list_populate_r:
             mock:
-              - flexget
+              - flexget*
             accept_all: yes
             list_add:
               - entry_list: accept-list
@@ -118,7 +118,7 @@ class TestContentFilter:
             content_filter:
               require:
                 from:
-                  - mock: ['ubuntu']
+                  - mock: ['ubuntu*']
 
           test_input_require_r:
             mock:
@@ -127,7 +127,7 @@ class TestContentFilter:
             content_filter:
               require:
                 from:
-                  - mock: ['flexget']
+                  - mock: ['*flexget*']
 
           test_input_require_all:
             mock:
@@ -136,7 +136,27 @@ class TestContentFilter:
             content_filter:
               require_all:
                 from:
-                  - mock: ['flexget', 'ubuntu']
+                  - mock: ['*flexget*', 'ubuntu*']
+
+          test_regexp_require_a:
+            mock:
+              - {title: 'test', file: '__tmp__/test.torrent'}
+            accept_all: yes
+            content_filter:
+              regexp_mode: yes
+              require:
+                from:
+                  - mock: ['ubuntu']
+
+          test_regexp_require_r:
+            mock:
+              - {title: 'test', file: '__tmp__/test.torrent'}
+            accept_all: yes
+            content_filter:
+              regexp_mode: yes
+              require:
+                from:
+                  - mock: ['flexget']
     """
 
     def test_reject1(self, execute_task):
@@ -227,3 +247,13 @@ class TestContentFilter:
         assert task.find_entry(
             'rejected', title='test'
         ), 'should have rejected, one mask isn\'t satisfied'
+
+    def test_regexp_require_a(self, execute_task):
+        task = execute_task('test_regexp_require_a')
+        assert task.find_entry('accepted', title='test'), 'should have accepted, contains ubuntu'
+
+    def test_regexp_require_r(self, execute_task):
+        task = execute_task('test_regexp_require_r')
+        assert task.find_entry(
+            'rejected', title='test'
+        ), 'should have rejected, mask isn\'t satisfied'

--- a/flexget/tests/test_content_filter.py
+++ b/flexget/tests/test_content_filter.py
@@ -87,6 +87,22 @@ class TestContentFilter:
             accept_all: yes
             content_filter:
               max_files: 3
+
+          test_list_populate:
+            mock:
+              - ubuntu
+            accept_all: yes
+            list_add:
+              - entry_list: accept-list
+
+          test_list_require:
+            mock:
+              - {title: 'test', file: '__tmp__/test.torrent'}
+            accept_all: yes
+            content_filter:
+              require:
+                from:
+                  - entry_list: accept-list
     """
 
     def test_reject1(self, execute_task):
@@ -149,3 +165,8 @@ class TestContentFilter:
 
         assert task.find_entry('rejected', title='manyfiles'), 'should have rejected, >3 files'
         assert task.find_entry('accepted', title='onefile'), 'should have accepted, has <=3 files'
+
+    def test_list_require(self, execute_task):
+        execute_task('test_list_populate')
+        task = execute_task('test_list_require')
+        assert task.find_entry('accepted', title='test'), 'should have accepted, contains ubuntu'

--- a/flexget/tests/test_content_filter.py
+++ b/flexget/tests/test_content_filter.py
@@ -88,9 +88,16 @@ class TestContentFilter:
             content_filter:
               max_files: 3
 
-          test_list_populate:
+          test_list_populate_a:
             mock:
               - ubuntu
+            accept_all: yes
+            list_add:
+              - entry_list: accept-list
+
+          test_list_populate_r:
+            mock:
+              - flexget
             accept_all: yes
             list_add:
               - entry_list: accept-list
@@ -103,6 +110,33 @@ class TestContentFilter:
               require:
                 from:
                   - entry_list: accept-list
+
+          test_input_require_a:
+            mock:
+              - {title: 'test', file: '__tmp__/test.torrent'}
+            accept_all: yes
+            content_filter:
+              require:
+                from:
+                  - mock: ['ubuntu']
+
+          test_input_require_r:
+            mock:
+              - {title: 'test', file: '__tmp__/test.torrent'}
+            accept_all: yes
+            content_filter:
+              require:
+                from:
+                  - mock: ['flexget']
+
+          test_input_require_all:
+            mock:
+              - {title: 'test', file: '__tmp__/test.torrent'}
+            accept_all: yes
+            content_filter:
+              require_all:
+                from:
+                  - mock: ['flexget', 'ubuntu']
     """
 
     def test_reject1(self, execute_task):
@@ -113,7 +147,7 @@ class TestContentFilter:
         task = execute_task('test_reject2')
         assert task.find_entry(
             'accepted', title='test'
-        ), 'should have accepted, doesn\t contain *.avi'
+        ), 'should have accepted, doesn\'t contain *.avi'
 
     def test_require1(self, execute_task):
         task = execute_task('test_require1')
@@ -123,7 +157,7 @@ class TestContentFilter:
         task = execute_task('test_require2')
         assert task.find_entry(
             'rejected', title='test'
-        ), 'should have rejected, doesn\t contain *.avi'
+        ), 'should have rejected, doesn\'t contain *.avi'
 
     def test_require_all1(self, execute_task):
         task = execute_task('test_require_all1')
@@ -166,7 +200,30 @@ class TestContentFilter:
         assert task.find_entry('rejected', title='manyfiles'), 'should have rejected, >3 files'
         assert task.find_entry('accepted', title='onefile'), 'should have accepted, has <=3 files'
 
-    def test_list_require(self, execute_task):
-        execute_task('test_list_populate')
+    def test_list_require_a(self, execute_task):
+        execute_task('test_list_populate_a')
         task = execute_task('test_list_require')
         assert task.find_entry('accepted', title='test'), 'should have accepted, contains ubuntu'
+
+    def test_list_require_r(self, execute_task):
+        execute_task('test_list_populate_r')
+        task = execute_task('test_list_require')
+        assert task.find_entry(
+            'rejected', title='test'
+        ), 'should have rejected, mask isn\'t satisfied'
+
+    def test_input_require_a(self, execute_task):
+        task = execute_task('test_input_require_a')
+        assert task.find_entry('accepted', title='test'), 'should have accepted, contains ubuntu'
+
+    def test_input_require_r(self, execute_task):
+        task = execute_task('test_input_require_r')
+        assert task.find_entry(
+            'rejected', title='test'
+        ), 'should have rejected, mask isn\'t satisfied'
+
+    def test_input_require_all(self, execute_task):
+        task = execute_task('test_input_require_all')
+        assert task.find_entry(
+            'rejected', title='test'
+        ), 'should have rejected, one mask isn\'t satisfied'


### PR DESCRIPTION
### Motivation for changes:
Wanted to reuse a list for `crossmatch` in `content_filter`

### Detailed changes:
- Added list plugins to schema under the `from` key to keep consistency with other plugins

### Addressed issues/feature requests:
- Fixes my use-case :P

### Config usage if relevant (new plugin or updated schema):
```yaml
      content_filter:
        [regexp_mode: yes]
        require:
          - '*.avi'
          - '*.mkv'
        reject:
          from:
            - regexp_list: my-rejections
            - mock: ['forbidden_file.ext']
```
### Log and/or tests output (preferably both):
```
$ pytest -v test_content_filter.py
=========================================================================================================== test session starts =========================================================================================================== platform win32 -- Python 3.11.4, pytest-7.4.4, pluggy-1.5.0 -- Flexget\Scripts\python.exe
cachedir: .pytest_cache
rootdir: Flexget
configfile: pyproject.toml
plugins: anyio-4.4.0, base-url-2.1.0, cov-6.0.0, playwright-0.4.4, xdist-3.6.1, time-machine-2.13.0
collected 17 items

test_content_filter.py::TestContentFilter::test_reject1 PASSED                                                                                                                                                                       [  5%] test_content_filter.py::TestContentFilter::test_reject2 PASSED                                                                                                                                                                       [ 11%] test_content_filter.py::TestContentFilter::test_require1 PASSED                                                                                                                                                                      [ 17%] test_content_filter.py::TestContentFilter::test_require2 PASSED                                                                                                                                                                      [ 23%] test_content_filter.py::TestContentFilter::test_require_all1 PASSED                                                                                                                                                                  [ 29%] test_content_filter.py::TestContentFilter::test_require_all2 PASSED                                                                                                                                                                  [ 35%] test_content_filter.py::TestContentFilter::test_strict PASSED                                                                                                                                                                        [ 41%] test_content_filter.py::TestContentFilter::test_cache PASSED                                                                                                                                                                         [ 47%] test_content_filter.py::TestContentFilter::test_min_files PASSED                                                                                                                                                                     [ 52%] test_content_filter.py::TestContentFilter::test_max_files PASSED                                                                                                                                                                     [ 58%] test_content_filter.py::TestContentFilter::test_list_require_a PASSED                                                                                                                                                                [ 64%] test_content_filter.py::TestContentFilter::test_list_require_r PASSED                                                                                                                                                                [ 70%] test_content_filter.py::TestContentFilter::test_input_require_a PASSED                                                                                                                                                               [ 76%] test_content_filter.py::TestContentFilter::test_input_require_r PASSED                                                                                                                                                               [ 82%] test_content_filter.py::TestContentFilter::test_input_require_all PASSED                                                                                                                                                             [ 88%] test_content_filter.py::TestContentFilter::test_regexp_require_a PASSED                                                                                                                                                              [ 94%] test_content_filter.py::TestContentFilter::test_regexp_require_r PASSED                                                                                                                                                              [100%]

============================================================================================================ warnings summary ============================================================================================================= ..\..\Lib\site-packages\flask_restx\api.py:19
..\..\Lib\site-packages\flask_restx\api.py:19
  Flexget\Lib\site-packages\flask_restx\api.py:19: DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the https://github.com/python-jsonschema/referencing library, which provides more compliant referencing behavior as well as more flexible APIs for customization. A future release will remove RefResolver. Please file a feature request (on referencing) if you are missing an API for the kind of customization you need.
    from jsonschema import RefResolver

flexget/tests/test_content_filter.py::TestContentFilter::test_reject1
  Flexget\Lib\site-packages\babelfish\converters\__init__.py:5: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import iter_entry_points, EntryPoint

flexget/tests/test_content_filter.py::TestContentFilter::test_reject1
  Flexget\Lib\site-packages\pkg_resources\__init__.py:3149: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('sphinxcontrib')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

flexget/tests/test_content_filter.py::TestContentFilter::test_reject1
  Flexget\Lib\site-packages\pkg_resources\__init__.py:3149: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zc')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

flexget/tests/test_content_filter.py::TestContentFilter::test_reject1
  Flexget\Lib\site-packages\telegram\files\inputfile.py:22: DeprecationWarning: 'imghdr' is deprecated and slated for removal in Python 3.13
    import imghdr

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================================== 17 passed, 6 warnings in 9.73s ======================================================================================================
```

### To do:
- Update [documentation](https://flexget.com/Plugins/content_filter)
<details><summary>Updated docs page</summary>

````markdown
# Content Filter
This allows filtering based on the filenames inside of torrents.
> This plugin does not accept entries on its own, only rejects already accepted entries that do not pass your requirements. You'll need another [filter plugin](/Plugins#Filters) in the task to accept the entries you want.
{.is-info}

> `content_filter` doesn't work with magnet links, as it works by analyzing the file list present in the .torrent file. You can include the [magnets](/Plugins/magnets) plugin to reject any magnet entries.
{.is-warning} 
 
 |---|---|---|
 | Field | Default | Description |
 | `require` | `None` | Reject the entry if **none** of the files in the torrent matches **any** of the masks |
 | `reject` | `None` | Reject the entry if **any** of the files in the torrent matches **any** of the masks |
 | `require_all` | `None` | Reject the entry if **all** of the masks **do not** match across the files in the torrent |
 | `reject_all` | `None` | Reject the entry if **all** of the masks match across the files in the torrent |
 | `require_mainfile` | `false` | Reject the entry unless the torrent contains a single file or one of the files accounts for at least 90% of the size |
 | `strict` | `false` | Reject the entry if `content_filter` is unable to parse its files |
 | `regexp_mode` | `false` | Switches filename matching from filesystem patterns to case-insensitive Regular Expressions |

For the requirement and rejection fields, you can specify a single mask, a list of masks or an input plugin.



## Examples
- Reject torrents that do not have mkv file in them:
```
content_filter:
  require: '*.mkv'
```
- Reject torrents that have rars in them:

```
content_filter:
  reject: '*.rar'
```
- Reject torrent if it doesn't have mp4 OR mkv in it. Reject also if there are wmv files
```
content_filter:
  require:
    - '*.mp4'
    - '*.mkv'
  reject: '*.wmv'
```
- Reject torrents that don't have a matroska container AND a nfo file:
```
content_filter:
  require_all: 
    - '*.mkv'
    - '*.nfo'
```
- Reject multifile torrents that don't have one file at least 90% of total size (single-file torrents are not affected)
```
content_filter:
  require_mainfile: yes
```
- Reject torrent if none of its files match any of the entries in a previously populated [`regexp_list`](/Plugins/List/regexp_list)
```
content_filter:
  regexp_mode: yes
  require:
    from:
      - regexp_list: my-wanted-files
```
````