### PR TITLE
Change `entry['location']` to use the `pathlib.Path` type

### DIFF
--- a/flexget/components/archives/archives.py
+++ b/flexget/components/archives/archives.py
@@ -47,8 +47,8 @@ class FilterArchives:
         utils.rarfile_set_tool_path(config)
 
         for entry in task.entries:
-            archive_path = entry.get('location', '')
-            entry.accept() if utils.is_archive(archive_path) else entry.reject()
+            archive_path = entry.get('location')
+            entry.accept() if archive_path and utils.is_archive(archive_path) else entry.reject()
 
 
 @event('plugin.register')

--- a/flexget/components/archives/decompress.py
+++ b/flexget/components/archives/decompress.py
@@ -23,11 +23,11 @@ def open_archive_entry(entry):
 
     Convenience function for opening archives from entries.
     """
-    archive_path = entry.get('location', '')
+    archive_path = entry.get('location')
     if not archive_path:
         logger.error('Entry does not appear to represent a local file.')
         return None
-    if not Path(archive_path).exists():
+    if not archive_path.exists():
         logger.error('File no longer exists: {}', entry['location'])
         return None
     try:
@@ -47,7 +47,7 @@ def get_output_path(to: str, entry) -> Path:
     try:
         if to:
             return Path(render_from_entry(to, entry))
-        return Path(entry.get('location')).parent
+        return entry.get('location').parent
     except RenderError:
         raise plugin.PluginError(f'Could not render path: {to}')
 

--- a/flexget/components/archives/utils.py
+++ b/flexget/components/archives/utils.py
@@ -217,7 +217,7 @@ def open_archive(archive_path):
     """Return the appropriate archive object."""
     archive = None
 
-    if not Path(archive_path).exists():
+    if not archive_path.exists():
         raise PathError("Path doesn't exist")
 
     if zipfile.is_zipfile(archive_path):

--- a/flexget/components/bittorrent/torrent_match.py
+++ b/flexget/components/bittorrent/torrent_match.py
@@ -46,7 +46,7 @@ class TorrentMatch:
         result = []
         for entry in entries:
             location = entry.get('location')
-            if not location or not Path(location).exists():
+            if not location or not location.exists():
                 logger.warning('{} is not a local file. Skipping.', entry['title'])
                 entry.reject('not a local file')
                 continue
@@ -54,8 +54,8 @@ class TorrentMatch:
             result.append(entry)
             entry['files'] = []
 
-            if Path(location).is_file():
-                entry['files'].append(TorrentMatchFile(location, Path(location).stat().st_size))
+            if location.is_file():
+                entry['files'].append(TorrentMatchFile(location, location.stat().st_size))
             else:
                 # change working dir to make things simpler
                 os.chdir(location)
@@ -65,7 +65,7 @@ class TorrentMatch:
                     for f in files:
                         file_path = Path(root) / f
                         # We need normpath to strip out the dot
-                        abs_file_path = os.path.normpath(Path(location) / file_path)
+                        abs_file_path = os.path.normpath(location / file_path)
                         entry['files'].append(
                             TorrentMatchFile(abs_file_path, file_path.stat().st_size)
                         )
@@ -133,8 +133,8 @@ class TorrentMatch:
                             and torrent_file.size == local_file.size
                         ):
                             # if the filename with ext is contained in 'location', we must grab its parent as path
-                            if os.path.basename(torrent_file.path) in str(local_entry['location']):
-                                entry['path'] = Path(local_entry['location']).parent
+                            if torrent_file.path.name in str(local_entry['location']):
+                                entry['path'] = local_entry['location'].parent
                             else:
                                 entry['path'] = local_entry['location']
                             logger.debug('Path for {} set to {}', entry['title'], entry['path'])

--- a/flexget/components/ftp/ftp_list.py
+++ b/flexget/components/ftp/ftp_list.py
@@ -1,4 +1,5 @@
 import ftplib
+from pathlib import Path
 
 from loguru import logger
 
@@ -84,7 +85,7 @@ class FTPList:
         location = self.FTP.path.abspath(path)
 
         entry['title'] = title
-        entry['location'] = location
+        entry['location'] = Path(location)
         entry['url'] = f'ftp://{self.username}:{self.password}@{self.host}:{self.port}/{location}'
         entry['filename'] = title
 

--- a/flexget/components/ftp/sftp.py
+++ b/flexget/components/ftp/sftp.py
@@ -1,5 +1,4 @@
 from itertools import groupby
-from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple, Optional
 from urllib.parse import unquote, urlparse
 
@@ -12,6 +11,8 @@ from flexget.event import event
 from flexget.utils.template import RenderError, render_from_entry
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from flexget.entry import Entry
     from flexget.task import Task
 
@@ -329,7 +330,7 @@ class SftpUpload:
     @classmethod
     def handle_entry(cls, entry: 'Entry', sftp: SftpClient, config: dict):
         to: str = config['to']
-        location: str = entry['location']
+        location: Path = entry['location']
         delete_origin: bool = config['delete_origin']
 
         if to:
@@ -346,9 +347,9 @@ class SftpUpload:
             entry.fail(str(e))
             return
 
-        if delete_origin and Path(location).is_file():
+        if delete_origin and location.is_file():
             try:
-                Path(location).unlink()
+                location.unlink()
             except Exception as e:
                 logger.warning('Failed to delete file {} ({})', location, e)
 

--- a/flexget/components/ftp/sftp_client.py
+++ b/flexget/components/ftp/sftp_client.py
@@ -4,7 +4,7 @@ import time
 from base64 import b64decode
 from dataclasses import dataclass
 from functools import partial
-from pathlib import Path, PurePath, PurePosixPath
+from pathlib import Path, PurePosixPath
 from stat import S_ISLNK
 from typing import Callable, Optional
 from urllib.parse import quote, urljoin
@@ -205,13 +205,13 @@ class SftpClient:
         else:
             logger.warning('Skipping unknown file: {}', source)
 
-    def upload(self, source: str, to: str) -> None:
+    def upload(self, source: Path, to: str) -> None:
         """Upload files or directories to an SFTP server.
 
         :param source: file or directory to upload
         :param to: destination
         """
-        if Path(source).is_dir():
+        if source.is_dir():
             logger.verbose('Skipping directory {}', source)
         else:
             self._upload_file(source, to)
@@ -342,8 +342,8 @@ class SftpClient:
         cnopts.hostkeys.add(self.host, self.host_key.key_type, key)
         return cnopts
 
-    def _upload_file(self, source: str, to: str) -> None:
-        if not Path(source).exists():
+    def _upload_file(self, source: Path, to: str) -> None:
+        if not source.exists():
             logger.warning('File no longer exists:', source)
             return
 
@@ -393,8 +393,8 @@ class SftpClient:
         if delete_origin:
             self.remove_file(source)
 
-    def _put_file(self, source: str, destination: str) -> None:
-        return self._sftp.put(source, destination)
+    def _put_file(self, source: Path, destination: str) -> None:
+        return self._sftp.put(str(source), destination)
 
     def _get_prefix(self) -> str:
         """Generate SFTP URL prefix."""
@@ -422,8 +422,8 @@ class SftpClient:
         return str(PurePosixPath(destination) / path)
 
     @staticmethod
-    def _get_upload_path(source: str, to: str):
-        basename: str = PurePath(source).name
+    def _get_upload_path(source: Path, to: str):
+        basename: str = source.name
         return str(PurePosixPath(to, basename))
 
 

--- a/flexget/entry.py
+++ b/flexget/entry.py
@@ -3,6 +3,7 @@ import types
 import warnings
 from datetime import date, datetime
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Optional, Union
 
 import pendulum
@@ -252,6 +253,10 @@ class Entry(LazyDict, Serializer):
             if not isinstance(value, (str, LazyLookup)):
                 raise plugin.PluginError(f'Tried to set title to {value!r}')
             self.setdefault('original_title', value)
+
+        # location handling
+        if key == 'location' and isinstance(value, str) and value != '':
+            value = Path(value)
 
         try:
             logger.trace('ENTRY SET: {} = {!r}', key, value)

--- a/flexget/plugins/clients/deluge.py
+++ b/flexget/plugins/clients/deluge.py
@@ -178,7 +178,7 @@ class InputDeluge(DelugePlugin):
                 config_path = Path(config['config_path']).expanduser()
                 torrent_path = config_path / 'state' / f'{hash}.torrent'
                 if torrent_path.is_file():
-                    entry['location'] = str(torrent_path)
+                    entry['location'] = torrent_path
                     entry['url'] = torrent_path.as_uri()
                 else:
                     logger.warning('Did not find torrent file at {}', torrent_path)

--- a/flexget/plugins/clients/transmission.py
+++ b/flexget/plugins/clients/transmission.py
@@ -1,11 +1,11 @@
 import importlib.metadata
 import os
-import pathlib
 import re
 from datetime import datetime, timedelta
 from fnmatch import fnmatch
 from functools import partial
 from netrc import NetrcParseError, netrc
+from pathlib import Path
 from time import sleep
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
@@ -221,8 +221,8 @@ class PluginTransmissionInput(TransmissionBase):
             )
             # Location of torrent is only valid if transmission is on same machine as flexget
             if config['host'] in ('localhost', '127.0.0.1'):
-                entry['location'] = torrent.torrent_file
-                entry['url'] = pathlib.Path(torrent.torrent_file).as_uri()
+                entry['location'] = Path(torrent.torrent_file)
+                entry['url'] = Path(torrent.torrent_file).as_uri()
             for attr, field in {
                 'id': 'id',
                 'activityDate': 'activity_date',

--- a/flexget/plugins/filter/abort_if_exists.py
+++ b/flexget/plugins/filter/abort_if_exists.py
@@ -31,7 +31,7 @@ class PluginAbortIfExists:
             if field not in entry:
                 logger.debug('Field {} not found. Skipping.', field)
                 continue
-            if abort_re.search(entry[field]):
+            if abort_re.search(str(entry[field])):
                 task.abort(
                     'An entry contained {} in field {}. Abort!'.format(config['regexp'], field)
                 )

--- a/flexget/plugins/input/filesystem.py
+++ b/flexget/plugins/input/filesystem.py
@@ -109,8 +109,8 @@ class Filesystem:
         """Create a single entry using a filepath and a type (file/dir)."""
         filepath = filepath.absolute()
         entry = Entry()
-        entry['location'] = str(filepath)
-        entry['url'] = filepath.absolute().as_uri()
+        entry['location'] = filepath
+        entry['url'] = filepath.as_uri()
         entry['filename'] = filepath.name
         if filepath.is_file():
             entry['title'] = filepath.stem

--- a/flexget/plugins/metainfo/content_size.py
+++ b/flexget/plugins/metainfo/content_size.py
@@ -1,6 +1,4 @@
-import os.path
 import re
-from pathlib import Path
 
 from loguru import logger
 
@@ -47,13 +45,11 @@ class MetainfoContentSize:
             if entry.get('location'):
                 # If it is a .torrent or .nzb, don't bother getting the size as it will not be the content's size
                 location = entry['location']
-                if isinstance(location, str):
-                    location = Path(location)
                 if location.suffix in ('.nzb', '.torrent'):
                     continue
                 try:
                     if location.is_file():
-                        amount = os.path.getsize(entry['location'])
+                        amount = entry['location'].stat().st_size
                         logger.trace('setting content size to {}', format_filesize(amount))
                         entry['content_size'] = amount
                         continue

--- a/flexget/plugins/metainfo/nfo_lookup.py
+++ b/flexget/plugins/metainfo/nfo_lookup.py
@@ -119,7 +119,7 @@ class NfoLookup:
 
         """
         location = entry.get('location')
