### PR TITLE
Adopt the `PTH` rules (Replace `os.path` with `pathlib`)

### DIFF
--- a/flexget/__init__.py
+++ b/flexget/__init__.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from typing import TYPE_CHECKING, Optional
 
@@ -50,7 +49,7 @@ def main(args: Optional['Sequence[str]'] = None):
                     'manager.start()',
                     globals(),
                     locals(),
-                    os.path.join(manager.config_base, manager.options.profile),
+                    str(manager.config_base / manager.options.profile),
                 )
             else:
                 manager.start()

--- a/flexget/api/app.py
+++ b/flexget/api/app.py
@@ -1,9 +1,9 @@
 import json
-import os
 import re
 from collections import deque
 from contextlib import suppress
 from functools import partial, wraps
+from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Optional, Union
 
 from flask import Flask, Request, Response, jsonify, make_response, request
@@ -203,7 +203,7 @@ class API(RestxAPI):
         return pagination
 
 
-api_app = Flask(__name__, template_folder=os.path.join(__path__[0], 'templates'))
+api_app = Flask(__name__, template_folder=Path(__path__[0]) / 'templates')
 api_app.config['REMEMBER_COOKIE_NAME'] = 'flexget.token'
 api_app.config['DEBUG'] = True
 api_app.config['RESTX_ERROR_404_HELP'] = False

--- a/flexget/components/archives/archives.py
+++ b/flexget/components/archives/archives.py
@@ -48,7 +48,7 @@ class FilterArchives:
 
         for entry in task.entries:
             archive_path = entry.get('location', '')
-            entry.accept() if utils.is_archive(str(archive_path)) else entry.reject()
+            entry.accept() if utils.is_archive(archive_path) else entry.reject()
 
 
 @event('plugin.register')

--- a/flexget/components/archives/decompress.py
+++ b/flexget/components/archives/decompress.py
@@ -1,5 +1,6 @@
 import os
 import re
+from pathlib import Path
 
 from loguru import logger
 
@@ -26,7 +27,7 @@ def open_archive_entry(entry):
     if not archive_path:
         logger.error('Entry does not appear to represent a local file.')
         return None
-    if not os.path.exists(archive_path):
+    if not Path(archive_path).exists():
         logger.error('File no longer exists: {}', entry['location'])
         return None
     try:
@@ -41,17 +42,17 @@ def open_archive_entry(entry):
         return archive
 
 
-def get_output_path(to, entry):
+def get_output_path(to: str, entry) -> Path:
     """Determine which path to output to."""
     try:
         if to:
-            return render_from_entry(to, entry)
-        return os.path.dirname(entry.get('location'))
+            return Path(render_from_entry(to, entry))
+        return Path(entry.get('location')).parent
     except RenderError:
         raise plugin.PluginError(f'Could not render path: {to}')
 
 
-def extract_info(info, archive, to, keep_dirs, test=False):
+def extract_info(info, archive, to: Path, keep_dirs, test=False):
     """Extract ArchiveInfo object."""
     destination = get_destination_path(info, to, keep_dirs)
 
@@ -69,11 +70,10 @@ def extract_info(info, archive, to, keep_dirs, test=False):
         logger.error('Failed to extract file: {} from {} ({})', info.filename, archive.path, error)
 
 
-def get_destination_path(info, to, keep_dirs):
+def get_destination_path(info, to: Path, keep_dirs) -> Path:
     """Generate the destination path for a given file."""
     path_suffix = info.path if keep_dirs else os.path.basename(info.path)
-
-    return os.path.join(to, path_suffix)
+    return to / path_suffix
 
 
 def is_match(info, pattern):

--- a/flexget/components/bittorrent/torrent.py
+++ b/flexget/components/bittorrent/torrent.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 from loguru import logger
 
@@ -25,19 +25,19 @@ class TorrentFilename:
             if 'file' not in entry:
                 logger.trace("{} doesn't have a file associated", entry['title'])
                 continue
-            if not os.path.exists(entry['file']):
+            if not Path(entry['file']).exists():
                 logger.debug('File {} does not exist', entry['file'])
                 continue
-            if os.path.getsize(entry['file']) == 0:
+            if Path(entry['file']).stat().st_size == 0:
                 logger.debug('File {} is 0 bytes in size', entry['file'])
                 continue
-            if not is_torrent_file(entry['file']):
+            if not is_torrent_file(Path(entry['file'])):
                 continue
             logger.debug('{} seems to be a torrent', entry['title'])
 
             # create torrent object from torrent
             try:
-                with open(entry['file'], 'rb') as f:
+                with Path(entry['file']).open('rb') as f:
                     # NOTE: this reads entire file into memory, but we're pretty sure it's
                     # a small torrent file since it starts with TORRENT_RE
                     data = f.read()
@@ -78,7 +78,7 @@ class TorrentFilename:
             if 'torrent' in entry and entry['torrent'].modified:
                 # re-write data into a file
                 logger.debug('Writing modified torrent file for {}', entry['title'])
-                with open(entry['file'], 'wb+') as f:
+                with Path(entry['file']).open('wb+') as f:
                     f.write(entry['torrent'].encode())
 
     def make_filename(self, torrent, entry):
@@ -104,9 +104,9 @@ class TorrentFilename:
         return fn
 
     def purge(self, entry):
-        if os.path.exists(entry['file']):
+        if Path(entry['file']).exists():
             logger.debug('removing temp file {} from {}', entry['file'], entry['title'])
-            os.remove(entry['file'])
+            Path(entry['file']).unlink()
         del entry['file']
 
 

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -223,8 +223,8 @@ class Manager:
             raise RuntimeError('Cannot call initialize on an already initialized manager.')
 
         plugin.load_plugins(
-            extra_plugins=[os.path.join(self.config_base, 'plugins')],
-            extra_components=[os.path.join(self.config_base, 'components')],
+            extra_plugins=[self.config_base / 'plugins'],
+            extra_components=[self.config_base / 'components'],
         )
 
         # Reparse CLI options now that plugins are loaded

--- a/flexget/plugin.py
+++ b/flexget/plugin.py
@@ -373,29 +373,29 @@ class PluginInfo(dict):
 register = PluginInfo
 
 
-def _get_standard_plugins_path() -> list[str]:
+def _get_standard_plugins_path() -> list[Path]:
     """Return list of directories where traditional plugins should be tried to load from."""
     # Get basic path from environment
     paths = []
     env_path = os.environ.get('FLEXGET_PLUGIN_PATH')
     if env_path:
-        paths = env_path.split(os.pathsep)
+        paths = [Path(path) for path in env_path.split(os.pathsep)]
 
     # Add flexget.plugins directory (core plugins)
-    paths.append(os.path.abspath(os.path.dirname(plugins_pkg.__file__)))
+    paths.append(Path(plugins_pkg.__file__).parent.resolve())
     return paths
 
 
-def _get_standard_components_path() -> list[str]:
+def _get_standard_components_path() -> list[Path]:
     """Return list of directories where component plugins should be tried to load from."""
     # Get basic path from environment
     paths = []
     env_path = os.environ.get('FLEXGET_COMPONENT_PATH')
     if env_path:
-        paths = env_path.split(os.pathsep)
+        paths = [Path(path) for path in env_path.split(os.pathsep)]
 
     # Add flexget.plugins directory (core plugins)
-    paths.append(os.path.abspath(os.path.dirname(components_pkg.__file__)))
+    paths.append(Path(components_pkg.__file__).parent.resolve())
     return paths
 
 
@@ -441,10 +441,10 @@ def _import_plugin(module_name: str, plugin_path: Union[str, Path]) -> None:
         logger.trace('Loaded module {} from {}', module_name, plugin_path)
 
 
