### PR TITLE
Enable the E711/E712 rules and use the `noqa` marker for lines related to SQLAlchemy.

### DIFF
--- a/flexget/components/estimate_release/estimators/est_series_tvmaze.py
+++ b/flexget/components/estimate_release/estimators/est_series_tvmaze.py
@@ -61,7 +61,7 @@ class EstimatesSeriesTVMaze:
             logger.debug('received air-date: {}', entity.airdate)
             entity_data['entity_date'] = entity.airdate
 
-        if entity_data['data_exists'] == False:
+        if entity_data['data_exists'] is False:
             # Make Lookup to series to see if failed because of no episode or no data
             lookup = api_tvmaze.series_lookup
             series = {}

--- a/flexget/components/imdb/imdb.py
+++ b/flexget/components/imdb/imdb.py
@@ -161,7 +161,7 @@ class FilterImdb:
                     if genre in accepted:
                         accept_genre = True
                         break
-                if accept_genre == False:
+                if accept_genre is False:
                     reasons.append('accept_genres')
 
             if 'reject_genres' in config:

--- a/flexget/components/notify/notifiers/telegram.py
+++ b/flexget/components/notify/notifiers/telegram.py
@@ -387,14 +387,15 @@ class TelegramNotifier:
         chat_id_entries = []
         cached_usernames = {
             x.username: x
-            for x in session.query(ChatIdEntry).filter(ChatIdEntry.username != None).all()
+            for x in session.query(ChatIdEntry).filter(ChatIdEntry.username != None).all()  # noqa: E711
         }
         cached_fullnames = {
             (x.firstname, x.surname): x
-            for x in session.query(ChatIdEntry).filter(ChatIdEntry.firstname != None).all()
+            for x in session.query(ChatIdEntry).filter(ChatIdEntry.firstname != None).all()  # noqa: E711
         }
         cached_groups = {
-            x.group: x for x in session.query(ChatIdEntry).filter(ChatIdEntry.group != None).all()
+            x.group: x
+            for x in session.query(ChatIdEntry).filter(ChatIdEntry.group != None).all()  # noqa: E711
         }
 
         len_ = len(usernames)

--- a/flexget/components/pending_approval/cli.py
+++ b/flexget/components/pending_approval/cli.py
@@ -87,7 +87,7 @@ def manage_entries(options, selection, approved):
 def clear_entries(options):
     """Clear pending entries"""
     with Session() as session:
-        query = session.query(db.PendingEntry).filter(db.PendingEntry.approved == False)
+        query = session.query(db.PendingEntry).filter(db.PendingEntry.approved == False)  # noqa: E712
         if options.task_name:
             query = query.filter(db.PendingEntry.task_name == options.task_name)
         deleted = query.delete()

--- a/flexget/components/pending_approval/pending_approval.py
+++ b/flexget/components/pending_approval/pending_approval.py
@@ -34,7 +34,7 @@ class PendingApproval:
             for approved_entry in (
                 session.query(db.PendingEntry)
                 .filter(db.PendingEntry.task_name == task.name)
-                .filter(db.PendingEntry.approved == True)
+                .filter(db.PendingEntry.approved == True)  # noqa: E712
                 .all()
             ):
                 e = approved_entry.entry

--- a/flexget/components/seen/db.py
+++ b/flexget/components/seen/db.py
@@ -67,7 +67,7 @@ def upgrade(ver, session):
         # setting the default to False in the last migration was broken, fix the data
         logger.info('Repairing seen table')
         entry_table = table_schema('seen_entry', session)
-        session.execute(update(entry_table, entry_table.c.local == None, {'local': False}))
+        session.execute(update(entry_table, entry_table.c.local == None, {'local': False}))  # noqa: E711
         ver = 4
 
     return ver
