### PR TITLE
Fix color space evaluation order

### DIFF
--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -157,13 +157,12 @@ hdr = r'hdr([^\w]?10)?'
 hdr_plus = r'hdr(10)?[^\w]?(\+|p|plus)'
 dovi = r'(dolby[^\w]?vision|dv|dovi)'
 _color_ranges = [
-    QualityComponent('color_range', 10, '8bit', r'8[^\w]?bits?|hi8p?'),
+    QualityComponent('color_range', 10, '8bit', r'8[^\w]?bits?|hi8p?|sdr'),
     QualityComponent('color_range', 20, '10bit', r'10[^\w]?bits?|hi10p?'),
-    # Must come before the individual ones since it's stripped from the title
-    QualityComponent('color_range', 60, 'hybrid-hdr', f'(({dovi}|{hdr_plus}|{hdr})\\W?){{2,3}}'),
     QualityComponent('color_range', 30, 'hdr', hdr),
     QualityComponent('color_range', 40, 'hdrplus', hdr_plus),
     QualityComponent('color_range', 50, 'dolbyvision', dovi),
+    QualityComponent('color_range', 60, 'hybrid-hdr', f'(({dovi}|{hdr_plus}|{hdr})\\W?){{2,3}}'),
 ]
 
 channels = r'(?:(?:[^\w+]?[1-7][\W_]?(?:0|1|ch)))'
@@ -226,7 +225,7 @@ class Quality(Serializer):
         self.resolution = self._find_best(_resolutions, _UNKNOWNS['resolution'], False)
         self.source = self._find_best(_sources, _UNKNOWNS['source'])
         self.codec = self._find_best(_codecs, _UNKNOWNS['codec'])
-        self.color_range = self._find_best(_color_ranges, _UNKNOWNS['color_range'])
+        self.color_range = self._find_best(_color_ranges, _UNKNOWNS['color_range'], False)
         self.audio = self._find_best(_audios, _UNKNOWNS['audio'])
         # If any of the matched components have defaults, set them now.
         for component in self.components:


### PR DESCRIPTION
### Detailed changes:

- Disabled `strip_all` property from `color_space` so the list can remain in natural order

### Addressed issues/feature requests:

- Fixes #4445 .

### Log and/or tests output (preferably both):

```
$ pytest tests\test_qualities.py
============================= test session starts =============================
platform win32 -- Python 3.11.4, pytest-8.3.4, pluggy-1.5.0
rootdir: Flexget
configfile: pyproject.toml
plugins: anyio-4.8.0, cov-6.0.0, mockito-0.0.4, xdist-3.6.1, time-machine-2.16.0
collected 158 items

tests\test_qualities.py ................................................ [ 30%]
........................................................................ [ 75%]
......................................                                   [100%]

============================== warnings summary ===============================
.venv\Lib\site-packages\flask_restx\api.py:19
.venv\Lib\site-packages\flask_restx\api.py:19
  Flexget\.venv\Lib\site-packages\flask_restx\api.py:19: DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the https://github.com/python-jsonschema/referencing library, which provides more compliant referencing behavior as well as more flexible APIs for customization. A future release will remove RefResolver. Please file a feature request (on referencing) if you are missing an API for the kind of customization you need.
    from jsonschema import RefResolver

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 158 passed, 2 warnings in 5.19s =======================
```

```yaml
tasks:
  test:
    mock:
      - title: "The.Movie.2160p.HDR"
      - title: "Any.Movie.1080p.SDR"
      - title: "Any.Other.Movie.2160p.HDR"
      - title: "Another.Movie.2160p.DV"
    quality:
      - <2160p
      - <hdr
    accept_all: yes
```
```
VERBOSE  details       test            Produced 4 entries.
VERBOSE  task          test            REJECTED: `The.Movie.2160p.HDR` by quality plugin because `2160p hdr` does not match any of quality requirements: `<2160p`, `<hdr`
VERBOSE  task          test            REJECTED: `Any.Other.Movie.2160p.HDR` by quality plugin because `2160p hdr` does not match any of quality requirements: `<2160p`, `<hdr`
VERBOSE  task          test            REJECTED: `Another.Movie.2160p.DV` by quality plugin because `2160p dolbyvision` does not match any of quality requirements: `<2160p`, `<hdr`
VERBOSE  task          test            ACCEPTED: `Any.Movie.1080p.SDR` by accept_all plugin
VERBOSE  details       test            Summary - Accepted: 1 (Rejected: 3 Undecided: 0 Failed: 0)
```