### PR TITLE
Disable `renovate-config-validator` on pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
   autoupdate_schedule: quarterly
-  skip: [ uv-lock ]
+  skip: [ renovate-config-validator,uv-lock ]
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.9


### PR DESCRIPTION
### Motivation for changes:
The latest version of `renovate-config-validator` cannot run on pre-commit.ci.

