### PR TITLE
Place type-checking-only imports behind `if TYPE_CHECKING:`

### DIFF
--- a/flexget/__init__.py
+++ b/flexget/__init__.py
@@ -1,7 +1,6 @@
 import os
 import sys
-from collections.abc import Sequence
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 # __version__ import need to be first in order to avoid circular import within logger
 from ._version import __version__  # noqa: F401
@@ -10,8 +9,11 @@ from ._version import __version__  # noqa: F401
 from flexget import log
 from flexget.manager import Manager
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
-def main(args: Optional[Sequence[str]] = None):
+
+def main(args: Optional['Sequence[str]'] = None):
     """Execute as the main entry point for Command Line Interface."""
     if args is None:
         args = sys.argv[1:]

--- a/flexget/api/app.py
+++ b/flexget/api/app.py
@@ -2,7 +2,6 @@ import json
 import os
 import re
 from collections import deque
-from collections.abc import Mapping
 from contextlib import suppress
 from functools import partial, wraps
 from typing import TYPE_CHECKING, Callable, Optional, Union
@@ -12,12 +11,9 @@ from flask_compress import Compress
 from flask_cors import CORS
 from flask_restx import Api as RestxAPI
 from flask_restx import Model, Resource
-from flask_restx.reqparse import RequestParser
-from jsonschema.exceptions import ValidationError as SchemaValidationError
 from loguru import logger
 from referencing.exceptions import Unresolvable
 from requests import HTTPError
-from sqlalchemy.orm import Session
 from werkzeug.http import generate_etag
 
 from flexget import manager
@@ -32,7 +28,12 @@ __version__ = '1.8.0'
 logger = logger.bind(name='api')
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from typing import TypedDict
+
+    from flask_restx.reqparse import RequestParser
+    from jsonschema.exceptions import ValidationError as SchemaValidationError
+    from sqlalchemy.orm import Session
 
     class _TypeDict(TypedDict):
         type: str
