### PR TITLE
Fix year being nested in releaseYear (imdb_watchlist)

### DIFF
--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -160,7 +160,7 @@ class ImdbWatchlist:
             entry = Entry()
             entry['title'] = item['listItem']['titleText']['text']
             with contextlib.suppress(ValueError, TypeError):
-                year = int(item['listItem']['releaseYear'])
+                year = int(item['listItem']['releaseYear']['year'])
                 entry['title'] += f' ({year})'
                 entry['imdb_year'] = year
             entry['url'] = link

--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -167,8 +167,9 @@ class ImdbWatchlist:
             entry['imdb_id'] = item['listItem']['id']
             entry['imdb_name'] = entry['title']
             with contextlib.suppress(ValueError, TypeError):
-                entry['imdb_user_score'] = float(item['listItem']['ratingsSummary']['aggregateRating'])
-                
+                entry['imdb_user_score'] = float(
+                    item['listItem']['ratingsSummary']['aggregateRating']
+                )
 
             entries.append(entry)
 

--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -160,16 +160,15 @@ class ImdbWatchlist:
             entry = Entry()
             entry['title'] = item['listItem']['titleText']['text']
             with contextlib.suppress(ValueError, TypeError):
-                year = int(item['listItem']['releaseYear']['year'])
+                year = item['listItem']['releaseYear']['year']
                 entry['title'] += f' ({year})'
                 entry['imdb_year'] = year
             entry['url'] = link
             entry['imdb_id'] = item['listItem']['id']
             entry['imdb_name'] = entry['title']
             with contextlib.suppress(ValueError, TypeError):
-                entry['imdb_user_score'] = int(
-                    item['listItem']['ratingsSummary']['aggregateRating']
-                )
+                entry['imdb_user_score'] = float(item['listItem']['ratingsSummary']['aggregateRating'])
+                
 
             entries.append(entry)
 


### PR DESCRIPTION
### Motivation for changes:
Thanks to @ranirahn, I noticied that releaseYear is actually a dict that contains the `year` field.
And in addition, use float instead of int for more accurate rating

### Detailed changes:
- use `item['listItem']['releaseYear']['year']` instead of `item['listItem']['releaseYear']`
- use `float(..)` instead of `int(...)` for imdb_user_score


