### PR TITLE
When using inline script metadata, even if uv run is used in a project, the project's dependencies will be ignored. The --no-project flag is not required.

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Update the Changelog
         run: |
           set -x
-          uv run --no-project update-changelog.py wiki/ChangeLog.md
+          uv run update-changelog.py wiki/ChangeLog.md
           cd wiki
           git add ChangeLog.md
           if ! git diff --cached --exit-code; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         if: env.release_tag
         run: |
           echo 'CHANGELOG_BODY<<EOF' >> $GITHUB_ENV
-          uv run --no-project dev_tools.py get-changelog ${{ env.release_tag }} >> $GITHUB_ENV
+          uv run dev_tools.py get-changelog ${{ env.release_tag }} >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
       - name: Create GitHub Release
         uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # v1

--- a/release.sh
+++ b/release.sh
@@ -19,8 +19,9 @@ fi
 if git log --skip 1 origin/master..origin/develop|grep '^commit '; then
 
   # Bump to new release version
-  uv run --no-project dev_tools.py bump-version release
-  export VERSION=$(uv run --no-project dev_tools.py version)
+  uv run dev_tools.py bump-version release
+  VERSION=$(uv run dev_tools.py version)
+  export VERSION
   uv lock --upgrade-package flexget
 
   # Build and upload to pypi.
@@ -38,11 +39,11 @@ if git log --skip 1 origin/master..origin/develop|grep '^commit '; then
   echo "release_tag=v${VERSION}" >> $GITHUB_ENV
 
   # Bump to new dev version, then commit again
-  uv run --no-project dev_tools.py bump-version dev
+  uv run dev_tools.py bump-version dev
   uv lock --upgrade-package flexget
   git add flexget/_version.py
   git add uv.lock
-  git commit -m "Prepare v$(uv run --no-project dev_tools.py version)"
+  git commit -m "Prepare v$(uv run dev_tools.py version)"
 
   # master branch should be at the release we tagged
   git branch -f master v${VERSION}


### PR DESCRIPTION
When using inline script metadata, even if uv run is [used in a project](https://docs.astral.sh/uv/concepts/projects/run/), the project's dependencies will be ignored. The --no-project flag is not required.

https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies:~:text=When%20using%20inline%20script%20metadata%2C%20even%20if%20uv%20run%20is%20used%20in%20a%20project%2C%20the%20project%27s%20dependencies%20will%20be%20ignored.%20The%20%2D%2Dno%2Dproject%20flag%20is%20not%20required.

Declare and assign separately to [avoid masking return values](https://github.com/koalaman/shellcheck/wiki/SC2155).