### PR TITLE
Pin the major version of urllib3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     # require urllib3 <2 on python < 3.10. In order to not be running different versions of urllib on different
     # versions of python, this is pinned in our deps. This can be removed completely if the issue gets solved.
     # https://github.com/kevin1024/vcrpy/issues/719
-    "urllib3 <2",
+    "urllib3 ~=1.26",
     # WebUI/API Deps
     "cherrypy ~=18.10",
     "flask-compress ~=1.17",

--- a/uv.lock
+++ b/uv.lock
@@ -1221,7 +1221,7 @@ requires-dist = [
     { name = "typing-extensions", marker = "extra == 'transmission'", specifier = "==4.12.2" },
     { name = "tzdata", marker = "extra == 'locked'", specifier = "==2024.2" },
     { name = "tzlocal", marker = "extra == 'locked'", specifier = "==5.2" },
-    { name = "urllib3", specifier = "<2" },
+    { name = "urllib3", specifier = "~=1.26" },
     { name = "urllib3", marker = "extra == 'all'", specifier = "==1.26.20" },
     { name = "urllib3", marker = "extra == 'locked'", specifier = "==1.26.20" },
     { name = "urllib3", marker = "extra == 'qbittorrent'", specifier = "==1.26.20" },


### PR DESCRIPTION
### Motivation for changes:
Fix the major version of urllib3 to avoid PRs like #4115 (the final versions resolved by uv for `urllib3<2` and `urllib3<3` are the same), which make no actual changes.

