### PR TITLE
fix(ci): Fortify Docker build against API rate-limiting errors

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -77,3 +77,5 @@ jobs:
             type=gha, scope=${{ github.ref_name }}
             type=gha, scope=${{ github.base_ref }}
           cache-to: type=gha, mode=max, scope=${{ github.ref_name }}
+        env:
+          GH_TOKEN: ${{ secrets.flexgetbot_pat }}

--- a/scripts/bundle_webui.py
+++ b/scripts/bundle_webui.py
@@ -85,8 +85,10 @@ def bundle_webui(ui_version: Optional[str] = None):
             if app_path.exists():
                 shutil.rmtree(app_path)
 
+            gh_token = os.environ.get('GH_TOKEN')
             release = requests.get(
-                'https://api.github.com/repos/Flexget/webui/releases/latest'
+                'https://api.github.com/repos/Flexget/webui/releases/latest',
+                headers={'Authorization': f'Bearer {gh_token}'} if gh_token else {},
             ).json()
 
             v2_package = None


### PR DESCRIPTION
The Docker image build process has been suffering from sporadic failures, a key cause of which has been identified and is addressed herein.

When fetching metadata for the latest Flexget webui release, the unauthenticated API call was susceptible to GitHub's IP-based rate limits. If the GitHub Actions runner's IP had exhausted its request quota, the build would fail. This commit remedies this vulnerability by leveraging a `GITHUB_TOKEN` to perform an authenticated API request.

This approach utilizes the significantly more generous rate limit granted to authenticated tokens, thereby circumventing the IP-based restriction and bolstering the overall stability and resilience of the build process.

A clear example of this failure mode can be observed in the following workflow run: https://github.com/Flexget/Flexget/actions/runs/15854586601

It is important to note that while this resolves a critical point of failure, other sources of build instability may still exist.

A key limitation of this approach is its ineffectiveness for `pull_request` events originating from forks. GitHub's security model restricts these workflow runs from accessing secrets. Therefore, these builds will fall back to unauthenticated requests and continue to be susceptible to IP-based rate limits.