@@ -236,7 +236,7 @@ def search_by_field_values(field_value_list, task_name, local=False, session=Non
         found = found.filter(SeenEntry.task == task_name)
     else:
         # Entries added from CLI were having local marked as None rather than False for a while gh#879
-        found = found.filter(or_(SeenEntry.local == False, SeenEntry.local == None))
+        found = found.filter(or_(SeenEntry.local == False, SeenEntry.local == None))  # noqa: E711, E712
     return found.first()
 
 

--- a/flexget/components/series/db.py
+++ b/flexget/components/series/db.py
@@ -650,9 +650,9 @@ def upgrade(ver: Optional[int], session: Session) -> int:
         ep_mode_series = select(series_table.c.id).where(series_table.c.identified_by == 'ep')
         where_clause = and_(
             ep_table.c.series_id.in_(ep_mode_series),
-            ep_table.c.season != None,
-            ep_table.c.number != None,
-            ep_table.c.identified_by == None,
+            ep_table.c.season != None,  # noqa: E711
+            ep_table.c.number != None,  # noqa: E711
+            ep_table.c.identified_by == None,  # noqa: E711
         )
         session.execute(
             update(ep_table).where(where_clause).values({ep_table.c.identified_by: 'ep'})
@@ -711,7 +711,7 @@ def upgrade(ver: Optional[int], session: Session) -> int:
         series_table = table_schema('series', session)
         session.execute(
             update(series_table)
-            .where(series_table.c.identified_by == None)
+            .where(series_table.c.identified_by == None)  # noqa: E711
             .values({series_table.c.identified_by: 'auto'})
         )
         ver = 13
@@ -727,7 +727,7 @@ def db_cleanup(manager, session: Session) -> None:
     # Clean up old undownloaded releases
     result = (
         session.query(EpisodeRelease)
-        .filter(EpisodeRelease.downloaded == False)
+        .filter(EpisodeRelease.downloaded == False)  # noqa: E712
         .filter(EpisodeRelease.first_seen < datetime.now() - timedelta(days=120))
         .delete(False)
     )
@@ -963,7 +963,7 @@ def get_series_summary(
     if premieres:
         query = (
             query.having(func.max(Episode.season) <= 1).having(func.max(Episode.number) <= 2)
-        ).filter(EpisodeRelease.downloaded == True)
+        ).filter(EpisodeRelease.downloaded == True)  # noqa: E712
     if count:
         return query.group_by(Series).count()
     if sort_by == 'show_name':
@@ -1042,7 +1042,7 @@ def get_latest_season_pack_release(
     )
 
     if downloaded:
-        releases = releases.filter(SeasonRelease.downloaded == True)
+        releases = releases.filter(SeasonRelease.downloaded == True)  # noqa: E712
 
     if season is not None:
         releases = releases.filter(Season.season == season)
@@ -1083,7 +1083,7 @@ def get_latest_episode_release(
     )
 
     if downloaded:
-        releases = releases.filter(EpisodeRelease.downloaded == True)
+        releases = releases.filter(EpisodeRelease.downloaded == True)  # noqa: E712
 
     if season is not None:
         releases = releases.filter(Episode.season == season)
@@ -1437,7 +1437,7 @@ def store_parser(
         series = (
             session.query(Series)
             .filter(Series.name == parser.name)
-            .filter(Series.id != None)
+            .filter(Series.id != None)  # noqa: E711
             .first()
         )
         if not series:
@@ -1480,7 +1480,7 @@ def store_parser(
                 session.query(Episode)
                 .filter(Episode.series_id == series.id)
                 .filter(Episode.identifier == identifier)
-                .filter(Episode.series_id != None)
+                .filter(Episode.series_id != None)  # noqa: E711
                 .first()
             )
             if not episode:
@@ -1518,7 +1518,7 @@ def store_parser(
             .filter(table.title == parser.data)
             .filter(table.quality == quality)
             .filter(table.proper_count == parser.proper_count)
-            .filter(filter_by != None)
+            .filter(filter_by != None)  # noqa: E711
             .first()
         )
         if not release:

--- a/flexget/components/series/internal_estimator.py
+++ b/flexget/components/series/internal_estimator.py
@@ -27,7 +27,7 @@ class EstimatesSeriesInternal:
             episodes = (
                 session.query(db.Episode)
                 .join(db.Episode.series)
-                .filter(db.Episode.season != None)
+                .filter(db.Episode.season != None)  # noqa: E711
                 .filter(db.Series.id == series.id)
                 .filter(db.Episode.season == func.max(db.Episode.season).select())
                 .order_by(desc(db.Episode.number))

--- a/flexget/components/series/next_series_episodes.py
+++ b/flexget/components/series/next_series_episodes.py
@@ -181,7 +181,7 @@ class NextSeriesEpisodes:
                         if latest_ep_this_season:
                             downloaded_this_season = (
                                 episodes_this_season.join(db.Episode.releases)
-                                .filter(db.EpisodeRelease.downloaded == True)
+                                .filter(db.EpisodeRelease.downloaded == True)  # noqa: E712
                                 .all()
                             )
                             # Calculate the episodes we still need to get from this season

--- a/flexget/components/series/series.py
+++ b/flexget/components/series/series.py
@@ -43,7 +43,7 @@ def repair(manager):
         try:
             # For some reason at least I have some releases in database which don't belong to any episode.
             for release in (
-                session.query(db.EpisodeRelease).filter(db.EpisodeRelease.episode == None).all()
+                session.query(db.EpisodeRelease).filter(db.EpisodeRelease.episode == None).all()  # noqa: E711
             ):
                 logger.info('Purging orphan release {} from database', release.title)
                 session.delete(release)

--- a/flexget/components/status/cli.py
+++ b/flexget/components/status/cli.py
@@ -72,7 +72,7 @@ def do_cli_summary(manager, options):
             ok = (
                 session.query(db.TaskExecution)
                 .filter(db.TaskExecution.task_id == task.id)
-                .filter(db.TaskExecution.succeeded == True)
+                .filter(db.TaskExecution.succeeded == True)  # noqa: E712
                 .filter(db.TaskExecution.produced > 0)
                 .order_by(db.TaskExecution.start.desc())
                 .first()

--- a/flexget/plugins/internal/api_rottentomatoes.py
+++ b/flexget/plugins/internal/api_rottentomatoes.py
@@ -55,7 +55,7 @@ def upgrade(ver: int, session: Session) -> int:
         ver = 1
     if ver == 1:
         table = table_schema('rottentomatoes_search_results', session)
-        session.execute(sql.delete(table, table.c.movie_id == None))
+        session.execute(sql.delete(table, table.c.movie_id == None))  # noqa: E711
         ver = 2
     return ver
 

--- a/flexget/tests/api_tests/test_seen_api.py
+++ b/flexget/tests/api_tests/test_seen_api.py
@@ -330,13 +330,13 @@ class TestSeenPagination:
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
         data = json.loads(rsp.get_data(as_text=True))
 
-        assert data[0]['local'] == True
+        assert data[0]['local'] is True
 
         rsp = api_client.get('/seen/?sort_by=local&order=asc')
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
         data = json.loads(rsp.get_data(as_text=True))
 
-        assert data[0]['local'] == False
+        assert data[0]['local'] is False
 
         # Combine sorting and pagination
         rsp = api_client.get('/seen/?sort_by=reason&per_page=2&page=2')

--- a/flexget/tests/test_trakt.py
+++ b/flexget/tests/test_trakt.py
@@ -334,7 +334,7 @@ class TestTraktWatchedAndCollected:
         entry = task.accepted[0]
         assert entry['title'] == 'Hawaii.Five-0.S04E13.HDTV-FlexGet', 'title was not accepted?'
         assert entry['series_name'] == 'Hawaii Five-0', 'wrong series was returned by lookup'
-        assert entry['trakt_watched'] == True, 'episode should be marked as watched'
+        assert entry['trakt_watched'] is True, 'episode should be marked as watched'
 
     def test_trakt_collected_lookup(self, execute_task):
         task = execute_task('test_trakt_collected')
@@ -342,7 +342,7 @@ class TestTraktWatchedAndCollected:
         entry = task.accepted[0]
         assert entry['title'] == 'Homeland.2011.S02E01.HDTV-FlexGet', 'title was not accepted?'
         assert entry['series_name'] == 'Homeland 2011', 'wrong series was returned by lookup'
-        assert entry['trakt_collected'] == True, 'episode should be marked as collected'
+        assert entry['trakt_collected'] is True, 'episode should be marked as collected'
 
     def test_trakt_watched_movie_lookup(self, execute_task):
         task = execute_task('test_trakt_watched_movie')
@@ -352,7 +352,7 @@ class TestTraktWatchedAndCollected:
         entry = task.accepted[0]
         assert entry['title'] == 'Inside.Out.2015.1080p.BDRip-FlexGet', 'title was not accepted?'
         assert entry['movie_name'] == 'Inside Out', 'wrong movie name'
-        assert entry['trakt_watched'] == True, 'movie should be marked as watched'
+        assert entry['trakt_watched'] is True, 'movie should be marked as watched'
 
     def test_trakt_collected_movie_lookup(self, execute_task):
         task = execute_task('test_trakt_collected_movie')
@@ -362,7 +362,7 @@ class TestTraktWatchedAndCollected:
         entry = task.accepted[0]
         assert entry['title'] == 'Inside.Out.2015.1080p.BDRip-FlexGet', 'title was not accepted?'
         assert entry['movie_name'] == 'Inside Out', 'wrong movie name'
-        assert entry['trakt_collected'] == True, 'movie should be marked as collected'
+        assert entry['trakt_collected'] is True, 'movie should be marked as collected'
 
     def test_trakt_show_watched_progress(self, execute_task):
         task = execute_task('test_trakt_show_watched_progress')
@@ -371,7 +371,7 @@ class TestTraktWatchedAndCollected:
         ), 'One show should have been accepted as it is watched on Trakt profile'
         entry = task.accepted[0]
         assert entry['trakt_series_name'] == 'Chuck', 'wrong series was accepted'
-        assert entry['trakt_watched'] == True, 'the whole series should be marked as watched'
+        assert entry['trakt_watched'] is True, 'the whole series should be marked as watched'
 
     def test_trakt_show_collected_progress(self, execute_task):
         task = execute_task('test_trakt_show_collected_progress')
@@ -380,21 +380,21 @@ class TestTraktWatchedAndCollected:
         ), 'One show should have been accepted as it is collected on Trakt profile'
         entry = task.accepted[0]
         assert entry['trakt_series_name'] == 'White Collar', 'wrong series was accepted'
-        assert entry['trakt_collected'] == True, 'the whole series should be marked as collected'
+        assert entry['trakt_collected'] is True, 'the whole series should be marked as collected'
 
     def test_trakt_season_collected(self, execute_task):
         task = execute_task('test_trakt_season_collected')
         assert len(task.accepted) == 1, 'Entry should have been accepted as it has been collected'
         entry = task.accepted[0]
         assert entry['trakt_series_name'] == 'The Expanse', 'wrong series was accepted'
-        assert entry['trakt_collected'] == True, 'the whole season should be marked as collected'
+        assert entry['trakt_collected'] is True, 'the whole season should be marked as collected'
 
     def test_trakt_season_watched(self, execute_task):
         task = execute_task('test_trakt_season_watched')
         assert len(task.accepted) == 1, 'Entry should have been accepted as it has been watched'
         entry = task.accepted[0]
         assert entry['trakt_series_name'] == 'Into the Badlands', 'wrong series was accepted'
-        assert entry['trakt_watched'] == True, 'the whole season should be marked as watched'
+        assert entry['trakt_watched'] is True, 'the whole season should be marked as watched'
 
     def test_trakt_user_lookup_fail(self, execute_task):
         # Just making sure we don't crash. See #2606

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,6 @@ extend-exclude = ["flexget/ui"]
 select = ["C4", "E", "F", "I", "ISC", "PLE", "RUF", "TCH", "UP"]
 ignore = [
     "E501", # We leave line length up to black
-    "E711", "E712", # Comparisons to True/False/None are valid for sqlalchemy
     "ISC001", # Ruff recommends disabling this when using the ruff formatter
     "PLE1205", # Thinks we are using stdlib logging rather than loguru
     "RUF001", # Some of these ambiguous unicode are in tests on purpose


### PR DESCRIPTION
Enable the E711/E712 rules and use the `noqa` marker for lines related to SQLAlchemy, because comparisons to `True`/`False`/`None` are valid for sqlalchemy.

E711: https://docs.astral.sh/ruff/rules/none-comparison/
E712: https://docs.astral.sh/ruff/rules/true-false-comparison/

