### PR TITLE
Bump the version number to avoid a failure during the next release

### DIFF
--- a/flexget/_version.py
+++ b/flexget/_version.py
@@ -10,4 +10,4 @@ and update the version again for continued development.
 NOTE: Should always have all three parts of the version, even on major and minor bumps. i.e. 4.0.0.dev, not 4.0.dev
 """
 
-__version__ = '3.15.35.dev'
+__version__ = '3.15.36.dev'


### PR DESCRIPTION
Previously, there was an error during deployment, but a new release has already been published on PyPI. Therefore, we need to manually bump the version number to avoid a failure during the next release.