### PR TITLE
[fix] Fix the issue where SQLAlchemy is throwing "Database is locked" on CLI action

### DIFF
--- a/flexget/utils/log.py
+++ b/flexget/utils/log.py
@@ -93,7 +93,7 @@ def log_once(
 
     row = LogMessage(md5sum)
     session.add(row)
-    session.flush()
+    session.commit()
 
     logger.log(once_level, message)
     return True


### PR DESCRIPTION
I am simply submitting the fix proposed by @siddhartha77 in #4331 as a PR.

Closes #4331

