### PR TITLE
chore: Add `typos` to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,10 @@ repos:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
         exclude_types: [python, yaml]
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.33.1
+    hooks:
+      - id: typos
   - repo: https://github.com/henryiii/validate-pyproject-schema-store
     rev: 2025.08.07
     hooks:

--- a/docs/contributor/Getting started/Development environment setup.rst
+++ b/docs/contributor/Getting started/Development environment setup.rst
@@ -94,7 +94,7 @@ dependencies at once. You can install it using::
 Installing the docs dependencies
 --------------------------------
 
-If you want to build the documentaion locally, additional docs dependencies must be installed::
+If you want to build the documentation locally, additional docs dependencies must be installed::
 
    $ uv sync --group docs
 

--- a/docs/contributor/Topic guides/Running and writing tests.rst
+++ b/docs/contributor/Topic guides/Running and writing tests.rst
@@ -284,7 +284,7 @@ Example:
 
 This will generate one entry in the task, notice that entry has two mandatory
 fields ``title`` and ``url``. If ``url`` is not defined the mock plugin will
-generate random url for localhost. The ``description`` filed is just arbitary
+generate random url for localhost. The ``description`` filed is just arbitrary
 field that we define in here. We can define any kind of basic text, number, list
 or dictionary fields in here.
 

--- a/flexget/api/core/server.py
+++ b/flexget/api/core/server.py
@@ -562,7 +562,7 @@ class LogParser:
 
 @server_api.route('/crash_logs/')
 class ServerCrashLogAPI(APIResource):
-    @api.response(200, 'Succesfully retreived crash logs', model=crash_logs_schema)
+    @api.response(200, 'Successfully retrieved crash logs', model=crash_logs_schema)
     def get(self, session: Session):
         """Get Crash logs."""
         path = self.manager.config_base

--- a/flexget/components/archives/decompress.py
+++ b/flexget/components/archives/decompress.py
@@ -105,7 +105,7 @@ class Decompress:
     to                 Destination path; supports Jinja2 templating on the input entry. Fields such
                        as series_name must be populated prior to input into this plugin using
                        metainfo_series or similar. If no path is specified, archive contents will
-                       be extraced in the same directory as the archve itself.
+                       be extracted in the same directory as the archive itself.
     keep_dirs          [yes|no] (default: yes) Indicates whether to preserve the directory
                        structure from within the archive in the destination path.
     mask               Shell-style file mask; any matching files will be extracted. When used, this

--- a/flexget/components/bittorrent/private_torrents.py
+++ b/flexget/components/bittorrent/private_torrents.py
@@ -23,7 +23,7 @@ class FilterPrivateTorrents:
 
     This would reject all public torrents.
 
