### PR TITLE
preserve transmission labels order

### DIFF
--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -744,12 +744,12 @@ class PluginTransmission(TransmissionBase):
             change['queuePosition'] = opt_dic['queue_position']
 
         if 'labels' in opt_dic:
-            labels = set()
+            labels = {}
             for obj in [config, entry]:
                 obj_labels = obj.get('labels', [])
                 if not isinstance(obj_labels, list):
                     obj_labels = [obj_labels]
-                labels.update(obj_labels)
+                labels.update({obj_label: None for obj_label in obj_labels})
             rendered_labels = []
             for label in labels:
                 try:

--- a/flexget/tests/test_transmission.py
+++ b/flexget/tests/test_transmission.py
@@ -1,0 +1,35 @@
+from unittest import mock
+
+
+@mock.patch('flexget.plugins.clients.transmission.transmission_rpc')
+class TestTransmissionTorrentPlugin:
+    config = """
+        tasks:
+            test_input:
+                mock:
+                    - {title: 'title1', url: 'url1', transmission_id: '321', file: 'file1'}
+                accept_all: yes
+                transmission:
+                    host: localhost
+                    port: 9091
+                    username: myusername
+                    password: mypassword
+                    labels:
+                      - "3"
+                      - "1"
+                      - z
+                      - aaa
+                      - "{{title}}"
+    """
+
+    def test_output_labels_order(self, mocked_transmission, execute_task):
+        mocked_client = mocked_transmission.Client.return_value
+        mocked_torrent = mock.Mock()
+        mocked_torrent.id = '321'
+
+        mocked_client.get_torrents.return_value = [mocked_torrent]
+
+        task = execute_task('test_input')
+
+        assert len(task.all_entries) == 1
+        mocked_client.change_torrent.assert_called_with('321', labels=['3', '1', 'z', 'aaa', 'title1'])

--- a/flexget/tests/test_transmission.py
+++ b/flexget/tests/test_transmission.py
@@ -1,6 +1,6 @@
-import pytest
-
 from unittest import mock
+
+import pytest
 
 
 @pytest.mark.require_optional_deps

--- a/flexget/tests/test_transmission.py
+++ b/flexget/tests/test_transmission.py
@@ -32,4 +32,6 @@ class TestTransmissionTorrentPlugin:
         task = execute_task('test_input')
 
         assert len(task.all_entries) == 1
-        mocked_client.change_torrent.assert_called_with('321', labels=['3', '1', 'z', 'aaa', 'title1'])
+        mocked_client.change_torrent.assert_called_with(
+            '321', labels=['3', '1', 'z', 'aaa', 'title1']
+        )

--- a/flexget/tests/test_transmission.py
+++ b/flexget/tests/test_transmission.py
@@ -1,6 +1,9 @@
+import pytest
+
 from unittest import mock
 
 
+@pytest.mark.require_optional_deps
 @mock.patch('flexget.plugins.clients.transmission.transmission_rpc')
 class TestTransmissionTorrentPlugin:
     config = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ plugin-test = [
     "plexapi ~=4.16",
     "pysftp ~=0.2.9",
     "subliminal ~= 2.1",
-    { include-group = "telegram" }
+    { include-group = "telegram" },
+    { include-group = "transmission" }
 ]
 deluge = ['deluge-client~=1.10']
 qbittorrent = ['qbittorrent-api~=2025.2']

--- a/uv.lock
+++ b/uv.lock
@@ -802,6 +802,7 @@ plugin-test = [
     { name = "rarfile" },
     { name = "subliminal", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "subliminal", version = "2.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "transmission-rpc" },
 ]
 qbittorrent = [
     { name = "qbittorrent-api" },
@@ -871,6 +872,7 @@ plugin-test = [
     { name = "python-telegram-bot", extras = ["http2", "socks"], specifier = "~=21.9" },
     { name = "rarfile", specifier = "~=4.0" },
     { name = "subliminal", specifier = "~=2.1" },
+    { name = "transmission-rpc", specifier = "~=7.0" },
 ]
 qbittorrent = [{ name = "qbittorrent-api", specifier = "~=2025.2" }]
 telegram = [{ name = "python-telegram-bot", extras = ["http2", "socks"], specifier = "~=21.9" }]


### PR DESCRIPTION
### Motivation for changes:

I have a task that adds labels to a torrent and another one that reads labels from torrents, expecting them to be in the same order they were added. Currently, because a regular set is used, the order in which they are defined in the config is not repected.

### Detailed changes:
- Used a dictionary instead of a set, since it preserves insertion order. Alternatively, it could be done with a list and an inclusion check.

### Addressed issues/feature requests:
- Fixes # . Didn't create an issue for this, but can do so if needed

### Config usage if relevant (new plugin or updated schema):
Added a unit test that was failing and now passing. Although the random nature of the set could eventually make it pass
### Log and/or tests output (preferably both):
```
...
flexget/tests/test_transmissiontorrent.py::TestTransmissionTorrentPlugin::test_output_labels_order
<redacted>/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zc')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 1 passed, 4 warnings in 1.39s ===========================================================
```
#### To Do:

- [ ] Stuff..

