### PR TITLE
Update our JSON schemas to draft 2020-12

### DIFF
--- a/flexget/components/ftp/sftp.py
+++ b/flexget/components/ftp/sftp.py
@@ -90,7 +90,7 @@ class SftpList:
                 'additionalProperties': False,
             },
         },
-        'additionProperties': False,
+        'additionalProperties': False,
         'required': ['host', 'username'],
     }
 
@@ -322,7 +322,7 @@ class SftpUpload:
             'socket_timeout_sec': {'type': 'integer', 'default': DEFAULT_SOCKET_TIMEOUT_SEC},
             'connection_tries': {'type': 'integer', 'default': DEFAULT_CONNECT_TRIES},
         },
-        'additionProperties': False,
+        'additionalProperties': False,
         'required': ['host', 'username'],
     }
 

--- a/flexget/components/notify/notifiers/email.py
+++ b/flexget/components/notify/notifiers/email.py
@@ -145,7 +145,7 @@ class EmailNotifier:
             'html': {'type': 'boolean', 'default': False},
         },
         'required': ['to'],
-        'dependencies': {
+        'dependentRequired': {
             'smtp_username': ['smtp_password'],
             'smtp_password': ['smtp_username'],
             'smtp_ssl': ['smtp_tls'],

--- a/flexget/components/notify/notifiers/mqtt.py
+++ b/flexget/components/notify/notifiers/mqtt.py
@@ -74,7 +74,7 @@ class MQTTNotifier:
         },
         'additionalProperties': False,
         'required': ['broker_address', 'topic'],
-        'dependencies': {'password': ['username']},
+        'dependentRequired': {'password': ['username']},
     }
 
     def notify(self, title, message, config):

--- a/flexget/components/notify/notifiers/slack.py
+++ b/flexget/components/notify/notifiers/slack.py
@@ -91,7 +91,7 @@ class SlackNotifier:
                         'callback_id': {'type': 'string'},
                     },
                     'required': ['fallback'],
-                    'dependencies': {'actions': ['callback_id']},
+                    'dependentRequired': {'actions': ['callback_id']},
                     'additionalProperties': False,
                 },
             },

--- a/flexget/components/series/series.py
+++ b/flexget/components/series/series.py
@@ -194,7 +194,7 @@ class FilterSeriesBase:
                     ]
                 },
             },