-    Non-torrent content is not interviened.
+    Non-torrent content is not intervened.
     """
 
     schema = {'type': 'boolean'}

--- a/flexget/components/bittorrent/torrent_alive.py
+++ b/flexget/components/bittorrent/torrent_alive.py
@@ -104,7 +104,7 @@ def get_udp_seeds(url, info_hash):
 
         # set 16 bytes ["QLL" = 16 bytes] for the fmq for unpack
         res = clisocket.recv(16)
-        # check recieved packet for response
+        # check received packet for response
         action, transaction_id, connection_id = struct.unpack(b'>LLQ', res)
 
         # build packet hash out of decoded info_hash
@@ -114,7 +114,7 @@ def get_udp_seeds(url, info_hash):
         packet = struct.pack(b'>QLL', connection_id, 2, transaction_id) + packet_hash
 
         clisocket.send(packet)
-        # set recieve size of 8 + 12 bytes
+        # set receive size of 8 + 12 bytes
         res = clisocket.recv(20)
 
     except OSError as e:

--- a/flexget/components/emby/api_emby.py
+++ b/flexget/components/emby/api_emby.py
@@ -203,7 +203,7 @@ class EmbyAuth(EmbyApiBase):
 
                     # Login to emby connect
                     args = {'nameOrEmail': self._username, 'rawpw': self._password}
-                    connect_data = EmbyApi.resquest_emby(
+                    connect_data = EmbyApi.request_emby(
                         EMBY_ENDPOINT_CONNECT_LOGIN, self, 'POST', emby_connect=True, **args
                     )
 
@@ -219,9 +219,9 @@ class EmbyAuth(EmbyApiBase):
 
                     self._connect_token = connect_data['AccessToken']
 
-                    # Retrive emby connect servers
+                    # Retrieve emby connect servers
                     args = {'userId': connect_data['User']['Id']}
-                    connect_servers = EmbyApi.resquest_emby(
+                    connect_servers = EmbyApi.request_emby(
                         EMBY_ENDPOINT_CONNECT_SERVERS, self, 'GET', emby_connect=True, **args
                     )
                     if not isinstance(connect_servers, list):
@@ -254,7 +254,7 @@ class EmbyAuth(EmbyApiBase):
                     self.host = connect_server['Url']
 
                     args = {'format': 'json', 'ConnectUserId': connect_data['User']['Id']}
-                    connect_exchange = EmbyApi.resquest_emby(
+                    connect_exchange = EmbyApi.request_emby(
                         EMBY_ENDPOINT_CONNECT_EXCHANGE, self, 'GET', **args
                     )
 
@@ -269,7 +269,7 @@ class EmbyAuth(EmbyApiBase):
                     self._userid = connect_exchange['LocalUserId']
                     self._token = connect_exchange['AccessToken']
                     self._logged = True
-                    userdata = EmbyApi.resquest_emby(EMBY_ENDPOINT_USERINFO, self, 'GET', {})
+                    userdata = EmbyApi.request_emby(EMBY_ENDPOINT_USERINFO, self, 'GET', {})
 
             else:
                 # Make Local user login
@@ -281,7 +281,7 @@ class EmbyAuth(EmbyApiBase):
                     )
                     args = {'Username': self._username, 'Pw': self._password}
 
-                    login_data = EmbyApi.resquest_emby(EMBY_ENDPOINT_LOGIN, self, 'POST', **args)
+                    login_data = EmbyApi.request_emby(EMBY_ENDPOINT_LOGIN, self, 'POST', **args)
 
                     if not login_data and optional:
                         return
@@ -315,7 +315,7 @@ class EmbyAuth(EmbyApiBase):
 
         self._logged = True
 
-        serverinfo = EmbyApi.resquest_emby(EMBY_ENDPOINT_SERVERINFO, self, 'GET')
+        serverinfo = EmbyApi.request_emby(EMBY_ENDPOINT_SERVERINFO, self, 'GET')
         if serverinfo:
             self._wanurl = serverinfo.get('WanAddress')
             self._lanurl = serverinfo.get('LocalAddress')
@@ -379,7 +379,7 @@ class EmbyAuth(EmbyApiBase):
         endpoint = EMBY_ENDPOINT_USERINFO.format(userid=token_data['userid'])
 
         try:
-            response = EmbyApi.resquest_emby(endpoint, self, 'GET')
+            response = EmbyApi.request_emby(endpoint, self, 'GET')
         except PluginError:
             response = None
 
@@ -489,7 +489,7 @@ class EmbyAuth(EmbyApiBase):
     def get_user_by_name(self, name: str) -> dict:
         """Get user by username."""
         args = {'IsDisabled': False}
-        useres = EmbyApi.resquest_emby(EMBY_ENDPOINT_GETUSERS, self, 'GET', **args)
+        useres = EmbyApi.request_emby(EMBY_ENDPOINT_GETUSERS, self, 'GET', **args)
         if not useres:
             return None
 
@@ -559,7 +559,7 @@ class EmbyApiListBase(EmbyApiBase):
         if not self.types or len(self.types) == 0:
             args['IncludeItemTypes'] = 'Movie,Episode'
         else:
-            args['IncludeItemTypes'] = ','.join(typ.title() for typ in self.types)
+            args['IncludeItemTypes'] = ','.join(type.title() for type in self.types)
 
     def add(self, entry: Entry):
         """Add a item to list."""
@@ -786,7 +786,7 @@ class EmbyApiLibrary(EmbyApiListBase):
         while True:
             args['Limit'] = self.iterator
             args['StartIndex'] = index * self.iterator
-            items = EmbyApi.resquest_emby(endpoint, self.auth, 'GET', **args)
+            items = EmbyApi.request_emby(endpoint, self.auth, 'GET', **args)
 
             self._len = items.get('TotalRecordCount', 0)
 
@@ -809,7 +809,7 @@ class EmbyApiLibrary(EmbyApiListBase):
         if not auth:
             auth = EmbyApi.get_auth()
 
-        additem = EmbyApi.resquest_emby(EMBY_ENDPOINT_LIBRARY_REFRESH, auth, 'POST')
+        additem = EmbyApi.request_emby(EMBY_ENDPOINT_LIBRARY_REFRESH, auth, 'POST')
         if not additem:
             logger.error('Not possible to refresh emby library')
 
@@ -824,7 +824,7 @@ class EmbyApiLibrary(EmbyApiListBase):
         args['IsHidden'] = False
 
         logger.debug('Search Library name list with: {}', args)
-        search_list_data = EmbyApi.resquest_emby(EMBY_ENDPOINT_LIBRARY, auth, 'GET', **args)
+        search_list_data = EmbyApi.request_emby(EMBY_ENDPOINT_LIBRARY, auth, 'GET', **args)
         if not search_list_data or not search_list_data['Items']:
             return None
 
@@ -896,7 +896,7 @@ class EmbyApiRootList(EmbyApiListBase):
         while True:
             args['Limit'] = self.iterator
             args['StartIndex'] = index * self.iterator
-            items = EmbyApi.resquest_emby(endpoint, self.auth, 'GET', **args)
+            items = EmbyApi.request_emby(endpoint, self.auth, 'GET', **args)
 
             self._len = items.get('TotalRecordCount', 0)
 
@@ -934,14 +934,14 @@ class EmbyApiWatchedList(EmbyApiListBase):
     def _add(self, item: EmbyApiMedia):
         args = {}
         endpoint = EMBY_ENDPOINT_WATCHED.format(userid=self.auth.uid, itemid=item.id)
-        additem = EmbyApi.resquest_emby(endpoint, self.auth, 'POST', **args)
+        additem = EmbyApi.request_emby(endpoint, self.auth, 'POST', **args)
         if not additem:
             logger.warning("Not possible to add item '{}' to watched list", item.fullname)
 
     def _remove(self, item: EmbyApiMedia):
         args = {}
         endpoint = EMBY_ENDPOINT_WATCHED.format(userid=self.auth.uid, itemid=item.id)
-        additem = EmbyApi.resquest_emby(endpoint, self.auth, 'DELETE', **args)
+        additem = EmbyApi.request_emby(endpoint, self.auth, 'DELETE', **args)
         if not additem:
             logger.warning("Not possible to remove item '{}' from watched list", item.fullname)
 
@@ -969,7 +969,7 @@ class EmbyApiWatchedList(EmbyApiListBase):
         while True:
             args['Limit'] = self.iterator
             args['StartIndex'] = index * self.iterator
-            items = EmbyApi.resquest_emby(endpoint, self.auth, 'GET', **args)
+            items = EmbyApi.request_emby(endpoint, self.auth, 'GET', **args)
 
             self._len = items.get('TotalRecordCount', 0)
 
@@ -1007,14 +1007,14 @@ class EmbyApiFavoriteList(EmbyApiListBase):
     def _add(self, item: EmbyApiMedia):
         args = {}
         endpoint = EMBY_ENDPOINT_FAVORITE.format(userid=self.auth.uid, itemid=item.id)
-        additem = EmbyApi.resquest_emby(endpoint, self.auth, 'POST', **args)
+        additem = EmbyApi.request_emby(endpoint, self.auth, 'POST', **args)
         if not additem:
             logger.warning("Not possible to add item '{}' to favorite list", item.fullname)
 
     def _remove(self, item: EmbyApiMedia):
         args = {}
         endpoint = EMBY_ENDPOINT_FAVORITE.format(userid=self.auth.uid, itemid=item.id)
-        additem = EmbyApi.resquest_emby(endpoint, self.auth, 'DELETE', **args)
+        additem = EmbyApi.request_emby(endpoint, self.auth, 'DELETE', **args)
         if not additem:
             logger.warning("Not possible to remove item '{}' from favorite list", item.fullname)
 
@@ -1042,7 +1042,7 @@ class EmbyApiFavoriteList(EmbyApiListBase):
         while True:
             args['Limit'] = self.iterator
             args['StartIndex'] = index * self.iterator
-            items = EmbyApi.resquest_emby(endpoint, self.auth, 'GET', **args)
+            items = EmbyApi.request_emby(endpoint, self.auth, 'GET', **args)
 
             self._len = items.get('TotalRecordCount', 0)
 
@@ -1096,7 +1096,7 @@ class EmbyApiPlayList(EmbyApiListBase):
         args['Ids'] = item.id
 
         endpoint = EMBY_ENDPOINT_PLAYLIST.format(listid=self.id)
-        additem = EmbyApi.resquest_emby(endpoint, self.auth, 'POST', **args)
+        additem = EmbyApi.request_emby(endpoint, self.auth, 'POST', **args)
         if not additem:
             logger.warning(
                 "Not possible to add item '{}' to Playlist '{}'", item.fullname, self.name
@@ -1120,7 +1120,7 @@ class EmbyApiPlayList(EmbyApiListBase):
         args['EntryIds'] = self.playlist_bind[item.id]
 
         endpoint = EMBY_ENDPOINT_PLAYLIST.format(listid=self.id)
-        additem = EmbyApi.resquest_emby(endpoint, self.auth, 'DELETE', **args)
+        additem = EmbyApi.request_emby(endpoint, self.auth, 'DELETE', **args)
         if not additem:
             logger.warning(
                 "Not possible to remove item '{}' from Playlist '{}'", item.fullname, self.name
@@ -1140,7 +1140,7 @@ class EmbyApiPlayList(EmbyApiListBase):
     def destroy(self):
         logger.debug('Deleting {}', self.fullname)
         endpoint = EMBY_ENDPOINT_DELETE_ITEM.format(itemid=self.id)
-        additem = EmbyApi.resquest_emby(endpoint, self.auth, 'DELETE')
+        additem = EmbyApi.request_emby(endpoint, self.auth, 'DELETE')
         if not additem:
             logger.warning('Not possible to delete {}', self.fullname)
             return
@@ -1159,7 +1159,7 @@ class EmbyApiPlayList(EmbyApiListBase):
         args['ParentId'] = self.id
         logger.debug('Search PlayList  with: {}', args)
         endpoint = EMBY_ENDPOINT_SEARCH.format(userid=self.auth.uid)
-        items = EmbyApi.resquest_emby(endpoint, self.auth, 'GET', **args)
+        items = EmbyApi.request_emby(endpoint, self.auth, 'GET', **args)
         self._internal_items = items['Items'] if items else []
 
         self.playlist_bind = {}
@@ -1199,7 +1199,7 @@ class EmbyApiPlayList(EmbyApiListBase):
         args['Type'] = 'Playlist'
 
         logger.debug('Search Playlist Name list with: {}', args)
-        search_list_data = EmbyApi.resquest_emby(EMBY_ENDPOINT_SEARCH, auth, 'GET', **args)
+        search_list_data = EmbyApi.request_emby(EMBY_ENDPOINT_SEARCH, auth, 'GET', **args)
         if not search_list_data or not search_list_data['Items']:
             return None
 
@@ -1228,7 +1228,7 @@ class EmbyApiPlayList(EmbyApiListBase):
         args['Ids'] = item.id
         logger.debug("Creating playlist '{}'", list_name)
 
-        items = EmbyApi.resquest_emby(EMBY_ENDPOINT_NEW_PLAYLIST, auth, 'POST', **args)
+        items = EmbyApi.request_emby(EMBY_ENDPOINT_NEW_PLAYLIST, auth, 'POST', **args)
         if not items:
             logger.warning("Not possible to create playlist '{}'", list_name)
             return None
@@ -1351,7 +1351,7 @@ class EmbyApiMedia(EmbyApiBase):
 
                         self.audio.append(stream['Language'])
 
-        self.library = self.get_libary()
+        self.library = self.get_library()
 
     def _get_parents(self) -> dict:
         if not self.id or not self.auth or not self.auth.uid:
@@ -1360,13 +1360,13 @@ class EmbyApiMedia(EmbyApiBase):
         args = {'userid': self.auth.uid}
 
         endpoint = EMBY_ENDPOINT_PARENTS.format(itemid=self.id)
-        parents = EmbyApi.resquest_emby(endpoint, self.auth, 'GET', **args)
+        parents = EmbyApi.request_emby(endpoint, self.auth, 'GET', **args)
         if not parents:
             return None
 
         return parents
 
-    def get_libary(self) -> EmbyApiLibrary:
+    def get_library(self) -> EmbyApiLibrary:
         parents = self._get_parents()
         if not parents:
             return None
@@ -1572,8 +1572,8 @@ class EmbyApiMedia(EmbyApiBase):
         if EmbyApiSeason.is_type(**kwargs):
             return EmbyApiSeason.search(**kwargs)
 
-        if EmbyApiSerie.is_type(**kwargs):
-            return EmbyApiSerie.search(**kwargs)
+        if EmbyApiSeries.is_type(**kwargs):
+            return EmbyApiSeries.search(**kwargs)
 
         if EmbyApiMovie.is_type(**kwargs):
             return EmbyApiMovie.search(**kwargs)
@@ -1586,7 +1586,7 @@ class EmbyApiMedia(EmbyApiBase):
         if not string:
             return None, None
 
-        name, year = EmbyApiSerie.parse_string(string)
+        name, year = EmbyApiSeries.parse_string(string)
         if name:
             return name, year
 
@@ -1606,8 +1606,8 @@ class EmbyApiMedia(EmbyApiBase):
 
         if 'id' in parameters:
             args['Ids'] = parameters.get('id')
-        elif EmbyApi.has_provideres_search_arg(**kwargs):
-            EmbyApi.set_provideres_search_arg(args, **kwargs)
+        elif EmbyApi.has_providers_search_arg(**kwargs):
+            EmbyApi.set_providers_search_arg(args, **kwargs)
         else:
             args['SearchTerm'], year = EmbyApiMedia.parse_string(
                 parameters.get('search_string', parameters.get('base_name'))
@@ -1623,10 +1623,10 @@ class EmbyApiMedia(EmbyApiBase):
                 args['Years'] = year
 
         logger.debug('Search media with: {}', args)
-        medias = EmbyApi.resquest_emby(EMBY_ENDPOINT_SEARCH, auth, 'GET', **args)
+        medias = EmbyApi.request_emby(EMBY_ENDPOINT_SEARCH, auth, 'GET', **args)
         if not medias or 'Items' not in medias or not medias['Items']:
-            if EmbyApi.has_provideres_search_arg(**parameters):
-                EmbyApi.remove_provideres_search(parameters)
+            if EmbyApi.has_providers_search_arg(**parameters):
+                EmbyApi.remove_providers_search(parameters)
                 return EmbyApiMedia.search(**parameters)
 
             logger.warning('No media found')
@@ -1643,26 +1643,26 @@ class EmbyApiMedia(EmbyApiBase):
         return media_api
 
 
-class EmbyApiSerie(EmbyApiMedia):
+class EmbyApiSeries(EmbyApiMedia):
     """Series."""
 
     TYPE = 'series'
 
     field_map_up = {
-        'id': 'serie_id',
-        'base_name': ['serie_name', 'series_name', 'SeriesName'],
-        'imdb_id': 'serie_imdb_id',
-        'tmdb_id': 'serie_tmdb_id',
-        'tvdb_id': 'serie_tvdb_id',
-        'page': 'serie_page',
-        'aired_date': 'serie_aired_date',
-        'overview': 'serie_overview',
-        'photo': 'serie_photo',
-        'serie_id': ['serie_id', 'SeriesId'],
-        'serie_name': ['serie_name', 'series_name', 'SeriesName'],
-        'serie_imdb_id': 'serie_imdb_id',
-        'serie_tmdb_id': 'serie_tmdb_id',
-        'serie_tvdb_id': 'serie_tvdb_id',
+        'id': 'series_id',
+        'base_name': ['series_name', 'series_name', 'SeriesName'],
+        'imdb_id': 'series_imdb_id',
+        'tmdb_id': 'series_tmdb_id',
+        'tvdb_id': 'series_tvdb_id',
+        'page': 'series_page',
+        'aired_date': 'series_aired_date',
+        'overview': 'series_overview',
+        'photo': 'series_photo',
+        'series_id': ['series_id', 'SeriesId'],
+        'series_name': ['series_name', 'series_name', 'SeriesName'],
+        'series_imdb_id': 'series_imdb_id',
+        'series_tmdb_id': 'series_tmdb_id',
+        'series_tvdb_id': 'series_tvdb_id',
     }
 
     def __init__(self, **kwargs):
@@ -1674,56 +1674,56 @@ class EmbyApiSerie(EmbyApiMedia):
 
         return {
             **EmbyApiMedia.to_dict(self),
-            'serie_id': self.serie_id,
-            'serie_name': self.serie_name,
-            'serie_imdb_id': self.serie_imdb_id,
-            'serie_tmdb_id': self.serie_tmdb_id,
-            'serie_tvdb_id': self.serie_tvdb_id,
-            'serie_aired_date': self.serie_aired_date,
-            'serie_year': self.serie_year,
-            'serie_overview': self.serie_overview,
-            'serie_photo': self.serie_photo,
-            'serie_page': self.serie_page,
+            'series_id': self.series_id,
+            'series_name': self.series_name,
+            'series_imdb_id': self.series_imdb_id,
+            'series_tmdb_id': self.series_tmdb_id,
+            'series_tvdb_id': self.series_tvdb_id,
+            'series_aired_date': self.series_aired_date,
+            'series_year': self.series_year,
+            'series_overview': self.series_overview,
+            'series_photo': self.series_photo,
+            'series_page': self.series_page,
         }
 
     @property
-    def serie_id(self) -> str:
+    def series_id(self) -> str:
         return self.id
 
     @property
-    def serie_name(self) -> str:
+    def series_name(self) -> str:
         return self.name
 
     @property
-    def serie_overview(self) -> str:
+    def series_overview(self) -> str:
         return self.overview
 
     @property
-    def serie_photo(self) -> str:
+    def series_photo(self) -> str:
         return self.photo
 
     @property
-    def serie_page(self) -> str:
+    def series_page(self) -> str:
         return self.page
 
     @property
-    def serie_imdb_id(self) -> str:
+    def series_imdb_id(self) -> str:
         return self.imdb_id
 
     @property
-    def serie_tmdb_id(self) -> str:
+    def series_tmdb_id(self) -> str:
         return self.tmdb_id
 
     @property
-    def serie_tvdb_id(self) -> str:
+    def series_tvdb_id(self) -> str:
         return self.tvdb_id
 
     @property
-    def serie_aired_date(self) -> datetime:
+    def series_aired_date(self) -> datetime:
         return self.aired_date
 
     @property
-    def serie_year(self) -> int:
+    def series_year(self) -> int:
         return self.year
 
     @property
@@ -1744,7 +1744,7 @@ class EmbyApiSerie(EmbyApiMedia):
             info = re.search(r'(.+) [s]([0-9]+)', string, re.IGNORECASE)
             if not info or not info.groups():
                 if force_parse:
-                    # I assume that it's only a serie if contains pathern, but I might need to assume it's a serie
+                    # I assume that it's only a series if contains pathern, but I might need to assume it's a series
                     return split_title_year(string)
                 return None, None
 
@@ -1756,14 +1756,14 @@ class EmbyApiSerie(EmbyApiMedia):
         return split_title_year(info)
 
     @staticmethod
-    def search(**kwargs) -> EmbyApiSerie:
+    def search(**kwargs) -> EmbyApiSeries:
         args = {}
 
         auth = EmbyApi.get_auth(**kwargs)
 
         parameters = {}
         field_map = EmbyApiBase.merge_field_map(
-            EmbyApiSerie.field_map_up,
+            EmbyApiSeries.field_map_up,
             EmbyApiMedia.field_map,
             allow_new=True,
         )
@@ -1772,12 +1772,12 @@ class EmbyApiSerie(EmbyApiMedia):
 
         EmbyApi.set_common_search_arg(args)
 
-        if 'serie_id' in parameters:
-            args['Ids'] = parameters.get('serie_id')
-        elif EmbyApi.has_provideres_search_arg(**parameters):
-            EmbyApi.set_provideres_search_arg(args, **parameters)
+        if 'series_id' in parameters:
+            args['Ids'] = parameters.get('series_id')
+        elif EmbyApi.has_providers_search_arg(**parameters):
+            EmbyApi.set_providers_search_arg(args, **parameters)
         else:
-            args['SearchTerm'], year = EmbyApiSerie.parse_string(
+            args['SearchTerm'], year = EmbyApiSeries.parse_string(
                 parameters.get('search_string', parameters.get('base_name')), True
             )
 
@@ -1792,44 +1792,44 @@ class EmbyApiSerie(EmbyApiMedia):
 
         args['IncludeItemTypes'] = 'Series'
 
-        logger.debug('Search serie with: {}', args)
-        series = EmbyApi.resquest_emby(EMBY_ENDPOINT_SEARCH, auth, 'GET', **args)
+        logger.debug('Search series with: {}', args)
+        series = EmbyApi.request_emby(EMBY_ENDPOINT_SEARCH, auth, 'GET', **args)
         if not series or 'Items' not in series or not series['Items']:
-            if EmbyApi.has_provideres_search_arg(**parameters):
-                EmbyApi.remove_provideres_search(parameters)
-                return EmbyApiSerie.search(**parameters)
+            if EmbyApi.has_providers_search_arg(**parameters):
+                EmbyApi.remove_providers_search(parameters)
+                return EmbyApiSeries.search(**parameters)
 
-            logger.warning('No serie found')
+            logger.warning('No series found')
             return None
 
         if len(series['Items']) == 1:
-            serie = series['Items'][0]
+            series = series['Items'][0]
         elif len(series['Items']) > 1:
-            serie_filter = list(
+            series_filter = list(
                 filter(lambda s: s.get('Name') == args.get('SearchTerm'), series['Items'])
             )
 
             if args.get('Years'):
-                serie_filter = list(
-                    filter(lambda s: s.get('Year') == args.get('Years'), serie_filter)
+                series_filter = list(
+                    filter(lambda s: s.get('Year') == args.get('Years'), series_filter)
                 )
 
-            if len(serie_filter) == 1:
-                serie = serie_filter[0]
+            if len(series_filter) == 1:
+                series = series_filter[0]
             else:
-                logger.warning('More than one serie found')
+                logger.warning('More than one series found')
                 return None
 
-        serie_api = EmbyApiSerie(auth=auth, **serie)
-        if serie_api:
-            logger.debug("Found serie '{}' in emby server", serie_api.fullname)
-            return serie_api
+        series_api = EmbyApiSeries(auth=auth, **series)
+        if series_api:
+            logger.debug("Found series '{}' in emby server", series_api.fullname)
+            return series_api
         return None
 
     @staticmethod
     def is_type(**kwargs) -> bool:
         mtype = EmbyApiMedia.get_mtype(**kwargs)
-        if mtype.lower() == EmbyApiSerie.TYPE.lower():
+        if mtype.lower() == EmbyApiSeries.TYPE.lower():
             return True
 
         if mtype:
@@ -1838,8 +1838,8 @@ class EmbyApiSerie(EmbyApiMedia):
         if kwargs.get('series_name'):
             return True
 
-        serie, _ = EmbyApiSerie.parse_string(kwargs.get('search_string', kwargs.get('title')))
-        return bool(serie)
+        series, _ = EmbyApiSeries.parse_string(kwargs.get('search_string', kwargs.get('title')))
+        return bool(series)
 
 
 class EmbyApiSeason(EmbyApiMedia):
@@ -1847,7 +1847,7 @@ class EmbyApiSeason(EmbyApiMedia):
 
     TYPE = 'season'
 
-    _serie = None
+    _series = None
     season = None
 
     field_map = {'season': ['season', 'IndexNumber']}
@@ -1876,19 +1876,19 @@ class EmbyApiSeason(EmbyApiMedia):
 
         EmbyApiBase.update_using_map(self, EmbyApiSeason.field_map, kwargs)
 
-        if isinstance(kwargs.get('api_serie'), EmbyApiSerie):
-            self._serie = kwargs.get('api_serie')
-        elif isinstance(self.serie, EmbyApiSerie):
-            self._serie = self.serie
+        if isinstance(kwargs.get('api_series'), EmbyApiSeries):
+            self._series = kwargs.get('api_series')
+        elif isinstance(self.series, EmbyApiSeries):
+            self._series = self.series
         else:
-            self._serie = EmbyApiSerie.search(**kwargs) or EmbyApiSerie(auth=self.auth)
+            self._series = EmbyApiSeries.search(**kwargs) or EmbyApiSeries(auth=self.auth)
 
     def to_dict(self) -> dict:
         if not self:
             return {}
 
         return {
-            **EmbyApiSerie.to_dict(self.serie),
+            **EmbyApiSeries.to_dict(self.series),
             **EmbyApiMedia.to_dict(self),
             'season': self.season,
             'season_id': self.season_id,
@@ -1902,14 +1902,14 @@ class EmbyApiSeason(EmbyApiMedia):
 
     @property
     def fullname(self) -> str:
-        if not self.serie:
+        if not self.series:
             return self.name
         if self.season == 0:
-            return f'{self.serie.fullname} S00'
+            return f'{self.series.fullname} S00'
         if not self.season:
-            return f'{self.serie.fullname} Sxx'
+            return f'{self.series.fullname} Sxx'
 
-        return f'{self.serie.fullname} S{self.season:02d}'
+        return f'{self.series.fullname} S{self.season:02d}'
 
     @property
     def season_name(self) -> str:
@@ -1920,7 +1920,7 @@ class EmbyApiSeason(EmbyApiMedia):
         return self.id
 
     @property
-    def serie_overview(self) -> str:
+    def series_overview(self) -> str:
         return self.overview
 
     @property
@@ -1944,12 +1944,12 @@ class EmbyApiSeason(EmbyApiMedia):
         return self.page
 
     @property
-    def serie(self) -> EmbyApiSerie:
-        if isinstance(self._serie, EmbyApiSerie):
-            return self._serie
+    def series(self) -> EmbyApiSeries:
+        if isinstance(self._series, EmbyApiSeries):
+            return self._series
 
-        self._serie = EmbyApiSerie.get_from_child(self)
-        return self._serie
+        self._series = EmbyApiSeries.get_from_child(self)
+        return self._series
 
     @staticmethod
     def is_type(**kwargs) -> bool:
@@ -1961,7 +1961,7 @@ class EmbyApiSeason(EmbyApiMedia):
             return False
 
         if (
-            EmbyApiSerie.is_type(**kwargs)
+            EmbyApiSeries.is_type(**kwargs)
             and 'series_season' in kwargs
             and not EmbyApiEpisode.is_type(**kwargs)
         ):
@@ -1999,7 +1999,7 @@ class EmbyApiSeason(EmbyApiMedia):
         parameters = {}
         field_map = EmbyApiBase.merge_field_map(
             EmbyApiSeason.field_map_up,
-            EmbyApiSerie.field_map_up,
+            EmbyApiSeries.field_map_up,
             EmbyApiMedia.field_map,
             allow_new=True,
         )
@@ -2007,28 +2007,28 @@ class EmbyApiSeason(EmbyApiMedia):
         EmbyApi.update_using_map(parameters, field_map, kwargs, allow_new=True)
 
         # We need to have information regarding the series
-        season_serie = None
-        if 'api_serie' in kwargs:
-            season_serie = kwargs.get('api_serie')
+        season_series = None
+        if 'api_series' in kwargs:
+            season_series = kwargs.get('api_series')
 
-        if not season_serie:
-            season_serie = EmbyApiSerie.search(**kwargs)
+        if not season_series:
+            season_series = EmbyApiSeries.search(**kwargs)
 
-        if not season_serie:
-            logger.warning('Not possible to determine season, serie not found')
+        if not season_series:
+            logger.warning('Not possible to determine season, series not found')
             return None
 
         if 'season_id' in parameters:
             args['Ids'] = parameters.get('season_id')
         else:
-            args['ParentId'] = season_serie.serie_id
+            args['ParentId'] = season_series.series_id
 
         args['IncludeItemTypes'] = 'Season'
 
         EmbyApi.set_common_search_arg(args)
 
         logger.debug('Search season with: {}', args)
-        seasons = EmbyApi.resquest_emby(EMBY_ENDPOINT_SEARCH, auth, 'GET', **args)
+        seasons = EmbyApi.request_emby(EMBY_ENDPOINT_SEARCH, auth, 'GET', **args)
         if not seasons or 'Items' not in seasons or not seasons['Items']:
             logger.warning('No season found')
             return None
@@ -2050,14 +2050,14 @@ class EmbyApiSeason(EmbyApiMedia):
             season = seasons[0]
         elif len(seasons) > 1:
             logger.warning(
-                'More than one season found for {} {}', season_serie.fullname, target_season
+                'More than one season found for {} {}', season_series.fullname, target_season
             )
             return None
         else:
             logger.warning('No season found')
             return None
 
-        season_api = EmbyApiSeason(auth=auth, api_serie=season_serie, **season)
+        season_api = EmbyApiSeason(auth=auth, api_series=season_series, **season)
         if season_api:
             logger.debug("Found season '{}' in emby server", season_api.fullname)
             return season_api
@@ -2069,7 +2069,7 @@ class EmbyApiEpisode(EmbyApiMedia):
 
     TYPE = 'episode'
 
-    _serie = None
+    _series = None
     _season = None
     episode = None
 
@@ -2100,12 +2100,12 @@ class EmbyApiEpisode(EmbyApiMedia):
 
         EmbyApiBase.update_using_map(self, EmbyApiEpisode.field_map, kwargs)
 
-        if isinstance(kwargs.get('api_serie'), EmbyApiSerie):
-            self._serie = kwargs.get('api_serie')
-        elif isinstance(self.serie, EmbyApiSerie):
-            self._serie = self.serie
+        if isinstance(kwargs.get('api_series'), EmbyApiSeries):
+            self._series = kwargs.get('api_series')
+        elif isinstance(self.series, EmbyApiSeries):
+            self._series = self.series
         else:
-            self._serie = EmbyApiSerie.search(**kwargs) or EmbyApiSerie(auth=self.auth)
+            self._series = EmbyApiSeries.search(**kwargs) or EmbyApiSeries(auth=self.auth)
 
         if isinstance(kwargs.get('api_season'), EmbyApiSeason):
             self._season = kwargs.get('api_season')
@@ -2120,7 +2120,7 @@ class EmbyApiEpisode(EmbyApiMedia):
 
         return {
             **EmbyApiSeason.to_dict(self.season),
-            **EmbyApiSerie.to_dict(self.serie),
+            **EmbyApiSeries.to_dict(self.series),
             **EmbyApiMedia.to_dict(self),
             'episode': self.episode,
             'ep_id': self.ep_id,
@@ -2136,16 +2136,16 @@ class EmbyApiEpisode(EmbyApiMedia):
 
     @property
     def fullname(self) -> str:
-        if not self.serie:
+        if not self.series:
             return self.name
         if not self.season:
-            return f'{self.serie.fullname} SxxExx'
+            return f'{self.series.fullname} SxxExx'
         if self.episode == 0:
-            return f'{self.serie.fullname} S{self.season.season:02d}E00'
+            return f'{self.series.fullname} S{self.season.season:02d}E00'
         if not self.episode:
-            return f'{self.serie.fullname} S{self.season.season:02d}Exx'
+            return f'{self.series.fullname} S{self.season.season:02d}Exx'
 
-        return f'{self.serie.fullname} S{self.season.season:02d}E{self.episode:02d} {self.name}'
+        return f'{self.series.fullname} S{self.season.season:02d}E{self.episode:02d} {self.name}'
 
     @property
     def ep_id(self) -> str:
@@ -2192,16 +2192,16 @@ class EmbyApiEpisode(EmbyApiMedia):
         return self._season
 
     @property
-    def serie(self) -> EmbyApiSerie:
-        if isinstance(self._serie, EmbyApiSerie):
-            return self._serie
+    def series(self) -> EmbyApiSeries:
+        if isinstance(self._series, EmbyApiSeries):
+            return self._series
 
-        self._serie = EmbyApiSerie.get_from_child(self)
-        return self._serie
+        self._series = EmbyApiSeries.get_from_child(self)
+        return self._series
 
     @staticmethod
     def search(**kwargs) -> EmbyApiEpisode:
-        episode_serie = None
+        episode_series = None
         episode_season = None
 
         auth = EmbyApi.get_auth(**kwargs)
@@ -2214,7 +2214,7 @@ class EmbyApiEpisode(EmbyApiMedia):
             EmbyApiEpisode.field_map,
             EmbyApiEpisode.field_map_up,
             EmbyApiSeason.field_map_up,
-            EmbyApiSerie.field_map_up,
+            EmbyApiSeries.field_map_up,
             EmbyApiMedia.field_map,
             allow_new=True,
         )
@@ -2222,14 +2222,14 @@ class EmbyApiEpisode(EmbyApiMedia):
         EmbyApi.update_using_map(parameters, field_map, kwargs, allow_new=True)
 
         # We need to have information regarding the series
-        if 'api_serie' in kwargs:
-            episode_serie = kwargs.get('api_serie')
+        if 'api_series' in kwargs:
+            episode_series = kwargs.get('api_series')
 
-        if not episode_serie:
-            episode_serie = EmbyApiSerie.search(**kwargs)
+        if not episode_series:
+            episode_series = EmbyApiSeries.search(**kwargs)
 
-        if not episode_serie:
-            logger.warning('Not possible to determine episode, serie not found')
+        if not episode_series:
+            logger.warning('Not possible to determine episode, series not found')
             return None
 
         # We need to have information regarding the season
@@ -2237,7 +2237,7 @@ class EmbyApiEpisode(EmbyApiMedia):
             episode_season = kwargs.get('api_season')
 
         if not episode_season:
-            episode_season = EmbyApiSeason.search(api_serie=episode_serie, **kwargs)
+            episode_season = EmbyApiSeason.search(api_series=episode_series, **kwargs)
 
         if not episode_season:
             logger.warning('Not possible to determine episode, season not found')
@@ -2248,14 +2248,14 @@ class EmbyApiEpisode(EmbyApiMedia):
             args['Ids'] = parameters.get('ep_id')
         elif episode_season and episode_season.season_id:
             args['ParentId'] = episode_season.season_id
-        elif episode_serie and episode_serie.serie_id:
-            args['ParentId'] = episode_serie.serie_id
+        elif episode_series and episode_series.series_id:
+            args['ParentId'] = episode_series.series_id
 
         EmbyApi.set_common_search_arg(args)
         args['IncludeItemTypes'] = 'Episode'
 
         logger.debug('Search episode with: {}', args)
-        response = EmbyApi.resquest_emby(EMBY_ENDPOINT_SEARCH, auth, 'GET', **args)
+        response = EmbyApi.request_emby(EMBY_ENDPOINT_SEARCH, auth, 'GET', **args)
         if not response or 'Items' not in response or not response['Items']:
             logger.warning('No episode found')
             return None
@@ -2293,7 +2293,7 @@ class EmbyApiEpisode(EmbyApiMedia):
 
         episode_api = EmbyApiEpisode(
             auth=auth,
-            api_serie=episode_serie,
+            api_series=episode_series,
             api_season=episode_season,
             **episode[0],
         )
@@ -2328,7 +2328,7 @@ class EmbyApiEpisode(EmbyApiMedia):
             return False
 
         if (
-            EmbyApiSerie.is_type(**kwargs)
+            EmbyApiSeries.is_type(**kwargs)
             and 'series_season' in kwargs
             and 'series_episode' in kwargs
         ):
@@ -2457,8 +2457,8 @@ class EmbyApiMovie(EmbyApiMedia):
             args['Ids'] = parameters.get('movie_id')
         elif 'id' in parameters:
             args['Ids'] = parameters.get('id')
-        elif EmbyApi.has_provideres_search_arg(**parameters):
-            EmbyApi.set_provideres_search_arg(args, **parameters)
+        elif EmbyApi.has_providers_search_arg(**parameters):
+            EmbyApi.set_providers_search_arg(args, **parameters)
         else:
             args['SearchTerm'], year = EmbyApiMovie.parse_string(
                 parameters.get('search_string', parameters.get('base_name'))
@@ -2476,10 +2476,10 @@ class EmbyApiMovie(EmbyApiMedia):
         args['IncludeItemTypes'] = 'Movie'
 
         logger.debug('Search movie with: {}', args)
-        movies = EmbyApi.resquest_emby(EMBY_ENDPOINT_SEARCH, auth, 'GET', **args)
+        movies = EmbyApi.request_emby(EMBY_ENDPOINT_SEARCH, auth, 'GET', **args)
         if not movies or 'Items' not in movies or not movies['Items']:
-            if EmbyApi.has_provideres_search_arg(**parameters):
-                EmbyApi.remove_provideres_search(parameters)
+            if EmbyApi.has_providers_search_arg(**parameters):
+                EmbyApi.remove_providers_search(parameters)
                 return EmbyApiMovie.search(**parameters)
 
             logger.warning('No movie found')
@@ -2553,7 +2553,7 @@ class EmbyApi(EmbyApiBase):
         args['IsMissing'] = False
 
     @staticmethod
-    def set_provideres_search_arg(args: dict, **kwargs):
+    def set_providers_search_arg(args: dict, **kwargs):
         providers = []
 
         if kwargs.get('imdb_id'):
@@ -2574,16 +2574,16 @@ class EmbyApi(EmbyApiBase):
         args['AnyProviderIdEquals'] = providers_str
 
     @staticmethod
-    def remove_provideres_search(args: dict):
+    def remove_providers_search(args: dict):
         args.pop('imdb_id', None)
         args.pop('tmdb_id', None)
         args.pop('tvdb_id', None)
         args.pop('tvrage_id', None)
 
     @staticmethod
-    def has_provideres_search_arg(**kwargs) -> bool:
+    def has_providers_search_arg(**kwargs) -> bool:
         providers = {}
-        EmbyApi.set_provideres_search_arg(providers, **kwargs)
+        EmbyApi.set_providers_search_arg(providers, **kwargs)
 
         return bool(providers and providers['AnyProviderIdEquals'])
 
@@ -2611,9 +2611,9 @@ class EmbyApi(EmbyApiBase):
         elif EmbyApiSeason.is_type(**kwargs):
             logger.debug('API search season')
             search_result = EmbyApiSeason.search(**kwargs)
-        elif EmbyApiSerie.is_type(**kwargs):
-            logger.debug('API search serie')
-            search_result = EmbyApiSerie.search(**kwargs)
+        elif EmbyApiSeries.is_type(**kwargs):
+            logger.debug('API search series')
+            search_result = EmbyApiSeries.search(**kwargs)
         elif EmbyApiMovie.is_type(**kwargs):
             logger.debug('API search movie')
             search_result = EmbyApiMovie.search(**kwargs)
@@ -2669,15 +2669,15 @@ class EmbyApi(EmbyApiBase):
             return EmbyApiEpisode.TYPE
         if EmbyApiSeason.is_type(**kwargs):
             return EmbyApiSeason.TYPE
-        if EmbyApiSerie.is_type(**kwargs):
-            return EmbyApiSerie.TYPE
+        if EmbyApiSeries.is_type(**kwargs):
+            return EmbyApiSeries.TYPE
         if EmbyApiMovie.is_type(**kwargs):
             return EmbyApiMovie.TYPE
 
         return EmbyApiMedia.TYPE
 
     @staticmethod
-    def resquest_emby(
+    def request_emby(
         endpoint: str,
         auth: EmbyAuth,
         method: str,
@@ -2733,9 +2733,9 @@ class EmbyApi(EmbyApiBase):
                     allow_redirects=True,
                     verify=verify_certificates,
                 )
-        except HTTPError as e:  # Autentication Problem
+        except HTTPError as e:  # Authentication Problem
             if e.response.status_code == 401:
-                logger.error('Autentication Error: {}', str(e))
+                logger.error('Authentication Error: {}', str(e))
                 return False
             raise PluginError(f'Could not connect to Emby Server: {e!s}') from e
 

--- a/flexget/components/emby/emby_lookup.py
+++ b/flexget/components/emby/emby_lookup.py
@@ -84,7 +84,7 @@ class EmbyLookup:
     @property
     def series_identifier(self):
         """Returns the plugin main identifier type."""
-        return 'emby_serie_id'
+        return 'emby_series_id'
 
 
 @event('plugin.register')

--- a/flexget/components/emby/emby_util.py
+++ b/flexget/components/emby/emby_util.py
@@ -33,7 +33,7 @@ SCHEMA_SERVER_TAG = {'server': {**SCHEMA_SERVER}}
 
 
 SORT_FIELDS = [
-    'comunity_rating',
+    'community_rating',
     'critic_rating',
     'date_created',
     'date_played',
@@ -71,17 +71,17 @@ field_map = {
         'emby_page': 'page',
     },
     'series': {
-        'emby_serie_year': 'serie_year',
-        'emby_serie_aired_date': 'serie_aired_date',
-        'emby_serie_id': 'serie_id',
-        'emby_serie_name': 'serie_name',
-        'emby_serie_photo': 'serie_photo',
-        'emby_serie_imdb_id': 'serie_imdb_id',
-        'emby_serie_tvdb_id': 'serie_tvdb_id',
-        'emby_serie_overview': 'serie_overview',
-        'emby_serie_page': 'serie_page',
-        'imdb_id': 'serie_imdb_id',
-        'tvdb_id': 'serie_tvdb_id',
+        'emby_series_year': 'series_year',
+        'emby_series_aired_date': 'series_aired_date',
+        'emby_series_id': 'series_id',
+        'emby_series_name': 'series_name',
+        'emby_series_photo': 'series_photo',
+        'emby_series_imdb_id': 'series_imdb_id',
+        'emby_series_tvdb_id': 'series_tvdb_id',
+        'emby_series_overview': 'series_overview',
+        'emby_series_page': 'series_page',
+        'imdb_id': 'series_imdb_id',
+        'tvdb_id': 'series_tvdb_id',
     },
     'season': {
         'emby_season': 'season',
@@ -128,7 +128,7 @@ def simplify_text(text: str) -> str:
     if not isinstance(text, str):
         return text
 
-    # Replace accented chars by their 'normal' couterparts
+    # Replace accented chars by their 'normal' counterparts
     result = normalize('NFKD', text)
 
     # Symbols that should be converted to white space

--- a/flexget/components/ftp/sftp.py
+++ b/flexget/components/ftp/sftp.py
@@ -53,7 +53,7 @@ class SftpList:
     recursive             Indicates whether the listing should be recursive.
     get_size              Indicates whetern to calculate the size of the remote file/directory.
                           WARNING: This can be very slow when computing the size of directories!
-    files_only            Indicates wheter to omit diredtories from the results.
+    files_only            Indicates whether to omit diredtories from the results.
     dirs_only             Indicates whether to omit files from the results.
     dirs                  List of directories to download.
     socket_timeout_sec    Socket timeout in seconds (default 15 seconds).

--- a/flexget/components/managed_lists/lists/imdb_list.py
+++ b/flexget/components/managed_lists/lists/imdb_list.py
@@ -178,7 +178,7 @@ class ImdbEntrySet(MutableSet):
                     self.user_id = self.get_user_id_and_hidden_value(self.cookies)
                 if not self.user_id:
                     raise PluginError(
-                        'Not possible to retrive userid, please check cookie information'
+                        'Not possible to retrieve userid, please check cookie information'
                     )
 
                 user = IMDBListUser(self.config['login'], self.user_id, self.cookies)

--- a/flexget/components/managed_lists/lists/ombi_list.py
+++ b/flexget/components/managed_lists/lists/ombi_list.py
@@ -205,7 +205,7 @@ class OmbiEntry:
 
         except (HTTPError, ApiError) as error:
             if isinstance(error, ApiError):
-                if error.response.get('errrorCode') == 'AlreadyRequested':
+                if error.response.get('errorCode') == 'AlreadyRequested':
                     log.verbose(f'{self.ombi_title} already requested in Ombi.')
                     return True
 
@@ -221,7 +221,7 @@ class OmbiEntry:
         return True
 
     def mark_available(self):
-        """Mark an entry in Ombi as avaliable."""
+        """Mark an entry in Ombi as available."""
         if self.data['available']:
             log.verbose(f'{self.ombi_title} already available in Ombi.')
             return
@@ -263,7 +263,7 @@ class OmbiEntry:
             log.debug(e)
 
     def mark_unavailable(self):
-        """Mark an entry in Ombi as unavaliable."""
+        """Mark an entry in Ombi as unavailable."""
         if not self.data['available']:
             log.verbose(f'{self.ombi_title} already unavailable in Ombi.')
             return
@@ -345,7 +345,7 @@ class OmbiMovie(OmbiEntry):
 
     def mark_requested(self):
         """Mark an entry in Ombi as being requested."""
-        # A status such as approved, denied and avaiable are a sub status of requested.
+        # A status such as approved, denied and available are a sub status of requested.
         # Which means you can not mark an entry as approved, denied or available without first marking it as requested.
         # You also can not mark an entry as requested if it is already approved, denied or available.
         already_requested, status = self.already_requested()

--- a/flexget/components/managed_lists/lists/plex_watchlist.py
+++ b/flexget/components/managed_lists/lists/plex_watchlist.py
@@ -65,7 +65,7 @@ class VideoStub:
     title: str
 
 
-# plexapi objects are build fomr XML. So we create a simple stub that works for watchlist calls
+# plexapi objects are build from XML. So we create a simple stub that works for watchlist calls
 def to_plex_item(entry):
     item = VideoStub()
     item.guid = entry['plex_guid']

--- a/flexget/components/managed_lists/lists/radarr_list.py
+++ b/flexget/components/managed_lists/lists/radarr_list.py
@@ -220,7 +220,7 @@ class RadarrAPIService:
 
 
 # Maps (lowercase) Radarr qualities to flexget
-# quality reqirement strings
+# quality requirement strings
 QUALITIES_MAP = {
     'workprint': 'workprint',
     'cam': 'cam',

--- a/flexget/components/notify/notifiers/discord.py
+++ b/flexget/components/notify/notifiers/discord.py
@@ -178,7 +178,7 @@ class DiscordNotifier:
                 tokens_reset = timedelta(
                     seconds=int(req.headers.get('x-ratelimit-reset-after', 3))
                 )
-                logger.trace(f'Remaining rate tokens: {tokens}. Resets afer {tokens_reset} secs.')
+                logger.trace(f'Remaining rate tokens: {tokens}. Resets after {tokens_reset} secs.')
                 session.add_domain_limiter(
                     TokenBucketLimiter('discord.com', tokens=tokens, rate=tokens_reset)
                 )

--- a/flexget/components/notify/notifiers/pushsafer.py
+++ b/flexget/components/notify/notifiers/pushsafer.py
@@ -29,7 +29,7 @@ class PushsaferNotifier:
                   private_key: <string> your private key (can also be a alias key) - Required
                   url: <string> (default: '{{imdb_url}}')
                   url_title: <string> (default: (none))
-                  device: <string> ypur device or device group id (default: (none))
+                  device: <string> your device or device group id (default: (none))
                   icon: <integer> (default is 1)
                   iconcolor: <string> (default is (none))
                   sound: <integer> (default is (none))

--- a/flexget/components/parsing/parsers/parser_guessit.py
+++ b/flexget/components/parsing/parsers/parser_guessit.py
@@ -298,18 +298,18 @@ class ParserGuessit:
 
         if country:
             try:
-                serie_result = guessit_api.guessit(name)
-                serie_country = str(serie_result.get('country', ''))
+                series_result = guessit_api.guessit(name)
+                series_country = str(series_result.get('country', ''))
                 allowed_countries = guessit_options.get('allowed_countries', [])
 
-                if country != serie_country or (
-                    not serie_country
+                if country != series_country or (
+                    not series_country
                     and allowed_countries
                     and country.lower() not in allowed_countries
                 ):
                     valid = False
             except GuessitException:
-                logger.warning('Parsing {} serie with guessit failed.', name)
+                logger.warning('Parsing {} series with guessit failed.', name)
 
         # Check the full list of 'episode_details' for special,
         # since things like 'pilot' and 'unaired' can also show up there

--- a/flexget/components/series/db.py
+++ b/flexget/components/series/db.py
@@ -291,7 +291,7 @@ class Episode(Base):
     def age(self):
         """Return Pretty string representing age of episode.
 
