### PR TITLE
[Change] Make `exists_movie` recurse subfolders

### DIFF
--- a/flexget/plugins/filter/exists_movie.py
+++ b/flexget/plugins/filter/exists_movie.py
@@ -28,6 +28,7 @@ class FilterExistsMovie:
         [type: {dirs|files}]
         [allow_different_qualities: {better|yes|no}]
         [lookup: {imdb|no}]
+        [recursive: {yes|no}]
     """
 
     schema = {
@@ -43,6 +44,7 @@ class FilterExistsMovie:
                     },
                     'type': {'enum': ['files', 'dirs'], 'default': 'dirs'},
                     'lookup': {'enum': ['imdb', False], 'default': False},
+                    'recursive': {'type': 'boolean', 'default': False},
                 },
                 'required': ['path'],
                 'additionalProperties': False,
@@ -109,7 +111,7 @@ class FilterExistsMovie:
 
             # scan through
             items = []
-            for p in folder.rglob('*'):
+            for p in folder.rglob('*') if config.get('recursive') else folder.iterdir():
                 if config.get('type') == 'dirs' and p.is_dir():
                     if self.dir_pattern.search(p.name):
                         continue

--- a/flexget/plugins/filter/exists_movie.py
+++ b/flexget/plugins/filter/exists_movie.py
@@ -109,7 +109,7 @@ class FilterExistsMovie:
 
             # scan through
             items = []
-            for p in folder.iterdir():
+            for p in folder.rglob('*'):
                 if config.get('type') == 'dirs' and p.is_dir():
                     if self.dir_pattern.search(p.name):
                         continue


### PR DESCRIPTION
### Motivation for changes:
The following `exists_movie` config 
```yaml
    exists_movie:
      allow_different_qualities: better
      type: files
      path:
        - /media/Movies/
```
didn't behave as expected because it doesn't support the following folder structure.
```
/media/Movies/
├─── Cool Movie [2025]
│   ├─── Cool.Movie.2025.BluRay.2160p.HDR.x265.AAC.mkv
```
Because it wouldn't look into the folders themselves that contain the files, so the `allow_different_qualities: better` and `type: files` would never match, causing no entries to be rejected and duplicates being downloaded on every run.

### Detailed changes:
- Changed the `iterdir` call for a `rglob` that does look recursively into the path if the new `recursive` boolean parameter is set to `true`.

### Addressed issues/feature requests:
- Personal gripe

### Config usage if relevant (new plugin or updated schema):
```diff
exists_movie:
  path: /path/to/movies
  [type: {dirs|files}]
  [allow_different_qualities: {better|yes|no}]
  [lookup: {imdb|no}]
+ [recursive: {yes|no}]
```

### Ideas
 - [x] Make it a setting to prevent introducing slowdowns on existing configs checking large trees?