-def _load_plugins_from_dirs(dirs: list[str]) -> None:
+def _load_plugins_from_dirs(dirs: list[Path]) -> None:
     """:param list dirs: Directories from where plugins are loaded from"""
     logger.debug('Trying to load plugins from: {}', dirs)
-    dir_paths = [Path(d) for d in dirs if os.path.isdir(d)]
+    dir_paths = [d for d in dirs if d.is_dir()]
     # add all dirs to plugins_pkg load path so that imports work properly from any of the plugin dirs
     plugins_pkg.__path__ = [str(d) for d in dir_paths]
     for plugins_dir in dir_paths:
@@ -461,10 +461,10 @@ def _load_plugins_from_dirs(dirs: list[str]) -> None:
 
 
 # TODO: this is now identical to _load_plugins_from_dirs, REMOVE
-def _load_components_from_dirs(dirs: list[str]) -> None:
+def _load_components_from_dirs(dirs: list[Path]) -> None:
     """:param list dirs: Directories where plugin components are loaded from"""
     logger.debug('Trying to load components from: {}', dirs)
-    dir_paths = [Path(d) for d in dirs if os.path.isdir(d)]
+    dir_paths = [d for d in dirs if d.is_dir()]
     for component_dir in dir_paths:
         for component_path in component_dir.glob('**/*.py'):
             if component_path.name == '__init__.py':
@@ -515,7 +515,7 @@ def _load_plugins_from_packages() -> None:
 
 
 def load_plugins(
-    extra_plugins: Optional[list[str]] = None, extra_components: Optional[list[str]] = None
+    extra_plugins: Optional[list[Path]] = None, extra_components: Optional[list[Path]] = None
 ) -> None:
     """Load plugins from the standard plugin and component paths.
 

--- a/flexget/plugins/cli/debug_info.py
+++ b/flexget/plugins/cli/debug_info.py
@@ -9,7 +9,7 @@ from flexget.utils.tools import io_encoding
 
 
 def print_debug_info(manager, options):
-    install_location = Path(__file__).absolute().parent.parent.parent
+    install_location = Path(__file__).absolute().parents[2]
     console(f'FlexGet Version: {flexget.__version__}')
     console(f'Install location: {install_location}')
     console(f'Config location: {manager.config_path}')

--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -2,6 +2,7 @@ import os
 import re
 import socket
 from io import BytesIO
+from pathlib import Path
 from time import sleep
 from urllib.parse import urljoin, urlparse, urlsplit
 from xmlrpc import client as xmlrpc_client
@@ -672,7 +673,7 @@ class RTorrentOutputPlugin(RTorrentPluginBase):
                 raise plugin.PluginError('Temporary download file is missing from disk')
 
             # Verify valid torrent file
-            if not is_torrent_file(entry['file']):
+            if not is_torrent_file(Path(entry['file'])):
                 entry.fail("Downloaded temp file '{}' is not a torrent file".format(entry['file']))
                 return
 

--- a/flexget/plugins/input/filesystem.py
+++ b/flexget/plugins/input/filesystem.py
@@ -110,7 +110,7 @@ class Filesystem:
         filepath = filepath.absolute()
         entry = Entry()
         entry['location'] = str(filepath)
-        entry['url'] = Path(filepath).absolute().as_uri()
+        entry['url'] = filepath.absolute().as_uri()
         entry['filename'] = filepath.name
         if filepath.is_file():
             entry['title'] = filepath.stem

--- a/flexget/plugins/operate/formlogin.py
+++ b/flexget/plugins/operate/formlogin.py
@@ -1,4 +1,3 @@
-import os
 import socket
 
 import requests
@@ -71,11 +70,11 @@ class FormLogin:
                 except mechanicalsoup.LinkNotFoundError:
                     pass
             else:
-                received = os.path.join(task.manager.config_base, 'received')
-                if not os.path.isdir(received):
-                    os.mkdir(received)
-                filename = os.path.join(received, f'{task.name}.formlogin.html')
-                with open(filename, 'wb') as f:
+                received = task.manager.config_base / 'received'
+                if not received.is_dir():
+                    received.mkdir()
+                filename = received / f'{task.name}.formlogin.html'
+                with filename.open('wb') as f:
                     f.write(response.content)
                 logger.critical(
                     'I have saved the login page content to {} for you to view', filename

--- a/flexget/plugins/operate/include.py
+++ b/flexget/plugins/operate/include.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import yaml
 from loguru import logger
@@ -34,10 +34,10 @@ class PluginInclude:
             files = [config]
 
         for file_name in files:
-            file = os.path.expanduser(file_name)
-            if not os.path.isabs(file):
-                file = os.path.join(task.manager.config_base, file)
-            with open(file, encoding='utf-8') as inc_file:
+            file = Path(file_name).expanduser()
+            if not file.is_absolute():
+                file = task.manager.config_base / file
+            with file.open(encoding='utf-8') as inc_file:
                 include = yaml.safe_load(inc_file)
                 inc_file.flush()
             errors = process_config(include, plugin.plugin_schemas(interface='task'))

--- a/flexget/tests/exec.py
+++ b/flexget/tests/exec.py
@@ -5,21 +5,21 @@ A file will be created in the output directory with the given filename.
 If there are more arguments to the script, they will be written 1 per line to the file.
 """
 
-import os
 import sys
+from pathlib import Path
 
 if __name__ == "__main__":
     # Make sure we have an output folder argument
     if len(sys.argv) < 3:
         print("exec.py must have parameter for output directory and filename")
         sys.exit(1)
-    out_dir = sys.argv[1]
+    out_dir = Path(sys.argv[1])
     filename = sys.argv[2]
     # Make sure the output folder exists
-    if not os.path.exists(out_dir):
+    if not out_dir.exists():
         print(f"output dir {sys.argv[1]} does not exist")
         sys.exit(1)
 
-    with open(os.path.join(out_dir, filename), 'w') as outfile:
+    with (out_dir / filename).open('w') as outfile:
         for arg in sys.argv[3:]:
             outfile.write(arg + '\n')

