### PR TITLE
ci: Skip redundant push builds after `merge_group` checks

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build:
     name: Docker build
+    if: github.actor != 'github-merge-queue[bot]'
     permissions:
       packages: write # to push to ghcr.io
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   tests:
     name: Run Tests
+    if: github.actor != 'github-merge-queue[bot]'
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
@@ -53,6 +54,7 @@ jobs:
 
   test-scripts:
     name: Test scripts
+    if: github.actor != 'github-merge-queue[bot]'
     runs-on: ubuntu-latest
     env:
       PYTHON_VERSION: '3.13' # renovate: datasource=python-version depName=python
@@ -78,6 +80,7 @@ jobs:
 
   zizmor:
     name: GitHub Actions Security Analysis with zizmor
+    if: github.actor != 'github-merge-queue[bot]'
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -103,12 +106,12 @@ jobs:
 
   test-results:
     name: Test results
+    if: always() && github.event_name != 'push'
     needs:
       - tests
       - test-scripts
       - zizmor
     runs-on: ubuntu-latest
-    if: always()
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1


### PR DESCRIPTION
When a pull request is merged via the merge queue, it triggers two separate CI workflow runs for the same commit:
1. One for the `merge_group` event.
2. A second, redundant one for the `push` event to the base branch.

This duplication consumes unnecessary CI minutes and slows down the feedback loop.

This commit adds a conditional `if` statement to our CI jobs. The jobs will now be skipped if the event is a `push` and the actor is `github-merge-queue[bot]`, which is the user responsible for merge queue merges.

This ensures that only the `merge_group` check is executed for commits entering the develop branch via the merge queue, thereby improving CI efficiency and saving resources.
