### PR TITLE
Skip `TestSftpDownload` for Windows, Python 3.10 as it fails intermittently.

### DIFF
--- a/flexget/tests/test_sftp_download.py
+++ b/flexget/tests/test_sftp_download.py
@@ -1,4 +1,6 @@
 import filecmp
+import platform
+import sys
 from pathlib import Path
 
 import pytest
@@ -7,6 +9,10 @@ from jinja2 import Template
 from .test_sftp_server import TestSFTPFileSystem, TestSFTPServerController
 
 
+@pytest.mark.skipif(
+    platform.system() == 'Windows' and sys.version_info[:2] == (3, 10),
+    reason='This test fails intermittently on Windows, Python 3.10.',
+)
 @pytest.mark.xdist_group(name="sftp")
 class TestSftpDownload:
     _config = """


### PR DESCRIPTION
### Motivation for changes:
It seems that `test_sftp_upload.py::TestSftpDownload` fails sporadically on Windows, Python 3.10.

Skip the test for Windows, Python 3.10, and observe whether it fails on other versions.

Failed workflow runs:
https://github.com/Flexget/Flexget/actions/runs/12634455764/job/35202227349
https://github.com/Flexget/Flexget/actions/runs/12649083903/job/35244719621
