### PR TITLE
ci(pre-commit): add validate-pyproject hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,10 @@ ci:
   autoupdate_schedule: quarterly
   skip: [uv-lock]
 repos:
+  - repo: https://github.com/henryiii/validate-pyproject-schema-store
+    rev: 2025.08.07
+    hooks:
+      - id: validate-pyproject
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: v2.6.0
     hooks:


### PR DESCRIPTION
Introduces a pre-commit hook to validate the `pyproject.toml` file.

This hook will run on every commit to ensure that the `pyproject.toml` file is compliant with relevant PEPs. By validating the file automatically, we can prevent syntax errors and ensure the project's metadata is correctly structured, improving the reliability of our build process.