--- a/flexget/tests/sftp/test_sftp_server.py
+++ b/flexget/tests/sftp/test_sftp_server.py
@@ -127,7 +127,7 @@ else:
             """
             canonicalized: Path = self.canonicalize(path)
             canonicalized.parent.mkdir(parents=True, exist_ok=True)
-            with open(canonicalized, 'wb') as file:
+            with canonicalized.open('wb') as file:
                 file.write(b'\0' * size)
             return canonicalized
 
@@ -173,7 +173,7 @@ else:
             canonicalized: Path
             if PurePosixPath(path).is_absolute():
                 path = path[1:]
-                canonicalized = Path(posixpath.normpath((self.__root / path).as_posix()))
+                canonicalized = Path(posixpath.normpath(self.__root / path))
             else:
                 canonicalized = Path(posixpath.normpath((self.__cwd or self.__home) / path))
 
@@ -300,9 +300,7 @@ else:
             try:
                 out = []
                 for filename in os.listdir(canonicalized_path):
-                    attr = SFTPAttributes.from_stat(
-                        os.stat(os.path.join(canonicalized_path, filename))
-                    )
+                    attr = SFTPAttributes.from_stat((canonicalized_path / filename).stat())
                     attr.filename = filename
                     out.append(attr)
             except OSError as e:
@@ -313,7 +311,7 @@ else:
             logger.debug('stat(%s)', path)
 
             try:
-                return SFTPAttributes.from_stat(os.stat(self.__fs.canonicalize(path)))
+                return SFTPAttributes.from_stat(self.__fs.canonicalize(path).stat())
             except OSError as e:
                 return TestSFTPServer.log_and_return_error_code(e)
 

--- a/flexget/tests/sftp/test_sftp_upload.py
+++ b/flexget/tests/sftp/test_sftp_upload.py
@@ -151,7 +151,7 @@ class TestSftpDownload:
     def create_file(root: Path, path: str, size: int = 0) -> Path:
         file_path = root / path
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(file_path, 'wb') as file:
+        with file_path.open('wb') as file:
             file.write(b'\0' * size)
         return file_path
 

--- a/flexget/tests/test_cached_input.py
+++ b/flexget/tests/test_cached_input.py
@@ -38,8 +38,8 @@ class TestInputCache:
         """Test memory input caching."""
         task = execute_task('test_memory')
         assert task.entries, 'should have created entries at the start'
-        tmp_path.joinpath('cached.xml').unlink()
-        tmp_path.joinpath('cached.xml').write_text('')
+        (tmp_path / 'cached.xml').unlink()
+        (tmp_path / 'cached.xml').write_text('')
         task = execute_task('test_memory')
         assert task.entries, 'should have created entries from the cache'
         # Turn the cache time down and run again to make sure the entries are not created again

--- a/flexget/tests/test_config.py
+++ b/flexget/tests/test_config.py
@@ -1,10 +1,10 @@
-import os
+from pathlib import Path
 
 import pytest
 
 from flexget.manager import Manager
 
-config_utf8 = os.path.join(os.path.dirname(__file__), 'config_utf8.yml')
+config_utf8 = Path(__file__).parent / 'config_utf8.yml'
 
 
 class TestConfig:

--- a/flexget/tests/test_couchpotato_list.py
+++ b/flexget/tests/test_couchpotato_list.py
@@ -1,18 +1,15 @@
 import json
-import os
+from pathlib import Path
 from unittest import mock
 
-movie_list_file = os.path.join(
-    os.path.dirname(__file__), 'couchpotato_movie_list_test_response.json'
-)
-qualities_profiles_file = os.path.join(
-    os.path.dirname(__file__), 'couchpotato_quality_profile_test_response.json'
-)
+movie_list_file = Path(__file__).parent / 'couchpotato_movie_list_test_response.json'
+qualities_profiles_file = Path(__file__).parent / 'couchpotato_quality_profile_test_response.json'
 
-with open(movie_list_file, encoding='utf-8') as data:
+
+with movie_list_file.open(encoding='utf-8') as data:
     movie_list_response = json.load(data)
 
-with open(qualities_profiles_file) as data:
+with qualities_profiles_file.open() as data:
     qualities_response = json.load(data)
 
 

--- a/flexget/tests/test_decompress.py
+++ b/flexget/tests/test_decompress.py
@@ -1,4 +1,4 @@
-import os.path
+from pathlib import Path
 
 import pytest
 
@@ -77,12 +77,12 @@ class TestExtract:
     out_file = 'hooray.txt'
 
     # Directories
-    source_dir = 'archives'
-    out_dir = 'directory'
+    source_dir = Path('archives')
+    out_dir = Path('directory')
 
     # Paths
-    rar_path = os.path.join(source_dir, rar_name)
-    zip_path = os.path.join(source_dir, zip_name)
+    rar_path = source_dir / rar_name
+    zip_path = source_dir / zip_name
 
     # Error messages
     error_not_local = 'Entry does not appear to represent a local file.'
@@ -93,31 +93,31 @@ class TestExtract:
         """Test basic RAR extraction."""
         execute_task('test_rar')
 
-        assert tmp_path.joinpath(self.out_file).exists(), (
+        assert (tmp_path / self.out_file).exists(), (
             'Output file does not exist at the correct path.'
         )
-        assert tmp_path.joinpath(self.rar_name).exists(), 'RAR archive should still exist.'
+        assert (tmp_path / self.rar_name).exists(), 'RAR archive should still exist.'
 
     @pytest.mark.filecopy(rar_path, '__tmp__')
     def test_delete_rar(self, execute_task, tmp_path):
         """Test RAR deletion after extraction."""
         execute_task('test_delete_rar')
-        assert not tmp_path.joinpath(self.rar_name).exists(), 'RAR archive was not deleted.'
+        assert not (tmp_path / self.rar_name).exists(), 'RAR archive was not deleted.'
 
     @pytest.mark.filecopy(zip_path, '__tmp__')
     def test_zip(self, execute_task, tmp_path):
         """Test basic Zip extraction."""
         execute_task('test_zip')
-        assert tmp_path.joinpath(self.out_file).exists(), (
+        assert (tmp_path / self.out_file).exists(), (
             'Output file does not exist at the correct path.'
         )
-        assert tmp_path.joinpath(self.zip_name).exists(), 'Zip archive should still exist.'
+        assert (tmp_path / self.zip_name).exists(), 'Zip archive should still exist.'
 
     @pytest.mark.filecopy(zip_path, '__tmp__')
     def test_keep_dirs(self, execute_task, tmp_path):
         """Test directory creation."""
         execute_task('test_keep_dirs')
-        assert tmp_path.joinpath(self.out_dir, self.out_file).exists(), (
+        assert (tmp_path / self.out_dir / self.out_file).exists(), (
             'Output file does not exist at the correct path.'
         )
 
@@ -125,7 +125,7 @@ class TestExtract:
     def test_delete_zip(self, execute_task, tmp_path):
         """Test Zip deletion after extraction."""
         execute_task('test_delete_zip')
-        assert not tmp_path.joinpath(self.zip_name).exists(), 'Zip archive was not deleted.'
+        assert not (tmp_path / self.zip_name).exists(), 'Zip archive was not deleted.'
 
     def test_empty_path(self, execute_task, caplog):
         """Test when an empty location is provided."""

--- a/flexget/tests/test_download.py
+++ b/flexget/tests/test_download.py
@@ -38,13 +38,13 @@ class TestDownload:
 
     @pytest.fixture
     def config(self, tmp_path):
-        temp_path_1 = tmp_path.joinpath('temp_path_1')
+        temp_path_1 = tmp_path / 'temp_path_1'
         temp_path_1.mkdir()
-        temp_path_2 = tmp_path.joinpath('temp_path_2')
+        temp_path_2 = tmp_path / 'temp_path_2'
         temp_path_2.mkdir()
 
         return Template(self._config).render(
-            {'temp_path_1': temp_path_1.as_posix(), 'temp_path_2': temp_path_2.as_posix()}
+            {'temp_path_1': temp_path_1, 'temp_path_2': temp_path_2}
         )
 
     def test_path_and_temp(self, execute_task):

--- a/flexget/tests/test_exec.py
+++ b/flexget/tests/test_exec.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 import pytest
@@ -46,14 +45,14 @@ class TestExec:
         task = execute_task('replace_from_entry')
         assert len(task.accepted) == 2, "not all entries were accepted"
         for entry in task.accepted:
-            assert tmp_path.joinpath(entry['title']).exists(), (
+            assert (tmp_path / entry['title']).exists(), (
                 "exec.py did not create a file for {}".format(entry['title'])
             )
 
     def test_adv_format(self, execute_task, tmp_path):
         task = execute_task('test_adv_format')
         for entry in task.accepted:
-            with tmp_path.joinpath(entry['title']).open('r') as infile:
+            with (tmp_path / entry['title']).open('r') as infile:
                 line = infile.readline().rstrip('\n')
                 assert line == '/path/with spaces', f'{line} != /path/with spaces'
                 line = infile.readline().rstrip('\n')
@@ -70,7 +69,7 @@ class TestExec:
     def test_auto_escape(self, execute_task):
         task = execute_task('test_auto_escape')
         for entry in task.accepted:
-            with open(os.path.join(self.__tmp__, entry['title'])) as infile:
+            with (self.__tmp__ / entry['title']).open() as infile:
                 line = infile.readline().rstrip('\n')
                 assert line == 'single \' double"', f'{line} != single \' double"'
                 line = infile.readline().rstrip('\n')

--- a/flexget/tests/test_exists_movie.py
+++ b/flexget/tests/test_exists_movie.py
@@ -100,14 +100,14 @@ class TestExistsMovie:
     def config(self, request, tmp_path):
         """Override and parametrize default config fixture for all series tests."""
         for test_dir in self.test_dirs:
-            tmp_path.joinpath(test_dir).mkdir()
+            (tmp_path / test_dir).mkdir()
         # create test files
         for test_file in self.test_files:
-            tmp_path.joinpath(test_file).write_text('')
+            (tmp_path / test_file).write_text('')
         return (
             Template(self._config)
             .render({'parser': request.param})
-            .replace('__tmp__', tmp_path.as_posix())
+            .replace('__tmp__', str(tmp_path))
         )
 
     def test_existing_dirs(self, execute_task):

--- a/flexget/tests/test_exists_series.py
+++ b/flexget/tests/test_exists_series.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 
@@ -103,10 +101,8 @@ class TestExistsSeries:
     def config(self, request, tmp_path):
         """Override and parametrize default config fixture for all series tests."""
         for test_dir in self.test_dirs:
-            os.makedirs(tmp_path.joinpath(test_dir).as_posix())
-        return self._config.replace('__parser__', request.param).replace(
-            '__tmp__', tmp_path.as_posix()
-        )
+            (tmp_path / test_dir).mkdir(parents=True)
+        return self._config.replace('__parser__', request.param).replace('__tmp__', str(tmp_path))
 
     def test_existing(self, execute_task):
         """Exists_series plugin: existing."""

--- a/flexget/tests/test_include.py
+++ b/flexget/tests/test_include.py
@@ -13,10 +13,10 @@ class TestInclude:
 
     @pytest.fixture
     def config(self, tmp_path):
-        test_dir = tmp_path.joinpath('include')
+        test_dir = tmp_path / 'include'
         test_dir.mkdir()
-        file_1 = test_dir.joinpath('foo.yml')
-        file_2 = test_dir.joinpath('baz.yml')
+        file_1 = test_dir / 'foo.yml'
+        file_2 = test_dir / 'baz.yml'
         file_1.write_text(
             """
             mock:
@@ -29,9 +29,7 @@ class TestInclude:
             - title: baz
         """
         )
-        return Template(self._config).render(
-            {'tmpfile_1': file_1.as_posix(), 'tmpfile_2': file_2.as_posix()}
-        )
+        return Template(self._config).render({'tmpfile_1': file_1, 'tmpfile_2': file_2})
 
     def test_include(self, execute_task):
         task = execute_task('include_test')
@@ -50,16 +48,16 @@ class TestIncludeChange:
 
     @pytest.fixture
     def config(self, tmp_path):
-        test_dir = tmp_path.joinpath('include')
+        test_dir = tmp_path / 'include'
         test_dir.mkdir()
-        file_1 = test_dir.joinpath('foo.yml')
+        file_1 = test_dir / 'foo.yml'
         file_1.write_text(
             """
             mock:
             - title: foo
         """
         )
-        return Template(self._config).render({'tmpfile_1': file_1.as_posix()})
+        return Template(self._config).render({'tmpfile_1': file_1})
 
     def test_include_update(self, execute_task, manager, tmp_path):
         task = execute_task('include_test')
@@ -71,16 +69,16 @@ class TestIncludeChange:
         assert not task.config_modified
 
         # Change file name
-        test_dir = tmp_path.joinpath('include_changed')
+        test_dir = tmp_path / 'include_changed'
         test_dir.mkdir()
-        file_1 = test_dir.joinpath('foo.yml')
+        file_1 = test_dir / 'foo.yml'
         file_1.write_text(
             """
             mock:
             - title: foo_change_1
         """
         )
-        new_file = Template('{{ tmpfile_1 }}').render({'tmpfile_1': file_1.as_posix()})
+        new_file = Template('{{ tmpfile_1 }}').render({'tmpfile_1': file_1})
         manager.config['tasks']['include_test']['include'].pop()
         manager.config['tasks']['include_test']['include'].append(new_file)
 

--- a/flexget/tests/test_migrate.py
+++ b/flexget/tests/test_migrate.py
@@ -14,8 +14,7 @@ class TestMigrate:
 
     @pytest.mark.filecopy('db-r1042.sqlite', '__tmp__/upgrade_test.sqlite')
     def test_upgrade(self, request, tmp_path):
-        db_filename = tmp_path.joinpath('upgrade_test.sqlite')
-        filename = db_filename.as_posix()
+        filename = tmp_path / 'upgrade_test.sqlite'
         database_uri = f'sqlite:///{filename}'
         # This will raise an error if the upgrade wasn't successful
         mockmanager = MockManager(

--- a/flexget/tests/test_misc.py
+++ b/flexget/tests/test_misc.py
@@ -2,6 +2,7 @@ import datetime
 import os
 import stat
 import time
+from pathlib import Path
 
 import pendulum
 import pytest
@@ -135,9 +136,9 @@ class TestDownload:
         # executes task and downloads the file
         task = execute_task('test')
         assert task.entries[0]['location'], 'location missing?'
-        testfile = task.entries[0]['location']
-        assert os.path.exists(testfile), 'download file does not exists'
-        testfile_stat = os.stat(testfile)
+        testfile = Path(task.entries[0]['location'])
+        assert testfile.exists(), 'download file does not exists'
+        testfile_stat = testfile.stat()
         assert 0o666 & ~curr_umask == stat.S_IMODE(testfile_stat.st_mode), (
             'download file mode not honoring umask'
         )

--- a/flexget/tests/test_move.py
+++ b/flexget/tests/test_move.py
@@ -16,7 +16,7 @@ class TestMove:
 
     @pytest.mark.filecopy('movie.mkv', '__tmp__/movie.mkv')
     def test_move(self, execute_task, tmp_path):
-        assert tmp_path.joinpath('movie.mkv').exists()
+        assert (tmp_path / 'movie.mkv').exists()
         execute_task('test_move')
-        assert not tmp_path.joinpath('movie.mkv').exists()
-        assert tmp_path.joinpath('newdir/movie.mkv').exists()
+        assert not (tmp_path / 'movie.mkv').exists()
+        assert (tmp_path / 'newdir/movie.mkv').exists()

--- a/flexget/tests/test_pluginapi.py
+++ b/flexget/tests/test_pluginapi.py
@@ -1,5 +1,5 @@
-import glob
 import os
+from pathlib import Path
 
 import pytest
 
@@ -27,9 +27,9 @@ class TestPluginApi:
 
     def test_load(self):
         plugin.load_plugins()
-        plugin_path = os.path.dirname(plugins.__file__)
+        plugin_path = Path(plugins.__file__).parent
         plugin_modules = {
-            os.path.basename(i) for k in ("/*.py", "/*/*.py") for i in glob.glob(plugin_path + k)
+            os.path.basename(i) for k in ("*.py", "*/*.py") for i in plugin_path.glob(k)
         }
         assert len(plugin_modules) >= 10, "Less than 10 plugin modules looks fishy"
         # Hmm, this test isn't good, because we have plugin modules that don't register a class (like cli ones)
@@ -70,9 +70,7 @@ class TestExternalPluginLoading:
 
     @pytest.fixture
     def config(self, request):
-        os.environ['FLEXGET_PLUGIN_PATH'] = request.node.path.parent.joinpath(
-            'external_plugins'
-        ).as_posix()
+        os.environ['FLEXGET_PLUGIN_PATH'] = str(request.node.path.parent / 'external_plugins')
         plugin.load_plugins()
         # fire the config register event again so that task schema is rebuilt with new plugin
         fire_event('config.register')

--- a/flexget/tests/test_rtorrent.py
+++ b/flexget/tests/test_rtorrent.py
@@ -1,15 +1,15 @@
-import os
 import re
+from pathlib import Path
 from unittest import mock
 from xmlrpc import client as xmlrpc_client
 
 from flexget.plugins.clients.rtorrent import RTorrent
 
-torrent_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'private.torrent')
+torrent_file = Path(__file__).resolve().parent / 'private.torrent'
 torrent_url = f'file:///{torrent_file}'
 torrent_info_hash = '09977FE761B8D293AD8A929CCAF2E9322D525A6C'
 
-with open(torrent_file, 'rb') as tor_file:
+with torrent_file.open('rb') as tor_file:
     torrent_raw = tor_file.read()
 
 

--- a/flexget/tests/test_subtitle_list.py
+++ b/flexget/tests/test_subtitle_list.py
@@ -2,6 +2,7 @@ import contextlib
 import datetime
 import os
 import platform
+from pathlib import Path
 
 import pytest
 
@@ -226,11 +227,11 @@ class TestSubtitleList:
     """
 
     def test_subtitle_list_del(self, execute_task):