@@ -170,11 +171,11 @@ class API(RestxAPI):
 
     def pagination_parser(
         self,
-        parser: RequestParser = None,
+        parser: 'RequestParser' = None,
         sort_choices: Optional[list[str]] = None,
         default: Optional[str] = None,
         add_sort: Optional[bool] = None,
-    ) -> RequestParser:
+    ) -> 'RequestParser':
         """Return a standardized pagination parser, to be used for any endpoint that has pagination.
 
         :param RequestParser parser: Can extend a given parser or create a new one
@@ -330,14 +331,14 @@ class ValidationError(APIError):
     )
 
     def __init__(
-        self, validation_errors: list[SchemaValidationError], message: str = 'validation error'
+        self, validation_errors: list['SchemaValidationError'], message: str = 'validation error'
     ) -> None:
         payload = {
             'validation_errors': [self._verror_to_dict(error) for error in validation_errors]
         }
         super().__init__(message, payload=payload)
 
-    def _verror_to_dict(self, error: SchemaValidationError) -> Mapping[str, Union[str, list]]:
+    def _verror_to_dict(self, error: 'SchemaValidationError') -> 'Mapping[str, Union[str, list]]':
         error_dict: dict[str, Union[str, list]] = {}
         for attr in self.verror_attrs:
             if isinstance(getattr(error, attr), deque):
@@ -370,7 +371,7 @@ def api_errors(error: APIError) -> tuple[dict, int]:
 
 
 @with_session
-def api_key(session: Session = None) -> str:
+def api_key(session: 'Session' = None) -> str:
     logger.debug('fetching token for internal lookup')
     return session.query(User).first().token
 

--- a/flexget/api/core/authentication.py
+++ b/flexget/api/core/authentication.py
@@ -1,13 +1,12 @@
 import base64
 from contextlib import suppress
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from flask import Request, Response, request
 from flask import session as flask_session
 from flask_login import LoginManager
 from flask_login.utils import current_app, current_user, login_user
 from flask_restx import inputs
-from sqlalchemy.orm import Session
 from werkzeug.security import check_password_hash
 
 from flexget.api import api_app
@@ -15,13 +14,16 @@ from flexget.api.app import APIResource, Unauthorized, api, base_message_schema,
 from flexget.utils.database import with_session
 from flexget.webserver import User
 
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
 login_manager = LoginManager()
 login_manager.init_app(api_app)
 
 
 @login_manager.request_loader
 @with_session
-def load_user_from_request(request: Request, session: Session = None) -> Optional[User]:
+def load_user_from_request(request: Request, session: 'Session' = None) -> Optional[User]:
     auth_value = request.headers.get('Authorization')
 
     if not auth_value:
@@ -46,7 +48,7 @@ def load_user_from_request(request: Request, session: Session = None) -> Optiona
 
 @login_manager.user_loader
 @with_session
-def load_user(username: str, session: Session = None) -> Optional[User]:
+def load_user(username: str, session: 'Session' = None) -> Optional[User]:
     return session.query(User).filter(User.name == username).first()
 
 
@@ -96,7 +98,7 @@ class LoginAPI(APIResource):
     @api.response(Unauthorized)
     @api.response(200, 'Login successful', model=base_message_schema)
     @api.doc(expect=[login_parser])
-    def post(self, session: Session = None) -> Response:
+    def post(self, session: 'Session' = None) -> Response:
         """Login with username and password."""
         data = request.json
         user_name = data.get('username')
@@ -122,7 +124,7 @@ class LoginAPI(APIResource):
 @auth_api.route('/logout/')
 class LogoutAPI(APIResource):
     @api.response(200, 'Logout successful', model=base_message_schema)
-    def post(self, session: Session = None) -> Response:
+    def post(self, session: 'Session' = None) -> Response:
         """Logout and clear session cookies."""
         flask_session.clear()
         resp = success_response('User logged out')

--- a/flexget/api/core/cached.py
+++ b/flexget/api/core/cached.py
@@ -1,12 +1,16 @@
-from flask import Response
+from typing import TYPE_CHECKING
+
 from flask.helpers import send_file
 from flask_restx import inputs
 from requests import RequestException
-from sqlalchemy.orm import Session
 
 from flexget.api import APIResource, api
 from flexget.api.app import APIError, BadRequest
 from flexget.utils.cache import cached_resource
+
+if TYPE_CHECKING:
+    from flask import Response
+    from sqlalchemy.orm import Session
 
 cached_api = api.namespace('cached', description='Cache remote resources')
 
@@ -24,7 +28,7 @@ class CachedResource(APIResource):
     @api.response(BadRequest)
     @api.response(APIError)
     @api.doc(expect=[cached_parser])
-    def get(self, session: Session = None) -> Response:
+    def get(self, session: 'Session' = None) -> 'Response':
         """Cache remote resources."""
         args = cached_parser.parse_args()
         url = args.get('url')

--- a/flexget/api/core/database.py
+++ b/flexget/api/core/database.py
@@ -1,10 +1,14 @@
+from typing import TYPE_CHECKING
+
 from flask import Response, jsonify, request
 from sqlalchemy import text
-from sqlalchemy.orm import Session
 
 from flexget.api import APIResource, api
 from flexget.api.app import BadRequest, base_message_schema, success_response
 from flexget.db_schema import plugin_schemas, reset_schema
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 db_api = api.namespace('database', description='Manage Flexget DB')
 
@@ -31,7 +35,7 @@ input_schema = api.schema_model('db_schema', ObjectsContainer.database_input_obj
 class DBOperation(APIResource):
     @api.validate(input_schema)
     @api.response(200, model=base_message_schema)
-    def post(self, session: Session = None) -> Response:
+    def post(self, session: 'Session' = None) -> Response:
         """Perform DB operations."""
         msg = ''
         data = request.json
@@ -60,6 +64,6 @@ class DBOperation(APIResource):
 @db_api.route('/plugins/')
 class DBCleanup(APIResource):
     @api.response(200, model=plugins_schema)
-    def get(self, session: Session = None) -> Response:
+    def get(self, session: 'Session' = None) -> Response:
         """List resettable DB plugins."""
         return jsonify(sorted(plugin_schemas))

--- a/flexget/api/core/format_checker.py
+++ b/flexget/api/core/format_checker.py
@@ -1,8 +1,11 @@
-from flask import Response
-from sqlalchemy.orm import Session
+from typing import TYPE_CHECKING
 
 from flexget.api import APIResource, api
 from flexget.api.app import base_message_schema, success_response
+
+if TYPE_CHECKING:
+    from flask import Response
+    from sqlalchemy.orm import Session
 
 schema_api = api.namespace(
     'format_check', description='Test Flexget custom schema format validations'
@@ -36,7 +39,7 @@ format_checker_schema = api.schema_model('format_checker', ObjectContainer.forma
 class SchemaTest(APIResource):
     @api.validate(format_checker_schema)
     @api.response(200, model=base_message_schema)
-    def post(self, session: Session = None) -> Response:
+    def post(self, session: 'Session' = None) -> 'Response':
         """Validate flexget custom schema."""
         # If validation passed, all is well
         return success_response('payload is valid')

--- a/flexget/api/core/plugins.py
+++ b/flexget/api/core/plugins.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Optional
 from flask import Response, jsonify, request
 from flask_restx import inputs
 from loguru import logger
-from sqlalchemy.orm import Session
 
 from flexget.api import APIResource, api
 from flexget.api.app import BadRequest, NotFoundError, etag, pagination_headers
@@ -63,6 +62,8 @@ plugins_parser.add_argument(
 if TYPE_CHECKING:
     from typing import TypedDict
 
+    from sqlalchemy.orm import Session
+
     from flexget.config_schema import JsonSchema
 
     class _PhaseHandler(TypedDict):
@@ -102,7 +103,7 @@ class PluginsAPI(APIResource):
     @api.response(BadRequest)
     @api.response(NotFoundError)
     @api.doc(expect=[plugins_parser])
-    def get(self, session: Session = None) -> Response:
+    def get(self, session: 'Session' = None) -> Response:
         """Get list of registered plugins."""
         args = plugins_parser.parse_args()
 

--- a/flexget/api/core/schema.py
+++ b/flexget/api/core/schema.py
@@ -1,10 +1,14 @@
+from typing import TYPE_CHECKING
+
 from flask import Response, jsonify, request
 from referencing.exceptions import Unresolvable
-from sqlalchemy.orm import Session
 
 from flexget.api import APIResource, api
 from flexget.api.app import NotFoundError
 from flexget.config_schema import resolve_ref, schema_paths
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 schema_api = api.namespace('schema', description='Config and plugin schemas')
 
@@ -40,7 +44,7 @@ def rewrite_refs(schema, base_url: str):
 @schema_api.route('/')
 class SchemaAllAPI(APIResource):
     @api.response(200, model=schema_api_list)
-    def get(self, session: Session = None) -> Response:
+    def get(self, session: 'Session' = None) -> Response:
         """List all schema definitions."""
         schemas = []
         for path in schema_paths:
@@ -55,7 +59,7 @@ class SchemaAllAPI(APIResource):
 @api.response(NotFoundError)
 class SchemaAPI(APIResource):
     @api.response(200, model=schema_api_list)
-    def get(self, path: str, session: Session = None) -> Response:
+    def get(self, path: str, session: 'Session' = None) -> Response:
         """Get schema definition."""
         try:
             schema = resolve_ref(request.full_path)

--- a/flexget/api/core/tasks.py
+++ b/flexget/api/core/tasks.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 from flask import Response, jsonify, request
 from flask_restx import inputs
-from sqlalchemy.orm import Session
 
 from flexget.api import APIResource, api
 from flexget.api.app import (
@@ -29,6 +28,9 @@ from flexget.terminal import capture_console
 from flexget.utils import json, requests
 from flexget.utils.lazy_dict import LazyLookup
 from flexget.utils.requests import parse_header
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 # Tasks API
 tasks_api = api.namespace('tasks', description='Manage Tasks')
@@ -200,7 +202,7 @@ class TasksAPI(APIResource):
     @etag
     @api.response(200, model=tasks_list_schema)
     @api.doc(expect=[tasks_parser])
-    def get(self, session: Session = None) -> Response:
+    def get(self, session: 'Session' = None) -> Response:
         """List all tasks."""
         active_tasks = {
             task: task_data
@@ -219,7 +221,7 @@ class TasksAPI(APIResource):
     @api.response(201, description='Newly created task', model=task_return_schema)
     @api.response(Conflict)
     @api.response(APIError)
-    def post(self, session: Session = None) -> Response:
+    def post(self, session: 'Session' = None) -> Response:
         """Add new task."""
         data = request.json
 
@@ -258,7 +260,7 @@ class TaskAPI(APIResource):
     @etag
     @api.response(200, model=task_return_schema)
     @api.response(NotFoundError, description='task not found')
-    def get(self, task, session: Session = None) -> Response:
+    def get(self, task, session: 'Session' = None) -> Response:
         """Get task config."""
         if task not in self.manager.user_config.get('tasks', {}):
             raise NotFoundError(f'task `{task}` not found')
@@ -269,7 +271,7 @@ class TaskAPI(APIResource):
     @api.response(200, model=task_return_schema)
     @api.response(NotFoundError)
     @api.response(BadRequest)
-    def put(self, task, session: Session = None) -> Response:
+    def put(self, task, session: 'Session' = None) -> Response:
         """Update tasks config."""
         data = request.json
 
@@ -314,7 +316,7 @@ class TaskAPI(APIResource):
 
     @api.response(200, model=base_message_schema, description='deleted task')
     @api.response(NotFoundError)
-    def delete(self, task, session: Session = None) -> Response:
+    def delete(self, task, session: 'Session' = None) -> Response:
         """Delete a task."""
         try:
             self.manager.config['tasks'].pop(task)
@@ -371,7 +373,7 @@ def _task_info_dict(task):
 @tasks_api.route('/queue/')
 class TaskQueueAPI(APIResource):
     @api.response(200, model=task_api_queue_schema)
-    def get(self, session: Session = None) -> Response:
+    def get(self, session: 'Session' = None) -> Response:
         """List task(s) in queue for execution."""
         tasks = [_task_info_dict(task) for task in self.manager.task_queue.run_queue.queue]
 
@@ -409,7 +411,7 @@ inject_api = api.namespace('inject', description='Entry injection API')
 class TaskExecutionParams(APIResource):
     @etag(cache_age=3600)
     @api.response(200, model=task_execution_params)
-    def get(self, session: Session = None) -> Response:
+    def get(self, session: 'Session' = None) -> Response:
         """Execute payload parameters."""
         return jsonify(ObjectsContainer.task_execution_input)
 
@@ -422,7 +424,7 @@ class TaskExecutionAPI(APIResource):
     @api.response(BadRequest)
     @api.response(200, model=task_api_execute_schema)
     @api.validate(task_execution_schema)
-    def post(self, session: Session = None) -> Response:
+    def post(self, session: 'Session' = None) -> Response:
         """Execute task and stream results."""
         data = request.json
         for task in data.get('tasks'):

--- a/flexget/api/core/user.py
+++ b/flexget/api/core/user.py
@@ -1,10 +1,14 @@
+from typing import TYPE_CHECKING
+
 from flask import Response, jsonify, request
 from flask_login import current_user
-from sqlalchemy.orm import Session
 
 from flexget.api import APIResource, api
 from flexget.api.app import BadRequest, base_message_schema, success_response
 from flexget.webserver import WeakPassword, change_password, generate_token
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 user_api = api.namespace('user', description='Manage user login credentials')
 
@@ -38,7 +42,7 @@ class UserManagementAPI(APIResource):
         description='Change user password. A score of at least 3 is needed.'
         'See https://github.com/dropbox/zxcvbn for details'
     )
-    def put(self, session: Session = None) -> Response:
+    def put(self, session: 'Session' = None) -> Response:
         """Change user password."""
         user = current_user
         data = request.json
@@ -54,13 +58,13 @@ class UserManagementAPI(APIResource):
 class UserManagementTokenAPI(APIResource):
     @api.response(200, 'Successfully got user token', user_token_response_schema)
     @api.doc(description='Get current user token')
-    def get(self, session: Session = None) -> Response:
+    def get(self, session: 'Session' = None) -> Response:
         token = current_user.token
         return jsonify({'token': token})
 
     @api.response(200, 'Successfully changed user token', user_token_response_schema)
     @api.doc(description='Get new user token')
-    def put(self, session: Session = None) -> Response:
+    def put(self, session: 'Session' = None) -> Response:
         """Change current user token."""
         token = generate_token(username=current_user.name, session=session)
         return jsonify({'token': token})

--- a/flexget/components/ftp/sftp.py
+++ b/flexget/components/ftp/sftp.py
@@ -1,6 +1,6 @@
 from itertools import groupby
 from pathlib import Path
-from typing import NamedTuple, Optional
+from typing import TYPE_CHECKING, NamedTuple, Optional
 from urllib.parse import unquote, urlparse
 
 from loguru import logger
@@ -8,10 +8,12 @@ from loguru import logger
 from flexget import plugin
 from flexget.components.ftp.sftp_client import HOST_KEY_TYPES, HostKey, SftpClient, SftpError
 from flexget.config_schema import one_or_more
-from flexget.entry import Entry
 from flexget.event import event
-from flexget.task import Task
 from flexget.utils.template import RenderError, render_from_entry
+
+if TYPE_CHECKING:
+    from flexget.entry import Entry
+    from flexget.task import Task
 
 logger = logger.bind(name='sftp')
 
@@ -108,7 +110,7 @@ class SftpList:
         return config
 
     @classmethod
-    def on_task_input(cls, task: Task, config: dict) -> list[Entry]:
+    def on_task_input(cls, task: 'Task', config: dict) -> list['Entry']:
         """Input task handler."""
         config = cls.prepare_config(config)
 
@@ -177,7 +179,7 @@ class SftpDownload:
     }
 
     @classmethod
-    def download_entry(cls, entry: Entry, config: dict, sftp: SftpClient) -> None:
+    def download_entry(cls, entry: 'Entry', config: dict, sftp: SftpClient) -> None:
         """Download the file(s) described in entry."""
         path: str = unquote(urlparse(entry['url']).path) or '.'
         delete_origin: bool = config['delete_origin']
@@ -197,11 +199,11 @@ class SftpDownload:
             entry.fail(e)
 
     @classmethod
-    def on_task_output(cls, task: Task, config: dict) -> None:
+    def on_task_output(cls, task: 'Task', config: dict) -> None:
         """Register this as an output plugin."""
 
     @classmethod
-    def on_task_download(cls, task: Task, config: dict) -> None:
+    def on_task_download(cls, task: 'Task', config: dict) -> None:
         """Task handler for sftp_download plugin."""
         socket_timeout_sec: int = config['socket_timeout_sec']
         connection_tries: int = config['connection_tries']
@@ -227,7 +229,7 @@ class SftpDownload:
                 sftp.close()
 
     @classmethod
-    def _get_sftp_config(cls, entry: Entry):
+    def _get_sftp_config(cls, entry: 'Entry'):
         """Parse a url and return a hashable config, source path, and destination path."""
         # parse url
         parsed = urlparse(entry['url'])
@@ -325,7 +327,7 @@ class SftpUpload:
         return config
 
     @classmethod
-    def handle_entry(cls, entry: Entry, sftp: SftpClient, config: dict):
+    def handle_entry(cls, entry: 'Entry', sftp: SftpClient, config: dict):
         to: str = config['to']
         location: str = entry['location']
         delete_origin: bool = config['delete_origin']
@@ -351,7 +353,7 @@ class SftpUpload:
                 logger.warning('Failed to delete file {} ({})', location, e)
 
     @classmethod
-    def on_task_output(cls, task: Task, config: dict) -> None:
+    def on_task_output(cls, task: 'Task', config: dict) -> None:
         """Upload accepted entries to the specified SFTP server."""
         config = cls.prepare_config(config)
 

--- a/flexget/components/parsing/parsers/parser_common.py
+++ b/flexget/components/parsing/parsers/parser_common.py
@@ -1,11 +1,13 @@
-import datetime
 import re
 from string import capwords
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from loguru import logger
 
 from flexget.utils.qualities import Quality
+
+if TYPE_CHECKING:
+    import datetime
 
 logger = logger.bind(name='parser')
 
@@ -105,7 +107,7 @@ class SeriesParseResult:
         name: Optional[str] = None,
         identified_by: Optional[str] = None,
         id_type: Optional[str] = None,
-        id: Optional[Union[tuple[int, int], str, int, datetime.date]] = None,
+        id: Optional[Union[tuple[int, int], str, int, 'datetime.date']] = None,
         episodes: int = 1,
         season_pack: bool = False,
         strict_name: bool = False,

--- a/flexget/components/seen/cli.py
+++ b/flexget/components/seen/cli.py
@@ -1,12 +1,16 @@
+from typing import TYPE_CHECKING
+
 from rich.markup import escape
 
 from flexget import options, plugin
 from flexget.event import event
-from flexget.manager import Manager
 from flexget.terminal import TerminalTable, console, table_parser
 from flexget.utils.database import with_session
 
 from . import db
+
+if TYPE_CHECKING:
+    from flexget.manager import Manager
 
 try:
     # NOTE: Importing other plugins is discouraged!
@@ -24,7 +28,7 @@ def do_cli(manager, options):
         seen_search(manager, options)
 
 
-def seen_forget(manager: Manager, options):
+def seen_forget(manager: 'Manager', options):
     forget_name = options.forget_value
     if is_imdb_url(forget_name):
         imdb_id = extract_id(forget_name)
@@ -54,7 +58,7 @@ def seen_forget(manager: Manager, options):
     manager.config_changed()
 
 
-def seen_add(manager: Manager, options):
+def seen_add(manager: 'Manager', options):
     default_task = 'cli_add'
 
     seen_name = options.add_value
@@ -93,7 +97,7 @@ def seen_add(manager: Manager, options):
 
 
 @with_session
-def seen_search(manager: Manager, options, session=None):
+def seen_search(manager: 'Manager', options, session=None):
     search_term = options.search_term
     if is_imdb_url(search_term):
         console('IMDB url detected, parsing ID')

--- a/flexget/components/series/db.py
+++ b/flexget/components/series/db.py
@@ -1,5 +1,4 @@
 import re
-from collections.abc import Iterable
 from datetime import datetime, timedelta
 from functools import total_ordering
 from typing import TYPE_CHECKING, Optional, Union
@@ -42,6 +41,8 @@ from flexget.utils.sqlalchemy_utils import (
 from flexget.utils.tools import parse_episode_identifier
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from flexget.components.parsing.parsers.parser_common import SeriesParseResult
     from flexget.utils.qualities import Quality
 
@@ -749,7 +750,7 @@ def db_cleanup(manager, session: Session) -> None:
         logger.verbose('Removed {} series without episodes.', result)
 
 
-def set_alt_names(alt_names: Iterable[str], db_series: Series, session: Session) -> None:
+def set_alt_names(alt_names: 'Iterable[str]', db_series: Series, session: Session) -> None:
     db_alt_names = []
     for alt_name in alt_names:
         db_series_alt = (
@@ -923,7 +924,7 @@ def get_series_summary(
     descending: Optional[bool] = None,
     session: Session = None,
     name: Optional[str] = None,
-) -> Union[int, Iterable[Series]]:
+) -> Union[int, 'Iterable[Series]']:
     """Return a query with results for all series.
 
     :param configured: 'configured' for shows in config, 'unconfigured' for shows not in config, 'all' for both.

