### PR TITLE
[Fix] Telegram preventing Flexget launch on dependency errors

### DIFF
--- a/flexget/components/notify/notifiers/telegram.py
+++ b/flexget/components/notify/notifiers/telegram.py
@@ -15,18 +15,19 @@ from sqlalchemy import Column, Integer, String
 from flexget import db_schema, plugin
 from flexget.event import event
 from flexget.manager import Session
-from flexget.plugin import PluginError
+from flexget.plugin import DependencyError, PluginError
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
 try:
-    if Version(version("python-telegram-bot")) < Version('21.9'):
-        raise plugin.PluginWarning('obsolete python-telegram-bot pkg')
-except PackageNotFoundError:
-    pass
-else:
     import telegram
+
+    if Version(version("python-telegram-bot")) < Version('21.9'):
+        raise ImportError
+except (ImportError, PackageNotFoundError):
+    telegram = None
+else:
     from telegram.error import ChatMigrated, NetworkError, TelegramError
     from telegram.ext import ApplicationBuilder
 
@@ -201,6 +202,11 @@ class TelegramNotifier:
     }
 
     def notify(self, title: str, message: str, config: dict) -> None:
+        if telegram == None:
+            raise PluginError(
+                DependencyError(_PLUGIN_NAME, 'python-telegram-bot >= 21.9')._get_message()
+            )
+
         self._load_config(config)
         asyncio.run(self.main(message))
 
@@ -352,7 +358,7 @@ class TelegramNotifier:
         usernames: list[str],
         fullnames: list[tuple[str, str]],
         groups: list[str],
-    ) -> (list[ChatIdEntry], bool):
+    ) -> tuple[list[ChatIdEntry], bool]:
         """get chat ids for `usernames`, `fullnames` & `groups`.
         entries with a matching chat ids will be removed from the input lists.
         """
@@ -462,7 +468,9 @@ class TelegramNotifier:
 
     async def _get_bot_updates(
         self,
-    ) -> (dict[str, telegram.Chat], dict[(str, str), telegram.Chat], dict[str, telegram.Chat]):
+    ) -> tuple[
+        dict[str, telegram.Chat], dict[(str, str), telegram.Chat], dict[str, telegram.Chat]  # type: ignore
+    ]:
         """get updated chats info from telegram"""
         # highly unlikely, but if there are more than `telegram.constants.PollingLimit.MAX_LIMIT`
         # msgs waiting for the bot, we should not miss one


### PR DESCRIPTION
### Motivation for changes:
Flexget would not start in a VENV with older `python-telegram-bot` and a config with the `telegram` plugin in an _unused_  template, giving a stack trace instead

### Detailed changes:
- Moved exception raising in case of no / obsolete dependency inside the class, so the plugin properly registers and the existing handlers take care of it

### Addressed issues/feature requests:
- Fixes https://discord.com/channels/536690097056120833/536690097496784906/1316804237656588368

### Config usage if relevant (new plugin or updated schema):
```
paste_config_here
```
### Log and/or tests output (preferably both):
With the previously recommended dependency version installed:
```yaml
tasks:
  test:
    mock: ['Test Entry']
    accept_all: yes
    exec: echo Ran!
    notify:
      abort:
        message: Abort!
        via:
          - telegram:
              bot_token: "foo"
              recipients:
                - username: "bar"
      entries:
        message: Entry!
        via:
          - telegram:
              bot_token: "foo"
              recipients:
                - username: "bar"
      task:
        message: Task!
        via:
          - telegram:
              bot_token: "foo"
              recipients:
                - username: "bar"

```
```
2024-12-14 23:50:20 INFO     manager                       Test mode, creating a copy from database ...
2024-12-14 23:50:23 VERBOSE  manager                       Creating new database C:\Users\BrutuZ\flexget\test-test.sqlite - DO NOT INTERRUPT ...
2024-12-14 23:50:26 VERBOSE  task_queue                    There are 1 tasks to execute. Shutdown will commence when they have completed.
2024-12-14 23:50:26 VERBOSE  details       test            Produced 1 entries.
2024-12-14 23:50:26 VERBOSE  task          test            ACCEPTED: `Test Entry` by accept_all plugin
2024-12-14 23:50:26 VERBOSE  details       test            Summary - Accepted: 1 (Rejected: 0 Undecided: 0 Failed: 0)
2024-12-14 23:50:26 INFO     exec          test            Would execute: echo Ran!
2024-12-14 23:50:26 ERROR    notify_entry  test            Plugin `telegram` requires dependency `python-telegram-bot >= 21.9`
2024-12-14 23:50:26 ERROR    notify_entry  test            Plugin `telegram` requires dependency `python-telegram-bot >= 21.9`
2024-12-14 23:50:27 INFO     manager                       Removed test database
```

