### PR TITLE
test: fix sporadic `sftp` test failures

### DIFF
--- a/tests/sftp/test_sftp_server.py
+++ b/tests/sftp/test_sftp_server.py
@@ -94,7 +94,9 @@ else:
                 server = TestServer(
                     username=self.__username, password=self.__password, key_only=self.__key_only
                 )
-                transport.start_server(server=server)
+                # These exceptions are expected when the client finishes its work and closes the connection. We can treat this as a normal shutdown.
+                with contextlib.suppress(ConnectionResetError, EOFError):
+                    transport.start_server(server=server)
 
                 # TODO: Things break if we don't assign this to something?
                 channel = transport.accept()  # noqa: F841


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
Sporadic `sftp`  test failures occured after merging #4490.

It wasn’t an issue caused by #4490, but rather that some test issues were ignored before using “treat warnings as errors.”