-        task = execute_task('subtitle_add')
+        execute_task('subtitle_add')
         task = execute_task('subtitle_emit')
         assert len(task.entries) == 2
 
-        task = execute_task('subtitle_remove')
+        execute_task('subtitle_remove')
         task = execute_task('subtitle_emit')
         assert len(task.entries) == 0
 
@@ -248,7 +249,7 @@ class TestSubtitleList:
             )
 
     def test_subtitle_list_old(self, execute_task):
-        task = execute_task('subtitle_test_expiration_add')
+        execute_task('subtitle_test_expiration_add')
 
         with Session() as session:
             s = session.query(SubtitleListFile).first()
@@ -282,7 +283,7 @@ class TestSubtitleList:
 
         # cleanup
         with contextlib.suppress(OSError):
-            os.remove('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.en.srt')
+            Path('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.en.srt').unlink()
 
         assert len(task.failed) == 1, (
             'Only one language should have been downloaded which results in failure'
@@ -296,13 +297,13 @@ class TestSubtitleList:
         task = execute_task('subtitle_add_another_local_file')
         assert len(task.entries) == 1, 'Task should have accepted jessica jones file'
 
-        with open('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.en.srt', 'a'):
+        with Path('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.en.srt').open('a'):
             os.utime('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.en.srt', None)
 
-        with open('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.ja.srt', 'a'):
+        with Path('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.ja.srt').open('a'):
             os.utime('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.ja.srt', None)
 
-        with open('subtitle_list_test_dir/Marvels.Jessica.Jones.S01E02-FlexGet.en.srt', 'a'):
+        with Path('subtitle_list_test_dir/Marvels.Jessica.Jones.S01E02-FlexGet.en.srt').open('a'):
             os.utime('subtitle_list_test_dir/Marvels.Jessica.Jones.S01E02-FlexGet.en.srt', None)
 
         task = execute_task('subtitle_simulate_success')
@@ -313,17 +314,17 @@ class TestSubtitleList:
         task = execute_task('subtitle_emit')
         assert len(task.entries) == 1, 'Walking Dead should have been removed from the list'
         with contextlib.suppress(OSError):
-            os.remove('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.en.srt')
+            Path('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.en.srt').unlink()
         with contextlib.suppress(OSError):
-            os.remove('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.ja.srt')
+            Path('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.ja.srt').unlink()
         with contextlib.suppress(OSError):
-            os.remove('subtitle_list_test_dir/Marvels.Jessica.Jones.S01E02-FlexGet.en.srt')
+            Path('subtitle_list_test_dir/Marvels.Jessica.Jones.S01E02-FlexGet.en.srt').unlink()
 
     @pytest.mark.require_optional_deps
     def test_subtitle_list_local_subtitles(self, execute_task):
-        task = execute_task('subtitle_add_local_file')
-        task = execute_task('subtitle_add_another_local_file')
-        task = execute_task('subtitle_add_a_third_local_file')
+        execute_task('subtitle_add_local_file')
+        execute_task('subtitle_add_another_local_file')
+        execute_task('subtitle_add_a_third_local_file')
 
         task = execute_task('subtitle_emit')
         assert len(task.entries) == 2, (
@@ -331,7 +332,7 @@ class TestSubtitleList:
         )
 
     def test_subtitle_list_local_dir(self, execute_task):
-        task = execute_task('subtitle_add_local_dir')
+        execute_task('subtitle_add_local_dir')
 
         with Session() as session:
             s = session.query(SubtitleListFile).first()
@@ -347,15 +348,15 @@ class TestSubtitleList:
 
     @pytest.mark.require_optional_deps
     def test_subtitle_list_subliminal_dir_success(self, execute_task):
-        task = execute_task('subtitle_add_local_dir')
+        execute_task('subtitle_add_local_dir')
 
-        with open('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.ja.srt', 'a'):
+        with Path('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.ja.srt').open('a'):
             os.utime('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.ja.srt', None)
 
-        with open('subtitle_list_test_dir/Marvels.Jessica.Jones.S01E02-FlexGet.ja.srt', 'a'):
+        with Path('subtitle_list_test_dir/Marvels.Jessica.Jones.S01E02-FlexGet.ja.srt').open('a'):
             os.utime('subtitle_list_test_dir/Marvels.Jessica.Jones.S01E02-FlexGet.ja.srt', None)
 
-        with open('subtitle_list_test_dir/The.Big.Bang.Theory.S09E09-FlexGet.ja.srt', 'a'):
+        with Path('subtitle_list_test_dir/The.Big.Bang.Theory.S09E09-FlexGet.ja.srt').open('a'):
             os.utime('subtitle_list_test_dir/The.Big.Bang.Theory.S09E09-FlexGet.ja.srt', None)
 
         task = execute_task('subtitle_simulate_success_no_check')
@@ -369,16 +370,16 @@ class TestSubtitleList:
             )
 
         with contextlib.suppress(OSError):
-            os.remove('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.ja.srt')
+            Path('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.ja.srt').unlink()
         with contextlib.suppress(OSError):
-            os.remove('subtitle_list_test_dir/Marvels.Jessica.Jones.S01E02-FlexGet.ja.srt')
+            Path('subtitle_list_test_dir/Marvels.Jessica.Jones.S01E02-FlexGet.ja.srt').unlink()
         with contextlib.suppress(OSError):
-            os.remove('subtitle_list_test_dir/The.Big.Bang.Theory.S09E09-FlexGet.ja.srt')
+            Path('subtitle_list_test_dir/The.Big.Bang.Theory.S09E09-FlexGet.ja.srt').unlink()
 
     def test_subtitle_list_force_file_existence_no(self, execute_task):
         task = execute_task('subtitle_add_force_file_no')
 
-        assert not os.path.exists(task.entries[0]['location']), 'File should not exist.'
+        assert not Path(task.entries[0]['location']).exists(), 'File should not exist.'
 
         with Session() as session:
             s = session.query(SubtitleListFile).first()
@@ -397,7 +398,7 @@ class TestSubtitleList:
     def test_subtitle_list_force_file_existence_yes(self, execute_task):
         task = execute_task('subtitle_add_force_file')
 
-        assert not os.path.exists(task.entries[0]['location']), 'File should not exist.'
+        assert not Path(task.entries[0]['location']).exists(), 'File should not exist.'
 
         with Session() as session:
             s = session.query(SubtitleListFile).first()
@@ -412,7 +413,7 @@ class TestSubtitleList:
     def test_subtitle_list_force_file_existence_yes_input(self, execute_task):
         task = execute_task('subtitle_add_force_file_no')
 
