### PR TITLE
ci: reduce CI overhead by running autofix and zizmor only when specific files have changed

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -4,7 +4,15 @@ on:
   push:
     branches:
       - develop
+    paths:
+      - pyproject.toml
+      - uv.lock
+      - .github/workflows/autofix.yml # This is needed because there might be `uv.lock` changes caused by a uv update.
   pull_request_target: # zizmor: ignore[dangerous-triggers]
+    paths:
+      - pyproject.toml
+      - uv.lock
+      - .github/workflows/autofix.yml # This is needed because there might be `uv.lock` changes caused by a uv update.
 permissions: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref || github.run_id }}

--- a/.github/workflows/renovate-config-validation.yml
+++ b/.github/workflows/renovate-config-validation.yml
@@ -2,9 +2,13 @@ name: Renovate config validation
 on:
   push:
     branches: [develop]
-    paths: [.github/renovate.json5]
+    paths:
+      - .github/renovate.json5
+      - .github/workflows/renovate-config-validation.yml
   pull_request:
-    paths: [.github/renovate.json5]
+    paths:
+      - .github/renovate.json5
+      - .github/workflows/renovate-config-validation.yml
 permissions: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref || github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,39 +78,12 @@ jobs:
           uv export --no-hashes --output-file scripts/update_changelog.txt --script scripts/update_changelog.py
           uv run --isolated --no-project --with pytest --with vcrpy --with-requirements scripts/update_changelog.txt -m pytest scripts/tests/test_update_changelog.py
 
-  zizmor:
-    name: GitHub Actions Security Analysis with zizmor
-    if: github.actor != 'github-merge-queue[bot]'
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
-      - name: Install uv
-        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6
-        with:
-          enable-cache: true
-          version: ${{ env.UV_VERSION }}
-      - name: Run zizmor
-        run: uvx zizmor -p --format sarif . > results.sarif
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3
-        with:
-          sarif_file: results.sarif
-          category: zizmor
-
   test-results:
     name: Test results
     if: always() && github.event_name != 'push'
     needs:
       - tests
       - test-scripts
-      - zizmor
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,38 @@
+name: GitHub Actions security analysis with zizmor
+on:
+  push:
+    branches: [develop]
+    paths: [.github/workflows]
+  pull_request:
+    paths: [.github/workflows]
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    env:
+      UV_VERSION: 0.8.4 # renovate: datasource=pypi depName=uv
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6
+        with:
+          enable-cache: true
+          version: ${{ env.UV_VERSION }}
+      - name: Run zizmor
+        run: uvx zizmor -p --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
Detailed changes:
- Run `autofix.yml` only when `pyproject.toml` or `uv.lock` changes.
- Run `zizmor.yml` only when `.github/workflows` changes.

Limitation:

- Due to https://github.com/orgs/community/discussions/44490, these checks cannot be set as a required check for now unless it is run for all PRs, which would increase CI overhead.

- Due to https://github.com/orgs/community/discussions/45899, these checks cannot be set to run in the GitHub Merge Queue for now unless it is run for all PRs, which would increase CI overhead.
