### PR TITLE
ci(renovate): automate merging of pre-commit hook updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,12 +50,16 @@
   },
   packageRules: [
     {
+      extends: [':automergeAll'],
+      matchManagers: ['pre-commit'],
+    },
+    {
       description: 'This pre-commit env takes a long time to rebuild. Limit updates to monthly.',
       matchPackageNames: ['renovatebot/pre-commit-hooks'],
       extends: ['schedule:monthly'],
     },
     {
-      description: 'Group all uv updates together. Wait before merge so both sources are out.',
+      description: 'Group all uv updates together. Wait before merge so all sources are out.',
       groupName: 'uv',
       matchPackageNames: [
         'uv',
@@ -63,6 +67,7 @@
         'astral-sh/uv-pre-commit',
       ],
       minimumReleaseAge: '6 hours',
+      extends: [':automergeAll'],
     },
   ],
 }


### PR DESCRIPTION
Enable the automerge feature in Renovate for all updates related to pre-commit hooks.

The rationale for this change is that our Continuous Integration (CI) pipeline already validates these updates. If the `pre-commit` job passes in CI with the new hook versions, it serves as a reliable confirmation that the update is safe and does not introduce any breaking changes.

Automating this process will:
- Reduce manual effort for routine maintenance.
- Keep our development tools up-to-date more quickly.
- Streamline the overall workflow by eliminating unnecessary reviews for low-risk updates.
