### PR TITLE
Fix the ruff check

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ For more detailed instructions see the `installation guide`_.
 How to contribute
 -----------------------
 
-Refer to `contributor guide <https://flexget.readthedocs.io/en/latest/contributor/index.html>`__.
+Refer to `the contributor guide <https://flexget.readthedocs.io/en/latest/contributor/index.html>`__.
 
 If you don't want to use virtualenv there's ``flexget_vanilla.py`` file which
 can be used to run FlexGet without virtualenv, note that you will need to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,7 @@ select = [
     "PIE",
     "PL",
     "PT",
+    'PTH',
     "PYI",
     "RET",
     "RSE",
@@ -221,6 +222,8 @@ quote-annotations = true
 known-first-party = ['flexget']
 
 [tool.ruff.lint.per-file-ignores]
+'docs/scripts/*'=['T20']
+"flexget/*"=["PTH"] # TODO
 'scripts/*' = ['T20']
 'tests/*' = ['T20']
 


### PR DESCRIPTION
### Motivation for changes:
#4307 enabled new Ruff rules, while the files added in #4326 violate these rules. Due to the simultaneous merging of two PRs, the `develop` branch failed checks after the merge, even though both PRs had passed all checks individually.

## My suggestion

To completely resolve the issue where both PRs pass all checks individually, but the `develop` branch fails checks after merging both, consider [enabling merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).

The simplest explanation of merge queues is that once enabled, every PR will be tested as if it had already been merged with the latest changes from the base branch before actually being merged. **This means PR authors no longer need to manually merge the latest changes into their PRs to avoid failing checks on the `develop` branch after merging.**

**Benefits of enabling merge queues:**

- Ensures the base branch (e.g., `develop`) always stays green by testing the actual merge result before it lands.
- Prevents broken code from being introduced due to conflicting or incompatible changes between parallel PRs.
- Automates the merge process and reduces the need for manual rebasing and re-approval.
- Improves CI efficiency by batching merges and reducing redundant builds.

If you @gazpachoking agree to enable merge queues, I’ll submit a PR. (Of course, some additional configuration on the FlexGet repository will be needed from your side.)