-            'dependencies': {
+            'dependentSchemas': {
                 'timeframe': {
                     'oneOf': [{'required': ['target']}, {'required': ['qualities']}],
                     'error': 'A `target` should be specified along with a timeframe.',

--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -25,11 +25,11 @@ from flexget.utils.tools import parse_episode_identifier, parse_filesize, parse_
 
 logger = logger.bind(name='config_schema')
 
-BASE_SCHEMA_NAME = 'draft4'
-BASE_SCHEMA_URI = 'http://json-schema.org/draft-04/schema#'
-BaseValidator = jsonschema.Draft4Validator
+BASE_SCHEMA_NAME = 'draft2020-12'
+BASE_SCHEMA_URI = 'https://json-schema.org/draft/2020-12/schema'
+BaseValidator = jsonschema.Draft202012Validator
 # Type hint for json schemas. (If we upgrade to a newer json schema version, the type might allow more than dicts.)
-JsonSchema = dict[str, Any]
+JsonSchema = Union[dict[str, Any], bool]
 schema_paths: dict[str, Union[JsonSchema, Callable[..., JsonSchema]]] = {}
 
 
@@ -519,7 +519,7 @@ def inline_refs(schema: JsonSchema) -> JsonSchema:
     the $refs to point to the right place."""
     definitions = {}
     schema = _inline_refs(schema, "", definitions)
-    schema.setdefault('definitions', {}).update(definitions)
+    schema.setdefault('$defs', {}).update(definitions)
     return schema
 
 

--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -498,9 +498,9 @@ def _rewrite_ref(identifier: str, definition_path: str, defs: dict) -> str:
             # We have to set this before we recurse to stop infinite recursion
             deep_set(path, defs, new_def)
             deep_set(path, defs, _inline_refs(new_def, path, defs))
-        return "#/definitions/" + path
+        return "#/$defs/" + path
     if identifier.startswith('#'):
-        return "#/definitions/" + definition_path + identifier[1:]
+        return "#/$defs/" + definition_path + identifier[1:]
     return identifier
 
 
@@ -515,7 +515,7 @@ def _inline_refs(schema: JsonSchema, definition_path: str, defs: dict) -> Union[
 
 
 def inline_refs(schema: JsonSchema) -> JsonSchema:
-    """Includes all $refs to subschemas in the definitions section of the schema, and rewrites
+    """Includes all $refs to subschemas in the $defs section of the schema, and rewrites
     the $refs to point to the right place."""
     definitions = {}
     schema = _inline_refs(schema, "", definitions)

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -549,14 +549,11 @@ class Manager:
         yaml.add_representer(collections.OrderedDict, represent_dict_order)
 
         # Set up the dumper to increase the indent for lists
-        def increase_indent_wrapper(func):
-            def increase_indent(self, flow=False, indentless=False):
-                func(self, flow, False)
+        def increase_indent(self, flow=False, indentless=False):
+            yaml.emitter.Emitter.increase_indent(self, flow, False)
 
-            return increase_indent
-
-        yaml.Dumper.increase_indent = increase_indent_wrapper(yaml.Dumper.increase_indent)
-        yaml.SafeDumper.increase_indent = increase_indent_wrapper(yaml.SafeDumper.increase_indent)
+        yaml.Dumper.increase_indent = increase_indent
+        yaml.SafeDumper.increase_indent = increase_indent
 
     def _init_config(self, create: bool = False) -> None:
         """

--- a/flexget/plugins/daemon/web_server.py
+++ b/flexget/plugins/daemon/web_server.py
@@ -33,7 +33,7 @@ web_config_schema = {
                 'run_v1': {'type': 'boolean'},
             },
             'additionalProperties': False,
-            'dependencies': {
+            'dependentRequired': {
                 'ssl_certificate': ['ssl_private_key'],
                 'ssl_private_key': ['ssl_certificate'],
             },

--- a/flexget/plugins/filter/regexp.py
+++ b/flexget/plugins/filter/regexp.py
@@ -41,15 +41,15 @@ class FilterRegexp:
     schema = {
         'type': 'object',
         'properties': {
-            'accept': {'$ref': '#/definitions/regex_list'},
-            'reject': {'$ref': '#/definitions/regex_list'},
-            'accept_excluding': {'$ref': '#/definitions/regex_list'},
-            'reject_excluding': {'$ref': '#/definitions/regex_list'},
+            'accept': {'$ref': '#/$defs/regex_list'},
+            'reject': {'$ref': '#/$defs/regex_list'},
+            'accept_excluding': {'$ref': '#/$defs/regex_list'},
+            'reject_excluding': {'$ref': '#/$defs/regex_list'},
             'rest': {'type': 'string', 'enum': ['accept', 'reject']},
             'from': one_or_more({'type': 'string'}),
         },
         'additionalProperties': False,
-        'definitions': {
+        '$defs': {
             # The validator for a list of regexps, each with or without settings
             'regex_list': {
                 'type': 'array',

--- a/flexget/plugins/input/from_telegram.py
+++ b/flexget/plugins/input/from_telegram.py
@@ -86,7 +86,7 @@ class TelegramInput:
             },
         },
         'required': ['token'],
-        'additonalProperties': False,
+        'additionalProperties': False,
     }
 
     @plugin.internet(logger)

--- a/flexget/plugins/input/plex.py
+++ b/flexget/plugins/input/plex.py
@@ -99,7 +99,7 @@ class InputPlex:
             'anyOf': [{'required': ['token', 'username']}, {'required': ['token', 'password']}]
         },
         'error_not': 'Cannot specify `username` and `password` with `token`',
-        'dependencies': {'username': ['password'], 'password': ['username']},
+        'dependentRequired': {'username': ['password'], 'password': ['username']},
         'additionalProperties': False,
     }
 

--- a/flexget/plugins/input/regexp_parse.py
+++ b/flexget/plugins/input/regexp_parse.py
@@ -82,7 +82,7 @@ class RegexpParse:
     FLAG_REGEX = r'^(\s?({})\s?(,|$))+$'.format('|'.join(FLAG_VALUES))
 
     schema = {
-        'definitions': {
+        '$defs': {
             'regex_list': {
                 'type': 'array',
                 'items': {
@@ -109,14 +109,14 @@ class RegexpParse:
                 ]
             },
             'encoding': {'type': 'string'},
-            'sections': {'$ref': '#/definitions/regex_list'},
+            'sections': {'$ref': '#/$defs/regex_list'},
             'keys': {
                 'type': 'object',
                 'additionalProperties': {
                     'type': 'object',
                     'properties': {
                         'required': {'type': 'boolean'},
-                        'regexps': {'$ref': '#/definitions/regex_list'},
+                        'regexps': {'$ref': '#/$defs/regex_list'},
                     },
                     'required': ['regexps'],
                     'additionalProperties': False,

--- a/flexget/plugins/input/text.py
+++ b/flexget/plugins/input/text.py
@@ -60,7 +60,7 @@ class Text:
             'format': {'type': 'object', 'additionalProperties': {'type': 'string'}},
         },
         'required': ['entry', 'url'],
-        'additonalProperties': False,
+        'additionalProperties': False,
     }
 
     def format_entry(self, entry, d):

--- a/flexget/plugins/operate/free_space.py
+++ b/flexget/plugins/operate/free_space.py
@@ -79,7 +79,7 @@ class PluginFreeSpace:
                     'allotment': {'type': 'number', 'default': -1},
                 },
                 'required': ['space'],
-                'dependencies': {'host': ['user', 'ssh_key_filepath', 'path']},
+                'dependentRequired': {'host': ['user', 'ssh_key_filepath', 'path']},
                 'additionalProperties': False,
             },
         ]

--- a/flexget/plugins/operate/template.py
+++ b/flexget/plugins/operate/template.py
@@ -45,7 +45,6 @@ class PluginTemplate:
             'template': {
                 'type': 'string',
                 'description': 'Name of a template which will be applied to this task.',
-                'links': [{'rel': 'settings', 'href': '/api/config/templates/{$}'}],
             }
         },
     }

--- a/flexget/plugins/operate/template.py
+++ b/flexget/plugins/operate/template.py
@@ -29,11 +29,11 @@ class PluginTemplate:
             {
                 'description': 'Apply multiple templates to this task.',
                 'type': 'array',
-                'items': {'$ref': '#/definitions/template'},
+                'items': {'$ref': '#/$defs/template'},
             },
             {
                 'description': 'Apply a single template to this task.',
-                'allOf': [{'$ref': '#/definitions/template'}],
+                'allOf': [{'$ref': '#/$defs/template'}],
             },
             {
                 'description': 'Disable all templates on this task.',
@@ -41,7 +41,7 @@ class PluginTemplate:
                 'enum': [False],
             },
         ],
-        'definitions': {
+        '$defs': {
             'template': {
                 'type': 'string',
                 'description': 'Name of a template which will be applied to this task.',

--- a/flexget/plugins/output/download_auth.py
+++ b/flexget/plugins/output/download_auth.py
@@ -23,7 +23,7 @@ class DownloadAuth:
             'required': ['username', 'password'],
         }
     }
-    schema = {'type': 'array', 'items': host_schema, 'minimumItems': 1}
+    schema = {'type': 'array', 'items': host_schema, 'minItems': 1}
 
     auth_mapper = {'basic': HTTPBasicAuth, 'digest': HTTPDigestAuth}
 

--- a/flexget/plugins/output/exec.py
+++ b/flexget/plugins/output/exec.py
@@ -56,11 +56,11 @@ class PluginExec:
             {
                 'type': 'object',
                 'properties': {
-                    'on_start': {'$ref': '#/definitions/phaseSettings'},
-                    'on_input': {'$ref': '#/definitions/phaseSettings'},
-                    'on_filter': {'$ref': '#/definitions/phaseSettings'},
-                    'on_output': {'$ref': '#/definitions/phaseSettings'},
-                    'on_exit': {'$ref': '#/definitions/phaseSettings'},
+                    'on_start': {'$ref': '#/$defs/phaseSettings'},
+                    'on_input': {'$ref': '#/$defs/phaseSettings'},
+                    'on_filter': {'$ref': '#/$defs/phaseSettings'},
+                    'on_output': {'$ref': '#/$defs/phaseSettings'},
+                    'on_exit': {'$ref': '#/$defs/phaseSettings'},
                     'fail_entries': {'type': 'boolean'},
                     'auto_escape': {'type': 'boolean'},
                     'encoding': {'type': 'string'},
@@ -69,7 +69,7 @@ class PluginExec:
                 'additionalProperties': False,
             },
         ],
-        'definitions': {
+        '$defs': {
             'phaseSettings': {
                 'type': 'object',
                 'properties': {

--- a/flexget/plugins/output/subtitles_subliminal.py
+++ b/flexget/plugins/output/subtitles_subliminal.py
@@ -68,7 +68,7 @@ class PluginSubliminal:
             'exact_match': {'type': 'boolean', 'default': True},
             'providers': {'type': 'array', 'items': {'type': 'string', 'enum': PROVIDERS}},
             'single': {'type': 'boolean', 'default': True},
-            'directory': {'type:': 'string'},
+            'directory': {'type': 'string'},
             'hearing_impaired': {'type': 'boolean', 'default': False},
             'authentication': {'type': 'object', 'properties': AUTHENTICATION_SCHEMA},
         },

--- a/flexget/tests/conftest.py
+++ b/flexget/tests/conftest.py
@@ -159,7 +159,7 @@ def schema_match(manager) -> Callable[[dict, Any], list[dict]]:
     """
 
     def match(schema: dict, response: Any) -> list[dict]:
-        validator = jsonschema.Draft4Validator(schema)
+        validator = jsonschema.Draft202012Validator(schema)
         errors = list(validator.iter_errors(response))
         return [{'value': list(e.path), 'message': e.message} for e in errors]
 


### PR DESCRIPTION
### Motivation for changes:
- Stay up to date with json schema versions
- Get on same version of json schema as pydantic generates to allow for possible use of pydantic models (#4208)
- Allows us to extend the metaschema to check for typos in our schemas

### Detailed changes:
- 'definitions' section of schemas changed to '$defs'
- 'dependencies' split up into 'dependentRequired' and 'dependentSchemas'
- strict testing of our schemas to make sure there are no unrecognized keywords
- fixed typos in schemas