--- a/flexget/entry.py
+++ b/flexget/entry.py
@@ -1,10 +1,9 @@
 import functools
 import types
 import warnings
-from collections.abc import Iterable, Mapping, Sequence
 from datetime import date, datetime
 from enum import Enum
-from typing import Callable, Optional, Union
+from typing import TYPE_CHECKING, Callable, Optional, Union
 
 import pendulum
 from loguru import logger
@@ -13,6 +12,9 @@ from flexget import plugin
 from flexget.utils.lazy_dict import LazyDict, LazyLookup
 from flexget.utils.serialization import Serializer, deserialize, serialize
 from flexget.utils.template import CoercingDateTime, FlexGetTemplate, render_from_entry
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
 
 logger = logger.bind(name='entry')
 
@@ -348,9 +350,9 @@ class Entry(LazyDict, Serializer):
     def add_lazy_fields(
         self,
         lazy_func: Union[Callable[['Entry'], None], str],
-        fields: Iterable[str],
-        args: Optional[Sequence] = None,
-        kwargs: Optional[Mapping] = None,
+        fields: 'Iterable[str]',
+        args: Optional['Sequence'] = None,
+        kwargs: Optional['Mapping'] = None,
     ):
         """Add lazy fields to an entry.
 

--- a/flexget/log.py
+++ b/flexget/log.py
@@ -8,13 +8,15 @@ import threading
 import uuid
 import warnings
 from collections import deque
-from collections.abc import Iterator
-from typing import Callable, Optional, Union
+from typing import TYPE_CHECKING, Callable, Optional, Union
 
 import loguru
 from loguru import logger
 
 from flexget import __version__
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 # A level more detailed than INFO
 VERBOSE = 15
@@ -32,7 +34,7 @@ local_context = threading.local()
 
 
 @contextlib.contextmanager
-def capture_logs(*args, **kwargs) -> Iterator:
+def capture_logs(*args, **kwargs) -> 'Iterator':
     """Take the same arguments as `logger.add`, but this sync will only log messages contained in context."""
     old_id = get_log_session_id()
     session_id = local_context.session_id = old_id or str(uuid.uuid4())

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -1,4 +1,3 @@
-import argparse
 import atexit
 import codecs
 import collections
@@ -12,7 +11,6 @@ import signal
 import sys
 import threading
 import traceback
-from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -51,6 +49,9 @@ from flexget.task_queue import TaskQueue  # noqa: E402
 from flexget.terminal import console, get_console_output  # noqa: E402
 
 if TYPE_CHECKING:
+    import argparse
+    from collections.abc import Iterator, Sequence
+
     from sqlalchemy.engine import Engine
 
     from flexget.tray_icon import TrayIcon
@@ -117,7 +118,7 @@ class Manager:
     """
 
     unit_test = False
