### PR TITLE
ci(pre-commit): implement pre-commit validation for `.readthedocs.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,10 @@ repos:
     rev: v2.0.0
     hooks:
       - id: doc8
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.33.2
+    hooks:
+      - id: check-readthedocs
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.7.22
     hooks:


### PR DESCRIPTION
This commit introduces a pre-commit hook to validate the `.readthedocs.yaml` configuration file. By leveraging the `check-readthedocs` hook, we can proactively ensure the correctness of our Read the Docs configuration before any changes are committed to the repository.

This validation step will help to:
- Catch syntax errors and invalid configuration options early.
- Prevent broken documentation builds caused by an incorrect `.readthedocs.yaml` file.
- Improve the overall stability and reliability of our documentation deployment process.