### PR TITLE
The "created" field is renamed to "ctime".

### DIFF
--- a/flexget/_version.py
+++ b/flexget/_version.py
@@ -10,4 +10,4 @@ and update the version again for continued development.
 NOTE: Should always have all three parts of the version, even on major and minor bumps. i.e. 4.0.0.dev, not 4.0.dev
 """
 
-__version__ = '3.15.43.dev'
+__version__ = '3.16.0.dev'

--- a/flexget/plugins/input/filesystem.py
+++ b/flexget/plugins/input/filesystem.py
@@ -117,14 +117,9 @@ class Filesystem:
         else:
             entry['title'] = filepath.name
         file_stat = filepath.stat()
-        try:
-            entry['timestamp'] = pendulum.from_timestamp(file_stat.st_mtime, tz='local')
-        except Exception as e:
-            logger.warning('Error setting timestamp for {}: {}', filepath, e)
-            entry['timestamp'] = None
-        entry['accessed'] = pendulum.from_timestamp(file_stat.st_atime, tz='local')
-        entry['modified'] = pendulum.from_timestamp(file_stat.st_mtime, tz='local')
-        entry['created'] = pendulum.from_timestamp(file_stat.st_ctime, tz='local')
+        entry['atime'] = pendulum.from_timestamp(file_stat.st_atime, tz='local')
+        entry['mtime'] = pendulum.from_timestamp(file_stat.st_mtime, tz='local')
+        entry['ctime'] = pendulum.from_timestamp(file_stat.st_ctime, tz='local')
         if entry.isvalid():
             if test_mode:
                 logger.info('Test mode. Entry includes:')


### PR DESCRIPTION
### Motivation for changes:
According to https://docs.python.org/3/library/stat.html#stat.ST_CTIME, `stat.ST_CTIME` is the “ctime” as reported by the operating system. On some systems (like Unix) is **the time of the last metadata change**, and, on others (like Windows), is the creation time (see platform documentation for details).

Since `ctime` is not always the creation time, renaming the "created" field to "ctime" can help avoid misunderstanding.

Closes #4150
