### PR TITLE
Enable GitHub Merge Queues

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -7,7 +7,7 @@ on:
   pull_request_target: # zizmor: ignore[dangerous-triggers]
 permissions: { }
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref || github.run_id }}
   cancel-in-progress: true
 env:
   PYTHON_VERSION: '3.13' # renovate: datasource=python-version depName=python

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,12 +7,14 @@ on:
     tags:
       - v*.*.*
   pull_request:
+  merge_group:
 permissions: { }
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   build:
+    name: Docker build
     permissions:
       packages: write # to push to ghcr.io
     runs-on: ubuntu-latest
@@ -32,7 +34,7 @@ jobs:
           install: true
 
       - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,10 @@ on:
     branches:
       - develop
   pull_request:
+  merge_group:
 permissions: { }
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref || github.run_id }}
   cancel-in-progress: true
 env:
   UV_VERSION: 0.6.14 # renovate: datasource=pypi depName=uv
@@ -113,3 +114,18 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@afb2984f4d89672b2f9d9c13ae23d53779671984 # v2
         with:
           files: artifacts/**/*.xml
+
+  test-results:
+    name: Test results
+    needs:
+      - publish-test-results
+      - tests
+      - test-scripts
+      - zizmor
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
### Motivation for changes:

To completely resolve the issue where all PRs pass all checks individually, but the `develop` branch fails checks after merging them, we should [enable merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).

The simplest explanation of merge queues is that once enabled, every PR will be tested as if it had already been merged with the latest changes from the base branch before actually being merged. **This means PR authors no longer need to manually merge the latest changes into their PRs to avoid failing checks on the `develop` branch after merging.**

**Benefits of enabling merge queues:**

- Ensures the base branch (e.g., `develop`) always stays green by testing the actual merge result before it lands.
- Prevents broken code from being introduced due to conflicting or incompatible changes between parallel PRs.
- Automates the merge process and reduces the need for manual rebasing and re-approval.
- Improves CI efficiency by batching merges and reducing redundant builds.

## What the Repository Administrator Needs to Do

This PR includes all the necessary changes for the workflow files.

You @gazpachoking just needs to enable the Ruleset for the default branch in the repository settings -> Rules -> Rulesets.

![435273968-3198c3ed-8ad9-4dde-85da-953cec081fb8](https://github.com/user-attachments/assets/4e2d8637-1cec-4b44-bcb4-9336653081b6)

![435278438-4d72d245-9900-4d80-9e12-dd1ec493073c](https://github.com/user-attachments/assets/55317177-7394-49da-8a2f-d12b24c122b6)


In the Ruleset, both **Require merge queue** and **Require status checks to pass** must be checked. 

![435256973-79483bea-7903-4430-83eb-42961c3ab463](https://github.com/user-attachments/assets/606fabd1-3759-43af-a08b-c831b1fe8c06)

Under “Require status checks to pass,” "Docker build", “pre-commit.ci - pr”, "Test results" and "zizmor" must be selected.

![435277709-68e1ea0c-e399-4b44-bb75-473331c0c932](https://github.com/user-attachments/assets/28675530-ff0c-4279-91fe-5cf037ad1aea)

I have thoroughly tested all of the above, and there should be no issues.

![435279341-712ee720-d117-4b31-a80c-f1674a22a10c](https://github.com/user-attachments/assets/fec484f8-7876-4e39-93e2-c6635ad5e8f5)

