### PR TITLE
Run uv-lock in github actions

### DIFF
--- a/.github/workflows/uv-lock.yml
+++ b/.github/workflows/uv-lock.yml
@@ -21,3 +21,4 @@ jobs:
     - uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: Update uv lock file
+        token: ${{ secrets.flexgetbot_pat }}

--- a/.github/workflows/uv-lock.yml
+++ b/.github/workflows/uv-lock.yml
@@ -3,6 +3,7 @@ name: Update uv.lock
 
 on:
   pull_request:
+  pull_request_target:
   push:
     branches: [develop]
 
@@ -13,9 +14,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.head_ref }}
-    - uses: tox-dev/action-pre-commit-uv@v1
-      with:
-        extra_args: uv-lock
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+    - name: Update lock
+      run: uv lock
     - uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: Update uv lock file

--- a/.github/workflows/uv-lock.yml
+++ b/.github/workflows/uv-lock.yml
@@ -1,0 +1,21 @@
+# pre-commit.ci does not allow network access, so we run this on github actions
+name: Update uv.lock
+
+on:
+  pull_request:
+  push:
+    branches: [develop]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.head_ref }}
+    - uses: tox-dev/action-pre-commit-uv@v1
+      with:
+        extra_args: uv-lock
+    - uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: Update uv lock file

--- a/.github/workflows/uv-lock.yml
+++ b/.github/workflows/uv-lock.yml
@@ -7,7 +7,7 @@ on:
     branches: [develop]
 
 jobs:
-  pre-commit:
+  uv-lock:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/uv-lock.yml
+++ b/.github/workflows/uv-lock.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
-        ref: ${{ github.head_ref }}
+        ref: ${{ github.event.pull_request.merge_commit_sha }}
     - name: Install uv
       uses: astral-sh/setup-uv@v5
     - name: Update lock

--- a/.github/workflows/uv-lock.yml
+++ b/.github/workflows/uv-lock.yml
@@ -2,7 +2,6 @@
 name: Update uv.lock
 
 on:
-  pull_request:
   pull_request_target:
   push:
     branches: [develop]
@@ -13,6 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.head_ref }}
     - name: Install uv
       uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
### Motivation for changes:
pre-commit.ci won't run our uv-lock because it requires network access. Make sure things are up to date by running it on github actions
