### PR TITLE
CI: Enable branch coverage for more accurate test metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,9 @@ exclude_also = [
     "if TYPE_CHECKING"
 ]
 
+[tool.coverage.run]
+branch = true
+
 [tool.doc8]
 ignore = [ "D004" ]
 max_line_length = 99


### PR DESCRIPTION
This pull request enables branch coverage analysis in our test suite.

Currently, our coverage reports only measure line coverage, which indicates whether a line of code has been executed. However, it doesn't tell us if all possible paths within that line (e.g., both the `if` and `else` parts of a conditional) have been tested.

By enabling branch coverage, our reports will become more insightful. They will highlight not just which lines are untested, but also which specific conditional branches lack test coverage. This provides a more accurate and meaningful picture of our test suite's effectiveness and helps developers identify subtle gaps in testing.

#### Changes Made

*   Added `branch = true` to the `[tool.coverage.run]` section in `pyproject.toml`.

#### How to Verify

1.  Check out this branch.
2.  Run the test suite with coverage enabled (e.g., `coverage run -m pytest`).
3.  Generate a coverage report (e.g., `coverage report -m` or `coverage html`).
4.  Observe that the report now includes a "BRANCH" column and lists missing branches, providing more detail than before.

This simple change will help us write more robust tests and improve the overall quality of the codebase.