### PR TITLE
test: treat warnings as errors

### DIFF
--- a/flexget/components/variables/variables.py
+++ b/flexget/components/variables/variables.py
@@ -1,4 +1,3 @@
-import codecs
 import os
 from datetime import datetime
 
@@ -37,7 +36,7 @@ def variables_from_file(config_base, filename):
     if not os.path.exists(variables_file):
         raise PluginError(f'File {variables_file} does not exist!')
     try:
-        with codecs.open(variables_file, 'rb', 'utf-8') as f:
+        with open(variables_file, 'rb') as f:
             variables_dict = yaml.safe_load(f.read())
     except yaml.YAMLError as e:
         raise PluginError(f'Invalid variables file: {e}')

--- a/flexget/plugins/input/npo_watchlist.py
+++ b/flexget/plugins/input/npo_watchlist.py
@@ -234,7 +234,7 @@ class NPOWatchlist:
         if tiles is not None:
             for tile in tiles:
                 # there is only one list_item per tile
-                for list_item in get_soup(tile).findAll('div', class_='npo-asset-tile-container'):
+                for list_item in get_soup(tile).find_all('div', class_='npo-asset-tile-container'):
                     episode_id = list_item['data-id']
                     premium = 'npo-premium-content' in list_item['class']
                     logger.debug('Parsing episode: {}', episode_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,19 @@ max_supported_python = '3.14'
 
 [tool.pytest.ini_options]
 addopts = '-p no:legacypath --strict-markers'
+filterwarnings = [
+  'error',
+  "ignore:jsonschema.RefResolver is deprecated as of v4.18.0",     # triggered by `python-restx` Consider migrate to `flask-smorest` to eliminate it. See https://github.com/python-restx/flask-restx/issues/633#issuecomment-2962412240
+  "ignore:'count' is passed as positional argument",               # triggered by `feedparser`
+  'ignore:tzname PST identified but not understood.',              # triggered by `dateutil`
+  'ignore:tzname EDT identified but not understood.',              # triggered by `dateutil`
+  "ignore:unclosed file <_io.BufferedReader name='photo.png'>",    # triggered by `python-telegram-bot`
+  "ignore:unclosed file <_io.BufferedReader name='document.jpg'>", # triggered by `python-telegram-bot`
+  "ignore:unclosed file <_io.BufferedReader name='",               # needs investigation
+  "ignore:unclosed file <_io.TextIOWrapper name='",                # needs investigation
+  "ignore:Implicitly cleaning up <addinfourl at ",                 # needs investigation
+  'ignore:Failed to load HostKeys from',                           # triggered by `pysftp` intermittently
+]
 markers = [
   'filecopy(src, dst): mark test to copy a file from `src` to `dst` before running',
   'online: mark test that goes online. VCR will automatically be used.',

--- a/tests/notifiers/test_telegram.py
+++ b/tests/notifiers/test_telegram.py
@@ -71,8 +71,6 @@ class TestTelegramNotifier:
                         bot_token: 7617087239:AAGUy118YHbBvGNwkDo4CDehF4gFgXq2ZqE
                         recipients:
                           - chat_id: -4882300333
-                        images:
-                          - document.jpg
         """
 
     def test_chat_id(self, execute_task):

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -175,7 +175,7 @@ class TestSchemaFormats:
                 config_schema.format_checker.check(item, format)
                 if invalid:
                     failures.append(f"'{item}' should not be a valid '{format}")
-            except jsonschema.FormatError as e:
+            except jsonschema.exceptions.FormatError as e:
                 if not invalid:
                     failures.append(e.message)
         return failures

--- a/tests/test_thetvdb.py
+++ b/tests/test_thetvdb.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 import pytest
@@ -217,7 +217,7 @@ class TestTVDBExpire:
         test_run()
 
         # Should not expire as it was checked less then an hour ago
-        persist['last_check'] = datetime.utcnow() - timedelta(hours=1)
+        persist['last_check'] = datetime.now(timezone.utc) - timedelta(hours=1)
         with (
             mock.patch(
                 'requests.sessions.Session.request',
@@ -251,7 +251,7 @@ class TestTVDBExpire:
         test_run()
 
         # Should expire
-        persist['last_check'] = datetime.utcnow() - timedelta(hours=3)
+        persist['last_check'] = datetime.now(timezone.utc) - timedelta(hours=3)
 
         expired_data = [
             {'id': 73255, 'lastUpdated': 1458186055},


### PR DESCRIPTION
### Motivation for changes:
Enabling `filterwarnings = 'error'` ensures that all warnings are treated as errors during test runs. This has several benefits:

* **Improves code quality** by forcing developers to address deprecation warnings, resource leaks, and other potential issues early.
* **Prevents silent failures** where a warning might indicate incorrect behavior that would otherwise be ignored.
* **Future-proofs the codebase** by ensuring compatibility with newer Python versions or dependency updates.
* **Makes CI stricter**, helping catch regressions or bad patterns during automated testing.

