### PR TITLE
Fix unhandled error in plugin filesystem: 'timestamp'

### DIFF
--- a/flexget/plugins/input/filesystem.py
+++ b/flexget/plugins/input/filesystem.py
@@ -127,7 +127,9 @@ class Filesystem:
                 logger.info(' URL: {}', entry['url'])
                 logger.info(' Filename: {}', entry['filename'])
                 logger.info(' Location: {}', entry['location'])
-                logger.info(' Timestamp: {}', entry['timestamp'])
+                logger.info(' atime: {}', entry['atime'])
+                logger.info(' ctime: {}', entry['ctime'])
+                logger.info(' mtime: {}', entry['mtime'])
             return entry
         logger.error('Non valid entry created: {} ', entry)
         return None


### PR DESCRIPTION
### Motivation for changes:

I forgot to update the other parts when I modified the `timestamp` field earlier.

Fix #4409