-        Exmaple: "23d 12h" or "No releases seen"
+        Example: "23d 12h" or "No releases seen"
         """
         if not self.first_seen:
             return 'No releases seen'
@@ -634,7 +634,7 @@ def upgrade(ver: int | None, session: Session) -> int:
         # Warn users about a possible config change needed.
         logger.warning(
             'If you are using `identified_by: id` for the series plugin for a date-identified '
-            'or abolute-numbered series, you will need to update your config. Two new identified_by modes have '
+            'or absolute-numbered series, you will need to update your config. Two new identified_by modes have '
             'been added: `date` and `sequence`. In addition, if you are using `identified_by: auto`, it will'
             'be relearned based on upcoming episodes.'
         )
@@ -895,7 +895,7 @@ def _add_alt_name(alt: str, db_series: Series, series_name: str, session: Sessio
         if not db_series_alt.series:
             # Not sure how this can happen
             logger.debug(
-                'Found an alternate name not attached to series. Re-attatching `{}` to `{}`.',
+                'Found an alternate name not attached to series. Re-attaching `{}` to `{}`.',
                 alt,
                 series_name,
             )

--- a/flexget/components/sites/sites/alpharatio.py
+++ b/flexget/components/sites/sites/alpharatio.py
@@ -307,7 +307,7 @@ class SearchAlphaRatio:
                     if src not in torrent_info:
                         continue
 
-                    # Some values are tagged with a ',' insted of a '.', replace them
+                    # Some values are tagged with a ',' instead of a '.', replace them
                     value = torrent_info[src].text.replace(',', '.')
 
                     try:

--- a/flexget/components/sites/sites/lostfilm.py
+++ b/flexget/components/sites/sites/lostfilm.py
@@ -297,7 +297,7 @@ class LostFilm:
                         logger.debug('The redirect page is downloaded from {}', redirect_url)
                         break
                     logger.verbose(
-                        'Got status {} while retriving the redirect page {}',
+                        'Got status {} while retrieving the redirect page {}',
                         response.status_code,
                         redirect_url,
                     )

--- a/flexget/components/sites/sites/passthepopcorn.py
+++ b/flexget/components/sites/sites/passthepopcorn.py
@@ -201,11 +201,11 @@ class SearchPassThePopcorn:
                     release_res = torrent['Resolution']
                     release_res = release_res.replace(
                         'PAL', '576p'
-                    )  # Common PAL DVD vertial resolution
+                    )  # Common PAL DVD vertical resolution
                     release_res = release_res.replace(
                         'NTSC', '480p'
-                    )  # Common NTSC DVD vertial resolution
-                    # many older releases have a resolution defined as 624x480 for example this will split the value at take the hight
+                    )  # Common NTSC DVD vertical resolution
+                    # many older releases have a resolution defined as 624x480 for example this will split the value at take the height
                     tsplit = release_res.split('x', 1)
                     if len(tsplit) > 1:
                         release_res = tsplit[1] + 'p'

--- a/flexget/components/sites/utils.py
+++ b/flexget/components/sites/utils.py
@@ -20,7 +20,7 @@ def normalize_unicode(text):
 def normalize_scene(text):
     """Normalize string according to scene standard.
 