-        assert not os.path.exists(task.entries[0]['location']), 'File should not exist.'
+        assert not Path(task.entries[0]['location']).exists(), 'File should not exist.'
 
         with Session() as session:
             s = session.query(SubtitleListFile).first()

--- a/flexget/tests/test_symlink.py
+++ b/flexget/tests/test_symlink.py
@@ -1,16 +1,19 @@
-import os
 import stat
+from typing import TYPE_CHECKING
 
 import pytest
 from jinja2 import Template
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 dirname = 'symlink_test_dir'
 subdirs = ['hardlink', 'softlink']
 
 
-def is_hard_link(file1, file2):
-    s1 = os.stat(file1)
-    s2 = os.stat(file2)
+def is_hard_link(file1: 'Path', file2: 'Path') -> bool:
+    s1 = file1.stat()
+    s2 = file2.stat()
     return (s1[stat.ST_INO], s1[stat.ST_DEV]) == (s2[stat.ST_INO], s2[stat.ST_DEV])
 
 
@@ -71,79 +74,75 @@ class TestSymlink:
 
     @pytest.fixture
     def config(self, tmp_path):
-        test_dir = tmp_path.joinpath(dirname)
-        test_dir.joinpath('hardlink').mkdir(parents=True)
-        test_dir.joinpath('softlink').mkdir(parents=True)
+        test_dir = tmp_path / dirname
+        (test_dir / 'hardlink').mkdir(parents=True)
+        (test_dir / 'softlink').mkdir(parents=True)
 
-        return Template(self._config).render({'tmpdir_1': test_dir.as_posix()})
+        return Template(self._config).render({'tmpdir_1': test_dir})
 
     def test_hardlink(self, execute_task, tmp_path):
-        tmp_path.joinpath(dirname).joinpath('test1.mkv').write_text('')
+        (tmp_path / dirname / 'test1.mkv').write_text('')
         execute_task('test_hardlink')
-        hardlink = tmp_path.joinpath(dirname).joinpath('hardlink').joinpath('test1.mkv')
+        hardlink = tmp_path / dirname / 'hardlink' / 'test1.mkv'
 
-        assert os.path.exists(hardlink.as_posix()), f'{hardlink.as_posix()} should exist'
-        assert is_hard_link(
-            tmp_path.joinpath(dirname).joinpath('test1.mkv').as_posix(), hardlink.as_posix()
-        )
+        assert hardlink.exists(), f'{hardlink} should exist'
+        assert is_hard_link(tmp_path / dirname / 'test1.mkv', hardlink)
 
     def test_hardlink_rename(self, execute_task, tmp_path):
-        tmp_path.joinpath(dirname).joinpath('test1.mkv').write_text('')
+        (tmp_path / dirname / 'test1.mkv').write_text('')
         execute_task('test_hardlink_rename')
-        hardlink = tmp_path.joinpath(dirname).joinpath('hardlink').joinpath('rename.mkv')
+        hardlink = tmp_path / dirname / 'hardlink' / 'rename.mkv'
 
-        assert os.path.exists(hardlink.as_posix()), f'{hardlink.as_posix()} should exist'
-        assert is_hard_link(
-            tmp_path.joinpath(dirname).joinpath('test1.mkv').as_posix(), hardlink.as_posix()
-        )
+        assert hardlink.exists(), f'{hardlink} should exist'
+        assert is_hard_link(tmp_path / dirname / 'test1.mkv', hardlink)
 
     def test_hardlink_dir(self, execute_task, tmp_path):
-        tmp = tmp_path.joinpath(dirname).joinpath('test2')
+        tmp = tmp_path / dirname / 'test2'
         tmp.mkdir()
-        test2 = tmp.joinpath('test2.mkv')
+        test2 = tmp / 'test2.mkv'
         test2.write_text('')
         execute_task('test_hardlink_dir')
-        hardlink_dir = tmp_path.joinpath(dirname).joinpath('hardlink').joinpath('test2')
+        hardlink_dir = tmp_path / dirname / 'hardlink' / 'test2'
 
-        assert os.path.exists(hardlink_dir.as_posix()), f'{hardlink_dir.as_posix()} should exist'
-        assert is_hard_link(test2.as_posix(), hardlink_dir.joinpath('test2.mkv').as_posix())
+        assert hardlink_dir.exists(), f'{hardlink_dir} should exist'
+        assert is_hard_link(test2, hardlink_dir / 'test2.mkv')
 
     def test_hardlink_fail(self, execute_task, tmp_path):
-        tmp_path.joinpath(dirname).joinpath('test1.mkv').write_text('')
-        hardlink = tmp_path.joinpath(dirname).joinpath('hardlink').joinpath('test1.mkv')
+        (tmp_path / dirname / 'test1.mkv').write_text('')
+        hardlink = tmp_path / dirname / 'hardlink' / 'test1.mkv'
         hardlink.write_text('')
         task = execute_task('test_hardlink')
 
         assert len(task.failed) == 1, 'should have failed test1.mkv'
 
     def test_softlink(self, execute_task, tmp_path):
-        tmp_path.joinpath(dirname).joinpath('test1.mkv').write_text('')
-        tmp_path.joinpath(dirname).joinpath('test1').mkdir()
+        (tmp_path / dirname / 'test1.mkv').write_text('')
+        (tmp_path / dirname / 'test1').mkdir()
         execute_task('test_softlink')
 
-        softlink = tmp_path.joinpath(dirname).joinpath('softlink')
-        f = softlink.joinpath('test1.mkv')
-        d = softlink.joinpath('test1')
-        assert os.path.exists(f.as_posix()), f'{f.as_posix()} should exist'
-        assert os.path.exists(d.as_posix()), f'{d.as_posix()} should exist'
-        assert os.path.islink(f.as_posix()), f'{f.as_posix()} should be a softlink'
-        assert os.path.islink(d.as_posix()), f'{d.as_posix()} should be a softlink'
+        softlink = tmp_path / dirname / 'softlink'
+        f = softlink / 'test1.mkv'
+        d = softlink / 'test1'
+        assert f.exists(), f'{f} should exist'
+        assert d.exists(), f'{d} should exist'
+        assert f.is_symlink(), f'{f} should be a softlink'
+        assert d.is_symlink(), f'{d} should be a softlink'
 
     def test_softlink_rename(self, execute_task, tmp_path):
-        tmp_path.joinpath(dirname).joinpath('test1.mkv').write_text('')
+        (tmp_path / dirname / 'test1.mkv').write_text('')
         execute_task('test_softlink_rename')
 
-        softlink = tmp_path.joinpath(dirname).joinpath('softlink')
-        f = softlink.joinpath('rename.mkv')
-        assert os.path.exists(f.as_posix()), f'{f.as_posix()} should exist'
-        assert os.path.islink(f.as_posix()), f'{f.as_posix()} should be a softlink'
+        softlink = tmp_path / dirname / 'softlink'
+        f = softlink / 'rename.mkv'
+        assert f.exists(), f'{f} should exist'
+        assert f.is_symlink(), f'{f} should be a softlink'
 
     def test_softlink_fail(self, execute_task, tmp_path):
-        tmp_path.joinpath(dirname).joinpath('test1.mkv').write_text('')
-        tmp_path.joinpath(dirname).joinpath('test1').mkdir()
+        (tmp_path / dirname / 'test1.mkv').write_text('')
+        (tmp_path / dirname / 'test1').mkdir()
 
-        tmp_path.joinpath(dirname).joinpath('softlink').joinpath('test1.mkv').write_text('')
-        tmp_path.joinpath(dirname).joinpath('softlink').joinpath('test1').mkdir()
+        (tmp_path / dirname / 'softlink' / 'test1.mkv').write_text('')
+        (tmp_path / dirname / 'softlink' / 'test1').mkdir()
         task = execute_task('test_softlink_fail')
 
         assert len(task.failed) == 2, 'Should have failed both entries since they already exist'

