### PR TITLE
ci(github-actions): remove `renovate-config-validator` from pre-commit hooks and validate the Renovate config in GitHub Actions.

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -54,12 +54,7 @@
       matchManagers: ['pre-commit'],
     },
     {
-      description: 'This pre-commit env takes a long time to rebuild. Limit updates to monthly.',
-      matchPackageNames: ['renovatebot/pre-commit-hooks'],
-      extends: ['schedule:monthly'],
-    },
-    {
-      description: 'Group all uv updates together. Wait before merge so all sources are out.',
+      description: 'Group all uv updates together.',
       groupName: 'uv',
       matchPackageNames: [
         'uv',

--- a/.github/workflows/renovate-config-validation.yml
+++ b/.github/workflows/renovate-config-validation.yml
@@ -1,0 +1,22 @@
+name: Renovate config validation
+on:
+  push:
+    branches: [develop]
+    paths: [.github/renovate.json5]
+  pull_request:
+    paths: [.github/renovate.json5]
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+jobs:
+  validate-renovate-config:
+    name: Validate Renovate config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+      - name: Validate Renovate config
+        run: npx --yes --package renovate@latest -- renovate-config-validator --strict


### PR DESCRIPTION
> Pre-commits are taking so long and asking for multiple firewall approvals often, I'm very tempted to disable them on my environment 😭
>
> _Originally posted by @BrutuZ on Discord_

Limitation:

- Due to https://github.com/orgs/community/discussions/44490, this check cannot be set as a required check for now unless it is run for all PRs, which would increase CI overhead.

- Due to https://github.com/orgs/community/discussions/45899, this check cannot be set to run in the GitHub Merge Queue for now unless it is run for all PRs, which would increase CI overhead.