-    Mainly, it replace accented chars by their 'normal' couterparts
+    Mainly, it replace accented chars by their 'normal' counterparts
     and removes special chars.
     https://en.wikipedia.org/wiki/Standard_(warez)#Naming for more information
     """

--- a/flexget/entry.py
+++ b/flexget/entry.py
@@ -359,7 +359,7 @@ class Entry(LazyDict, Serializer):
     ):
         """Add lazy fields to an entry.
 
-        :param lazy_func: should be a funciton previously registered with the `register_lazy_func` decorator,
+        :param lazy_func: should be a function previously registered with the `register_lazy_func` decorator,
             or the name it was registered under.
         :param fields: list of fields this function will fill
         :param args: Arguments that will be passed to the lazy lookup function when called.

--- a/flexget/plugins/clients/aria2.py
+++ b/flexget/plugins/clients/aria2.py
@@ -261,9 +261,11 @@ class OutputAria2:
                         ) as response:
                             content_disposition = response.headers.get('content-disposition', None)
                     except Exception:
-                        logger.warning('Not possible to retrive file info from `{}`', entry['url'])
+                        logger.warning(
+                            'Not possible to retrieve file info from `{}`', entry['url']
+                        )
                         entry.fail(
-                            'Not possible to retrive file info from `{}`'.format(entry['url'])
+                            'Not possible to retrieve file info from `{}`'.format(entry['url'])
                         )
                         return None
 