-        nfo_full_filename = os.path.splitext(location)[0] + self.nfo_file_extension
+        nfo_full_filename = str(location.parent / location.stem) + self.nfo_file_extension
 
         if os.path.isfile(nfo_full_filename):
             return nfo_full_filename

--- a/flexget/plugins/metainfo/subtitles_check.py
+++ b/flexget/plugins/metainfo/subtitles_check.py
@@ -57,8 +57,8 @@ class MetainfoSubs:
         if (
             entry.get('subtitles', eval_lazy=False)
             or 'location' not in entry
-            or ('$RECYCLE.BIN' in entry['location'])
-            or not os.path.exists(entry['location'])
+            or ('$RECYCLE.BIN' in str(entry['location']))
+            or not entry['location'].exists()
         ):
             return
         from subliminal import scan_video

--- a/flexget/plugins/output/download.py
+++ b/flexget/plugins/output/download.py
@@ -6,6 +6,7 @@ import socket
 import sys
 import tempfile
 from http.client import BadStatusLine
+from pathlib import Path
 from urllib.parse import unquote
 
 from loguru import logger
@@ -418,26 +419,23 @@ class PluginDownload:
 
             # expand variables in path
             try:
-                path = os.path.expanduser(entry.render(path))
+                path = Path(entry.render(path)).expanduser()
             except RenderError as e:
                 entry.fail(f'Could not set path. Error during string replacement: {e}')
                 return
