### PR TITLE
Full Optional Dependency Support via Extras and Docker Integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         run: uv run pytest -m 'not require_optional_deps' -n logical --dist loadgroup --junit-xml test-results.xml
       - name: Run tests requiring optional dependencies
         if: ${{!cancelled() && steps.core-tests.outcome != 'skipped'}}
-        run: uv run --group plugin-test pytest -m 'require_optional_deps' -n logical --dist loadgroup --junit-xml test-results.xml
+        run: uv run --group all pytest -m 'require_optional_deps' -n logical --dist loadgroup --junit-xml test-results.xml
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,25 +65,28 @@ docs = [
     'sphinx-copybutton~=0.5',
     'sphinx-design~=0.6'
 ]
-plugin-test = [
-    # These are optional dependencies for plugins that have tests in the test suite
-    # Tests that need these must add the `require_optional_deps` pytest mark
-    "boto3 ~=1.35",
-    "pillow~=11.0",
-    "plexapi ~=4.16",
-    "pysftp ~=0.2.9",
-    'rarfile~=4.0',
-    "subliminal ~= 2.1",
-    { include-group = "all" }
-]
+
+boto3=["boto3~=1.35"]
 deluge = ['deluge-client~=1.10']
+ftp = ['ftputil~=5.1']
+plexapi=["plexapi~=4.16"]
 qbittorrent = ['qbittorrent-api~=2025.2']
-telegram = ['python-telegram-bot[http2,socks]~=21.9']
+rarfile=['rarfile~=4.0']
+sftp=['pysftp~=0.2.9']
+subliminal=["subliminal ~= 2.1"]
+telegram = ['python-telegram-bot[http2,socks]~=21.9',"pillow~=11.0"]
 transmission = ['transmission-rpc~=7.0']
-# This is all our optional deps installable via extras. Not actually 'all'
+# This is all our optional deps installable via extras, not actually 'all'.
+# Tests that need these must add the `require_optional_deps` pytest mark.
 all = [
+    {include-group='boto3'},
     { include-group = "deluge" },
+    { include-group = 'ftp' },
+    {include-group='plexapi'},
     { include-group = "qbittorrent" },
+    {include-group='rarfile'},
+    {include-group='sftp'},
+    {include-group='subliminal'},
     { include-group = "telegram" },
     { include-group = "transmission" }
 ]
@@ -110,7 +113,19 @@ max_line_length = 99
 [tool.hatch.metadata.hooks.custom]
 # Extras with locked dependencies will be generated if BUILD_LOCKED env variable is specified
 path = "scripts/build_locked_extras.py"
-locked-groups = ["deluge", "qbittorrent", "telegram", "transmission", "all"]
+locked-groups = [
+    'boto3',
+    "deluge",
+    'ftp',
+    'plexapi',
+    "qbittorrent",
+    'rarfile',
+    'sftp',
+    'subliminal',
+    "telegram",
+    "transmission",
+    "all"
+]
 
 [tool.hatch.version]
 path = "flexget/_version.py"