-    options: argparse.Namespace
+    options: 'argparse.Namespace'
 
     def __init__(self, args: list[str]) -> None:
         """:param args: CLI args"""
@@ -189,7 +190,7 @@ class Manager:
         tray_icon.add_menu_separator(index=4)
 
     @staticmethod
-    def parse_initial_options(args: list[str]) -> argparse.Namespace:
+    def parse_initial_options(args: list[str]) -> 'argparse.Namespace':
         """Parse what we can from cli args before plugins are loaded."""
         try:
             options = CoreArgumentParser().parse_known_args(args, do_help=False)[0]
@@ -267,9 +268,9 @@ class Manager:
 
     def execute(
         self,
-        options: Optional[Union[dict, argparse.Namespace]] = None,
+        options: Optional[Union[dict, 'argparse.Namespace']] = None,
         priority: int = 1,
-        suppress_warnings: Optional[Sequence[str]] = None,
+        suppress_warnings: Optional['Sequence[str]'] = None,
     ) -> list[tuple[str, str, threading.Event]]:
         """Run all (can be limited with options) tasks from the config.
 
@@ -382,7 +383,7 @@ class Manager:
             self._shutdown()
             return None
 
-    def handle_cli(self, options: Optional[argparse.Namespace] = None) -> None:
+    def handle_cli(self, options: Optional['argparse.Namespace'] = None) -> None:
         """Dispatch a cli command to the appropriate function.
 
         * :meth:`.execute_command`
