### PR TITLE
Add export-schema cli option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,12 +42,16 @@ jobs:
           echo 'CHANGELOG_BODY<<EOF' >> $GITHUB_ENV
           uv run dev_tools.py get-changelog ${{ env.release_tag }} >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
+      - name: Export config schema
+        if: env.release_tag
+        run: |
+          uv run flexget export-schema --output-file flexget-config.schema.json
       - name: Create GitHub Release
         uses: ncipollo/release-action@cdcc88a9acf3ca41c16c37bb7d21b9ad48560d87 # v1
         if: env.release_tag
         with:
           tag: ${{ env.release_tag }}
-          artifacts: dist/*
+          artifacts: dist/*,flexget-config.schema.json
           token: ${{ secrets.GITHUB_TOKEN }}
           body: ${{ env.CHANGELOG_BODY }}
       - name: Set Deployment Status Success

--- a/flexget/plugins/operate/template.py
+++ b/flexget/plugins/operate/template.py
@@ -125,7 +125,7 @@ def register_plugin():
 def register_config():
     root_config_schema = {
         'type': 'object',
-        'additionalProperties': plugin.plugin_schemas(interface='task'),
+        'additionalProperties': {'$ref': '/schema/plugins?interface=task'},
     }
     register_config_key('templates', root_config_schema)
 

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -776,7 +776,7 @@ class Task:
 def register_config_key():
     task_config_schema = {
         'type': 'object',
-        'additionalProperties': plugin_schemas(interface='task'),
+        'additionalProperties': {'$ref': '/schema/plugins?interface=task'},
     }
 
     config_schema.register_config_key('tasks', task_config_schema, required=True)


### PR DESCRIPTION
### Motivation for changes:
Multiple editors allow editing a yaml file with completion/hints based on a json schema. This adds an export-schema cli command to get the schema for the current version of flexget which can be used with such tools. It also will publish the json schema for each version as a release artifact, so that we can register the flexget config file on https://www.schemastore.org/json/

Here's the kind of feedback/completions that are possible shown in vs code.
![image](https://github.com/user-attachments/assets/d2a18596-ba2c-43ab-89dd-2cb5e4b415a2)

I feel like perhaps more of how the schemas work should be rewritten with this sort of output in mind, but this solution is a bit less intrusive for a quick fix.