### PR TITLE
[Change] Renamed colorspace quality `hybrid-hdr` to `hybrid_hdr`

### DIFF
--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -164,7 +164,7 @@ _color_ranges = [
     QualityComponent('color_range', 30, 'hdr', hdr),
     QualityComponent('color_range', 40, 'hdrplus', hdr_plus),
     QualityComponent('color_range', 50, 'dolbyvision', dovi),
-    QualityComponent('color_range', 60, 'hybrid-hdr', f'(({dovi}|{hdr_plus}|{hdr})\\W?){{2,3}}'),
+    QualityComponent('color_range', 60, 'hybrid_hdr', f'(({dovi}|{hdr_plus}|{hdr})\\W?){{2,3}}'),
 ]
 
 channels = r'(?:(?:[^\w+]?[1-7][\W_]?(?:0|1|ch)))'

--- a/tests/test_qualities.py
+++ b/tests/test_qualities.py
@@ -102,8 +102,8 @@ class TestQualityParser:
             ('Test.File.DTSHDMA5.1', 'dtshd'),
             ('Test.File.DD2.0', 'dd5.1', False),
             ('Test.File.AC35.1', 'ac3', False),
-            ('Test.File.HDR.DOVI', 'hybrid-hdr', False),
-            ('Test.File.DV.HDR10+', 'hybrid-hdr', False),
+            ('Test.File.HDR.DOVI', 'hybrid_hdr', False),
+            ('Test.File.DV.HDR10+', 'hybrid_hdr', False),
         ],
     )
     def test_quality_failures(self, parser, test_quality):
@@ -166,6 +166,13 @@ class TestFilterQuality:
             mock:
               - {title: 'Test S01E01 HDTV 1080p', quality: 'hdtv 1080p dd+5.1'}
             accept_all: yes
+          hybrid:
+            template: no_global
+            mock:
+              - {title: 'Test.File.DV.HDR10+'}
+              - {title: 'Test.File.DV'}
+            quality: "hybrid_hdr"
+            accept_all: yes
     """
 
     @pytest.fixture(scope='class', params=['internal', 'guessit'], ids=['internal', 'guessit'])
@@ -224,6 +231,13 @@ class TestFilterQuality:
             'Wrong quality type, should be Quality not str'
         )
         assert str(entry['quality']) == '1080p hdtv dd+5.1'
+
+    def test_hybrid(self, execute_task):
+        task = execute_task('hybrid')
+        entry = task.find_entry('accepted', title='Test.File.DV.HDR10+')
+        assert len(task.rejected) == 1, 'wrong number of entries rejected'
+        assert len(task.accepted) == 1, 'wrong number of entries accepted'
+        assert str(entry['quality']) == 'hybrid_hdr'
 
 
 class TestQualityAudio:


### PR DESCRIPTION
### Motivation for changes:
`hybrid-hdr`'s dash caused the `quality` filter to interpret it as a range
### Detailed changes:

- Renamed `hybrid-hdr` quality to `hybrid_hdr`
- Added test for this scenario

### Addressed issues/feature requests:

- Fixes #4505 

### Config usage if relevant (new plugin or updated schema):

```diff
- quality: hybrid-hdr
+ quality: hybrid_hdr
```