-
-            # Clean illegal characters from path name
-            path = pathscrub(path)
 
             # If we are in test mode, report and return
             if task.options.test:
                 logger.info('Would write `{}` to `{}`', entry['title'], path)
                 # Set a fake location, so the exec plugin can do string replacement during --test #1015
-                entry['location'] = os.path.join(path, 'TEST_MODE_NO_OUTPUT')
+                entry['location'] = path / 'TEST_MODE_NO_OUTPUT'
                 return
 
             # make path
-            if not os.path.isdir(path):
+            if not path.is_dir():
                 logger.debug('Creating directory {}', path)
                 try:
-                    os.makedirs(path)
+                    path.mkdir(parents=True)
                 except Exception:
                     raise plugin.PluginError(f'Cannot create path {path}', logger)
 
@@ -480,10 +478,10 @@ class PluginDownload:
             # remove duplicate spaces
             name = ' '.join(name.split())
             # combine to full path + filename
-            destfile = os.path.join(path, name)
+            destfile = path / name
             logger.debug('destfile: {}', destfile)
 
-            if os.path.exists(destfile):
+            if destfile.exists():
                 import filecmp
 
                 if filecmp.cmp(entry['file'], destfile):
@@ -506,7 +504,7 @@ class PluginDownload:
                     # ignore permission errors, see ticket #555
                     import errno
 