--- a/uv.lock
+++ b/uv.lock
@@ -871,10 +871,21 @@ dependencies = [
 
 [package.dev-dependencies]
 all = [
+    { name = "boto3" },
     { name = "deluge-client" },
+    { name = "ftputil" },
+    { name = "pillow" },
+    { name = "plexapi" },
+    { name = "pysftp" },
     { name = "python-telegram-bot", extra = ["http2", "socks"] },
     { name = "qbittorrent-api" },
+    { name = "rarfile" },
+    { name = "subliminal", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "subliminal", version = "2.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "transmission-rpc" },
+]
+boto3 = [
+    { name = "boto3" },
 ]
 deluge = [
     { name = "deluge-client" },
@@ -892,23 +903,27 @@ docs = [
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
 ]
-plugin-test = [
-    { name = "boto3" },
-    { name = "deluge-client" },
-    { name = "pillow" },
+ftp = [
+    { name = "ftputil" },
+]
+plexapi = [
     { name = "plexapi" },
-    { name = "pysftp" },
-    { name = "python-telegram-bot", extra = ["http2", "socks"] },
-    { name = "qbittorrent-api" },
-    { name = "rarfile" },
-    { name = "subliminal", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "subliminal", version = "2.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "transmission-rpc" },
 ]
 qbittorrent = [
     { name = "qbittorrent-api" },
 ]
+rarfile = [
+    { name = "rarfile" },
+]
+sftp = [
+    { name = "pysftp" },
+]
+subliminal = [
+    { name = "subliminal", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "subliminal", version = "2.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
 telegram = [
+    { name = "pillow" },
     { name = "python-telegram-bot", extra = ["http2", "socks"] },
 ]
 transmission = [
@@ -952,11 +967,19 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 all = [
+    { name = "boto3", specifier = "~=1.35" },
     { name = "deluge-client", specifier = "~=1.10" },
+    { name = "ftputil", specifier = "~=5.1" },
+    { name = "pillow", specifier = "~=11.0" },
+    { name = "plexapi", specifier = "~=4.16" },
+    { name = "pysftp", specifier = "~=0.2.9" },
     { name = "python-telegram-bot", extras = ["http2", "socks"], specifier = "~=21.9" },
     { name = "qbittorrent-api", specifier = "~=2025.2" },
+    { name = "rarfile", specifier = "~=4.0" },
+    { name = "subliminal", specifier = "~=2.1" },
     { name = "transmission-rpc", specifier = "~=7.0" },
 ]
+boto3 = [{ name = "boto3", specifier = "~=1.35" }]
 deluge = [{ name = "deluge-client", specifier = "~=1.10" }]
 dev = [
     { name = "pre-commit", specifier = "~=4.0" },
@@ -971,21 +994,23 @@ docs = [
     { name = "sphinx-copybutton", specifier = "~=0.5" },
     { name = "sphinx-design", specifier = "~=0.6" },
 ]
-plugin-test = [
-    { name = "boto3", specifier = "~=1.35" },
-    { name = "deluge-client", specifier = "~=1.10" },
-    { name = "pillow", specifier = "~=11.0" },
-    { name = "plexapi", specifier = "~=4.16" },
-    { name = "pysftp", specifier = "~=0.2.9" },
-    { name = "python-telegram-bot", extras = ["http2", "socks"], specifier = "~=21.9" },
-    { name = "qbittorrent-api", specifier = "~=2025.2" },
-    { name = "rarfile", specifier = "~=4.0" },
-    { name = "subliminal", specifier = "~=2.1" },
-    { name = "transmission-rpc", specifier = "~=7.0" },
-]
+ftp = [{ name = "ftputil", specifier = "~=5.1" }]
+plexapi = [{ name = "plexapi", specifier = "~=4.16" }]
 qbittorrent = [{ name = "qbittorrent-api", specifier = "~=2025.2" }]
-telegram = [{ name = "python-telegram-bot", extras = ["http2", "socks"], specifier = "~=21.9" }]
+rarfile = [{ name = "rarfile", specifier = "~=4.0" }]
+sftp = [{ name = "pysftp", specifier = "~=0.2.9" }]
+subliminal = [{ name = "subliminal", specifier = "~=2.1" }]
+telegram = [
+    { name = "pillow", specifier = "~=11.0" },
+    { name = "python-telegram-bot", extras = ["http2", "socks"], specifier = "~=21.9" },
+]
 transmission = [{ name = "transmission-rpc", specifier = "~=7.0" }]
+
+[[package]]
+name = "ftputil"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/dc/83f3fa78a9c8a8fe119a70d040df67799094821d3cad511ee0987d544a10/ftputil-5.1.0.tar.gz", hash = "sha256:e9e62d3fd307ef9c52e43b33fd92759fc94c04d8b5178f85f641b183906d4353", size = 86403 }
 
 [[package]]
 name = "greenlet"
@@ -1184,7 +1209,7 @@ name = "importlib-metadata"
 version = "8.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/08/c1395a292bb23fd03bdf572a1357c5a733d3eecbab877641ceacab23db6e/importlib_metadata-8.6.1.tar.gz", hash = "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580", size = 55767 }
 wheels = [


### PR DESCRIPTION
### Motivation for changes:

Currently, we only provide a limited set of extras: `deluge`, `qbittorrent`, `telegram`, and `transmission`. This PR extends support by exposing **all** optional dependencies as extras and bundling them directly into the Docker image. This approach offers several advantages:

1. **Improved dependency resolution** — All optional dependencies are included in UV's resolution process, ensuring full compatibility across the entire dependency tree.

2. **Simplified installation** — Users can easily install the required dependencies using `flexget[extra_1, extra_2]`, without needing to manage them individually.

3. **Streamlined Docker usage** — Bundling all dependencies into the Docker image simplifies usage. As first-party dependencies, there's no strong reason to exclude them, especially considering the minimal impact on image size. The current uncompressed image is 305MB, and with all dependencies included, it increases to just 313MB.