@@ -409,7 +410,7 @@ class Manager:
             # Otherwise dispatch the command to the callback function
             options.cli_command_callback(self, command_options)
 
-    def execute_command(self, options: argparse.Namespace) -> None:
+    def execute_command(self, options: 'argparse.Namespace') -> None:
         """Handle the 'execute' CLI command.
 
         If there is already a task queue running in this process, adds the execution to the queue.
@@ -446,7 +447,7 @@ class Manager:
             self.task_queue.wait()
         fire_event('manager.execute.completed', self, options)
 
-    def daemon_command(self, options: argparse.Namespace) -> None:
+    def daemon_command(self, options: 'argparse.Namespace') -> None:
         """Handle the 'daemon' CLI command.
 
         Fires events:
@@ -859,7 +860,7 @@ class Manager:
         return None
 
     @contextmanager
-    def acquire_lock(self, event: bool = True) -> Iterator:
+    def acquire_lock(self, event: bool = True) -> 'Iterator':
         """:param bool event: If True, the 'manager.lock_acquired' event will be fired after a lock is obtained"""
         acquired = False
         try:

--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -1,12 +1,11 @@
 import os
 import re
 import time
-from collections.abc import Iterable
 from functools import total_ordering
 from http.client import BadStatusLine
 from importlib import import_module
 from pathlib import Path
-from typing import Callable, Optional, Union
+from typing import TYPE_CHECKING, Callable, Optional, Union
 from urllib.error import HTTPError, URLError
 
 import loguru
@@ -24,6 +23,9 @@ from flexget import config_schema
 from flexget import plugins as plugins_pkg
 from flexget.event import Event, event, fire_event, remove_event_handlers
 from flexget.event import add_event_handler as add_phase_handler
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 logger = loguru.logger.bind(name='plugin')
 
