### PR TITLE
Add strip_dates property and more Entry fields to imdb_watchlist

### DIFF
--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -136,7 +136,6 @@ class ImdbWatchlist:
             logger.verbose('Nothing found in imdb list: {}', config['list'])
             return []
 
-        entries = []
         page_no = 1
 
         while len(items) < total_item_count:
@@ -156,10 +155,7 @@ class ImdbWatchlist:
             except Exception:
                 raise plugin.PluginError('Received invalid list data')
 
-        for item in items:
-            entries.append(self.parse_entry(item['listItem'], config))
-
-        return entries
+        return [self.parse_entry(item['listItem'], config) for item in items]
 
     def parse_entry(self, item, config) -> Entry:
         entry = Entry()

--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -1,5 +1,3 @@
-import contextlib
-
 from loguru import logger
 
 from flexget import plugin

--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -172,17 +172,16 @@ class ImdbWatchlist:
 
         entry['imdb_name'] = title
         entry['imdb_original_name'] = item['originalTitleText']['text']
-        if title_type in ['movie' , 'tvMovie']:
+        if title_type in ['movie', 'tvMovie']:
             entry['movie_name'] = title
         elif title_type in ['tvSeries', 'tvMiniSeries']:
             entry['series_name'] = title
-
 
         with contextlib.suppress(ValueError, TypeError):
             year = item['releaseYear']['year']
             entry['imdb_year'] = year
 
-            if title_type in ['movie' , 'tvMovie']:
+            if title_type in ['movie', 'tvMovie']:
                 entry['movie_year'] = year
             elif title_type in ['tvSeries', 'tvMiniSeries']:
                 entry['series_year'] = year

--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -55,6 +55,7 @@ class ImdbWatchlist:
                     {'type': 'string', 'enum': ['all']},
                 ]
             },
+            'strip_dates': {'type': 'boolean', 'default': False},
         },
         'additionalProperties': False,
         'required': ['list'],
@@ -161,7 +162,8 @@ class ImdbWatchlist:
             entry['title'] = item['listItem']['titleText']['text']
             with contextlib.suppress(ValueError, TypeError):
                 year = item['listItem']['releaseYear']['year']
-                entry['title'] += f' ({year})'
+                if not config.get('strip_dates'):
+                    entry['title'] += f' ({year})'
                 entry['imdb_year'] = year
             entry['url'] = link
             entry['imdb_id'] = item['listItem']['id']

--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -173,7 +173,7 @@ class ImdbWatchlist:
         elif title_type in ['tvSeries', 'tvMiniSeries']:
             entry['series_name'] = title
 
-        with contextlib.suppress(ValueError, TypeError):
+        if 'year' in item['releaseYear']:
             year = item['releaseYear']['year']
             entry['imdb_year'] = year
 
@@ -185,10 +185,9 @@ class ImdbWatchlist:
             if not config.get('strip_dates'):
                 entry['title'] += f' ({year})'
 
-        with contextlib.suppress(ValueError, TypeError):
-            entry['imdb_user_score'] = entry['imdb_score'] = float(
-                item['ratingsSummary']['aggregateRating']
-            )
+        rating = item['ratingsSummary']['aggregateRating']
+        if isinstance(rating, float):
+            entry['imdb_user_score'] = entry['imdb_score'] = rating
             entry['imdb_votes'] = item['ratingsSummary']['voteCount']
 
         return entry


### PR DESCRIPTION
### Motivation for changes:

Since most *_list plugins have it, adds strip_dates property to imdb_watchlist
Also adds more Entry fields when parsing items.

### Detailed changes:
- add `strip_dates` property
- append the date to the title depending on the config
- add `imdb_url`, `imdb_original_name`, `movie_name`, `series_name`, `movie_year`, `series_year`, `imdb_score` and `imdb_votes`

