### PR TITLE
ci(renovate): remove useless `minimumReleaseAge`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -66,7 +66,6 @@
         'ghcr.io/astral-sh/uv',
         'astral-sh/uv-pre-commit',
       ],
-      minimumReleaseAge: '6 hours',
       extends: [':automergeAll'],
     },
   ],


### PR DESCRIPTION
Setting `minimumReleaseAge` makes Renovate require **each dependency** in the group to have been published for 6 hours, rather than requiring only the first dependency to have been published for 6 hours.

For example, if `uv` has been published for 6 hours but `ghcr.io/astral-sh/uv` and `astral-sh/uv-pre-commit` have only been published for 5 hours, and Renovate runs at this time, it will create a PR containing only the `uv` update, excluding the other two.

You can also see [this PR](https://github.com/Flexget/Flexget/pull/4462): `astral-sh/uv-pre-commit` and `ghcr.io/astral-sh/uv` were updated to 0.7.16, but `uv` was updated to 0.7.17. The updates for `astral-sh/uv-pre-commit` and `ghcr.io/astral-sh/uv` to 0.7.17 were shown as **“Pending” due to insufficient release age**.

<img width="297" height="333" alt="image" src="https://github.com/user-attachments/assets/aa79392d-6226-4415-83d4-f37d46a05590" />

This shows that setting `minimumReleaseAge` did not achieve the intended effect of having all three updated simultaneously.