@@ -556,7 +558,7 @@ def get_plugins(
     category: Optional[str] = None,
     name: Optional[str] = None,
     min_api: Optional[int] = None,
-) -> Iterable[PluginInfo]:
+) -> 'Iterable[PluginInfo]':
     """Query other plugins characteristics.
 
     :param string phase: Require phase

--- a/flexget/plugins/metainfo/assume_quality.py
+++ b/flexget/plugins/metainfo/assume_quality.py
@@ -1,11 +1,13 @@
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 from loguru import logger
 
 from flexget import plugin
 from flexget.event import event
 from flexget.utils import qualities
-from flexget.utils.qualities import Quality, Requirements
+
+if TYPE_CHECKING:
+    from flexget.utils.qualities import Quality, Requirements
 
 logger = logger.bind(name='assume_quality')
 
@@ -77,8 +79,8 @@ class AssumeQuality:
             config = {'any': config}
 
         class Assume(NamedTuple):
-            target: Requirements
-            quality: Quality
+            target: 'Requirements'
+            quality: 'Quality'
 
         self.assumptions = []
         for target, quality in list(config.items()):

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -5,7 +5,6 @@ import itertools
 import random
 import string
 import threading
-from collections.abc import Iterable, Iterator
 from functools import total_ordering, wraps
 from typing import TYPE_CHECKING, Optional, Union
 
@@ -30,14 +29,16 @@ from flexget.terminal import capture_console
 from flexget.utils import requests
 from flexget.utils.database import with_session
 from flexget.utils.simple_persistence import SimpleTaskPersistence
-from flexget.utils.sqlalchemy_utils import ContextSession
 from flexget.utils.template import FlexGetTemplate, render_from_task
 from flexget.utils.tools import MergeException, get_config_hash, merge_dict_from_to
 
 logger = logger.bind(name='task')
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
     from flexget.db_schema import VersionedBaseMeta
+    from flexget.utils.sqlalchemy_utils import ContextSession
 
     Base = VersionedBaseMeta
 else:
@@ -58,7 +59,7 @@ class TaskConfigHash(Base):
 
 
 @with_session
-def config_changed(task: Optional[str] = None, session: ContextSession = None) -> None:
+def config_changed(task: Optional[str] = None, session: 'ContextSession' = None) -> None:
     """Force config_modified flag to come out true on next run of `task`.
 
     Used when the db changes, and all entries need to be reprocessed.
@@ -94,13 +95,13 @@ def use_task_logging(func):
 class EntryIterator:
     """An iterator over a subset of entries to emulate old task.accepted/rejected/failed/entries properties."""
 
-    def __init__(self, entries: list[Entry], states: Union[EntryState, Iterable[EntryState]]):
+    def __init__(self, entries: list[Entry], states: Union[EntryState, 'Iterable[EntryState]']):
         self.all_entries = entries
         if isinstance(states, EntryState):
             states = [states]
         self.filter = lambda e: e._state in states
 
-    def __iter__(self) -> Iterator[Entry]:
+    def __iter__(self) -> 'Iterator[Entry]':
         return filter(self.filter, self.all_entries)
 
     def __bool__(self):
@@ -115,7 +116,7 @@ class EntryIterator:
     def __radd__(self, other):
         return itertools.chain(other, self)
 
-    def __getitem__(self, item) -> Union[Entry, Iterable[Entry]]:
+    def __getitem__(self, item) -> Union[Entry, 'Iterable[Entry]']:
         if isinstance(item, slice):
             return list(itertools.islice(self, item.start, item.stop))
         if not isinstance(item, int):

--- a/flexget/terminal.py
+++ b/flexget/terminal.py
@@ -1,9 +1,8 @@
 import contextlib
 import os
 import threading
-from collections.abc import Iterator
 from textwrap import wrap
-from typing import Any, Optional, TextIO, Union
+from typing import TYPE_CHECKING, Any, Optional, TextIO, Union
 
 import rich
 import rich.box
@@ -14,6 +13,9 @@ import rich.table
 import rich.text
 
 from flexget.options import ArgumentParser
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 local_context = threading.local()
 
@@ -216,7 +218,7 @@ def disable_colors():
 
 
 @contextlib.contextmanager
-def capture_console(filelike: TextIO) -> Iterator:
+def capture_console(filelike: TextIO) -> "Iterator":
     old_output = get_console_output()
     local_context.output = filelike
     try:

--- a/flexget/tests/conftest.py
+++ b/flexget/tests/conftest.py
@@ -1,4 +1,3 @@
-import argparse
 import itertools
 import logging
 import os
@@ -7,10 +6,9 @@ import shutil
 from contextlib import contextmanager, suppress
 from http import client
 from pathlib import Path
-from typing import Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 from unittest import mock
 
-import flask
 import jsonschema
 import pytest
 import requests
@@ -28,6 +26,11 @@ from flexget.manager import Manager, Session
 from flexget.plugin import load_plugins
 from flexget.task import Task, TaskAbort
 from flexget.webserver import User
+
+if TYPE_CHECKING:
+    import argparse
+
+    import flask
 
 logger = logger.bind(name='tests')
 
