### PR TITLE
[fix] Properly pin alpine version in docker image to fix segfault with pendulum - fixes #4085

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN pip install -f /dep-wheels click requests && python /flexget/dev_tools.py bu
 COPY . /flexget
 RUN pip wheel --no-deps --wheel-dir /wheels -e /flexget
 
-FROM docker.io/python:3.11-alpine
+# TODO: Alpine version is pinned due to https://github.com/Flexget/Flexget/issues/4085
+FROM docker.io/python:3.11-alpine3.20
 ENV PYTHONUNBUFFERED=1
 
 RUN apk add --no-cache --upgrade \


### PR DESCRIPTION
Confirmed fix - container starts and no longer segfaults. 

It needed to be pinned in two places - 257af95 was only a partial fix.