### PR TITLE
Even if "Run tests not requiring optional dependencies" fails, still run "Run tests requiring optional dependencies".

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           version: ${{ env.UV_VERSION }}
       - name: Run tests not requiring optional dependencies
+        id: core-tests
         run: uv run pytest -m 'not require_optional_deps' -n logical --dist loadgroup --junit-xml test-results.xml
       - name: Run tests requiring optional dependencies
+        if: ${{!cancelled() && steps.core-tests.outcome != 'skipped'}}
         run: uv run --group plugin-test pytest -m 'require_optional_deps' -n logical --dist loadgroup --junit-xml test-results.xml
       - name: Upload Test Results
         if: always()


### PR DESCRIPTION
### Motivation for changes:
This allows PR authors to discover all issues at once, rather than encountering new errors only after fixing the ones from "Run tests not requiring optional dependencies".