-                    if not os.path.exists(destfile):
+                    if not destfile.exists():
                         raise plugin.PluginError(f'Unable to write {destfile}: {err}')
                     if err.errno not in (errno.EPERM, errno.EACCES):
                         raise

--- a/flexget/plugins/output/sabnzbd.py
+++ b/flexget/plugins/output/sabnzbd.py
@@ -84,7 +84,7 @@ class OutputSabnzbd:
             # check whether file is local or remote
             if entry['url'].startswith('file://'):
                 params['mode'] = 'addlocalfile'
-                params['name'] = entry['location']
+                params['name'] = str(entry['location'])
             else:
                 params['mode'] = 'addurl'
 

--- a/flexget/plugins/output/subtitles_periscope.py
+++ b/flexget/plugins/output/subtitles_periscope.py
@@ -82,17 +82,19 @@ class PluginPeriscope:
         for entry in task.accepted:
             if 'location' not in entry:
                 logger.warning('Cannot act on entries that do not represent a local file.')
-            elif not os.path.exists(entry['location']):
+            elif not entry['location'].exists():
                 entry.fail('file not found: {}'.format(entry['location']))
-            elif '$RECYCLE.BIN' in entry['location']:
+            elif '$RECYCLE.BIN' in str(entry['location']):
                 continue  # ignore deleted files in Windows shares
             elif not config['overwrite'] and self.subbed(entry['location']):
                 logger.warning('cannot overwrite existing subs for {}', entry['location'])
             else:
                 try:
-                    if psc.downloadSubtitle(entry['location'].encode('utf8'), langs):
+                    if psc.downloadSubtitle(str(entry['location']).encode('utf8'), langs):
                         logger.info('Subtitles found for {}', entry['location'])
