### PR TITLE
fix: eliminate renovate warning for `re-actors/alls-green`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This resolves the warning:
"Could not determine new digest for update (github-tags package re-actors/alls-green)"

<img width="1039" height="187" alt="image" src="https://github.com/user-attachments/assets/9374f678-031d-4097-884d-b7cc1fe7df77" />


<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
