### PR TITLE
Enforce the PGH rules to prevent the indiscriminate use of `noqa`

### DIFF
--- a/flexget/__init__.py
+++ b/flexget/__init__.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 # __version__ import need to be first in order to avoid circular import within logger
-from ._version import __version__  # noqa
+from ._version import __version__  # noqa: F401
 
 # isort: split
 from flexget import log

--- a/flexget/api/__init__.py
+++ b/flexget/api/__init__.py
@@ -1,5 +1,5 @@
-from .app import APIClient, APIResource, api, api_app  # noqa
-from .core import (  # noqa
+from .app import APIClient, APIResource, api, api_app  # noqa: F401
+from .core import (  # noqa: F401
     authentication,
     cached,
     database,

--- a/flexget/api/app.py
+++ b/flexget/api/app.py
@@ -371,7 +371,7 @@ def api_errors(error: APIError) -> tuple[dict, int]:
 @with_session
 def api_key(session: Session = None) -> str:
     logger.debug('fetching token for internal lookup')
-    return session.query(User).first().token  # type: ignore
+    return session.query(User).first().token
 
 
 def etag(method: Optional[Callable] = None, cache_age: int = 0):

--- a/flexget/components/bittorrent/convert_magnet.py
+++ b/flexget/components/bittorrent/convert_magnet.py
@@ -76,7 +76,7 @@ class ConvertMagnet:
         if config is False:
             return
         try:
-            import libtorrent  # noqa
+            import libtorrent  # noqa: F401
         except ImportError:
             raise plugin.DependencyError(
                 'convert_magnet', 'libtorrent', 'libtorrent package required', logger

--- a/flexget/components/ftp/sftp.py
+++ b/flexget/components/ftp/sftp.py
@@ -193,13 +193,13 @@ class SftpDownload:
             to = render_from_entry(to, entry)
         except RenderError as e:
             logger.error('Could not render path: {}', to)
-            entry.fail(str(e))  # type: ignore
+            entry.fail(str(e))
             return
 
         try:
             sftp.download(path, to, recursive, delete_origin)
         except SftpError as e:
-            entry.fail(e)  # type: ignore
+            entry.fail(e)
 
     @classmethod
     def on_task_output(cls, task: Task, config: dict) -> None:
@@ -349,20 +349,20 @@ class SftpUpload:
                 to = render_from_entry(to, entry)
             except RenderError as e:
                 logger.error('Could not render path: {}', to)
-                entry.fail(str(e))  # type: ignore
+                entry.fail(str(e))
                 return
 
         try:
             sftp.upload(location, to)
         except SftpError as e:
-            entry.fail(str(e))  # type: ignore
+            entry.fail(str(e))
             return
 
         if delete_origin and Path(location).is_file():
             try:
                 Path(location).unlink()
             except Exception as e:
-                logger.warning('Failed to delete file {} ({})', location, e)  # type: ignore
+                logger.warning('Failed to delete file {} ({})', location, e)
 
     @classmethod
     def on_task_output(cls, task: Task, config: dict) -> None:

--- a/flexget/components/ftp/sftp_client.py
+++ b/flexget/components/ftp/sftp_client.py
@@ -219,7 +219,7 @@ class SftpClient:
         :param to: destination
         """
         if Path(source).is_dir():
-            logger.verbose('Skipping directory {}', source)  # type: ignore
+            logger.verbose('Skipping directory {}', source)
         else:
             self._upload_file(source, to)
 
@@ -326,7 +326,7 @@ class SftpClient:
                     private_key_pass=self.private_key_pass,
                     cnopts=self._get_cnopts(),
                 )
-                logger.verbose('Connected to {}', self.host)  # type: ignore
+                logger.verbose('Connected to {}', self.host)
             except Exception as e:
                 tries -= 1
                 logger.debug('Caught exception: {}', e)
@@ -374,7 +374,7 @@ class SftpClient:
 
         try:
             self._put_file(source, destination)
-            logger.verbose('Successfully uploaded {} to {}', source, destination_url)  # type: ignore
+            logger.verbose('Successfully uploaded {} to {}', source, destination_url)
         except OSError:
             raise SftpError(f'Remote directory does not exist: {to}')
         except Exception as e:
@@ -385,14 +385,14 @@ class SftpClient:
         destination_dir: str = Path(destination_path).parent.as_posix()
 
         if Path(destination_path).exists():
-            logger.verbose(  # type: ignore
+            logger.verbose(
                 'Skipping {} because destination file {} already exists.', source, destination_path
             )
             return
 
         Path(destination_dir).mkdir(parents=True, exist_ok=True)
 
-        logger.verbose('Downloading file {} to {}', source, destination)  # type: ignore
+        logger.verbose('Downloading file {} to {}', source, destination)
 
         try:
             self._sftp.get(source, destination_path)

--- a/flexget/components/notify/notifiers/xmpp.py
+++ b/flexget/components/notify/notifiers/xmpp.py
@@ -52,10 +52,10 @@ class XMPPNotifier:
                 plugin_name, 'sleekxmpp', f'SleekXMPP module required. ImportError: {e}'
             )
         try:
-            import dns  # noqa
+            import dns  # noqa: F401
         except ImportError:
             try:
-                import dnspython  # noqa
+                import dnspython  # noqa: F401
             except ImportError as e:
                 logger.debug('Error importing dnspython: {}', e)
                 raise DependencyError(

--- a/flexget/components/sites/sites/awesomehd.py
+++ b/flexget/components/sites/sites/awesomehd.py
@@ -48,7 +48,7 @@ class SearchAwesomeHD:
         """
         # need lxml to parse xml
         try:
-            import lxml  # noqa
+            import lxml  # noqa: F401
         except ImportError as e:
             logger.debug('Error importing lxml: {}', e)
             raise plugin.DependencyError(

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -35,14 +35,19 @@ from flexget.utils.tools import get_current_flexget_version, io_encoding, pid_ex
 Base = declarative_base()
 Session: type[ContextSession] = sessionmaker(class_=ContextSession)
 
-import flexget.log  # noqa
-from flexget import config_schema, db_schema, plugin  # noqa
-from flexget.event import fire_event  # noqa
-from flexget.ipc import IPCClient, IPCServer  # noqa
-from flexget.options import CoreArgumentParser, ParserError, get_parser, manager_parser  # noqa
-from flexget.task import Task  # noqa
-from flexget.task_queue import TaskQueue  # noqa
-from flexget.terminal import console, get_console_output  # noqa
+import flexget.log  # noqa: E402
+from flexget import config_schema, db_schema, plugin  # noqa: E402
+from flexget.event import fire_event  # noqa: E402
+from flexget.ipc import IPCClient, IPCServer  # noqa: E402
+from flexget.options import (  # noqa: E402
+    CoreArgumentParser,
+    ParserError,
+    get_parser,
+    manager_parser,
+)
+from flexget.task import Task  # noqa: E402
+from flexget.task_queue import TaskQueue  # noqa: E402
+from flexget.terminal import console, get_console_output  # noqa: E402
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Engine

--- a/flexget/plugins/input/filmweb_watchlist.py
+++ b/flexget/plugins/input/filmweb_watchlist.py
@@ -43,7 +43,7 @@ class FilmwebWatchlist:
     def on_task_start(self, task, config):
         """Raise a DependencyError if our dependencies aren't available"""
         try:
-            from filmweb.filmweb import Filmweb as FilmwebAPI  # noqa
+            from filmweb.filmweb import Filmweb as FilmwebAPI  # noqa: F401
         except ImportError as e:
             logger.debug('Error importing pyfilmweb: {}', e)
             raise plugin.DependencyError(

--- a/flexget/plugins/input/twitterfeed.py
+++ b/flexget/plugins/input/twitterfeed.py
@@ -69,7 +69,7 @@ class TwitterFeed:
 
     def on_task_start(self, task, config):
         try:
-            import twitter  # noqa
+            import twitter  # noqa: F401
         except ImportError:
             raise plugin.PluginError('twitter module required', logger=logger)
 

--- a/flexget/plugins/output/sns.py
+++ b/flexget/plugins/output/sns.py
@@ -57,7 +57,7 @@ class SNSNotification:
     def on_task_start(self, task, config):
         # verify that we actually support Boto 3
         try:
-            import boto3  # noqa
+            import boto3  # noqa: F401
         except ImportError as e:
             logger.debug('Error importing boto3: {}', e)
             raise plugin.DependencyError(

--- a/flexget/plugins/output/subtitles_periscope.py
+++ b/flexget/plugins/output/subtitles_periscope.py
@@ -49,7 +49,7 @@ class PluginPeriscope:
 
     def on_task_start(self, task, config):
         try:
-            import periscope  # noqa
+            import periscope  # noqa: F401
         except ImportError as e:
             logger.debug('Error importing Periscope: {}', e)
             raise plugin.DependencyError(

--- a/flexget/plugins/output/subtitles_subliminal.py
+++ b/flexget/plugins/output/subtitles_subliminal.py
@@ -77,14 +77,14 @@ class PluginSubliminal:
 
     def on_task_start(self, task, config):
         try:
-            import babelfish  # noqa
+            import babelfish  # noqa: F401
         except ImportError as e:
             logger.debug('Error importing Babelfish: {}', e)
             raise plugin.DependencyError(
                 'subliminal', 'babelfish', f'Babelfish module required. ImportError: {e}'
             )
         try:
-            import subliminal  # noqa
+            import subliminal  # noqa: F401
         except ImportError as e:
             logger.debug('Error importing Subliminal: {}', e)
             raise plugin.DependencyError(

--- a/flexget/tests/conftest.py
+++ b/flexget/tests/conftest.py
@@ -288,8 +288,8 @@ def no_requests(monkeypatch):
 
     # Don't monkey patch HTTPSConnection if ssl not installed as it won't exist in backports
     try:
-        import ssl  # noqa
-        from ssl import SSLContext  # noqa
+        import ssl  # noqa: F401
+        from ssl import SSLContext  # noqa: F401
 
         online_funcs.append('http.client.HTTPSConnection.request')
     except ImportError:

--- a/flexget/tests/test_sftp_server.py
+++ b/flexget/tests/test_sftp_server.py
@@ -288,7 +288,7 @@ class TestSFTPServer(SFTPServerInterface):
             return SFTPServer.convert_errno(e.errno)
 
         if (flags & os.O_CREAT) and (attr is not None):
-            attr._flags &= ~attr.FLAG_PERMISSIONS  # type: ignore
+            attr._flags &= ~attr.FLAG_PERMISSIONS
             SFTPServer.set_file_attr(path, attr)
         if flags & os.O_WRONLY:
             if flags & os.O_APPEND:

--- a/flexget/utils/json.py
+++ b/flexget/utils/json.py
@@ -16,11 +16,11 @@ try:
     import simplejson as json
 except ImportError:
     try:
-        import json  # type: ignore  # python/mypy#1153
+        import json
     except ImportError:
         try:
             # Google Appengine offers simplejson via django
-            from django.utils import simplejson as json  # type: ignore
+            from django.utils import simplejson as json
         except ImportError:
             raise DependencyError(missing='simplejson')
 

--- a/flexget/utils/parsers/__init__.py
+++ b/flexget/utils/parsers/__init__.py
@@ -1,7 +1,7 @@
 # make importing these a bit less hassle
-from flexget.utils.parsers.movie import MovieParser  # noqa pylint: disable=unused-import
-from flexget.utils.parsers.parser import TitleParser  # noqa pylint: disable=unused-import
-from flexget.utils.parsers.series import (  # noqa pylint: disable=unused-import
+from flexget.utils.parsers.movie import MovieParser  # noqa: F401
+from flexget.utils.parsers.parser import TitleParser  # noqa: F401
+from flexget.utils.parsers.series import (  # noqa: F401
     ID_TYPES,
     SeriesParser,
 )

--- a/flexget/utils/serialization.py
+++ b/flexget/utils/serialization.py
@@ -196,7 +196,7 @@ class TupleSerializer(Serializer):
 
     @classmethod
     def deserialize(cls, data: list, version: int) -> tuple:
-        return tuple(deserialize(data))  # type: ignore
+        return tuple(deserialize(data))
 
 
 def _serializer_for(value) -> Optional[type[Serializer]]:

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -155,7 +155,7 @@ class ReList(list):
             self.flags = kwargs.pop('flags')
         list.__init__(self, *args, **kwargs)
 
-    def __getitem__(self, k) -> Pattern:  # type: ignore
+    def __getitem__(self, k) -> Pattern:
         # Doesn't support slices. Do we care?
         item = list.__getitem__(self, k)
         if isinstance(item, str):
@@ -203,7 +203,7 @@ def parse_timedelta(value: Union[timedelta, str, None]) -> timedelta:
         unit += 's'
     params = {unit: float(amount)}
     try:
-        return timedelta(**params)  # type: ignore
+        return timedelta(**params)
     except TypeError:
         raise ValueError(f"Invalid time format '{value}'")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ line-length = 99
 extend-exclude = ["flexget/ui"]
 
 [tool.ruff.lint]
-select = ["C4", "E", "F", "I", "ISC", "PLE", "RUF", "TCH", "UP"]
+select = ["C4", "E", "F", "I", "ISC", "PGH", "PLE", "RUF", "TCH", "UP"]
 ignore = [
     "E501", # We leave line length up to black
     "ISC001", # Ruff recommends disabling this when using the ruff formatter


### PR DESCRIPTION
### Motivation for changes:
Suppressing all diagnostics can hide issues in the code.

Blanket `noqa` annotations are also more difficult to interpret and maintain, as the annotation does not clarify which diagnostics are intended to be suppressed.

PGH rules: https://docs.astral.sh/ruff/rules/#pygrep-hooks-pgh