### PR TITLE
ci: auto-close pull requests from pre-commit-ci[bot]

### DIFF
--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -1,0 +1,20 @@
+name: Close pre-commit-ci pull requests
+on:
+  pull_request:
+    paths: [.pre-commit-config.yaml]
+    types: [opened]
+permissions: {}
+jobs:
+  close-pr:
+    name: Close pre-commit-ci pull requests
+    if: github.event.pull_request.user.login == 'pre-commit-ci[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Close pre-commit-ci[bot] pull requests
+        run: |
+          gh pr close ${{ github.event.pull_request.number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
We are already using Renovate to manage our dependency updates, which makes the auto-updates provided by pre-commit-ci[bot] redundant.

To reduce the noise from bot-created pull requests, such as #4480, this commit introduces a new GitHub Actions workflow. To minimize any additional CI overhead, this workflow is specifically configured to run only on pull requests that modify the `.pre-commit-config.yaml` file. It will then automatically close the PR if it was initiated by pre-commit-ci[bot].

This change will help keep our pull request list clean and allow us to focus on core development contributions, without incurring significant CI costs.

<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
