### PR TITLE
Return true even if a path doesn't exist

### DIFF
--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -274,11 +274,10 @@ def is_path(instance) -> bool:
     result = pat.search(instance)
     if result:
         instance = os.path.dirname(instance[0 : result.start()])
-    if os.path.isdir(os.path.expanduser(instance)):
-        return True
-    error: str = f'`{instance}` does not exist'
-    logger.warning(error)
-    return False
+    if not os.path.isdir(os.path.expanduser(instance)):
+        error: str = f'`{instance}` does not exist'
+        logger.warning(error)
+    return True
 
 
 # TODO: jsonschema has a format checker for uri if rfc3987 is installed, perhaps we should use that

--- a/tests/api_tests/test_format_checker_api.py
+++ b/tests/api_tests/test_format_checker_api.py
@@ -170,7 +170,7 @@ class TestFormatChecker:
         payload2 = {'path': 'bla'}
 
         rsp = api_client.json_post('/format_check/', data=json.dumps(payload2))
-        assert rsp.status_code == 422, f'Response code is {rsp.status_code}'
+        assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
         data = json.loads(rsp.get_data(as_text=True))
 
         errors = schema_match(base_message, data)


### PR DESCRIPTION
This makes it clear that even a non-existent path will pass validation.