### PR TITLE
Make a missing path log a warning rather than causing a fatal error

### DIFF
--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from json import JSONDecodeError
 from json import loads as json_loads
 from re import Match, Pattern
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import Any, Callable, Optional, Union
 from urllib.parse import parse_qsl, urlparse
 
 import jsonschema

--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -2,6 +2,7 @@ import datetime
 import functools
 import os
 import re
+import string
 from collections import defaultdict
 from json import JSONDecodeError
 from json import loads as json_loads
@@ -276,7 +277,8 @@ def is_path(instance) -> bool:
         instance = os.path.dirname(instance[0 : result.start()])
     if os.path.isdir(os.path.expanduser(instance)):
         return True
-    logger.warning(f'`{instance}` does not exist')
+    error: string = f'`{instance}` does not exist'
+    logger.warning(error)
     return False
 
 

--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -265,7 +265,7 @@ def is_file(instance) -> bool:
     raise ValueError(f'`{instance}` does not exist')
 
 
-@format_checker.checks('path', raises=ValueError)
+@format_checker.checks('path')
 def is_path(instance) -> bool:
     if not isinstance(instance, str):
         return True
@@ -276,7 +276,8 @@ def is_path(instance) -> bool:
         instance = os.path.dirname(instance[0 : result.start()])
     if os.path.isdir(os.path.expanduser(instance)):
         return True
-    raise ValueError(f'`{instance}` does not exist')
+    logger.warning(f'`{instance}` does not exist')
+    return False
 
 
 # TODO: jsonschema has a format checker for uri if rfc3987 is installed, perhaps we should use that

--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -9,9 +9,6 @@ from re import Match, Pattern
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 from urllib.parse import parse_qsl, urlparse
 
-if TYPE_CHECKING:
-    import string
-
 import jsonschema
 from jsonschema import ValidationError
 from loguru import logger
@@ -279,7 +276,7 @@ def is_path(instance) -> bool:
         instance = os.path.dirname(instance[0 : result.start()])
     if os.path.isdir(os.path.expanduser(instance)):
         return True
-    error: string = f'`{instance}` does not exist'
+    error: str = f'`{instance}` does not exist'
     logger.warning(error)
     return False
 

--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -2,13 +2,15 @@ import datetime
 import functools
 import os
 import re
-import string
 from collections import defaultdict
 from json import JSONDecodeError
 from json import loads as json_loads
 from re import Match, Pattern
-from typing import Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 from urllib.parse import parse_qsl, urlparse
+
+if TYPE_CHECKING:
+    import string
 
 import jsonschema
 from jsonschema import ValidationError


### PR DESCRIPTION
### Motivation for changes:

A nonexistent path will cause the entire schema to fail validation. This can be super annoying.

### Detailed changes:
- Change `is_path` to log a warning rather than raise a ValueError
