### PR TITLE
Fix releaseYear being`None` when unavailable

### DIFF
--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -171,7 +171,7 @@ class ImdbWatchlist:
         elif title_type in ['tvSeries', 'tvMiniSeries']:
             entry['series_name'] = title
 
-        if 'year' in item['releaseYear']:
+        if item['releaseYear']:
             year = item['releaseYear']['year']
             entry['imdb_year'] = year
 


### PR DESCRIPTION
### Motivation for changes:

`json.loads` parses `"releaseYear": "None"` to `"releaseYear": None`, no to a string containing the word "None", so `if 'year' in item['releaseYear']` statement is wrong... my bad!