-                    elif alts and psc.downloadSubtitle(entry['location'].encode('utf8'), alts):
+                    elif alts and psc.downloadSubtitle(
+                        str(entry['location']).encode('utf8'), alts
+                    ):
                         entry.fail('subtitles found for a second-choice language.')
                     else:
                         entry.fail('cannot find any subtitles for now.')

--- a/flexget/plugins/output/subtitles_subliminal.py
+++ b/flexget/plugins/output/subtitles_subliminal.py
@@ -166,18 +166,22 @@ class PluginSubliminal:
                 if 'location' not in entry:
                     logger.warning('Cannot act on entries that do not represent a local file.')
                     continue
-                if not os.path.exists(entry['location']):
+                if not entry['location'].exists():
                     entry.fail('file not found: {}'.format(entry['location']))
                     continue
-                if '$RECYCLE.BIN' in entry['location']:  # ignore deleted files in Windows shares
+                if '$RECYCLE.BIN' in str(
+                    entry['location']
+                ):  # ignore deleted files in Windows shares
                     continue
 
                 try:
                     entry_languages = set(entry.get('subtitle_languages', [])) or languages
 
-                    if entry['location'].endswith(VIDEO_EXTENSIONS):
-                        video = scan_video(entry['location'])
-                    elif entry['location'].endswith(ARCHIVE_EXTENSIONS):
+                    if entry['location'].suffix in VIDEO_EXTENSIONS:
+                        video = scan_video(
+                            str(entry['location'])
+                        )  # TODO: remove str() type conversion after Python 3.9 support is dropped
+                    elif entry['location'].suffix in ARCHIVE_EXTENSIONS:
                         video = scan_archive(entry['location'])
                     else:
                         entry.reject(

--- a/tests/test_abort_if_exists.py
+++ b/tests/test_abort_if_exists.py
@@ -9,8 +9,8 @@ class TestAbortIfExists:
           global:
             disable: [seen]
             mock:
-              - {title: 'test', location: 'mock://some_file.lftp-get-status'}
-              - {title: 'test2', location: 'mock://some_file.mkv'}
+              - {title: 'test', location: 'some_file.lftp-get-status'}
+              - {title: 'test2', location: 'some_file.mkv'}
         tasks:
           test_abort:
             abort_if_exists:

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -54,13 +55,13 @@ class TestExec:
         for entry in task.accepted:
             with (tmp_path / entry['title']).open('r') as infile:
                 line = infile.readline().rstrip('\n')
-                assert line == '/path/with spaces', f'{line} != /path/with spaces'
+                assert Path(line) == Path('/path/with spaces'), f'{line} != /path/with spaces'
                 line = infile.readline().rstrip('\n')
                 assert line == '/the/final destinaton/', f'{line} != /the/final destinaton/'
                 line = infile.readline().rstrip('\n')
                 assert line == "a with'quote", f"{line} != a with'quote"
                 line = infile.readline().rstrip('\n')
-                assert line == '/a hybrid/path/with spaces', (
+                assert Path(line) == Path('/a hybrid/path/with spaces'), (
                     f'{line} != /a hybrid/path/with spaces'
                 )
 

--- a/tests/test_jinja_filters.py
+++ b/tests/test_jinja_filters.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import jinja2
 import pytest
 
@@ -32,6 +34,16 @@ class TestJinjaFilters:
             set:
               size: "{{title|parse_size}}"
               size_si: "{{title|parse_size(si=True)}}"
+          path:
+            mock:
+              - {"title":"path", "location": "/a/b/c.d"}
+            accept_all: yes
+            set:
+              pathdir: "{{location|pathdir}}"
+              pathbase: "{{location|pathbase}}"
+              pathbase2: "{{location|pathdir|pathbase}}"
+              pathname: "{{location|pathname}}"
+              pathext: "{{location|pathext}}"
     """
 
     custom_filters = [
@@ -98,6 +110,14 @@ class TestJinjaFilters:
 
         assert task.accepted[4]['size'] == int(task.accepted[4]['actual'] * 1024**3)
         assert task.accepted[4]['size_si'] == int(task.accepted[4]['actual'] * 1000**3)
+
+    def test_path(self, execute_task):
+        task = execute_task('path')
+        assert Path(task.accepted[0]['pathdir']) == Path('/a/b')
+        assert task.accepted[0]['pathbase'] == 'c.d'
+        assert task.accepted[0]['pathbase2'] == 'b'
+        assert task.accepted[0]['pathname'] == 'c'
+        assert task.accepted[0]['pathext'] == '.d'
 
     @pytest.mark.parametrize('test_filter', custom_filters)
     def test_undefined_preserved(self, test_filter):

--- a/tests/test_regex_extract.py
+++ b/tests/test_regex_extract.py
@@ -26,7 +26,7 @@ class TestRegexExtract:
             regex_extract:
               field: title
               regex:
-                - The\.Event\.(?P<location>.*)
+                - The\.Event\.(?P<loc>.*)
 
           test_4:
             mock:
@@ -56,8 +56,8 @@ class TestRegexExtract:
         task = execute_task('test_3')
         entry = task.find_entry('entries', title='The.Event.New.York')
         assert entry is not None
-        assert 'location' in entry
-        assert entry['location'] == 'New.York'
+        assert 'loc' in entry
+        assert entry['loc'] == 'New.York'
 
     def test_multi_group(self, execute_task):
         task = execute_task('test_4')

--- a/tests/test_subtitle_list.py
+++ b/tests/test_subtitle_list.py
@@ -9,7 +9,6 @@ import pytest
 from flexget.components.managed_lists.lists.subtitle_list import (
     SubtitleListFile,
     SubtitleListLanguage,
-    normalize_path,
 )
 from flexget.manager import Session
 
@@ -435,8 +434,9 @@ class TestSubtitleList:
         with Session() as session:
             s = session.query(SubtitleListFile).first()
             assert s, 'The file should have been added to the list'
-            assert s.location == normalize_path(
-                'subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.mp4'
+            assert (
+                Path(s.location)
+                == Path('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.mp4').resolve()
             ), 'location should be what the output field was set to'
 
     def test_subtitle_list_relative_path(self, execute_task):
@@ -445,6 +445,7 @@ class TestSubtitleList:
         with Session() as session:
             s = session.query(SubtitleListFile).first()
             assert s, 'The file should have been added to the list'
-            assert s.location == normalize_path(
-                'subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.mp4'
+            assert (
+                Path(s.location)
+                == Path('subtitle_list_test_dir/The.Walking.Dead.S06E08-FlexGet.mp4').resolve()
             ), 'location should be what the output field was set to'

--- a/tests/test_torrent_match.py
+++ b/tests/test_torrent_match.py
@@ -86,7 +86,7 @@ class TestTorrentMatch:
         task = execute_task('test_multi_torrent_empty_name')
 
         assert len(task.accepted) == 1, 'Should have accepted torrent1.mkv'
-        assert task.accepted[0]['path'] == 'torrent_match_test_dir/torrent1'
+        assert task.accepted[0]['path'] == Path('torrent_match_test_dir/torrent1')
 
     @pytest.mark.skipif(
         platform.system() == 'Windows',


### PR DESCRIPTION
### Motivation for changes:

```
tasks:
  task:
    filesystem:
      path:
        - "/home/k/test"
      mask: '*.torrent'
      retrieve: files
    accept_all: yes
    exec:
      auto_escape: yes
      on_output:
        for_accepted:
          - rm -f -- "{{ location }}"
          - echo "location {{location}}"
          - echo "pathbase {{location|pathbase}}"
          - echo 'pathdir {{location | pathdir}}'
          - echo "pathbase {{location|pathdir|pathbase}}"
    set:
      label: "tv-{{location | pathdir | pathbase }}"
```
In the above configuration, the bug occurred because `entry['location']` was of type `str`, while `filter_pathdir()` expected a `Path` type parameter. To resolve this, `entry['location']` is now stored as a `Path` type.