--- a/flexget/tests/test_torrent_match.py
+++ b/flexget/tests/test_torrent_match.py
@@ -1,4 +1,5 @@
 import platform
+from pathlib import Path
 
 import pytest
 
@@ -97,7 +98,7 @@ class TestTorrentMatch:
         task = execute_task('test_single_torrent')
 
         assert len(task.accepted) == 1, 'Should have accepted torrent1.mkv'
-        assert task.accepted[0]['path'] == 'torrent_match_test_dir'
+        assert task.accepted[0]['path'] == Path('torrent_match_test_dir')
 
     @pytest.mark.skipif(
         platform.system() == 'Windows',
@@ -109,7 +110,7 @@ class TestTorrentMatch:
         task = execute_task('test_single_torrent_in_other_dir')
 
         assert len(task.accepted) == 1, 'Should have accepted torrent1.mkv'
-        assert task.accepted[0]['path'] == 'torrent_match_test_dir/torrent1'
+        assert task.accepted[0]['path'] == Path('torrent_match_test_dir/torrent1')
 
     def test_single_torrent_wrong_size(self, execute_task):
         task = execute_task('test_single_torrent_wrong_size')

--- a/flexget/tests/test_yaml_list.py
+++ b/flexget/tests/test_yaml_list.py
@@ -84,10 +84,10 @@ class TestYamlLists:
     @pytest.fixture
     def config(self, tmp_path):
         """Prepare config."""
-        yaml_dir = tmp_path.joinpath('yaml_lists')
+        yaml_dir = tmp_path / 'yaml_lists'
         yaml_dir.mkdir()
 
-        return Template(self._config).render({'yaml_dir': yaml_dir.as_posix()})
+        return Template(self._config).render({'yaml_dir': yaml_dir})
 
     def test_list_create(self, execute_task):
         task = execute_task('yaml_list_create')

--- a/flexget/utils/bittorrent.py
+++ b/flexget/utils/bittorrent.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterator
+    from pathlib import Path
 
 logger = logger.bind(name='torrent')
 
@@ -81,7 +82,7 @@ def clean_meta(
     return modified
 
 
-def is_torrent_file(metafilepath: str) -> bool:
+def is_torrent_file(metafilepath: 'Path') -> bool:
     """Check whether a file looks like a metafile by peeking into its content.
 
     Note that this doesn't ensure that the file is a complete and valid torrent,
@@ -90,7 +91,7 @@ def is_torrent_file(metafilepath: str) -> bool:
     @param metafilepath: Path to the file to check, must have read permissions for it.
     @return: True if there is a high probability this is a metafile.
     """
-    with open(metafilepath, 'rb') as f:
+    with metafilepath.open('rb') as f:
         data = f.read(200)
 
     magic_marker = bool(TORRENT_RE.match(data))
@@ -213,9 +214,9 @@ class Torrent:
     KEY_TYPE = str
 
     @classmethod
-    def from_file(cls, filename: str) -> 'Torrent':
+    def from_file(cls, file: 'Path') -> 'Torrent':
         """Create torrent from file on disk."""
-        with open(filename, 'rb') as handle:
+        with file.open('rb') as handle:
             return cls(handle.read())
 
     def __init__(self, content: bytes) -> None:

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -1,6 +1,4 @@
 import locale
-import os
-import os.path
 import re
 from contextlib import suppress
 from copy import copy
@@ -32,6 +30,7 @@ from flexget.utils.tools import format_filesize, parse_filesize, split_title_yea
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+    from pathlib import Path
 
     from flexget.entry import Entry
     from flexget.manager import Manager
@@ -136,24 +135,24 @@ class CoercingDateTime(DateTime):
         return Interval(self, dt, absolute=abs)
 
 
-def filter_pathbase(val: Optional[str]) -> str:
+def filter_pathbase(val: 'Path') -> str:
     """Return base name of a path."""
-    return os.path.basename(val or '')
+    return val.name
 
 
-def filter_pathname(val: Optional[str]) -> str:
+def filter_pathname(val: 'Path') -> str:
     """Return base name of a path, without its extension."""
-    return os.path.splitext(os.path.basename(val or ''))[0]
+    return val.stem
 
 
-def filter_pathext(val: Optional[str]) -> str:
+def filter_pathext(val: 'Path') -> str:
     """Extension of a path (including the '.')."""
-    return os.path.splitext(val or '')[1]
+    return val.suffix
 
 
-def filter_pathdir(val: Optional[str]) -> str:
+def filter_pathdir(val: 'Path') -> 'Path':
     """Directory containing the given path."""
-    return os.path.dirname(val or '')
+    return val.parent
 
 
 def filter_pathscrub(val: str, os_mode: Optional[str] = None) -> str:
@@ -281,19 +280,19 @@ def filter_format_size(size: float, si=False, unit=None):
     return format_filesize(size, si=si, unit=unit)
 
 
-def is_fs_file(pathname: Union[str, os.PathLike]) -> bool:
+def is_fs_file(pathname: 'Path') -> bool:
     """Test whether item is existing file in filesystem."""
-    return os.path.isfile(pathname)
+    return pathname.is_file()
 
 
-def is_fs_dir(pathname: Union[str, os.PathLike]) -> bool:
+def is_fs_dir(pathname: 'Path') -> bool:
     """Test whether item is existing directory in filesystem."""
-    return os.path.isdir(pathname)
+    return pathname.is_dir()
 
 
-def is_fs_link(pathname: Union[str, os.PathLike]) -> bool:
+def is_fs_link(pathname: 'Path') -> bool:
     """Test whether item is existing link in filesystem."""
-    return os.path.islink(pathname)
+    return pathname.is_symlink()
 
 
 class FlexGetTemplate(Template):
@@ -324,7 +323,7 @@ def make_environment(manager: 'Manager') -> None:
         loader=ChoiceLoader(
             [
                 PackageLoader('flexget'),
-                FileSystemLoader(os.path.join(manager.config_base, 'templates')),
+                FileSystemLoader(manager.config_base / 'templates'),
             ]
         ),
         extensions=['jinja2.ext.loopcontrols'],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,7 @@ ignore = [
     "PLW0603", # global-statement
     "PLW0642", # self-or-cls-assignment
     "PLW2901", # redefined-loop-name
+    "PTH119", # TODO
     "RUF012", # Maybe can re-enable after https://github.com/astral-sh/ruff/issues/5243
     "TD002", # missing-todo-author
     "TD003", # missing-todo-link

--- a/scripts/bundle_webui.py
+++ b/scripts/bundle_webui.py
@@ -28,7 +28,7 @@ else:
             return ["requests"]
 
         def clean(self, versions: list[str]) -> None:
-            p = Path(__file__).resolve().parent.parent
+            p = Path(__file__).resolve().parents[1]
             v1_path = p / "flexget" / "ui" / "v1" / "app"
             v2_path = p / "flexget" / "ui" / "v2" / "dist"
             if v1_path.exists():
@@ -50,7 +50,7 @@ def bundle_webui(ui_version: Optional[str] = None):
     # once it is registered it can install the dep automatically during the build process.
     import requests
 
-    ui_path = Path(__file__).resolve().parent.parent / "flexget" / "ui"
+    ui_path = Path(__file__).resolve().parents[1] / "flexget" / "ui"
 
     def download_extract(url, dest_path):
         print(dest_path)

--- a/scripts/dev_tools.py
+++ b/scripts/dev_tools.py
@@ -8,6 +8,7 @@
 import fileinput
 import os
 import subprocess
+from pathlib import Path
 from typing import Optional
 
 import click
@@ -20,7 +21,7 @@ else:
 
 
 def _get_version():
-    with open('flexget/_version.py') as f:
+    with Path('flexget/_version.py').open() as f:
         g = globals()
         loc = {}
         exec(f.read(), g, loc)
@@ -91,7 +92,7 @@ def cli_bundle_webui(ui_version: Optional[str] = None):
 def autoformat(files):
     """Reformat code with Ruff."""
     if not files:
-        project_root = os.path.dirname(os.path.realpath(__file__))
+        project_root = Path(__file__).resolve().parent
         files = (project_root,)
     venv_path = os.environ['VIRTUAL_ENV']
     if not venv_path:

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -1,15 +1,16 @@
 import os
 from http import client
+from pathlib import Path
 
 import pytest
 from vcr import VCR
 from vcr.stubs import VCRHTTPConnection, VCRHTTPSConnection
 
-VCR_CASSETTE_DIR = os.path.join(os.path.dirname(__file__), 'cassettes')
+VCR_CASSETTE_DIR = Path(__file__).parent / 'cassettes'
 VCR_RECORD_MODE = os.environ.get('VCR_RECORD_MODE', 'once')
 
 vcr = VCR(
-    cassette_library_dir=VCR_CASSETTE_DIR,
+    cassette_library_dir=str(VCR_CASSETTE_DIR),
     record_mode=VCR_RECORD_MODE,
     custom_patches=(
         (client, 'HTTPSConnection', VCRHTTPSConnection),
@@ -32,6 +33,6 @@ def online(request, monkeypatch):
         module = request.module.__name__.split('tests.')[-1]
         class_name = request.cls.__name__
         cassette_name = f'{module}.{class_name}.{request.function.__name__}'
-        cassette_path = os.path.join(VCR_CASSETTE_DIR, cassette_name)
-        with vcr.use_cassette(path=cassette_path) as cassette:
+        cassette_path = VCR_CASSETTE_DIR / cassette_name
+        with vcr.use_cassette(path=str(cassette_path)) as cassette:
             yield cassette

--- a/scripts/tests/test_bundle_webui.py
+++ b/scripts/tests/test_bundle_webui.py
@@ -17,8 +17,8 @@ class TestBundleWebUI:
     )
     def test_bundle_webui(self, online):
         os.environ['BUNDLE_WEBUI'] = 'true'
-        v1_path = Path(__file__).parent.parent.parent / 'flexget' / 'ui' / 'v1' / 'app'
-        v2_path = Path(__file__).parent.parent.parent / 'flexget' / 'ui' / 'v2' / 'dist'
+        v1_path = Path(__file__).parents[2] / 'flexget' / 'ui' / 'v1' / 'app'
+        v2_path = Path(__file__).parents[2] / 'flexget' / 'ui' / 'v2' / 'dist'
         shutil.rmtree(v1_path, ignore_errors=True)
         shutil.rmtree(v2_path, ignore_errors=True)
         bundle_webui()

--- a/scripts/tests/test_dev_tools.py
+++ b/scripts/tests/test_dev_tools.py
@@ -11,7 +11,7 @@ from scripts.dev_tools import bump_version, cli_bundle_webui, get_changelog, ver
 
 class TestDevTools:
     def test_version(self, tmp_path):
-        os.makedirs(tmp_path / 'flexget', exist_ok=True)
+        (tmp_path / 'flexget').mkdir(parents=True, exist_ok=True)
         shutil.copy(
             Path(__file__).parent / 'dev_tools' / 'dev_version.py',
             tmp_path / 'flexget' / '_version.py',
@@ -38,7 +38,7 @@ class TestDevTools:
         ],
     )
     def test_bump_version(self, tmp_path, bump_from, bump_to, version):
-        os.makedirs(tmp_path / 'flexget', exist_ok=True)
+        (tmp_path / 'flexget').mkdir(parents=True, exist_ok=True)
         shutil.copy(
             Path(__file__).parent / 'dev_tools' / f'{bump_from}_version.py',
             tmp_path / 'flexget' / '_version.py',
@@ -47,7 +47,7 @@ class TestDevTools:
         runner = CliRunner()
         result = runner.invoke(bump_version, [bump_to])
         assert result.exit_code == 0
-        with open(tmp_path / 'flexget' / '_version.py') as f:
+        with (tmp_path / 'flexget' / '_version.py').open() as f:
             assert f"__version__ = '{version}'\n" in f
 
     @pytest.mark.skipif(
@@ -61,8 +61,8 @@ class TestDevTools:
     )
     def test_cli_bundle_webui(self, args, online):
         os.environ['BUNDLE_WEBUI'] = 'true'
-        v1_path = Path(__file__).parent.parent.parent / 'flexget' / 'ui' / 'v1' / 'app'
-        v2_path = Path(__file__).parent.parent.parent / 'flexget' / 'ui' / 'v2' / 'dist'
+        v1_path = Path(__file__).parents[2] / 'flexget' / 'ui' / 'v1' / 'app'
+        v2_path = Path(__file__).parents[2] / 'flexget' / 'ui' / 'v2' / 'dist'
         shutil.rmtree(v1_path, ignore_errors=True)
         shutil.rmtree(v2_path, ignore_errors=True)
         runner = CliRunner()

--- a/scripts/tests/test_update_changelog.py
+++ b/scripts/tests/test_update_changelog.py
@@ -22,7 +22,7 @@ def test_update_changelog(tmp_path, n):
         tmp_path
     )
     os.chdir(tmp_path)
-    update_changelog('ChangeLog.md')
+    update_changelog(Path('ChangeLog.md'))
     assert filecmp.cmp(
         'ChangeLog.md',
         Path(__file__).parent / 'update_changelog' / f'test_{n}' / 'new_ChangeLog.md',

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -8,6 +8,7 @@
 import collections
 import re
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from git import Repo
@@ -101,8 +102,8 @@ def isplit(
     return head, None, iterator
 
 
-def update_changelog(filename: str) -> None:
-    with open(filename, encoding='utf-8') as logfile:
+def update_changelog(file: Path) -> None:
+    with file.open(encoding='utf-8') as logfile:
         pre_lines, start_comment, tail = isplit('<!---', logfile)
         active_lines, end_comment, tail = isplit('<!---', tail)
         post_lines = list(tail)
@@ -150,7 +151,7 @@ def update_changelog(filename: str) -> None:
 
     if modified:
         print('Writing modified changelog.')
-        with open(filename, 'w', encoding='utf-8') as logfile:
+        with file.open('w', encoding='utf-8') as logfile:
             logfile.writelines(pre_lines)
             logfile.write(f'<!---{commit.hexsha}--->\n')
             logfile.writelines(cur_ver.to_md_lines())
@@ -168,4 +169,4 @@ if __name__ == '__main__':
     except IndexError:
         print('No filename specified, using ChangeLog.md')
         filename = 'ChangeLog.md'
-    update_changelog(filename)
+    update_changelog(Path(filename))


### PR DESCRIPTION
### Motivation for changes:

This PR introduces a manual replacement of `os.path` with Python's `pathlib` module. The benefits of using `pathlib` include:

- **Improved Readability:** `pathlib` provides an object-oriented interface that makes file path operations clearer and more intuitive.
- **Enhanced Maintainability:** The API of `pathlib` is more modern and consistent, which simplifies future code maintenance and reduces potential errors.
- **Cross-Platform Compatibility:** `pathlib` abstracts many OS-specific nuances, ensuring more robust cross-platform behavior.

Due to the extensive amount of manual modifications required, this PR only covers a subset of the necessary changes. This incremental submission aims to reduce the code review workload and allow for a smoother transition. Future PRs will address the remaining instances.

`PTH` rules: https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth

