### PR TITLE
Remove unused pylint pragmas

### DIFF
--- a/flexget/components/imdb/imdb_lookup.py
+++ b/flexget/components/imdb/imdb_lookup.py
@@ -277,7 +277,7 @@ class ImdbLookup:
             genre = session.query(db.Genre).filter(db.Genre.name == name).first()
             if not genre:
                 genre = db.Genre(name)
-            movie.genres.append(genre)  # pylint:disable=E1101
+            movie.genres.append(genre)
         for index, name in enumerate(parser.languages):
             language = session.query(db.Language).filter(db.Language.name == name).first()
             if not language:
@@ -287,24 +287,24 @@ class ImdbLookup:
             actor = session.query(db.Actor).filter(db.Actor.imdb_id == imdb_id).first()
             if not actor:
                 actor = db.Actor(imdb_id, name)
-            movie.actors.append(actor)  # pylint:disable=E1101
+            movie.actors.append(actor)
         for imdb_id, name in parser.directors.items():
             director = session.query(db.Director).filter(db.Director.imdb_id == imdb_id).first()
             if not director:
                 director = db.Director(imdb_id, name)
-            movie.directors.append(director)  # pylint:disable=E1101
+            movie.directors.append(director)
         for imdb_id, name in parser.writers.items():
             writer = session.query(db.Writer).filter(db.Writer.imdb_id == imdb_id).first()
             if not writer:
                 writer = db.Writer(imdb_id, name)
-            movie.writers.append(writer)  # pylint:disable=E1101
+            movie.writers.append(writer)
         for name in parser.plot_keywords:
             plot_keyword = (
                 session.query(db.PlotKeyword).filter(db.PlotKeyword.name == name).first()
             )
             if not plot_keyword:
                 plot_keyword = db.PlotKeyword(name)
-            movie.plot_keywords.append(plot_keyword)  # pylint:disable=E1101
+            movie.plot_keywords.append(plot_keyword)
         # so that we can track how long since we've updated the info later
         movie.updated = datetime.now()
         return movie

--- a/flexget/components/seen/seen_info_hash.py
+++ b/flexget/components/seen/seen_info_hash.py
@@ -15,7 +15,7 @@ class FilterSeenInfoHash(plugin_seen.FilterSeen):
         self.keyword = 'seen_info_hash'
 
     @plugin.priority(180)
-    def on_task_filter(self, task, config):  # pylint: disable=W0221
+    def on_task_filter(self, task, config):
         # Return if we are disabled.
         if config is False:
             return

--- a/flexget/components/seen/seen_movies.py
+++ b/flexget/components/seen/seen_movies.py
@@ -41,7 +41,7 @@ class FilterSeenMovies(plugin_seen.FilterSeen):
 
     # We run last to make sure we don't reject duplicates before all the other plugins get a chance to reject.
     @plugin.priority(plugin.PRIORITY_LAST)
-    def on_task_filter(self, task, config):  # pylint: disable=W0221
+    def on_task_filter(self, task, config):
         if not isinstance(config, dict):
             config = {'matching': config}
         # Reject all entries without

--- a/flexget/components/series/db.py
+++ b/flexget/components/series/db.py
@@ -1476,7 +1476,7 @@ def store_parser(
                 elif parser.id_type == 'sequence':
                     episode.season = 0
                     episode.number = parser.id + ix
-                series.episodes.append(episode)  # pylint:disable=E1103
+                series.episodes.append(episode)
                 logger.debug('-> added `{}`', episode)
             session.flush()
 
@@ -1508,7 +1508,7 @@ def store_parser(
             release.quality = quality
             release.proper_count = parser.proper_count
             release.title = parser.data
-            entity.releases.append(release)  # pylint:disable=E1103
+            entity.releases.append(release)
             logger.debug('-> added `{}`', release)
         releases.append(release)
     session.flush()  # Make sure autonumber ids are populated

--- a/flexget/options.py
+++ b/flexget/options.py
@@ -341,7 +341,7 @@ class ArgumentParser(ArgParser):
         namespace: Optional[Namespace] = None,
         raise_errors: bool = False,
         file: Optional[TextIO] = None,
-    ):  # pylint: disable=W0221
+    ):
         """:param raise_errors: If this is true, errors will be raised as `ParserError`s instead of calling sys.exit"""
         ArgumentParser.file = file
         try:

--- a/flexget/tests/test_misc.py
+++ b/flexget/tests/test_misc.py
@@ -1,4 +1,3 @@
-# pylint: disable=no-self-use
 import datetime
 import os
 import stat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,6 @@ select = [
     "SLOT",
     "T10",
     "TC",
-    "TCH",
     "TD",
     "TID",
     "TRY",
@@ -183,6 +182,8 @@ select = [
 ignore = [
     "B904", # TODO: enable this rule (requires a lot of manual work)
     "D1", # Missing docstring
+    "D203", # incorrect-blank-line-before-class
+    "D213", # multi-line-summary-second-line
     "E501", # TODO: enable this rule (requires a lot of manual work)
     "N817", # camelcase-imported-as-acronym
     "N818", # error-suffix-on-exception-name


### PR DESCRIPTION
### Motivation for changes:

Considering that pylint is no longer used, we should remove the unused pylint pragmas.

