### PR TITLE
chore(deps): pin `paramiko` to v3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,11 +87,12 @@ plugin-test = [
   # These are optional dependencies for plugins that have tests in the test suite
   # Tests that need these must add the `require_optional_deps` pytest mark
   "boto3~=1.35",
+  "paramiko~=3.5",
   "pillow~=11.0",
   "plexapi~=4.16",
-  "pysftp~=0.2.9",
+  "pysftp~=0.2.9",           # TODO: `pysftp` was last updated in 2016 and is merely a wrapper around `paramiko`. It is now incompatible with `paramiko` 4.0, so consider migrating to `paramiko` directly. See https://github.com/Flexget/Flexget/issues/4532
   "rarfile~=4.0",
-  "subliminal<2.3",          # TODO: Update subliminal after https://github.com/Diaoul/subliminal/issues/1302 is resolved.
+  "subliminal==2.2.1",       # TODO: Update subliminal after https://github.com/Diaoul/subliminal/issues/1302 is resolved.
   { include-group = "all" },
 ]
 deluge = [ "deluge-client~=1.10" ]

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ name = "brotlicffi"
 version = "1.1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
+    { name = "cffi", marker = "platform_python_implementation == 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/9d/70caa61192f570fcf0352766331b735afa931b4c6bc9a348a0925cc13288/brotlicffi-1.1.0.0.tar.gz", hash = "sha256:b77827a689905143f87915310b93b273ab17888fd43ef350d4832c4a71083c13", size = 465192, upload-time = "2023-09-14T14:22:40.707Z" }
 wheels = [
@@ -719,7 +719,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -893,6 +893,7 @@ docs = [
 plugin-test = [
     { name = "boto3" },
     { name = "deluge-client" },
+    { name = "paramiko" },
     { name = "pillow" },
     { name = "plexapi" },
     { name = "pysftp" },
@@ -969,13 +970,14 @@ docs = [
 plugin-test = [
     { name = "boto3", specifier = "~=1.35" },
     { name = "deluge-client", specifier = "~=1.10" },
+    { name = "paramiko", specifier = "~=3.5" },
     { name = "pillow", specifier = "~=11.0" },
     { name = "plexapi", specifier = "~=4.16" },
     { name = "pysftp", specifier = "~=0.2.9" },
     { name = "python-telegram-bot", extras = ["http2", "socks"], specifier = "~=22.0" },
     { name = "qbittorrent-api", specifier = "~=2025.2" },
     { name = "rarfile", specifier = "~=4.0" },
-    { name = "subliminal", specifier = "<2.3" },
+    { name = "subliminal", specifier = "==2.2.1" },
     { name = "transmission-rpc", specifier = "~=7.0" },
 ]
 qbittorrent = [{ name = "qbittorrent-api", specifier = "~=2025.2" }]


### PR DESCRIPTION
This PR aims to avoid completely blocking the "lock file maintenance" PR:
  - #4529

`pysftp` was last updated in 2016 and is merely a wrapper around `paramiko`. It is now incompatible with `paramiko` 4.0.

The temporary workaround is to pin `paramiko` to version 3, while the better solution is to migrate to `paramiko` directly. See https://github.com/Flexget/Flexget/issues/4532.

<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