@@ -79,7 +82,7 @@ def execute_task(manager: Manager) -> Callable[..., Task]:
     def execute(
         task_name: str,
         abort: bool = False,
-        options: Optional[Union[dict, argparse.Namespace]] = None,
+        options: Optional[Union[dict, 'argparse.Namespace']] = None,
     ) -> Task:
         """Use to execute one test task from config.
 
@@ -160,10 +163,10 @@ def schema_match(manager) -> Callable[[dict, Any], list[dict]]:
 
 
 @pytest.fixture
-def link_headers(manager) -> Callable[[flask.Response], dict[str, dict]]:
+def link_headers(manager) -> Callable[['flask.Response'], dict[str, dict]]:
     """Parse link headers and return them in dict form."""
 
-    def headers(response: flask.Response) -> dict[str, dict]:
+    def headers(response: 'flask.Response') -> dict[str, dict]:
         links = {}
         for link in requests.utils.parse_header_links(response.headers.get('link')):
             url = link['url']
@@ -388,43 +391,43 @@ class APIClient:
 
         kwargs['headers'][key] = value
 
-    def json_post(self, *args, **kwargs) -> flask.Response:
+    def json_post(self, *args, **kwargs) -> 'flask.Response':
         self._append_header('Content-Type', 'application/json', kwargs)
         if kwargs.get('auth', True):
             self._append_header('Authorization', f'Token {self.api_key}', kwargs)
         return self.client.post(*args, **kwargs)
 
-    def json_put(self, *args, **kwargs) -> flask.Response:
+    def json_put(self, *args, **kwargs) -> 'flask.Response':
         self._append_header('Content-Type', 'application/json', kwargs)
         if kwargs.get('auth', True):
             self._append_header('Authorization', f'Token {self.api_key}', kwargs)
         return self.client.put(*args, **kwargs)
 
-    def json_patch(self, *args, **kwargs) -> flask.Response:
+    def json_patch(self, *args, **kwargs) -> 'flask.Response':
         self._append_header('Content-Type', 'application/json', kwargs)
         if kwargs.get('auth', True):
             self._append_header('Authorization', f'Token {self.api_key}', kwargs)
         return self.client.patch(*args, **kwargs)
 
-    def get(self, *args, **kwargs) -> flask.Response:
+    def get(self, *args, **kwargs) -> 'flask.Response':
         if kwargs.get('auth', True):
             self._append_header('Authorization', f'Token {self.api_key}', kwargs)
 
         return self.client.get(*args, **kwargs)
 
-    def delete(self, *args, **kwargs) -> flask.Response:
+    def delete(self, *args, **kwargs) -> 'flask.Response':
         if kwargs.get('auth', True):
             self._append_header('Authorization', f'Token {self.api_key}', kwargs)
 
         return self.client.delete(*args, **kwargs)
 
-    def json_delete(self, *args, **kwargs) -> flask.Response:
+    def json_delete(self, *args, **kwargs) -> 'flask.Response':
         self._append_header('Content-Type', 'application/json', kwargs)
         if kwargs.get('auth', True):
             self._append_header('Authorization', f'Token {self.api_key}', kwargs)
         return self.client.delete(*args, **kwargs)
 
-    def head(self, *args, **kwargs) -> flask.Response:
+    def head(self, *args, **kwargs) -> 'flask.Response':
         if kwargs.get('auth', True):
             self._append_header('Authorization', f'Token {self.api_key}', kwargs)
 

--- a/flexget/tests/sftp/conftest.py
+++ b/flexget/tests/sftp/conftest.py
@@ -1,21 +1,24 @@
 from importlib.util import find_spec
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 if find_spec('paramiko'):
     from flexget.tests.sftp.test_sftp_server import TestSFTPServerController
 
 
 @pytest.fixture
-def sftp_root(tmp_path: Path):
+def sftp_root(tmp_path: 'Path'):
     sftp_root = tmp_path / 'sftp_root'
     sftp_root.mkdir()
     return sftp_root
 
 
 @pytest.fixture
-def sftp(sftp_root: Path):
+def sftp(sftp_root: 'Path'):
     test_server = TestSFTPServerController(sftp_root)
     yield test_server
     test_server.kill()

--- a/flexget/utils/bittorrent.py
+++ b/flexget/utils/bittorrent.py
@@ -4,11 +4,13 @@
 # Test scripts and other short code fragments can be considered as being in the public domain.
 import binascii
 import re
-from collections.abc import Generator, Iterator
 from contextlib import suppress
-from typing import Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from loguru import logger
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterator
 
 logger = logger.bind(name='torrent')
 
@@ -103,7 +105,7 @@ def is_torrent_file(metafilepath: str) -> bool:
 def tokenize(
     text: bytes,
     match=re.compile(rb'([idel])|(\d+):|(-?\d+)').match,  # type: Callable[[bytes, int], Match[bytes]]
-) -> Generator[bytes, None, None]:
+) -> 'Generator[bytes, None, None]':
     i = 0
     while i < len(text):
         m = match(text, i)
@@ -117,7 +119,7 @@ def tokenize(
             yield s
 
 
-def decode_item(src_iter: Iterator[bytes], token: bytes) -> Union[bytes, str, int, list, dict]:
+def decode_item(src_iter: 'Iterator[bytes]', token: bytes) -> Union[bytes, str, int, list, dict]:
     data: Union[bytes, str, int, list, dict]
     if token == b'i':
         # integer: "i" value "e"

--- a/flexget/utils/cached_input.py
+++ b/flexget/utils/cached_input.py
@@ -1,6 +1,5 @@
 import copy
 import pickle
-from collections.abc import Iterable
 from datetime import datetime, timedelta
 from functools import partial
 from typing import TYPE_CHECKING, Callable, Optional
@@ -23,6 +22,7 @@ from flexget.utils.tools import TimedDict, get_config_hash, parse_timedelta
 logger = logger.bind(name='input_cache')
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
 
     class Base:
         def __init__(self, *args, **kwargs) -> None: ...
@@ -221,7 +221,9 @@ class IterableCache:
     If `finished_hook` is supplied, it will be called the first time the iterable is run to the end.
     """
 
-    def __init__(self, iterable: Iterable, finished_hook: Optional[Callable[[list], None]] = None):
+    def __init__(
+        self, iterable: 'Iterable', finished_hook: Optional[Callable[[list], None]] = None
+    ):
         self.iterable = iter(iterable)
         self.cache: list = []
         self.finished_hook = finished_hook

--- a/flexget/utils/log.py
+++ b/flexget/utils/log.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Optional
 
 from loguru import logger
 from sqlalchemy import Column, DateTime, Index, Integer, String
-from sqlalchemy.orm import Session
 
 from flexget import db_schema
 from flexget.event import event
@@ -17,6 +16,7 @@ logger = logger.bind(name='util.log')
 
 if TYPE_CHECKING:
     import loguru
+    from sqlalchemy.orm import Session
 
     Base = object
 else:
@@ -24,7 +24,7 @@ else:
 
 
 @db_schema.upgrade('log_once')
