### PR TITLE
fix(pre-commit): Migrate from legacy 'ruff' hook ID to 'ruff-check'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.11
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/PyCQA/doc8


### PR DESCRIPTION
### Summary

This commit migrates our pre-commit configuration from using the legacy `ruff` hook ID to the new `ruff-check` ID.

### Problem

The `ruff` project has updated its pre-commit hook definitions. The simple `ruff` ID is now considered a "legacy alias," and `ruff-check` is the new, explicit ID for the linter hook. This was observed today when running the pre-commit hooks locally.

### Solution

The hook ID in `.pre-commit-config.yaml` has been changed:

```diff
- id: ruff
+ id: ruff-check
```

This change aligns our configuration with the official [ruff documentation](https://github.com/astral-sh/ruff-pre-commit) and prevents potential warnings or breakages in future releases. It has no impact on the hook's functionality.