@@ -287,8 +289,8 @@ class OutputAria2:
                     ext = add_extension if add_extension[0] == '.' else '.' + add_extension
 
                 if not ext:
-                    logger.warning('Not possible to retrive extension')
-                    entry.fail('Not possible to retrive extension')
+                    logger.warning('Not possible to retrieve extension')
+                    entry.fail('Not possible to retrieve extension')
                     return None
 
                 logger.debug('Adding extension `{}` to file `{}`', ext, filename)

--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -148,7 +148,7 @@ class OutputQBitTorrent:
         params = {'hashes': hash_torrent}
 
         try:
-            respose = self.session.request(
+            response = self.session.request(
                 'get',
                 url,
                 params=params,
@@ -158,15 +158,15 @@ class OutputQBitTorrent:
             logger.error('Error getting torrent info, request to hash {} failed', hash_torrent)
             return False
 
-        if respose.status_code != 200:
+        if response.status_code != 200:
             logger.error(
                 'Error getting torrent info, hash {} search returned',
                 hash_torrent,
-                respose.status_code,
+                response.status_code,
             )
             return False
 
-        check_file = respose.json()
+        check_file = response.json()
 
         if isinstance(check_file, list) and check_file:
             logger.warning('File with hash {} already in qbittorrent', hash_torrent)

--- a/flexget/plugins/input/betaseries_list.py
+++ b/flexget/plugins/input/betaseries_list.py
@@ -16,7 +16,7 @@ API_URL_PREFIX = 'https://api.betaseries.com/'
 
 
 class BetaSeriesList:
-    """Emit an entry for each serie followed by one or more BetaSeries account.
+    """Emit an entry for each series followed by one or more BetaSeries account.
 
     See https://www.betaseries.com/
 
@@ -168,7 +168,7 @@ def query_series(api_key, user_token, member_name=None):
     :param string user_token: Obtained with a call to create_token()
     :param string member_name: [optional] A member name to get the list of series from. If None, will query the member
         for whom the user_token was for
-    :return: List of serie titles or empty list
+    :return: List of series titles or empty list
     """
     params = {}
     if member_name:

--- a/flexget/plugins/input/gazelle.py
+++ b/flexget/plugins/input/gazelle.py
@@ -141,7 +141,7 @@ class InputGazelle:
         task.no_entries_ok = True
 
     def resume_session(self):
-        """Resume an existing session from the datebase.
+        """Resume an existing session from the database.
 
         Return True on successful recovery, False otherwise
         """

--- a/flexget/plugins/input/html.py
+++ b/flexget/plugins/input/html.py
@@ -19,7 +19,7 @@ logger = logger.bind(name='html')
 class InputHtml:
     """Parse urls from html page.
 
-    Usefull on sites which have direct download links of any type (mp3, jpg, torrent, ...).
+    Useful on sites which have direct download links of any type (mp3, jpg, torrent, ...).
 
     Many anime-fansubbers do not provide RSS-feed, this works well in many cases.
 

--- a/flexget/plugins/input/json.py
+++ b/flexget/plugins/input/json.py
@@ -24,7 +24,7 @@ class Json:
         - <entry field>: <corresponding JSON key>
 
     Note: each entry must have at least two fields, 'title' and 'url'. If not specified in the config,
-    this plugin asssumes that keys named 'title' and 'url' exist within the JSON.
+    this plugin assumes that keys named 'title' and 'url' exist within the JSON.
     'encoding' defaults to 'utf-8'
 
     Example::

--- a/flexget/plugins/input/npo_watchlist.py
+++ b/flexget/plugins/input/npo_watchlist.py
@@ -45,8 +45,8 @@ class NPOWatchlist:
           auto_escape: yes
           on_output:
             for_accepted:
-              - download-npo -o "path/to/directory/{{series_name_plain}}" -f "{serie_titel} - {datum} \
-                  {aflevering_titel} ({episode_id})" -t {{url}}
+              - download-npo -o "path/to/directory/{{series_name_plain}}" -f "{series_title} - {datum} \
+                  {aflevering_title} ({episode_id})" -t {{url}}
     """
 
     schema = {
@@ -121,7 +121,7 @@ class NPOWatchlist:
 
             if 'isAuthenticatedUser' not in requests.cookies:
                 raise plugin.PluginError('Failed to login. Check username and password.')
-            logger.debug('Succesfully logged in: {}', email)
+            logger.debug('Successfully logged in: {}', email)
         except RequestException as e:
             raise plugin.PluginError(f'Request error: {e!s}')
 

--- a/flexget/plugins/input/pogcal.py
+++ b/flexget/plugins/input/pogcal.py
@@ -47,7 +47,7 @@ class InputPogDesign:
             for s in spantags:
                 s.extract()
             t = row.text
-            # remove newlines and whitepsace
+            # remove newlines and whitespace
             t = t.replace('\n', '').strip()
 
             if t.endswith('[The]'):

--- a/flexget/plugins/input/regexp_parse.py
+++ b/flexget/plugins/input/regexp_parse.py
@@ -133,12 +133,12 @@ class RegexpParse:
         self.required = []
 
     def flagstr_to_flags(self, flag_str):
-        """Turn a comma seperated list of flags into the int value."""
-        combind_flags = 0
+        """Turn a comma separated list of flags into the int value."""
+        combined_flags = 0
         split_flags = flag_str.split(',')
         for flag in split_flags:
-            combind_flags = combind_flags | RegexpParse.FLAG_VALUES[flag.strip()]
-        return combind_flags
+            combined_flags = combined_flags | RegexpParse.FLAG_VALUES[flag.strip()]
+        return combined_flags
 
     def compile_regexp_dict_list(self, re_list):
         """Turn a list of dicts containing regexps information into a list of compiled regexps."""
@@ -175,15 +175,15 @@ class RegexpParse:
             content = resp.text
 
         sections = []
-        seperators = config.get('sections')
-        if seperators:
-            for sep in seperators:
+        separators = config.get('sections')
+        if separators:
+            for sep in separators:
                 flags = 0
                 if 'flags' in sep:
                     flags = self.flagstr_to_flags(sep['flags'])
                 sections.extend(re.findall(sep['regexp'], content, flags))
 
-        # no seperators just do work on the whole content
+        # no separators just do work on the whole content
         else:
             sections.append(content)
 

--- a/flexget/plugins/input/rss.py
+++ b/flexget/plugins/input/rss.py
@@ -324,7 +324,7 @@ class InputRSS:
                 content = content.decode('utf-8', 'ignore').encode('ascii', 'ignore')
 
         if not content:
-            logger.error('No data recieved for rss feed.')
+            logger.error('No data received for rss feed.')
             return []
         if config.get('escape'):
             logger.debug('Trying to escape unescaped in RSS')

--- a/flexget/plugins/internal/api_rottentomatoes.py
+++ b/flexget/plugins/internal/api_rottentomatoes.py
@@ -280,7 +280,7 @@ def lookup_movie(
     :param smart_match: attempt to clean and parse title and year from a string
     :param only_cached: if this is specified, an online lookup will not occur if the movie is not in the cache
     :param session: optionally specify a session to use, if specified, returned Movie will be live in that session
-    :param api_key: optionaly specify an API key to use
+    :param api_key: optionally specify an API key to use
     :returns: The Movie object populated with data from Rotten Tomatoes
     :raises: PluginError if a match cannot be found or there are other problems with the lookup
     """
@@ -405,7 +405,7 @@ def lookup_movie(
                                 continue
 
                         if not results:
-                            raise PluginError('no appropiate results')
+                            raise PluginError('no appropriate results')
 
                         if len(results) == 1:
                             logger.debug('SUCCESS: only one movie remains')

--- a/flexget/plugins/modify/sort_by_weight.py
+++ b/flexget/plugins/modify/sort_by_weight.py
@@ -146,7 +146,7 @@ class PluginSortByWeight:
         elif isinstance(value, bool):
             min_value = False
         elif isinstance(value, datetime):
-            min_value = datetime.now()  # assume date comparision vs now()
+            min_value = datetime.now()  # assume date comparison vs now()
         elif isinstance(value, timedelta):
             min_value = timedelta(0)
         return min_value

--- a/flexget/plugins/operate/verbose_details.py
+++ b/flexget/plugins/operate/verbose_details.py
@@ -19,7 +19,7 @@ class PluginDetails:
             else:
                 logger.warning(
                     "Task didn't produce any entries. "
-                    'This is likely due to a mis-configured or non-functional input.'
+                    'This is likely due to a misconfigured or non-functional input.'
                 )
         else:
             logger.verbose('Produced {} entries.', len(task.entries))

--- a/flexget/plugins/output/download.py
+++ b/flexget/plugins/output/download.py
@@ -192,7 +192,7 @@ class PluginDownload:
         for entry in task.accepted:
             self.get_temp_file(task, entry, require_path, handle_magnets, fail_html, tmp_path)
 
-    # TODO: a bit silly method, should be get rid of now with simplier exceptions ?
+    # TODO: a bit silly method, should be get rid of now with simpler exceptions ?
     def process_entry(self, task, entry, url, tmp_path):
         """Process `entry` by using `url`. Do not use entry['url'].
 
@@ -370,7 +370,7 @@ class PluginDownload:
                 if any(entry['filename'].endswith(extension) for extension in extensions):
                     logger.debug('Filename {} extension matches to mime-type', entry['filename'])
                 else:
-                    # mimetypes library has no concept of a 'prefered' extension when there are multiple possibilites
+                    # mimetypes library has no concept of a 'preferred' extension when there are multiple possibilities
                     # this causes the first to be used which is not always desirable, e.g. 'ksh' for 'text/plain'
                     extension = mimetypes.guess_extension(entry['mime-type'], strict=False)
                     logger.debug(

--- a/flexget/plugins/output/memusage.py
+++ b/flexget/plugins/output/memusage.py
@@ -18,7 +18,7 @@ logger = logger.bind(name='mem_usage')
 # def update():
 #     print heapy.heap()
 #
-# # Print relative memory consumption since last sycle
+# # Print relative memory consumption since last cycle
 # def update():
 #     print heapy.heap()
 #     heapy.setref()

--- a/flexget/plugins/output/rss.py
+++ b/flexget/plugins/output/rss.py
@@ -94,7 +94,7 @@ class OutputRSS:
 
     RSS feed properties:
 
-    You can specify the URL, title, and description to include in tthe header
+    You can specify the URL, title, and description to include in the header
     of the RSS feed.
 
     Example::

--- a/flexget/plugins/output/subtitles_subliminal.py
+++ b/flexget/plugins/output/subtitles_subliminal.py
@@ -17,13 +17,14 @@ try:
     PROVIDERS = provider_manager.names()
 except ImportError:
     PROVIDERS = [
-        'argenteam',
-        'legendastv',
+        'addic7ed',
+        'gestdown',
+        'napiprojekt',
         'opensubtitles',
+        'opensubtitlescom',
+        'opensubtitlescomvip',
         'opensubtitlesvip',
         'podnapisi',
-        'shooter',
-        'thesubdb',
         'tvsubtitles',
     ]
 
@@ -48,14 +49,14 @@ class PluginSubliminal:
           alternatives:
             - eng
           exact_match: no
-          providers: legendastv, opensubtitles
+          providers: gestdown, opensubtitles
           single: no
           directory: /disk/subtitles
           hearing_impaired: yes
           authentication:
-            legendastv:
+            opensubtitles:
               username: myuser
-              passsword: mypassword
+              password: mypassword
     """
 
     schema = {

--- a/flexget/plugins/services/myepisodes.py
+++ b/flexget/plugins/services/myepisodes.py
@@ -115,7 +115,7 @@ class MyEpisodes:
                 logger.warning(w)
 
     def _validate_entry(self, entry):
-        """Check an entry for all of the fields needed to comunicate with myepidoes.
+        """Check an entry for all of the fields needed to communicate with myepidoes.
 
         Return: boolean
         """
@@ -279,7 +279,7 @@ class MyEpisodes:
         logger.info('Marked {} of `{}` as acquired.', entry['series_id'], entry['series_name'])
 
     def _login(self, config):
-        """Authenicate with the myepisodes service and return a requests session.
+        """Authenticate with the myepisodes service and return a requests session.
 
         Return:
             requests session

--- a/flexget/templates/task/html.template
+++ b/flexget/templates/task/html.template
@@ -230,7 +230,7 @@ div.clear {
                 {% endif %}
 
                 <div id="info-{{ loop.index }}" style="display: none;">
-                    <!-- a hack to keep browser from reseting position to top when clicking the Details link -->
+                    <!-- a hack to keep browser from resetting position to top when clicking the Details link -->
                     <a name="a-{{ loop.index }}" style="display:none;">&nbsp;</a>
 
                     {% if entry.tvdb_genres is defined and entry.tvdb_genres is iterable %}

--- a/flexget/ui/v1/src/blocks/router/router-helper.provider.js
+++ b/flexget/ui/v1/src/blocks/router/router-helper.provider.js
@@ -16,7 +16,7 @@
       $window.location.hash = '/';
     }
 
-    //TODO: Figure out if htlm5Mode is possible
+    //TODO: Figure out if html5Mode is possible
     //$locationProvider.html5Mode(true);
 
     this.configureStates = configureStates;

--- a/flexget/ui/v1/src/components/404/404.route.spec.js
+++ b/flexget/ui/v1/src/components/404/404.route.spec.js
@@ -28,8 +28,8 @@ describe('404 Routes: ', function () {
       expect($state.is('404')).to.be.true;
     });
 
-    it("should work with '/unkown' path", function () {
-      $location.path('/unkown');
+    it("should work with '/unknown' path", function () {
+      $location.path('/unknown');
       $rootScope.$digest();
       expect($state.is('404')).to.be.true;
     });

--- a/flexget/ui/v1/src/components/home/home.route.spec.js
+++ b/flexget/ui/v1/src/components/home/home.route.spec.js
@@ -2,7 +2,7 @@
 describe('Home Routes: ', function () {
   beforeEach(function () {
     //Create abstract parent state first
-    //TODO: create funcion for this, so we can just call the function and not need to inject the entire block everywhere
+    //TODO: create function for this, so we can just call the function and not need to inject the entire block everywhere
     module('ui.router', function ($stateProvider) {
       $stateProvider.state('flexget', { abstract: true });
     });

--- a/flexget/ui/v1/src/plugins/config/config.route.spec.js
+++ b/flexget/ui/v1/src/plugins/config/config.route.spec.js
@@ -2,7 +2,7 @@
 describe('Config Routes:', function () {
   beforeEach(function () {
     //Create abstract parent state first
-    //TODO: create funcion for this, so we can just call the function and not need to inject the entire block everywhere
+    //TODO: create function for this, so we can just call the function and not need to inject the entire block everywhere
     module('ui.router', function ($stateProvider) {
       $stateProvider.state('flexget', { abstract: true });
     });

--- a/flexget/ui/v1/src/plugins/execute/components/execute-input/execute-input.tmpl.html
+++ b/flexget/ui/v1/src/plugins/execute/components/execute-input/execute-input.tmpl.html
@@ -45,7 +45,7 @@
           placeholder="Enter task(s) to execute"
           md-item-text="task"
         >
-          <span ng-hightlight-text="vm.searchTerm">{{ task }}</span>
+          <span ng-highlight-text="vm.searchTerm">{{ task }}</span>
         </md-autocomplete>
       </md-chips>
       <div flex></div>

--- a/flexget/ui/v1/src/plugins/execute/execute.route.spec.js
+++ b/flexget/ui/v1/src/plugins/execute/execute.route.spec.js
@@ -2,7 +2,7 @@
 describe('Execute Routes:', function () {
   beforeEach(function () {
     //Create abstract parent state first
-    //TODO: create funcion for this, so we can just call the function and not need to inject the entire block everywhere
+    //TODO: create function for this, so we can just call the function and not need to inject the entire block everywhere
     module('ui.router', function ($stateProvider) {
       $stateProvider.state('flexget', { abstract: true });
     });

--- a/flexget/ui/v1/src/plugins/history/history.route.spec.js
+++ b/flexget/ui/v1/src/plugins/history/history.route.spec.js
@@ -2,7 +2,7 @@
 describe('History Routes:', function () {
   beforeEach(function () {
     //Create abstract parent state first
-    //TODO: create funcion for this, so we can just call the function and not need to inject the entire block everywhere
+    //TODO: create function for this, so we can just call the function and not need to inject the entire block everywhere
     module('ui.router', function ($stateProvider) {
       $stateProvider.state('flexget', { abstract: true });
     });

--- a/flexget/ui/v1/src/plugins/log/log.component.spec.js
+++ b/flexget/ui/v1/src/plugins/log/log.component.spec.js
@@ -43,7 +43,7 @@ describe('Plugin: Log.component', function () {
 
       controller.$onDestroy();
 
-      expect(controller.stop).to.have.been.calleOnce;
+      expect(controller.stop).to.have.been.calledOnce;
     });
   });
 

--- a/flexget/ui/v1/src/plugins/log/log.route.spec.js
+++ b/flexget/ui/v1/src/plugins/log/log.route.spec.js
@@ -2,7 +2,7 @@
 describe('Log Routes:', function () {
   beforeEach(function () {
     //Create abstract parent state first
-    //TODO: create funcion for this, so we can just call the function and not need to inject the entire block everywhere
+    //TODO: create function for this, so we can just call the function and not need to inject the entire block everywhere
     module('ui.router', function ($stateProvider) {
       $stateProvider.state('flexget', { abstract: true });
     });

--- a/flexget/ui/v1/src/plugins/movies/components/new-list/new-list.component.spec.js
+++ b/flexget/ui/v1/src/plugins/movies/components/new-list/new-list.component.spec.js
@@ -57,7 +57,7 @@ describe('Plugin: New-list.Component', function () {
       expect(moviesService.createList).to.have.been.calledOnce;
     });
 
-    it('should close the dialog when successfull', function () {
+    it('should close the dialog when successful', function () {
       sinon.spy($mdDialog, 'hide');
 
       deferred.resolve();

--- a/flexget/ui/v1/src/plugins/movies/movies.route.spec.js
+++ b/flexget/ui/v1/src/plugins/movies/movies.route.spec.js
@@ -2,7 +2,7 @@
 describe('Movies Routes:', function () {
   beforeEach(function () {
     //Create abstract parent state first
-    //TODO: create funcion for this, so we can just call the function and not need to inject the entire block everywhere
+    //TODO: create function for this, so we can just call the function and not need to inject the entire block everywhere
     module('ui.router', function ($stateProvider) {
       $stateProvider.state('flexget', { abstract: true });
     });

--- a/flexget/ui/v1/src/plugins/schedule/schedule.route.spec.js
+++ b/flexget/ui/v1/src/plugins/schedule/schedule.route.spec.js
@@ -2,7 +2,7 @@
 describe('Schedule Routes:', function () {
   beforeEach(function () {
     //Create abstract parent state first
-    //TODO: create funcion for this, so we can just call the function and not need to inject the entire block everywhere
+    //TODO: create function for this, so we can just call the function and not need to inject the entire block everywhere
     module('ui.router', function ($stateProvider) {
       $stateProvider.state('flexget', { abstract: true });
     });

--- a/flexget/ui/v1/src/plugins/seen/seen.route.spec.js
+++ b/flexget/ui/v1/src/plugins/seen/seen.route.spec.js
@@ -2,7 +2,7 @@
 describe('Seen Routes:', function () {
   beforeEach(function () {
     //Create abstract parent state first
-    //TODO: create funcion for this, so we can just call the function and not need to inject the entire block everywhere
+    //TODO: create function for this, so we can just call the function and not need to inject the entire block everywhere
     module('ui.router', function ($stateProvider) {
       $stateProvider.state('flexget', { abstract: true });
     });

--- a/flexget/ui/v1/src/plugins/series/series.route.spec.js
+++ b/flexget/ui/v1/src/plugins/series/series.route.spec.js
@@ -2,7 +2,7 @@
 describe('Series Routes:', function () {
   beforeEach(function () {
     //Create abstract parent state first
-    //TODO: create funcion for this, so we can just call the function and not need to inject the entire block everywhere
+    //TODO: create function for this, so we can just call the function and not need to inject the entire block everywhere
     module('ui.router', function ($stateProvider) {
       $stateProvider.state('flexget', { abstract: true });
     });

--- a/flexget/ui/v1/src/plugins/series/series.tmpl.html
+++ b/flexget/ui/v1/src/plugins/series/series.tmpl.html
@@ -2,7 +2,7 @@
   <md-toolbar class="md-warn">
     <span class="md-toolbar-tools" flex>
       Please note that performed operations on this page might not be
-      persistent. Depending on your config, settings might get overriden and
+      persistent. Depending on your config, settings might get overridden and
       data might be recreated.
     </span>
   </md-toolbar>

--- a/flexget/ui/v1/tests-mock-data/series.js
+++ b/flexget/ui/v1/tests-mock-data/series.js
@@ -142,7 +142,7 @@ var mockSeriesData = (function () {
       last_updated: '2016-06-09 11:14:09',
       network: 'The CW',
       overview:
-        "Olivia “Liv” Moore was a rosy-cheeked, disciplined, over-achieving medical resident who had her life path completely mapped out…until the night she attended a party that unexpectedly turned into a zombie feeding frenzy. Now a med sudent-turned-zombie, she takes a job in the coroner's office to gain acces to the brains she must reluctantly eat to maintain her humanity, but with each brain she consumes, she inherits the corpse's memories. With the help of her medical examiner boss and a police detective, she solves homicide cases in order to quiet the disturbing voices in her head. ",
+        "Olivia “Liv” Moore was a rosy-cheeked, disciplined, over-achieving medical resident who had her life path completely mapped out…until the night she attended a party that unexpectedly turned into a zombie feeding frenzy. Now a med student-turned-zombie, she takes a job in the coroner's office to gain access to the brains she must reluctantly eat to maintain her humanity, but with each brain she consumes, she inherits the corpse's memories. With the help of her medical examiner boss and a police detective, she solves homicide cases in order to quiet the disturbing voices in her head. ",
       posters: [
         'http://thetvdb.com/banners/posters/281470-2.jpg',
         'http://thetvdb.com/banners/posters/281470-1.jpg',

--- a/flexget/ui/v2/README.rst
+++ b/flexget/ui/v2/README.rst
@@ -2,6 +2,6 @@ FlexGet Web UI (v2)
 ===================
 
 The Flexget WebUI is currently being rewritten in ReactJS.
-The WebUI has been seperated into it's own repository.
+The WebUI has been separated into its own repository.
 
 The source code is now available at https://github.com/Flexget/webui

--- a/flexget/utils/parsers/movie.py
+++ b/flexget/utils/parsers/movie.py
@@ -101,7 +101,7 @@ class MovieParser(TitleParser):
         if cut_part != 256:
             logger.debug('parts: {}, cut is: {}', parts, parts[cut_part])
 
-        # calculate cut positon from cut_part
+        # calculate cut position from cut_part
         abs_cut = len(' '.join(parts[:cut_part]))
 
         logger.debug(

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -25,7 +25,7 @@ logger = logger.bind(name='utils.requests')
 
 # Don't emit info level urllib3 log messages or below
 logging.getLogger('requests.packages.urllib3').setLevel(logging.WARNING)
-# same as above, but for systems where urllib3 isn't part of the requests pacakge (i.e., Ubuntu)
+# same as above, but for systems where urllib3 isn't part of the requests package (i.e., Ubuntu)
 logging.getLogger('urllib3').setLevel(logging.WARNING)
 
 # Time to wait before trying an unresponsive site again

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,3 +255,29 @@ branch = true
 [tool.doc8]
 ignore = [ 'D001', "D004" ]
 max_line_length = 99
+
+[tool.typos.default]
+extend-ignore-re = [
+  "idel",
+  "parametros",
+  'Programe',
+  'searchin',
+  'SerieS',
+  '23BA98',
+]
+
+[tool.typos.default.extend-words]
+nd = 'nd'
+sur = 'sur'
+hime = 'hime'
+
+[tool.typos.default.extend-identifiers]
+McClory = 'McClory'
+
+[tool.typos.files]
+extend-exclude = [
+  "**/cassettes/*",
+  'tests/couchpotato_movie_list_test_response.json',
+  'tests/couchpotato_quality_profile_test_response.json',
+  'tests/test_thetvdb.py',
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,7 +238,7 @@ def filecopy(request):
         dst = Path(dst)
         paths: itertools.chain[Path] = itertools.chain(
             *(Path().glob(str(src)) for src in sources)
-        )  # TODO: remove str(src) type convertion once Python 3.12 support dropped
+        )  # TODO: remove str(src) type conversion once Python 3.12 support dropped
         for f in paths:
             dest_path = dst
             if dest_path.is_dir():
@@ -395,7 +395,7 @@ class DoublePhaseChecker:
 
 @event('plugin.register')
 def register_plugin():
-    plugin.register(DoublePhaseChecker, 'test_dobule_phase', api_ver=2, debug=True, builtin=True)
+    plugin.register(DoublePhaseChecker, 'test_double_phase', api_ver=2, debug=True, builtin=True)
 
 
 class APIClient:

--- a/tests/sftp/test_sftp_download.py
+++ b/tests/sftp/test_sftp_download.py
@@ -56,7 +56,7 @@ class TestSftpDownload:
             sftp_download:
               to: {{ download_path }}
 
-          sftp_download_dir_recusive_true:
+          sftp_download_dir_recursive_true:
             mock:
               - *mock_dir
             accept_all: True
@@ -114,14 +114,14 @@ class TestSftpDownload:
         assert filecmp.dircmp(remote_file, download_path / 'dir/file.mkv')
         assert not (download_path / 'nested/file.mkv').exists()
 
-    def test_sftp_download_dir_recusive(
+    def test_sftp_download_dir_recursive(
         self, execute_task, download_path: Path, sftp_fs: TestSFTPFileSystem
     ):
         remote_dir = sftp_fs.create_dir('dir')
         sftp_fs.create_file('dir/file.mkv', 100)
         sftp_fs.create_file('dir/nested/file.mkv', 100)
 
-        execute_task('sftp_download_dir_recusive_true')
+        execute_task('sftp_download_dir_recursive_true')
         assert filecmp.dircmp(remote_dir, download_path / 'dir')
 
     def test_sftp_download_file_and_delete(

--- a/tests/sftp/test_sftp_list.py
+++ b/tests/sftp/test_sftp_list.py
@@ -198,7 +198,7 @@ class TestSftpList:
                 'url': 'sftp://test_user:test_pass@127.0.0.1:40022/home/test_user/dir',
                 'content_size': 100,
             },
-            allow_unexpected_entires=True,
+            allow_unexpected_entries=True,
         )
 
     def test_sftp_list_symlink_file(
@@ -277,7 +277,7 @@ def assert_entries(
     task: Task,
     entry_matcher: dict[str, Any],
     *argv: dict[str, Any],
-    allow_unexpected_entires: bool = False,
+    allow_unexpected_entries: bool = False,
 ):
     """Assert that the entries generated for a given task match the list of dictionaries given as entry matches.
 
@@ -286,17 +286,17 @@ def assert_entries(
     :param task: Task to assert the entries from.
     :param entry_matcher: Dict continain the expected entry values, must have at least a 'title'
                           set.
-    :param allow_unexpected_entires: bool to assert if there are any additional entries generated
+    :param allow_unexpected_entries: bool to assert if there are any additional entries generated
                                      that matchers arn't specified for.
     """
     expected = [m['title'] for m in [entry_matcher, *argv]]
     found = [m['title'] for m in task.all_entries]
-    if not allow_unexpected_entires:
+    if not allow_unexpected_entries:
         unexpected: list[str] = [title for title in found if title not in expected]
         assert not unexpected, f'Found unexpected entries {unexpected}'
 
     not_found: list[str] = [title for title in expected if title not in found]
-    assert not not_found, f'Entires not found {not_found} in {found}'
+    assert not not_found, f'Entries not found {not_found} in {found}'
 
     for matcher in [entry_matcher, *argv]:
         entry = task.find_entry(title=matcher['title'])
@@ -311,7 +311,7 @@ def assert_entries(
 def assert_no_entries(task: Task):
     """Assert that there are no entries generated for a given task.
 
-    :param task: Task to assert no entires are generated for.
+    :param task: Task to assert no entries are generated for.
     """
     assert len(task.all_entries) == 0, (
         f'Expected no entries, but found {[m["title"] for m in task.all_entries]}'

--- a/tests/sftp/test_sftp_server.py
+++ b/tests/sftp/test_sftp_server.py
@@ -123,7 +123,7 @@ else:
         def create_file(self, path: str, size: int = 0) -> Path:
             """Create a file on the :class: `StubSFTPServer` instance.
 
-            If the path is relative it will be created realative to the users home directory
+            If the path is relative it will be created relative to the users home directory
 
             :param path: The path of the file to create absolute or relative
             :param size: The size in bytes of the file to create, defaults to 0
@@ -172,8 +172,8 @@ else:
             """Canonicalizes the given SFTP path to the local file system either from the cwd, or the user home if none is set.
 
             :param path: The path to canonicalize.
-            :param resolve: If symlinks shoul be resovled.
-            :raises ValueError: If the path or taget is relative and would take return a directory outside the SFTP filesytem.
+            :param resolve: If symlinks should be resolved.
+            :raises ValueError: If the path or target is relative and would take return a directory outside the SFTP filesystem.
             :return: An :class:`pathlib.Path` of the canonicalized path.
             """
             canonicalized: Path
@@ -227,7 +227,7 @@ else:
 
         def __init__(self, filename: str, read_file, write_file, flags: int = 0) -> None:
             super().__init__(flags)
-            # Note these names are used in the default SFTPHandle, hense no __ to
+            # Note these names are used in the default SFTPHandle, hence no __ to
             # indicate private
             self.filename = filename
             self.readfile = read_file
@@ -259,9 +259,9 @@ else:
         __test__ = False
 
         def __init__(
-            self, server: ServerInterface, fs: TestSFTPFileSystem, *larg, **kwarg
+            self, server: ServerInterface, fs: TestSFTPFileSystem, *args, **kwargs
         ) -> None:
-            super().__init__(server, *larg, **kwarg)
+            super().__init__(server, *args, **kwargs)
             self.__fs = fs
 
         def session_started(self):
@@ -348,7 +348,7 @@ else:
             files that cross disk partition boundaries, if at all possible.
             .. note:: You should return an error if a file with the same name as
                 ``newpath`` already exists.  (The rename operation should be
-                non-desctructive.)
+                non-destructive.)
             .. note::
                 This method implements 'standard' SFTP ``RENAME`` behavior; those
                 seeking the OpenSSH "POSIX rename" extension behavior should use

--- a/tests/test_exists_movie.py
+++ b/tests/test_exists_movie.py
@@ -198,7 +198,7 @@ class TestExistsMovie:
         task = execute_task('test_propers')
         assert task.find_entry('accepted', title='Mock.S01E01.Proper'), 'new proper not accepted'
         assert task.find_entry('rejected', title='Test.S01E01'), (
-            'pre-existin proper should have caused reject'
+            'pre-existing proper should have caused reject'
         )
 
     def test_invalid(self, execute_task):

--- a/tests/test_exists_series.py
+++ b/tests/test_exists_series.py
@@ -147,7 +147,7 @@ class TestExistsSeries:
         task = execute_task('test_propers')
         assert task.find_entry('accepted', title='Mock.S01E01.Proper'), 'new proper not accepted'
         assert task.find_entry('rejected', title='Test.S01E01'), (
-            'pre-existin proper should have caused reject'
+            'pre-existing proper should have caused reject'
         )
 
     def test_invalid(self, execute_task):

--- a/tests/test_movieparser.py
+++ b/tests/test_movieparser.py
@@ -62,7 +62,7 @@ class TestParser:
         assert movie.quality.name == '720p h264'
 
     def test_multiple_property_values(self, parse):
-        """Test correct parsing for title's with multiple propertie definitions."""
+        """Test correct parsing for title's with multiple property definitions."""
         movie = parse(
             name='FlexGet',
             data='FlexGet (premiere 2018)(2016/MHD/1080P/AC3 5.1/DUAL/SUB/bluray/Webrip)',

--- a/tests/test_nfo_lookup.py
+++ b/tests/test_nfo_lookup.py
@@ -194,7 +194,7 @@ class TestNfoLookupWithMovies:
         task = execute_task('test_8')
         for entry in task.entries:
             # Since the entry was not processed again then no new fields besides the fields added by the mock
-            # configiration in test_8 should be present.
+            # configuration in test_8 should be present.
             keys = sorted(entry.keys())
             assert entry['nfo_id'] == 'tt2316801'
 

--- a/tests/test_npo_watchlist.py
+++ b/tests/test_npo_watchlist.py
@@ -83,7 +83,7 @@ class TestNpoWatchlistPremium:
         task = execute_task('test')
         entry = task.find_entry(
             url='https://www.npostart.nl/hollands-hoop/08-02-2020/BV_101396963'
-        )  # a premium serie
+        )  # a premium series
         assert entry['npo_id'] == 'BV_101396963'
         assert entry['npo_url'] == 'https://www.npostart.nl/hollands-hoop/BV_101385153'
         assert entry['npo_name'] == 'Hollands Hoop'

--- a/tests/test_proper_movies.py
+++ b/tests/test_proper_movies.py
@@ -37,7 +37,7 @@ class TestProperMovies:
         return Template(self._config).render({'parser': request.param})
 
     def test_proper_movies(self, execute_task):
-        # first occurence
+        # first occurrence
         task = execute_task('test1')
         assert task.find_entry('accepted', title='Movie.Name.2011.720p-FlexGet')
 

--- a/tests/test_rtorrent.py
+++ b/tests/test_rtorrent.py
@@ -45,7 +45,7 @@ class TestRTorrentClient:
         fields = list(called_args[2:])
         assert len(fields) == 3
         # TODO: check the note in clients/rtorrent.py about this escaping.
-        # The client should be fixed to work consistenly on all python versions
+        # The client should be fixed to work consistently on all python versions
         # Calling re.escape here is a workaround so test works on python 3.7 and older versions
         assert ('d.directory.set=' + re.escape('/data/downloads')) in fields
         assert 'd.custom1.set=testing' in fields

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1578,7 +1578,7 @@ class TestImportSeries:
     def test_timeframe_max(self, execute_task):
         """Tests configure_series as well as timeframe with max_quality."""
         task = execute_task('timeframe_max')
-        assert not task.accepted, 'Entry shouldnot have been accepted on first run.'
+        assert not task.accepted, 'Entry shouldnt have been accepted on first run.'
         age_series(minutes=6)
         task = execute_task('timeframe_max')
         assert task.find_entry('accepted', title='the show s03e02 hdtv'), (
@@ -1593,7 +1593,7 @@ class TestImportSeries:
         assert entry['series_name'] == 'the show', 'entry series should be set to the main name'
 
     def test_manual_config_override(self, execute_task):
-        """Settings configued manually in series plugin should override those from configure_series."""
+        """Settings configured manually in series plugin should override those from configure_series."""
         task = execute_task('test_manual_config_override')
         series_config = task.config['series'][0]['my show']
         assert series_config['quality'] == '720p', 'configure_series settings should be merged in'

--- a/tests/test_seriesparser.py
+++ b/tests/test_seriesparser.py
@@ -451,7 +451,7 @@ class TestSeriesParser:
         s = parse('Red Tomato (US) S01E02 720p-FlexGet', name='Red Tomato', strict_name=True)
         assert not s.valid, 'Red Tomato (US) should not match Red Tomato in exact mode'
 
-    def test_name_word_boundries(self, parse):
+    def test_name_word_boundaries(self, parse):
         name = 'test'
         s = parse('Test.S01E02.720p-FlexGet', name=name)
         assert s.valid, 'normal failed'

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -53,5 +53,5 @@ class TestUniques:
     def test_missing_field(self, execute_task):
         """Unique plugin: Ensure we ignore entries with missing fields."""
         task = execute_task('missing_field')
-        assert len(task.rejected) == 1, 'should reject 1 entires'
+        assert len(task.rejected) == 1, 'should reject 1 entries'
         assert task.rejected[0]['title'] == 'bla3', 'should reject bla3'

--- a/tests/test_urlrewriting.py
+++ b/tests/test_urlrewriting.py
@@ -4,7 +4,7 @@ from flexget.plugin import get_plugin_by_name
 
 
 class TestURLRewriters:
-    """Bad example, does things manually, you should use task.find_entry to check existance."""
+    """Bad example, does things manually, you should use task.find_entry to check existence."""
 
     config = """
         tasks:


### PR DESCRIPTION
Integrates the `typos` spell checker into our pre-commit configuration (`.pre-commit-config.yaml`).

This will automatically scan staged files for spelling errors before a commit is created, providing immediate feedback to developers. This helps maintain high-quality documentation and prevents typos from entering the repository in the first place.

Developers should run `pre-commit install` to enable the hook locally.
