### PR TITLE
refactor: Fix a minor flaw in the path validator code

### DIFF
--- a/flexget/config_schema.py
+++ b/flexget/config_schema.py
@@ -275,8 +275,7 @@ def is_path(instance) -> bool:
     if result:
         instance = os.path.dirname(instance[0 : result.start()])
     if not os.path.isdir(os.path.expanduser(instance)):
-        error: str = f'`{instance}` does not exist'
-        logger.warning(error)
+        logger.warning('`{}` does not exist', instance)
     return True
 
 


### PR DESCRIPTION
## Motivation for changes:

### 1. Semantic Mismatch between Variable Name and Log Level

The variable is named `error`, but it's being logged as a `warning`. This can be a bit confusing for future readers, as the name `error` typically implies a more severe issue that might halt execution (corresponding to `logger.error` or an exception).

### 2. Use Deferred Formatting for Better Performance

The current code uses an f-string to create the log message. For logging, it's a best practice to use the logger's own substitution mechanism instead.

As the **[ruff documentation on `G004`](https://docs.astral.sh/ruff/rules/logging-f-string/)** explains, the logging module uses "lazy" or "deferred" formatting. This means it only constructs the full message string *if* the message's level (e.g., `WARNING`) is high enough to actually be processed by a handler.

When you use an f-string, the string is formatted *immediately*, even if the log level is configured to ignore warnings. This can waste CPU cycles, especially if the log statement is in a frequently called function.