-def upgrade(ver: Optional[int], session: Session):
+def upgrade(ver: Optional[int], session: 'Session'):
     if ver is None:
         logger.info('Adding index to md5sum column of log_once table.')
         table = table_schema('log_once', session)
@@ -50,7 +50,7 @@ class LogMessage(Base):
 
 
 @event('manager.db_cleanup')
-def purge(manager, session: Session) -> None:
+def purge(manager, session: 'Session') -> None:
     """Purge old messages from database."""
     old = datetime.now() - timedelta(days=365)
 
@@ -65,7 +65,7 @@ def log_once(
     logger: Optional['loguru.Logger'] = None,
     once_level: str = 'INFO',
     suppressed_level: str = 'VERBOSE',
-    session: Session = None,
+    session: 'Session' = None,
 ) -> Optional[bool]:
     """Log message only once using given logger`.
 

--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -1,12 +1,14 @@
 import copy
 import functools
 import re
-from collections.abc import Iterator
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from loguru import logger
 
 from flexget.utils.serialization import Serializer
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 logger = logger.bind(name='utils.qualities')
 
@@ -188,7 +190,7 @@ for items in (_resolutions, _sources, _codecs, _color_ranges, _audios):
         _registry[item.name] = item
 
 
-def all_components() -> Iterator[QualityComponent]:
+def all_components() -> 'Iterator[QualityComponent]':
     return iter(_registry.values())
 
 

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -4,7 +4,6 @@ import time
 
 # Allow some request objects to be imported from here instead of requests
 import warnings
-from collections.abc import Mapping
 from datetime import datetime, timedelta
 from email.message import EmailMessage
 from typing import TYPE_CHECKING, Optional, Union
@@ -32,6 +31,7 @@ WAIT_TIME = timedelta(seconds=60)
 unresponsive_hosts = TimedDict(WAIT_TIME)
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from typing import TypedDict
 
     class StateCacheDict(TypedDict):
@@ -177,7 +177,7 @@ def limit_domains(url: str, limit_dict: dict[str, DomainLimiter]) -> None:
             break
 
 
-def parse_header(header: str) -> tuple[str, Mapping]:
+def parse_header(header: str) -> tuple[str, 'Mapping']:
     """Parse a MIME header (such as Content-Type) into a main value and a dictionary of parameters.
 
     Replaces function in the deprecated cgi stdlib module.

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -2,7 +2,6 @@ import locale
 import os
 import os.path
 import re
-from collections.abc import Mapping
 from contextlib import suppress
 from copy import copy
 from datetime import date, datetime, time
@@ -32,6 +31,8 @@ from flexget.utils.pathscrub import pathscrub
 from flexget.utils.tools import format_filesize, parse_filesize, split_title_year
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from flexget.entry import Entry
     from flexget.manager import Manager
     from flexget.task import Task
@@ -372,7 +373,7 @@ def get_template(template_name: str, scope: Optional[str] = 'task') -> FlexGetTe
     raise ValueError(err)
 
 
-def render(template: Union[FlexGetTemplate, str], context: Mapping, native: bool = False) -> str:
+def render(template: Union[FlexGetTemplate, str], context: 'Mapping', native: bool = False) -> str:
     """Render a Template with `context` as its context.
 
     :param template: Template or template string to render.
@@ -430,7 +431,7 @@ def render_from_task(template: Union[FlexGetTemplate, str], task: 'Task') -> str
     return render(template, variables)
 
 
-def evaluate_expression(expression: str, context: Mapping) -> Any:
+def evaluate_expression(expression: str, context: 'Mapping') -> Any:
     """Evaluate a jinja `expression` using a given `context` with support for `LazyDict`s (`Entry`s.).
 
     :param str expression:  A jinja expression to evaluate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,6 +206,9 @@ ignore = [
     "TRY400", # error-instead-of-exception
 ]
 
+[tool.ruff.lint.flake8-type-checking]
+quote-annotations = true
+
 [tool.ruff.lint.isort]
 known-first-party = ['flexget']
 

--- a/scripts/build_locked_extras.py
+++ b/scripts/build_locked_extras.py
@@ -1,15 +1,17 @@
 import os
 import subprocess
 import sys
-from collections.abc import MutableMapping
 from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from hatchling.metadata.plugin.interface import MetadataHookInterface
 
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
 
 def update_metadata_with_locked(
-    metadata: MutableMapping[str, Any], root: Path, groups: Optional[list[str]] = None
+    metadata: "MutableMapping[str, Any]", root: Path, groups: Optional[list[str]] = None
 ) -> None:  # pragma: no cover
     """Inplace update the metadata(pyproject.toml) with the locked dependencies.
 

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -8,10 +8,12 @@
 import collections
 import re
 import sys
-from collections.abc import Generator, Iterable
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from git import Repo
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
 
 
 class MDChangeSet:
@@ -75,7 +77,7 @@ class MDChangeSet:
                 return cat_item[0]
         return None
 
-    def to_md_lines(self) -> Generator[str, None, None]:
+    def to_md_lines(self) -> 'Generator[str, None, None]':
         """Return an iterator over the markdown lines representing this changeset."""
         yield from self.pre_header
         yield self.version_header
@@ -87,8 +89,8 @@ class MDChangeSet:
 
 
 def isplit(
-    start_text: str, iterator: Iterable[str]
-) -> tuple[list[str], Optional[str], Iterable[str]]:
+    start_text: str, iterator: 'Iterable[str]'
+) -> tuple[list[str], Optional[str], 'Iterable[str]']:
     """Return head, match, tail tuple, where match is the first line that starts with `start_text`."""
     head: list[str] = []
     iterator = iter(iterator)


### PR DESCRIPTION
### Motivation for changes:
Placing type-checking-only imports behind `if TYPE_CHECKING:` reduces runtime overhead, prevents circular imports, lowers memory usage, and improves code readability. It ensures that type hints are available for static analysis tools like `mypy` while avoiding unnecessary imports during execution. This approach also helps with forward references and keeps runtime dependencies minimal, making the codebase more efficient and maintainable.

