### PR TITLE
[Add] `hybrid-hdr` Quality for Color Range

### DIFF
--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -153,12 +153,17 @@ _codecs = [
     QualityComponent('codec', 50, 'av1', 'av-?1'),
 ]
 
+hdr = r'hdr([^\w]?10)?'
+hdr_plus = r'hdr(10)?[^\w]?(\+|p|plus)'
+dovi = r'(dolby[^\w]?vision|dv|dovi)'
 _color_ranges = [
     QualityComponent('color_range', 10, '8bit', r'8[^\w]?bits?|hi8p?'),
     QualityComponent('color_range', 20, '10bit', r'10[^\w]?bits?|hi10p?'),
-    QualityComponent('color_range', 30, 'hdr', r'hdr([^\w]?10)?'),
-    QualityComponent('color_range', 40, 'hdrplus', r'hdr(10)?[^\w]?(\+|p|plus)'),
-    QualityComponent('color_range', 50, 'dolbyvision', r'(dolby[^\w]?vision|dv|dovi)'),
+    # Must come before the individual ones since it's stripped from the title
+    QualityComponent('color_range', 60, 'hybrid-hdr', f'(({dovi}|{hdr_plus}|{hdr})\\W?){{2,3}}'),
+    QualityComponent('color_range', 30, 'hdr', hdr),
+    QualityComponent('color_range', 40, 'hdrplus', hdr_plus),
+    QualityComponent('color_range', 50, 'dolbyvision', dovi),
 ]
 
 channels = r'(?:(?:[^\w+]?[1-7][\W_]?(?:0|1|ch)))'

--- a/tests/test_qualities.py
+++ b/tests/test_qualities.py
@@ -102,6 +102,8 @@ class TestQualityParser:
             ('Test.File.DTSHDMA5.1', 'dtshd'),
             ('Test.File.DD2.0', 'dd5.1', False),
             ('Test.File.AC35.1', 'ac3', False),
+            ('Test.File.HDR.DOVI', 'hybrid-hdr', False),
+            ('Test.File.DV.HDR10+', 'hybrid-hdr', False),
         ],
     )
     def test_quality_failures(self, parser, test_quality):


### PR DESCRIPTION
### Motivation for changes:
User requests on the referenced issues
### Detailed changes:

- Added new `hybrid-hdr` color space Quality above `dolbyvision`
  - Included a couple of tests

### Addressed issues/feature requests:

- Closes #4042
- Fixes #4043
- Fixes #4074

### Config usage if relevant (new plugin or updated schema):

```
quality: hybrid-hdr
```

### Log and/or tests output (preferably both):

```
$ pytest tests\test_qualities.py
=========================================================================================== test session starts ============================================================================================
platform win32 -- Python 3.11.4, pytest-8.3.4, pluggy-1.5.0
rootdir: Flexget
configfile: pyproject.toml
plugins: anyio-4.8.0, cov-6.0.0, mockito-0.0.4, xdist-3.6.1, time-machine-2.16.0
collected 158 items

tests\test_qualities.py ..............................................................................................................................................................                [100%]

============================================================================================= warnings summary ============================================================================================= 
.venv\Lib\site-packages\flask_restx\api.py:19
.venv\Lib\site-packages\flask_restx\api.py:19
  Flexget\.venv\Lib\site-packages\flask_restx\api.py:19: DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the https://github.com/python-jsonschema/referencing library, which provides more compliant referencing behavior as well as more flexible APIs for customization. A future release will remove RefResolver. Please file a feature request (on referencing) if you are missing 
an API for the kind of customization you need.
    from jsonschema import RefResolver

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================== 158 passed, 2 warnings in 5.63s ======================================================================================

```

### To-Do
- Add to https://flexget.com/Qualities