### PR TITLE
Move pytest configuration so developers can run tests locally with the same configuration as GitHub Actions.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
       run: poetry install --no-interaction
     - name: Test with pytest
       run: |
-        poetry run pytest -n logical -p no:legacypath --dist loadgroup --junit-xml=test-results.xml
+        poetry run pytest --junit-xml=test-results.xml
     - name: Upload Test Results
       if: always()
       uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ flexget = 'flexget:main'
 ## Other tool settings
 
 [tool.pytest.ini_options]
+addopts = '-n logical -p no:legacypath --dist loadgroup'
 testpaths = ["flexget/tests"]
 
 # We switched to using ruff for formatting, but leaving this in for now


### PR DESCRIPTION
### Motivation for changes:
Move pytest configuration so developers can run tests locally with the same configuration as GitHub Actions.

