### PR TITLE
chore: remove `renovate-config-validator` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
   autoupdate_schedule: quarterly
-  skip: [renovate-config-validator, uv-lock]
+  skip: [uv-lock]
 repos:
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: v2.6.0
@@ -50,8 +50,3 @@ repos:
     rev: v1.7.7
     hooks:
       - id: actionlint
-  - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 41.43.0
-    hooks:
-      - id: renovate-config-validator
-        args: [--strict]


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
@gazpachoking I just realized that the previous PR only added the check in GitHub Actions, but I forgot to remove `renovate-config-validator` from pre-commit.
