### PR TITLE
Fix Renovate Occasionally Failing to Create PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,7 +5,6 @@
     ':automergeDigest',
     ':automergePatch',
     ':enablePreCommit',
-    ':maintainLockFilesWeekly',
     ':prConcurrentLimitNone',
     ':prHourlyLimitNone',
     ':preserveSemverRanges',
@@ -15,6 +14,13 @@
     "* 16-23 * * 0",
     "* 0-12 * * 1"
   ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": [
+      "* 16-23 * * 0",
+      "* 0-12 * * 1"
+    ]
+  },
   gitIgnoredAuthors: [
     'github-actions[bot]@users.noreply.github.com',
     '66853113+pre-commit-ci[bot]@users.noreply.github.com',


### PR DESCRIPTION
### Motivation for changes:

This is part of #4400. #4400 didn’t change the schedule for lock file maintenance PRs — it only modified the schedule for other types of PRs. This PR fixes the part that was missed in #4400.


