### PR TITLE
Fix default value for list kind in imdb_watchlist

### DIFF
--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -115,9 +115,7 @@ class ImdbWatchlist:
             )
         return page
 
-    def parse_html_list(
-        self, task, config, url, params, headers, kind='list'
-    ) -> list[Entry]:
+    def parse_html_list(self, task, config, url, params, headers, kind='list') -> list[Entry]:
         page = self.fetch_page(task, url, params, headers)
         soup = get_soup(page.text)
         try:

--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -116,7 +116,7 @@ class ImdbWatchlist:
         return page
 
     def parse_html_list(
-        self, task, config, url, params, headers, kind='predefinedList'
+        self, task, config, url, params, headers, kind='list'
     ) -> list[Entry]:
         page = self.fetch_page(task, url, params, headers)
         soup = get_soup(page.text)


### PR DESCRIPTION
### Motivation for changes:

I realised that, in my previous PR, I wrongfully set the default value of `kind` to "predefinedList" instead of "list".  
"predefinedList" is used for IMDB's watchlist only, other list use the "list" key so it should be the default `kind`.

My bad!

