### PR TITLE
Adopt the `N` rules

### DIFF
--- a/flexget/__init__.py
+++ b/flexget/__init__.py
@@ -42,7 +42,7 @@ def main(args: Optional[Sequence[str]] = None):
         try:
             if manager.options.profile:
                 try:
-                    import cProfile as profile
+                    import cProfile as profile  # noqa: N813
                 except ImportError:
                     import profile
                 profile.runctx(

--- a/flexget/api/core/server.py
+++ b/flexget/api/core/server.py
@@ -280,13 +280,13 @@ class ServerDumpThreads(APIResource):
         """Dump Server threads for debugging"""
         id2name = {th.ident: th.name for th in threading.enumerate()}
         threads = []
-        for threadId, stack in sys._current_frames().items():
+        for thread_id, stack in sys._current_frames().items():
             dump = []
             for filename, lineno, name, line in traceback.extract_stack(stack):
                 dump.append(f'File: "{filename}", line {lineno}, in {name}')
                 if line:
                     dump.append(line.strip())
-            threads.append({'name': id2name.get(threadId), 'id': threadId, 'dump': dump})
+            threads.append({'name': id2name.get(thread_id), 'id': thread_id, 'dump': dump})
 
         return jsonify(threads=threads)
 

--- a/flexget/components/ftp/sftp_client.py
+++ b/flexget/components/ftp/sftp_client.py
@@ -346,7 +346,7 @@ class SftpClient:
     def _get_cnopts(self) -> Optional['pysftp.CnOpts']:
         if not self.host_key:
             return None
-        KeyClass = getattr(
+        KeyClass = getattr(  # noqa: N806 It's a class
             importlib.import_module("paramiko"), HOST_KEY_TYPES[self.host_key.key_type]
         )
         key = KeyClass(data=b64decode(self.host_key.public_key))

--- a/flexget/components/managed_lists/lists/imdb_list.py
+++ b/flexget/components/managed_lists/lists/imdb_list.py
@@ -357,7 +357,8 @@ class ImdbEntrySet(MutableSet):
             return '{} list is not modifiable'.format(self.config['list'])
         return None
 
-    def _from_iterable(cls, it):
+    @staticmethod
+    def _from_iterable(it):
         # TODO: is this the right answer? the returned object won't have our custom __contains__ logic
         return set(it)
 

--- a/flexget/components/managed_lists/lists/ombi_list.py
+++ b/flexget/components/managed_lists/lists/ombi_list.py
@@ -152,7 +152,7 @@ class OmbiEntry:
             self.ombi_title = self.ombi_title + ' E' + str(data['tmdb_episode']).zfill(2)
 
     @property
-    def requestId(self) -> str:
+    def request_id(self) -> str:
         if "requestId" in self.data:
             return self.data['requestId']
 
@@ -160,8 +160,8 @@ class OmbiEntry:
         self.data = new_data
         return self.data['requestId']
 
-    @requestId.setter
-    def requestId(self, value: str):
+    @request_id.setter
+    def request_id(self, value: str):
         self.data['requestId'] = value
 
     def already_requested(self) -> tuple[bool, str]:
@@ -197,7 +197,7 @@ class OmbiEntry:
                 endpoint=endpoint, data=data, headers=headers
             )
 
-            self.requestId = response['requestId']
+            self.request_id = response['requestId']
 
             log.info(f"{self.ombi_title} was requested in Ombi.")
             return True
@@ -229,7 +229,7 @@ class OmbiEntry:
 
         api_endpoint = f"api/v1/Request/{self.entry_type}/available"
 
-        data = {"id": self.requestId}
+        data = {"id": self.request_id}
 
         headers = self._request.create_json_headers()
 
@@ -252,7 +252,7 @@ class OmbiEntry:
 
         log.info(f"Marking {self.ombi_title} as deleted in Ombi.")
 
-        api_endpoint = f"api/v1/Request/{self.entry_type}/{self.requestId}"
+        api_endpoint = f"api/v1/Request/{self.entry_type}/{self.request_id}"
 
         headers = self._request.create_json_headers()
 
@@ -281,7 +281,7 @@ class OmbiEntry:
 
         api_endpoint = f"api/v1/Request/{self.entry_type}/unavailable"
 
-        data = {"id": self.requestId}
+        data = {"id": self.request_id}
 
         headers = self._request.create_json_headers()
 
@@ -307,7 +307,7 @@ class OmbiEntry:
         api_endpoint = f"api/v1/Request/{self.entry_type}/deny"
 
         # In the future, we might want to allow the user to specify a reason.
-        data = {"id": self.requestId, "reason": "Denied by Flexget automation."}
+        data = {"id": self.request_id, "reason": "Denied by Flexget automation."}
 
         headers = self._request.create_json_headers()
 
@@ -333,7 +333,7 @@ class OmbiEntry:
         api_endpoint = f"api/v1/Request/{self.entry_type}/approve"
 
         # In the future, we might want to allow the user to specify a reason.
-        data = {"id": self.requestId}
+        data = {"id": self.request_id}
 
         headers = self._request.create_json_headers()
 

--- a/flexget/components/managed_lists/lists/plex_watchlist.py
+++ b/flexget/components/managed_lists/lists/plex_watchlist.py
@@ -92,7 +92,7 @@ class PlexManagedWatchlist(MutableSet):
 
     @property
     def account(self) -> "MyPlexAccount":
-        MyPlexAccount = import_plexaccount()
+        MyPlexAccount = import_plexaccount()  # noqa: N806 It's a class
         if self._account is None:
             self._account = MyPlexAccount(self.username, self.password, self.token)
         return self._account

--- a/flexget/components/seen/cli.py
+++ b/flexget/components/seen/cli.py
@@ -55,7 +55,7 @@ def seen_forget(manager: Manager, options):
 
 
 def seen_add(manager: Manager, options):
-    DEFAULT_TASK = 'cli_add'
+    default_task = 'cli_add'
 
     seen_name = options.add_value
     if is_imdb_url(seen_name):
@@ -78,13 +78,13 @@ def seen_add(manager: Manager, options):
             console('No specified tasks in config.')
             return
     else:
-        tasks = [DEFAULT_TASK]
+        tasks = [default_task]
         local = None
 
     for task in tasks:
         db.add(seen_name, task, {'cli_add': seen_name}, local=local)
 
-    if tasks == [DEFAULT_TASK]:
+    if tasks == [default_task]:
         console(f'Added `{seen_name}` as seen. This will affect all tasks.')
     else:
         console(

--- a/flexget/components/series/api.py
+++ b/flexget/components/series/api.py
@@ -24,14 +24,14 @@ from .utils import normalize_series_name
 
 try:
     # NOTE: Importing other plugins is discouraged!
-    from flexget.components.thetvdb.api import ObjectsContainer as tvdb
+    from flexget.components.thetvdb.api import ObjectsContainer as TvdbOC
 except ImportError:
     raise plugin.DependencyError(issued_by=__name__, missing='tvdb_lookup')
 
 
 try:
     # NOTE: Importing other plugins is discouraged!
-    from flexget.components.tvmaze.api import ObjectsContainer as tvmaze
+    from flexget.components.tvmaze.api import ObjectsContainer as TvmazeOC
 except ImportError:
     raise plugin.DependencyError(issued_by=__name__, missing='tvmaze_lookup')
 
@@ -129,8 +129,8 @@ class ObjectsContainer:
             'lookup': {
                 'type': 'object',
                 'properties': {
-                    'tvmaze': tvmaze.tvmaze_series_object,
-                    'tvdb': tvdb.tvdb_series_object,
+                    'tvmaze': TvmazeOC.tvmaze_series_object,
+                    'tvdb': TvdbOC.tvdb_series_object,
                 },
             },
             'latest_episode': episode_object,

--- a/flexget/components/series/db.py
+++ b/flexget/components/series/db.py
@@ -172,10 +172,10 @@ class Season(Base):
         return min(release.first_seen for release in self.releases)
 
     @first_seen.expression
-    def first_seen(cls):
+    def first_seen(self):
         return (
             select(func.min(SeasonRelease.first_seen))
-            .where(SeasonRelease.season_id == cls.id)
+            .where(SeasonRelease.season_id == self.id)
             .correlate(Season.__table__)
             .label('first_seen')
         )
@@ -281,10 +281,10 @@ class Episode(Base):
         return min(release.first_seen for release in self.releases)
 
     @first_seen.expression
-    def first_seen(cls):
+    def first_seen(self):
         return (
             select(func.min(EpisodeRelease.first_seen))
-            .where(EpisodeRelease.episode_id == cls.id)
+            .where(EpisodeRelease.episode_id == self.id)
             .correlate(Episode.__table__)
             .label('first_seen')
         )

--- a/flexget/components/series/db.py
+++ b/flexget/components/series/db.py
@@ -172,10 +172,11 @@ class Season(Base):
         return min(release.first_seen for release in self.releases)
 
     @first_seen.expression
-    def first_seen(self):
+    @classmethod
+    def first_seen(cls):
         return (
             select(func.min(SeasonRelease.first_seen))
-            .where(SeasonRelease.season_id == self.id)
+            .where(SeasonRelease.season_id == cls.id)
             .correlate(Season.__table__)
             .label('first_seen')
         )
@@ -281,10 +282,11 @@ class Episode(Base):
         return min(release.first_seen for release in self.releases)
 
     @first_seen.expression
-    def first_seen(self):
+    @classmethod
+    def first_seen(cls):
         return (
             select(func.min(EpisodeRelease.first_seen))
-            .where(EpisodeRelease.episode_id == self.id)
+            .where(EpisodeRelease.episode_id == cls.id)
             .correlate(Episode.__table__)
             .label('first_seen')
         )

--- a/flexget/components/sites/sites/ncore.py
+++ b/flexget/components/sites/sites/ncore.py
@@ -85,7 +85,7 @@ class UrlRewriteNcore:
         page = task.requests.post(URL + "/login.php", data=data, headers=HEADERS)
         soup = get_soup(page.content)
         passkey_line = str(soup.find('link', href=re.compile(r'rss\.php\?key=')))
-        PASSKEY = passkey_line[passkey_line.find("key=") : passkey_line.find('"', 20, 90)]
+        passkey = passkey_line[passkey_line.find("key=") : passkey_line.find('"', 20, 90)]
 
         for search_string in entry.get('search_strings', [entry['title']]):
             data = {
@@ -113,7 +113,7 @@ class UrlRewriteNcore:
                     id = href[href.find("id=") + 3 :]
 
                     e['title'] = a.get('title')
-                    e['url'] = URL + f'/torrents.php?action=download&id={id}&' + PASSKEY
+                    e['url'] = URL + f'/torrents.php?action=download&id={id}&' + passkey
 
                     parent = a.parent.parent.parent.parent
 

--- a/flexget/components/status/db.py
+++ b/flexget/components/status/db.py
@@ -47,10 +47,10 @@ class StatusTask(Base):
         return max(execution.start for execution in self.executions)
 
     @last_execution_time.expression
-    def last_execution_time(cls):
+    def last_execution_time(self):
         return (
             select(func.max(TaskExecution.start))
-            .where(TaskExecution.task_id == cls.id)
+            .where(TaskExecution.task_id == self.id)
             .correlate(StatusTask.__table__)
             .label('last_execution_time')
         )

--- a/flexget/components/status/db.py
+++ b/flexget/components/status/db.py
@@ -47,10 +47,11 @@ class StatusTask(Base):
         return max(execution.start for execution in self.executions)
 
     @last_execution_time.expression
-    def last_execution_time(self):
+    @classmethod
+    def last_execution_time(cls):
         return (
             select(func.max(TaskExecution.start))
-            .where(TaskExecution.task_id == self.id)
+            .where(TaskExecution.task_id == cls.id)
             .correlate(StatusTask.__table__)
             .label('last_execution_time')
         )

--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -436,13 +436,13 @@ def validate_properties_w_defaults(validator, properties, instance, schema):
     yield from BaseValidator.VALIDATORS["properties"](validator, properties, instance, schema)
 
 
-def validate_anyOf(validator, anyOf, instance, schema):
-    errors = BaseValidator.VALIDATORS["anyOf"](validator, anyOf, instance, schema)
+def validate_any_of(validator, any_of, instance, schema):
+    errors = BaseValidator.VALIDATORS["anyOf"](validator, any_of, instance, schema)
     yield from select_child_errors(validator, errors)
 
 
-def validate_oneOf(validator, oneOf, instance, schema):
-    errors = BaseValidator.VALIDATORS["oneOf"](validator, oneOf, instance, schema)
+def validate_one_of(validator, one_of, instance, schema):
+    errors = BaseValidator.VALIDATORS["oneOf"](validator, one_of, instance, schema)
     yield from select_child_errors(validator, errors)
 
 
@@ -451,16 +451,16 @@ def validate_deprecated(validator, deprecated, instance, schema):
         logger.warning(deprecated)
 
 
-def validate_deprecationMessage(validator, message, instance, schema):
+def validate_deprecation_message(validator, message, instance, schema):
     """Not really a validator, just warns if deprecated section of config is being used."""
     logger.warning(message)
 
 
 validators = {
-    'anyOf': validate_anyOf,
-    'oneOf': validate_oneOf,
+    'anyOf': validate_any_of,
+    'oneOf': validate_one_of,
     'deprecated': validate_deprecated,
-    'deprecationMessage': validate_deprecationMessage,
+    'deprecationMessage': validate_deprecation_message,
 }
 
 SchemaValidator = jsonschema.validators.extend(BaseValidator, validators)

--- a/flexget/db_schema.py
+++ b/flexget/db_schema.py
@@ -224,23 +224,23 @@ def register_plugin_table(tablename: str, plugin: str, version: int):
 class VersionedBaseMeta(DeclarativeMeta):
     """Metaclass for objects returned by versioned_base factory"""
 
-    def __new__(mcs, metaname, bases, dict_):
+    def __new__(cls, metaname, bases, dict_):
         """This gets called when a class that subclasses VersionedBase is defined."""
-        new_class = super().__new__(mcs, str(metaname), bases, dict_)
+        new_class = super().__new__(cls, str(metaname), bases, dict_)
         if metaname != 'VersionedBase':
             register_plugin_table(new_class.__tablename__, new_class._plugin, new_class._version)
         return new_class
 
-    def register_table(cls, table: Union[str, Table]) -> None:
+    def register_table(self, table: Union[str, Table]) -> None:
         """
         This can be used if a plugin is declaring non-declarative sqlalchemy tables.
 
         :param table: Can either be the name of the table, or an :class:`sqlalchemy.Table` instance.
         """
         if isinstance(table, str):
-            register_plugin_table(table, cls._plugin, cls._version)
+            register_plugin_table(table, self._plugin, self._version)
         else:
-            register_plugin_table(table.name, cls._plugin, cls._version)
+            register_plugin_table(table.name, self._plugin, self._version)
 
 
 def versioned_base(plugin: str, version: int) -> VersionedBaseMeta:

--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -108,7 +108,7 @@ class PluginError(Exception):
 
 
 # TODO: move to utils or somewhere more appropriate
-class internet:
+class internet:  # noqa: N801 It acts like a function in usage
     """@internet decorator for plugin phase methods.
 
     Catches all internet related exceptions and raises PluginError with relevant message.

--- a/flexget/plugins/cli/win32_service.py
+++ b/flexget/plugins/cli/win32_service.py
@@ -29,14 +29,14 @@ try:
             socket.setdefaulttimeout(60)
             self.manager = None
 
-        def SvcStop(self):
+        def SvcStop(self):  # noqa: N802
             self.ReportServiceStatus(win32service.SERVICE_STOP_PENDING)
             from flexget.manager import manager
 
             manager.shutdown(finish_queue=False)
             self.ReportServiceStatus(win32service.SERVICE_STOPPED)
 
-        def SvcDoRun(self):
+        def SvcDoRun(self):  # noqa: N802
             servicemanager.LogMsg(
                 servicemanager.EVENTLOG_INFORMATION_TYPE,
                 servicemanager.PYS_SERVICE_STARTED,

--- a/flexget/plugins/clients/aria2.py
+++ b/flexget/plugins/clients/aria2.py
@@ -61,10 +61,12 @@ class JsonRpcClient(RpcClient):
             del req_params['params']
         return req_params
 
+    @staticmethod
     def _default_error_handle(code, message):
         logger.critical('Fault code {} message {}', code, message)
         raise plugin.PluginError(f'Fault code {code} message {message}', logger)
 
+    @staticmethod
     def _default_success_handle(response):
         return response.text
 

--- a/flexget/plugins/input/kitsu.py
+++ b/flexget/plugins/input/kitsu.py
@@ -97,8 +97,8 @@ class KitsuAnime:
 
                 types = config.get('type')
                 if types is not None:
-                    subType = anime['attributes']['subtype']
-                    if subType is None or subType.lower() not in types:
+                    sub_type = anime['attributes']['subtype']
+                    if sub_type is None or sub_type.lower() not in types:
                         continue
 
                 entry = Entry()

--- a/flexget/plugins/input/npo_watchlist.py
+++ b/flexget/plugins/input/npo_watchlist.py
@@ -124,7 +124,7 @@ class NPOWatchlist:
         except RequestException as e:
             raise plugin.PluginError(f'Request error: {e!s}')
 
-    def _get_favourites_entries(self, task, config, profileId):
+    def _get_favourites_entries(self, task, config, profile_id):
         # Details of profile using the $profileId:
         # https://www.npostart.nl/api/account/@me/profile/$profileId  (?refresh=1)
         # XMLHttpRequest could also be done on, but is not reliable, because if a series is
@@ -134,7 +134,7 @@ class NPOWatchlist:
 
         entries = []
         try:
-            profile = requests.get(profile_details_url + profileId).json()
+            profile = requests.get(profile_details_url + profile_id).json()
             logger.info('Retrieving favorites for profile {}', profile['name'])
             for favourite in profile['favourites']:
                 if favourite['mediaType'] == 'series':
@@ -143,7 +143,7 @@ class NPOWatchlist:
             raise plugin.PluginError(f'Request error: {e!s}')
         return entries
 
-    def _get_series_episodes(self, task, config, mediaId, series_info=None, page=1):
+    def _get_series_episodes(self, task, config, media_id, series_info=None, page=1):
         episode_tiles_url = 'https://www.npostart.nl/media/series/{0}/episodes'
         episode_tiles_parameters = {
             'page': str(page),
@@ -153,9 +153,11 @@ class NPOWatchlist:
         entries = []
 
         if not series_info:
-            series_info = self._get_series_info(task, config, mediaId)
+            series_info = self._get_series_info(task, config, media_id)
             if not series_info:  # if fetching series_info failed, return empty entries
-                logger.error('Failed to fetch series information for {}, skipping series', mediaId)
+                logger.error(
+                    'Failed to fetch series information for {}, skipping series', media_id
+                )
                 return entries
 
         headers = {
@@ -165,15 +167,17 @@ class NPOWatchlist:
         }
         if page > 1:
             headers['Referer'] = (
-                episode_tiles_url.format(mediaId) + f'?page={page - 1}'
+                episode_tiles_url.format(media_id) + f'?page={page - 1}'
             )  # referer from prev page
 
         logger.debug(
-            'Retrieving episodes page {} for {} ({})', page, series_info['npo_name'], mediaId
+            'Retrieving episodes page {} for {} ({})', page, series_info['npo_name'], media_id
         )
         try:
             episodes = requests.get(
-                episode_tiles_url.format(mediaId), params=episode_tiles_parameters, headers=headers
+                episode_tiles_url.format(media_id),
+                params=episode_tiles_parameters,
+                headers=headers,
             ).json()
             new_entries = self._parse_tiles(task, config, episodes['tiles'], series_info)
             entries += new_entries
@@ -185,7 +189,7 @@ class NPOWatchlist:
                 entries += self._get_series_episodes(
                     task,
                     config,
-                    mediaId,
+                    media_id,
                     series_info,
                     page=int(episodes['nextLink'].rsplit('page=')[1]),
                 )
@@ -193,15 +197,15 @@ class NPOWatchlist:
             logger.error('Request error: {}', str(e))  # if it fails, just go to next favourite
 
         if not entries and page == 1:
-            logger.verbose('No new episodes found for {} ({})', series_info['npo_name'], mediaId)
+            logger.verbose('No new episodes found for {} ({})', series_info['npo_name'], media_id)
         return entries
 
-    def _get_series_info(self, task, config, mediaId):
+    def _get_series_info(self, task, config, media_id):
         series_info_url = 'https://www.npostart.nl/{0}'
         series_info = None
-        logger.verbose('Retrieving series info for {}', mediaId)
+        logger.verbose('Retrieving series info for {}', media_id)
         try:
-            response = requests.get(series_info_url.format(mediaId))
+            response = requests.get(series_info_url.format(media_id))
             logger.debug('Series info found at: {}', response.url)
             page = get_soup(response.content)
             series = page.find('section', class_='npo-header-episode-meta')
@@ -216,7 +220,7 @@ class NPOWatchlist:
                     'npo_language': 'nl',  # hard-code the language as if in NL, for lookup plugins
                     'npo_version': page.find('meta', attrs={'name': 'generator'})['content'],
                 }  # include NPO website version
-                logger.debug('Parsed series info for: {} ({})', series_info['npo_name'], mediaId)
+                logger.debug('Parsed series info for: {} ({})', series_info['npo_name'], media_id)
         except RequestException as e:
             logger.error('Request error: {}', str(e))
         return series_info
@@ -296,8 +300,8 @@ class NPOWatchlist:
         profilejson = self._get_page(task, config, account_profile_url).json()
         if 'profileId' not in profilejson:
             raise plugin.PluginError('Failed to fetch profile for NPO account')
-        profileId = profilejson['profileId']
-        return self._get_favourites_entries(task, config, profileId)
+        profile_id = profilejson['profileId']
+        return self._get_favourites_entries(task, config, profile_id)
 
     def entry_complete(self, e, task=None):
         if not e.accepted:

--- a/flexget/plugins/input/regexp_parse.py
+++ b/flexget/plugins/input/regexp_parse.py
@@ -133,11 +133,11 @@ class RegexpParse:
 
     def flagstr_to_flags(self, flag_str):
         """turns a comma seperated list of flags into the int value."""
-        COMBIND_FLAGS = 0
+        combind_flags = 0
         split_flags = flag_str.split(',')
         for flag in split_flags:
-            COMBIND_FLAGS = COMBIND_FLAGS | RegexpParse.FLAG_VALUES[flag.strip()]
-        return COMBIND_FLAGS
+            combind_flags = combind_flags | RegexpParse.FLAG_VALUES[flag.strip()]
+        return combind_flags
 
     def compile_regexp_dict_list(self, re_list):
         """turns a list of dicts containing regexps information into a list of compiled regexps."""

--- a/flexget/tests/api_tests/test_series_api.py
+++ b/flexget/tests/api_tests/test_series_api.py
@@ -14,8 +14,8 @@ from flexget.components.series.db import (
     Series,
     SeriesTask,
 )
-from flexget.components.thetvdb.api import ObjectsContainer as tvdb
-from flexget.components.tvmaze.api import ObjectsContainer as tvmaze
+from flexget.components.thetvdb.api import ObjectsContainer as TvdbOC
+from flexget.components.tvmaze.api import ObjectsContainer as TvmazeOC
 from flexget.manager import Session
 from flexget.utils import json
 
@@ -221,12 +221,12 @@ class TestSeriesRootAPI:
         for show in data:
             tvdb_lookup = show['lookup']['tvdb']
             assert tvdb_lookup
-            errors = schema_match(tvdb.tvdb_series_object, tvdb_lookup)
+            errors = schema_match(TvdbOC.tvdb_series_object, tvdb_lookup)
             assert not errors
 
             tvmaze_lookup = show['lookup']['tvmaze']
             assert tvmaze_lookup
-            errors = schema_match(tvmaze.tvmaze_series_object, tvmaze_lookup)
+            errors = schema_match(TvmazeOC.tvmaze_series_object, tvmaze_lookup)
             assert not errors
 
     def test_series_post(self, api_client, schema_match):

--- a/flexget/tests/api_tests/test_tmdb_lookup.py
+++ b/flexget/tests/api_tests/test_tmdb_lookup.py
@@ -1,7 +1,7 @@
 import pytest
 
 from flexget.api.app import base_message
-from flexget.components.tmdb.api import ObjectsContainer as oc
+from flexget.components.tmdb.api import ObjectsContainer as OC
 from flexget.utils import json
 
 
@@ -21,7 +21,7 @@ class TestTMDBMovieLookupAPI:
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
 
         data = json.loads(rsp.get_data(as_text=True))
-        errors = schema_match(oc.movie_object, data)
+        errors = schema_match(OC.movie_object, data)
         assert not errors
 
         values = {'id': 603, 'name': 'The Matrix', 'year': 1999, 'imdb_id': 'tt0133093'}
@@ -33,7 +33,7 @@ class TestTMDBMovieLookupAPI:
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
 
         data = json.loads(rsp.get_data(as_text=True))
-        errors = schema_match(oc.movie_object, data)
+        errors = schema_match(OC.movie_object, data)
         assert not errors
 
         values = {'id': 604, 'name': 'The Matrix Reloaded', 'year': 2003, 'imdb_id': 'tt0234215'}
@@ -45,7 +45,7 @@ class TestTMDBMovieLookupAPI:
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
 
         data = json.loads(rsp.get_data(as_text=True))
-        errors = schema_match(oc.movie_object, data)
+        errors = schema_match(OC.movie_object, data)
         assert not errors
 
         assert 'posters' in data
@@ -56,7 +56,7 @@ class TestTMDBMovieLookupAPI:
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
 
         data = json.loads(rsp.get_data(as_text=True))
-        errors = schema_match(oc.movie_object, data)
+        errors = schema_match(OC.movie_object, data)
         assert not errors
 
         assert 'backdrops' in data

--- a/flexget/tests/api_tests/test_trakt_lookup_api.py
+++ b/flexget/tests/api_tests/test_trakt_lookup_api.py
@@ -1,7 +1,7 @@
 import pytest
 
 from flexget.api.app import base_message
-from flexget.components.trakt.api import ObjectsContainer as oc
+from flexget.components.trakt.api import ObjectsContainer as OC
 from flexget.utils import json
 
 
@@ -19,7 +19,7 @@ class TestTraktSeriesLookupAPI:
 
         data = json.loads(rsp.get_data(as_text=True))
 
-        errors = schema_match(oc.series_return_object, data)
+        errors = schema_match(OC.series_return_object, data)
         assert not errors
 
         values = {
@@ -52,7 +52,7 @@ class TestTraktSeriesLookupAPI:
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
 
         data = json.loads(rsp.get_data(as_text=True))
-        errors = schema_match(oc.series_return_object, data)
+        errors = schema_match(OC.series_return_object, data)
         assert not errors
 
         for field, value in values.items():
@@ -66,7 +66,7 @@ class TestTraktSeriesLookupAPI:
 
         data = json.loads(rsp.get_data(as_text=True))
 
-        errors = schema_match(oc.series_return_object, data)
+        errors = schema_match(OC.series_return_object, data)
         assert not errors
 
         for field, value in values.items():
@@ -87,7 +87,7 @@ class TestTraktSeriesLookupAPI:
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
 
         data = json.loads(rsp.get_data(as_text=True))
-        errors = schema_match(oc.series_return_object, data)
+        errors = schema_match(OC.series_return_object, data)
         assert not errors
 
         for field, value in values.items():
@@ -126,7 +126,7 @@ class TestTraktSeriesLookupAPI:
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
 
         data = json.loads(rsp.get_data(as_text=True))
-        errors = schema_match(oc.series_return_object, data)
+        errors = schema_match(OC.series_return_object, data)
         assert not errors
 
         for field, value in values.items():
@@ -147,7 +147,7 @@ class TestTraktSeriesLookupAPI:
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
 
         data = json.loads(rsp.get_data(as_text=True))
-        errors = schema_match(oc.series_return_object, data)
+        errors = schema_match(OC.series_return_object, data)
         assert not errors
 
         for field, value in values.items():
@@ -160,7 +160,7 @@ class TestTraktSeriesLookupAPI:
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
 
         data = json.loads(rsp.get_data(as_text=True))
-        errors = schema_match(oc.series_return_object, data)
+        errors = schema_match(OC.series_return_object, data)
         assert not errors
 
         for field, value in values.items():
@@ -171,7 +171,7 @@ class TestTraktSeriesLookupAPI:
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
 
         data = json.loads(rsp.get_data(as_text=True))
-        errors = schema_match(oc.series_return_object, data)
+        errors = schema_match(OC.series_return_object, data)
         assert not errors
 
         assert 'actors' in data
@@ -182,7 +182,7 @@ class TestTraktSeriesLookupAPI:
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
 
         data = json.loads(rsp.get_data(as_text=True))
-        errors = schema_match(oc.series_return_object, data)
+        errors = schema_match(OC.series_return_object, data)
         assert not errors
 
         assert 'translations' in data
@@ -209,7 +209,7 @@ class TestTraktMovieLookupAPI:
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
 
         data = json.loads(rsp.get_data(as_text=True))
-        errors = schema_match(oc.movie_return_object, data)
+        errors = schema_match(OC.movie_return_object, data)
         assert not errors
 
         values = {
@@ -227,7 +227,7 @@ class TestTraktMovieLookupAPI:
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
 
         data = json.loads(rsp.get_data(as_text=True))
-        errors = schema_match(oc.movie_return_object, data)
+        errors = schema_match(OC.movie_return_object, data)
         assert not errors
 
         values = {
@@ -245,7 +245,7 @@ class TestTraktMovieLookupAPI:
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
 
         data = json.loads(rsp.get_data(as_text=True))
-        errors = schema_match(oc.movie_return_object, data)
+        errors = schema_match(OC.movie_return_object, data)
         assert not errors
 
         values = {
@@ -263,7 +263,7 @@ class TestTraktMovieLookupAPI:
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
 
         data = json.loads(rsp.get_data(as_text=True))
-        errors = schema_match(oc.movie_return_object, data)
+        errors = schema_match(OC.movie_return_object, data)
         assert not errors
 
         values = {
@@ -284,7 +284,7 @@ class TestTraktMovieLookupAPI:
         assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
 
         data = json.loads(rsp.get_data(as_text=True))
-        errors = schema_match(oc.movie_return_object, data)
+        errors = schema_match(OC.movie_return_object, data)
         assert not errors
 
         values = {

--- a/flexget/tests/test_config_schema.py
+++ b/flexget/tests/test_config_schema.py
@@ -33,7 +33,7 @@ class TestSchemaValidator:
             "properties": custom_properties,
             "unevaluatedProperties": False,
         }
-        Validator = validator_for(meta_schema)
+        Validator = validator_for(meta_schema)  # noqa: N806 It's a class
         validator = Validator(
             schema=strict,
             format_checker=format_checker,
@@ -118,7 +118,7 @@ class TestSchemaValidator:
         assert 'object' not in errors[0].message
         assert 'dict' in errors[0].message
 
-    def test_anyOf_branch_is_chosen_based_on_type_errors(self):
+    def test_any_of_branch_is_chosen_based_on_type_errors(self):
         schema = {
             "anyOf": [
                 {"type": ["string", "array"]},
@@ -136,7 +136,7 @@ class TestSchemaValidator:
         assert len(errors) == 1
         assert errors[0].validator == 'minimum'
 
-    def test_oneOf_branch_is_chosen_based_on_type_errors(self):
+    def test_one_of_branch_is_chosen_based_on_type_errors(self):
         schema = {
             "oneOf": [
                 {"type": ["string", "array"]},

--- a/flexget/tests/test_series.py
+++ b/flexget/tests/test_series.py
@@ -1290,7 +1290,7 @@ class TestBacklog:
               - test: {timeframe: 6 hours, target: 720p hdtv+}
     """
 
-    def testBacklog(self, manager, execute_task):
+    def test_backlog(self, manager, execute_task):
         """Series plugin: backlog"""
         task = execute_task('backlog')
         assert task.entries, 'no entries at the start'
@@ -1326,7 +1326,7 @@ class TestManipulate:
                   extract: '^PREFIX: (.*)'
     """
 
-    def testManipulate(self, execute_task):
+    def test_manipulate(self, execute_task):
         """Series plugin: test manipulation priority"""
         # should not work with the prefix
         task = execute_task('test_1')
@@ -1527,7 +1527,7 @@ class TestSeriesPremiere:
               - {title: 'Foobar.S02E02.HR-FlexGet'}
     """
 
-    def testOnlyPremieres(self, execute_task):
+    def test_only_premieres(self, execute_task):
         """Test series premiere"""
         task = execute_task('test')
         assert task.find_entry(

--- a/flexget/tests/test_sns.py
+++ b/flexget/tests/test_sns.py
@@ -6,11 +6,11 @@ from flexget.task import Task
 
 class TestNotifySNS:
     @patch('boto3.Session')
-    def test_emitter_build_session_from_empty_config(self, Session):
+    def test_emitter_build_session_from_empty_config(self, session):
         e = sns.SNSNotificationEmitter({'aws_region': 'test'})
         e.build_session()
-        assert e.session is Session.return_value
-        Session.assert_called_once_with(
+        assert e.session is session.return_value
+        session.assert_called_once_with(
             region_name='test',
             aws_access_key_id=None,
             aws_secret_access_key=None,
@@ -18,7 +18,7 @@ class TestNotifySNS:
         )
 
     @patch('boto3.Session')
-    def test_emitter_uses_config_credentials(self, Session):
+    def test_emitter_uses_config_credentials(self, session):
         e = sns.SNSNotificationEmitter(
             {
                 'aws_region': None,
@@ -28,7 +28,7 @@ class TestNotifySNS:
             }
         )
         e.build_session()
-        Session.assert_called_once_with(
+        session.assert_called_once_with(
             region_name=None,
             aws_access_key_id='DUMMY',
             aws_secret_access_key='DUMMYKEY',
@@ -52,7 +52,7 @@ class TestNotifySNS:
         assert not topic.publish.called
 
     @patch('flexget.plugins.output.sns.SNSNotificationEmitter.get_topic')
-    def test_send_message_for_Event(self, get_topic):
+    def test_send_message_for_event(self, get_topic):
         topic = get_topic.return_value
         manager = Mock()
         manager.config = {'tasks': {}}

--- a/flexget/tests/test_sort_by.py
+++ b/flexget/tests/test_sort_by.py
@@ -96,6 +96,7 @@ class TestSortBy:
               dict_field: {a: 2, b: 0}
     """
 
+    @staticmethod
     def generate_test_ids(param):
         if param[0:5] == 'test_' or not isinstance(param, list):
             return param

--- a/flexget/tests/test_sort_by.py
+++ b/flexget/tests/test_sort_by.py
@@ -96,8 +96,8 @@ class TestSortBy:
               dict_field: {a: 2, b: 0}
     """
 
-    @staticmethod
-    def generate_test_ids(param):
+    # TODO: remove noqa and use @staticmethod after we drop Python 3.9
+    def generate_test_ids(param):  # noqa: N805
         if param[0:5] == 'test_' or not isinstance(param, list):
             return param
         return '|'

--- a/flexget/utils/cached_input.py
+++ b/flexget/utils/cached_input.py
@@ -104,7 +104,7 @@ def db_cleanup(manager, session: DBSession) -> None:
         logger.verbose('Removed {} old input caches.', result)
 
 
-class cached:
+class cached:  # noqa: N801 It acts like a function in usage
     """
     Implements transparent caching decorator @cached for inputs.
 

--- a/flexget/utils/database.py
+++ b/flexget/utils/database.py
@@ -34,10 +34,10 @@ def with_session(*args, **kwargs):
     if len(args) == 1 and not kwargs and callable(args[0]):
         # Used without arguments, e.g. @with_session
         # We default to expire_on_commit being false, in case the decorated function returns db instances
-        _Session = functools.partial(Session, expire_on_commit=False)
+        _Session = functools.partial(Session, expire_on_commit=False)  # noqa: N806 It's acting as a class
         return decorator(args[0])
     # Arguments were specified, turn them into arguments for Session creation e.g. @with_session(autocommit=True)
-    _Session = functools.partial(Session, *args, **kwargs)
+    _Session = functools.partial(Session, *args, **kwargs)  # noqa: N806 It's acting as a class
     return decorator
 
 

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -218,7 +218,7 @@ def pid_exists(pid: int):
         return False
 
 
-_binOps = {
+_bin_ops = {
     ast.Add: operator.add,
     ast.Sub: operator.sub,
     ast.Mult: operator.mul,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ select = [
     "ICN",
     "ISC",
     "LOG",
+    "N",
     "PERF",
     "PGH",
     "PL",
@@ -178,21 +179,22 @@ select = [
 ignore = [
     "B904", # TODO: enable this rule (requires a lot of manual work)
     "E501", # TODO: enable this rule (requires a lot of manual work)
+    "N817", # camelcase-imported-as-acronym
+    "N818", # error-suffix-on-exception-name
     "PERF203", # TODO: remove this after Python 3.10 is dropped
     "PLE1205", # Maybe can re-enable after https://github.com/astral-sh/ruff/issues/13390
-    # Enabling these PL rules would require extensive code refactoring, which may not be worth the effort.
-    "PLR0911",
-    "PLR0912",
-    "PLR0913",
-    "PLR0915",
-    "PLR1704",
-    "PLR2004",
-    "PLW0603",
-    "PLW0642",
-    "PLW2901",
+    "PLR0911", # too-many-return-statements
+    "PLR0912", # too-many-branches
+    "PLR0913", # too-many-arguments
+    "PLR0915", # too-many-statements
+    "PLR1704", # redefined-argument-from-local
+    "PLR2004", # magic-value-comparison
+    "PLW0603", # global-statement
+    "PLW0642", # self-or-cls-assignment
+    "PLW2901", # redefined-loop-name
     "RUF012", # Maybe can re-enable after https://github.com/astral-sh/ruff/issues/5243
-    "TD002", # Check for missing author in TODO
-    "TD003", # Check for missing issue link for this TODO
+    "TD002", # missing-todo-author
+    "TD003", # missing-todo-link
 ]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
### Motivation for Changes:

The `N` rules ensure our code adheres to the [PEP 8](https://www.python.org/dev/peps/pep-0008/) naming conventions, which we should follow.

All fixes have been applied manually.

For more information on the `N` rules, refer to the documentation: [Ruff PEP 8 Naming Rules](https://docs.astral.sh/ruff/rules/#pep8-naming-n).
