### PR TITLE
chore(ci): Make patch coverage check non-blocking

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,11 +2,12 @@ codecov:
   notify:
     after_n_builds: 15
 
-comment:
-  layout: 'diff, flags, files'
-
 coverage:
   status:
+    patch:
+      default:
+        target: 100%
+        informational: true
     project:
       default:
         target: auto

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ intersphinx_mapping = {
     'loguru': ('https://loguru.readthedocs.io/en/stable', None),
     'python': ('https://docs.python.org/3', None),
     'python-telegram-bot': ('https://docs.python-telegram-bot.org/en/stable', None),
-    'requests': ('https://docs.python-requests.org/en/stable', None),
+    'requests': ('https://requests.readthedocs.io/en/stable', None),
     'rich': ('https://rich.readthedocs.io/en/stable/', None),
     'sqlalchemy': ('https://docs.sqlalchemy.org', None),
     'transmission-rpc': ('https://transmission-rpc.readthedocs.io/en/stable', None),

--- a/tests/sftp/test_sftp_server.py
+++ b/tests/sftp/test_sftp_server.py
@@ -75,7 +75,7 @@ else:
 
         def __run_server(self):
             logger.debug('Starting sftp server 127.0.0.1:40022 with root fs at %s', self.__root)
-            try:
+            with contextlib.suppress(ConnectionAbortedError):
                 conn, addr = self.__server_socket.accept()
 
                 host_key = RSAKey.from_private_key_file('test_sftp_server.key')
@@ -93,10 +93,6 @@ else:
 
                 while transport.is_active():
                     time.sleep(1)
-            except ConnectionAbortedError:
-                pass
-            except Exception as e:
-                logger.critical(e, exc_info=True)
 
         def kill(self) -> None:
             with contextlib.suppress(OSError):


### PR DESCRIPTION
The strict patch coverage check requires that all new and modified lines in a PR are accompanied by tests. Given the project's currently low overall test coverage, this often forces developers to write a substantial number of new tests even for minor changes, which creates a high barrier for contributions.

To unblock the development workflow, this change sets the patch coverage check to "informational". This means the check will now always pass, but it will continue to report on the coverage of each commit and pull request, providing valuable feedback to developers without halting the release process.

![image](https://github.com/user-attachments/assets/8ecef7cc-74f0-4461-9310-7bca327d8901)

Crucially, the project-level coverage check remains active and blocking. Any PR that causes a decrease in the total project coverage will still fail the build.

![image](https://github.com/user-attachments/assets/b14316e7-b7df-444b-8c18-88c76f1df999)

