### PR TITLE
fix: Correctly append file extension instead of replacing it

### DIFF
--- a/flexget/plugins/output/file_operations.py
+++ b/flexget/plugins/output/file_operations.py
@@ -311,7 +311,7 @@ class TransformingOps(BaseFileOps):
             and dst_ext != src_ext
         ):
             self.logger.verbose('Adding extension `{}` to dst `{}`', src_ext, dst)
-            dst = dst.with_suffix(src_ext)
+            dst = Path(f'{dst}{src_ext}')
             dst_file += dst_ext  # this is used for sibling files. dst_ext turns out not to be an extension!
 
         funct_name = 'move' if self.move else 'copy'


### PR DESCRIPTION
The previous code used `pathlib.Path.with_suffix()` to add an extension. This method replaces the existing suffix, leading to incorrect behavior when the original filename already contained an extension.

For example, 'file.log' with extension '.bak' would become 'file.bak' instead of the intended 'file.log.bak'.

This commit changes the implementation to use an f-string for concatenation, ensuring the new extension is always appended to the full original filename.

