### PR TITLE
More fork-friendly

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,8 +29,8 @@ jobs:
           ref: main
       - name: Setup Git User
         run: |
-          git config --global user.email ${{ secrets.git_email }}
-          git config --global user.name ${{ secrets.git_user }}
+          git config --global user.email github-actions[bot]@users.noreply.github.com
+          git config --global user.name github-actions[bot]
       - name: Install uv
         uses: astral-sh/setup-uv@887a942a15af3a7626099df99e897a18d9e5ab3a # v5
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -51,8 +51,8 @@ jobs:
         uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5
         with:
           images: |
-            flexget/flexget
-            ghcr.io/flexget/flexget
+            ${{ secrets.DOCKERHUB_USERNAME }}/flexget
+            ghcr.io/${{ github.repository_owner }}/flexget
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
           fetch-depth: 0
       - name: Setup Git User
         run: |
-          git config user.email ${{ secrets.git_email }}
-          git config user.name ${{ secrets.git_user }}
+          git config user.email github-actions[bot]@users.noreply.github.com
+          git config user.name github-actions[bot]
       - name: Install uv
         uses: astral-sh/setup-uv@887a942a15af3a7626099df99e897a18d9e5ab3a # v5
         with:


### PR DESCRIPTION
### Motivation for changes:
When switching to uv, I noticed during testing of the Docker and release pipelines that some adjustments were needed:
- The name and email of FlexGet-Bot should not be considered secret, as they can be directly seen in the Git history. This PR makes them more straightforward and thus less configurations are required for forked versions of FlexGet to PyPI or Docker Hub.
-  The Docker image name should not be hardcoded.

This PR simplifies the process of releasing forked versions of FlexGet to PyPI or Docker Hub.

If you feel that displaying your email here is inappropriate, you can also consider showing it as `github-actions`.

