### PR TITLE
[feature] Update Slack notifier to handle two separate versions, Legacy and Block Kit

### DIFF
--- a/flexget/components/notify/notifiers/slack.py
+++ b/flexget/components/notify/notifiers/slack.py
@@ -16,21 +16,82 @@ logger = logger.bind(name=plugin_name)
 class SlackNotifier:
     """Send a Slack notification.
 
+    `Sending messages using incoming webhooks <https://api.slack.com/messaging/webhooks>`__
+
     Example::
 
-        notify:
-          entries:
-            via:
-              - slack:
-                  web_hook_url: <string>
-                  [channel: <string>] (override channel, use "@username" or "#channel")
-                  [username: <string>] (override username)
-                  [icon_emoji: <string>] (override emoji icon)
-                  [icon_url: <string>] (override emoji icon)
-                  [attachments: <array>[<object>]] (override attachments)
+      notify:
+        entries:
+          via:
+            - slack:
+                web_hook_url: "https://hooks.slack.com/services/..."
+                blocks:
+                  - section:
+                      text: '<{{ tvdb_url }}|{{ series_name }} ({{ series_id }})>'
+                  - section:
+                      text: '{{ tvdb_ep_overview }}'
+                      image:
+                        url: "https://api.slack.com/img/blocks/bkb_template_images/plants.png"
+                        alt_text: 'plants'
+                      fields:
+                        - '*Score*'
+                        - '*Genres*'
+                        - '{{ imdb_score }}'
+                        - "{{ imdb_genres | join(', ') | title }}"
+                        - '*Rating*'
+                        - '*Cast*'
+                        - '{{ imdb_mpaa_rating }}'
+                        - >
+                          {% for key, value in imdb_actors.items() %}{{ value }}{% if not loop.last %}, {% endif %}
+                          {% endfor %}
+                  - image:
+                      url: "{{ tvdb_banner }}"
+                      alt_text: "{{ series_name }} Banner"
+                  - context:
+                      - image:
+                          url: 'https://image.freepik.com/free-photo/red-drawing-pin_1156-445.jpg'
+                          alt_text: 'red pin'
+                      - text: ':round_pushpin:'
+                      - text: 'Task: {{ task }}'
+
+    `Legacy custom integrations incoming webhooks <https://api.slack.com/legacy/custom-integrations/messaging/webhooks>`__
+
+    Example (legacy)::
+
+      notify:
+        entries:
+          via:
+            - slack:
+                web_hook_url: <string>
+                [channel: <string>] (override channel, use "@username" or "#channel")
+                [username: <string>] (override username)
+                [icon_emoji: <string>] (override emoji icon)
+                [icon_url: <string>] (override emoji icon)
+                [attachments: <array>[<object>]] (override attachments)
     """
 
     schema = {
+        'definitions': {
+            'image_block': {
+                'type': 'object',
+                'properties': {
+                    'url': {'type': 'string', 'format': 'uri'},
+                    'alt_text': {'type': 'string'},
+                },
+                'required': ['url', 'alt_text'],
+                'additionalProperties': False,
+            },
+            'image_block_w_title': {
+                'type': 'object',
+                'properties': {
+                    'url': {'type': 'string', 'format': 'uri'},
+                    'title': {'type': 'string'},
+                    'alt_text': {'type': 'string'},
+                },
+                'required': ['url', 'alt_text'],
+                'additionalProperties': False,
+            },
+        },
         'type': 'object',
         'properties': {
             'web_hook_url': {'type': 'string', 'format': 'uri'},
@@ -95,25 +156,182 @@ class SlackNotifier:
                     'additionalProperties': False,
                 },
             },
+            'blocks': {
+                'type': 'array',
+                'minItems': 1,
+                'maxItems': 50,
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'section': {
+                            'type': 'object',
+                            'properties': {
+                                'text': {'type': 'string'},
+                                'image': {'$ref': '#/definitions/image_block'},
+                                'fields': {
+                                    'type': 'array',
+                                    'minItems': 1,
+                                    'maxItems': 10,
+                                    'items': {'type': 'string'},
+                                },
+                            },
+                            'anyOf': [{'required': ['text']}, {'required': ['fields']}],
+                            'additionalProperties': False,
+                        },
+                        'image': {
+                            'type': 'object',
+                            'properties': {
+                                'text': {'type': 'string'},
+                                'image': {'$ref': '#/definitions/image_block_w_title'},
+                            },
+                        },
+                        'context': {
+                            'type': 'array',
+                            'minItems': 1,
+                            'maxItems': 10,
+                            'items': {
+                                'type': 'object',
+                                'properties': {
+                                    'text': {'type': 'string'},
+                                    'image': {'$ref': '#/definitions/image_block'},
+                                },
+                                'anyOf': [
+                                    {'required': ['text']},
+                                    {'required': ['image']},
+                                ],
+                            },
+                        },
+                        'divider': {'type': 'boolean'},
+                    },
+                    'additionalProperties': False,
+                },
+            },
         },
-        'not': {'required': ['icon_emoji', 'icon_url']},
-        'error_not': "Can only use one of 'icon_emoji' or 'icon_url'",
+        'allOf': [
+            {
+                'if': {'required': ['blocks']},
+                'then': {
+                    'allOf': [
+                        {
+                            'not': {'required': ['message']},
+                            'error_not': "Cannot specify 'message' while using version 2 Slack formatting",
+                        },
+                        {
+                            'not': {'required': ['attachments']},
+                            'error_not': "Cannot specify 'attachments' while using version 2 Slack formatting",
+                        },
+                    ],
+                },
+                'else': {
+                    'anyOf': [{'required': ['message']}, {'required': ['attachments']}],
+                    'allOf': [
+                        {
+                            'not': {'required': ['icon_emoji', 'icon_url']},
+                            'error_not': "Can only use one of 'icon_emoji' or 'icon_url'",
+                        },
+                        {
+                            'not': {'required': ['blocks']},
+                            'error_not': "Cannot specify 'blocks' while using version 1 Slack formatting",
+                        },
+                    ],
+                },
+            }
+        ],
         'required': ['web_hook_url'],
         'additionalProperties': False,
     }
 
     def notify(self, title, message, config):
         """Send a Slack notification."""
-        notification = {
-            'text': message,
-            'username': config.get('username'),
-            'channel': config.get('channel'),
-            'attachments': config.get('attachments'),
-        }
-        if config.get('icon_emoji'):
-            notification['icon_emoji'] = ':{}:'.format(config['icon_emoji'].strip(':'))
-        if config.get('icon_url'):
-            notification['icon_url'] = config['icon_url']
+        # version 2 Block Kit formatting
+        if config.get('blocks'):
+            """
+                        Using the Block Kit Builder can help preview how your configuration will be displayed:
+                        https://api.slack.com/tools/block-kit-builder?mode=message
+                        """
+            notification = {'blocks': []}
+
+            for block in config.get('blocks'):
+                if block.get('section'):
+                    logger.trace('section block')
+                    section = {
+                        'type': 'section',
+                        'text': {
+                            'type': 'mrkdwn',
+                            'text': block['section']['text'],
+                        },
+                    }
+
+                    if block['section'].get('image', {}).get('url'):
+                        section['accessory'] = {
+                            'type': 'image',
+                            'image_url': block['section']['image']['url'],
+                            'alt_text': block['section']['image']['alt_text'],
+                        }
+
+                    if block['section'].get('fields'):
+                        section['fields'] = []
+
+                        for field in block['section'].get('fields'):
+                            section['fields'].append({'type': 'mrkdwn', 'text': field})
+
+                    notification['blocks'].append(section)
+
+                elif block.get('image'):
+                    logger.trace('image block')
+                    image = {
+                        'type': 'image',
+                        'image_url': block['image']['url'],
+                        'alt_text': block['image']['alt_text'],
+                    }
+
+                    if block['image'].get('title'):
+                        image['title'] = {
+                            'type': 'plain_text',
+                            'text': block['image']['title'],
+                            'emoji': True,
+                        }
+
+                    notification['blocks'].append(image)
+
+                elif block.get('context'):
+                    logger.trace('context block')
+                    context = {'type': 'context', 'elements': []}
+
+                    for block_context in block.get('context'):
+                        if block_context.get('text'):
+                            context['elements'].append({
+                                'type': 'mrkdwn',
+                                'text': block_context['text'],
+                            })
+
+                        elif block_context.get('image'):
+                            context['elements'].append({
+                                'type': 'image',
+                                'image_url': block_context['image']['url'],
+                                'alt_text': block_context['image']['alt_text'],
+                            })
+
+                    notification['blocks'].append(context)
+
+                elif block.get('divider'):
+                    logger.trace('divider block')
+                    notification['blocks'].append({'type': 'divider'})
+
+        # version 1 is the Legacy formatting
+        else:
+            # username, channel, icon_emoji, and icon_url are deprecated and ignored by the Slack API,
+            # therefore they've been removed from the posted data
+            notification = {
+                'text': message,
+                'username': config.get('username'),
+                'channel': config.get('channel'),
+                'attachments': config.get('attachments'),
+            }
+            if config.get('icon_emoji'):
+                notification['icon_emoji'] = f':{config["icon_emoji"].strip(":")}:'
+            if config.get('icon_url'):
+                notification['icon_url'] = config['icon_url']
 
         try:
             requests.post(config['web_hook_url'], json=notification)

--- a/tests/cassettes/test_slack.TestSlackNotifier.test_slack.yml
+++ b/tests/cassettes/test_slack.TestSlackNotifier.test_slack.yml
@@ -1,0 +1,84 @@
+interactions:
+- request:
+    body: '{"blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "<https://thetvdb.com/series/star-trek-picard/episodes/7550686|Star
+      Trek: Picard (S01E03)>"}}, {"type": "section", "text": {"type": "mrkdwn", "text":
+      "Completely unaware of her special nature, Soji continues her work and captures
+      the attention of the Borg cube research project\u2019s executive director. After
+      rehashing past events with a reluctant Raffi, Picard seeks others willing to
+      join his search for Bruce Maddox, including pilot and former Starfleet officer
+      Crist\u00f3bal Rios."}, "accessory": {"type": "image", "image_url": "https://api.slack.com/img/blocks/bkb_template_images/plants.png",
+      "alt_text": "plants"}, "fields": [{"type": "mrkdwn", "text": "*Score*"}, {"type":
+      "mrkdwn", "text": "*Genres*"}, {"type": "mrkdwn", "text": "8.6"}, {"type": "mrkdwn",
+      "text": "Action, Adventure, Drama, Sci-Fi"}, {"type": "mrkdwn", "text": "*Rating*"},
+      {"type": "mrkdwn", "text": "*Cast*"}, {"type": "mrkdwn", "text": "TV-MA"}, {"type":
+      "mrkdwn", "text": "Patrick Stewart,  Alison Pill,  Isa Briones,  Harry Treadaway
+      "}]}, {"type": "image", "image_url": "https://artworks.thetvdb.com/banners/v4/series/364093/posters/61e846a7440f8.jpg",
+      "alt_text": "Star Trek: Picard Banner"}, {"type": "divider"}, {"type": "context",
+      "elements": [{"type": "image", "image_url": "https://image.freepik.com/free-photo/red-drawing-pin_1156-445.jpg",
+      "alt_text": "red pin"}, {"type": "mrkdwn", "text": ":round_pushpin:"}, {"type":
+      "mrkdwn", "text": "Task: slack"}]}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1517'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FlexGet/3.17.8.dev (www.flexget.com)
+    method: POST
+    uri: https://hooks.slack.com/services/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
+  response:
+    body:
+      string: ok
+    headers:
+      access-control-allow-origin:
+      - '*'
+      content-encoding:
+      - br
+      content-length:
+      - '6'
+      content-type:
+      - text/html
+      date:
+      - Sun, 10 Aug 2025 09:10:02 GMT
+      referrer-policy:
+      - no-referrer
+      server:
+      - Apache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      timing-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      via:
+      - 1.1 slack-prod.tinyspeck.com, envoy-www-iad-gkaxujhk,envoy-edge-nrt-efigbjib
+      x-backend:
+      - main_normal main_canary_with_overflow main_control_with_overflow
+      x-edge-backend:
+      - envoy-www
+      x-envoy-attempt-count:
+      - '1'
+      x-envoy-upstream-service-time:
+      - '543'
+      x-frame-options:
+      - SAMEORIGIN
+      x-server:
+      - slack-www-hhvm-main-iad-yhxu
+      x-slack-backend:
+      - r
+      x-slack-edge-shared-secret-outcome:
+      - no-match
+      x-slack-shared-secret-outcome:
+      - no-match
+      x-slack-unique-id:
+      - aJhh6RNZ3ZRTOLBXO2aOigAAEAA
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/notifiers/test_slack.py
+++ b/tests/notifiers/test_slack.py
@@ -1,0 +1,64 @@
+import pytest
+
+
+@pytest.mark.online
+class TestSlackNotifier:
+    config = """
+        templates:
+            global:
+                accept_all: yes
+        tasks:
+            slack:
+              mock:
+                  - title: title
+                    tvdb_url: https://thetvdb.com/series/star-trek-picard/episodes/7550686
+                    series_name: 'Star Trek: Picard'
+                    series_id: S01E03
+                    tvdb_ep_overview: 'Completely unaware of her special nature, Soji continues her work and captures the attention of the Borg cube research project’s executive director. After rehashing past events with a reluctant Raffi, Picard seeks others willing to join his search for Bruce Maddox, including pilot and former Starfleet officer Cristóbal Rios.'
+                    imdb_score: 8.6
+                    imdb_genres: [Action,Adventure,Drama,Sci-Fi]
+                    imdb_mpaa_rating: TV-MA
+                    imdb_actors:
+                      1: Patrick Stewart
+                      2: Alison Pill
+                      3: Isa Briones
+                      4: Harry Treadaway
+                    tvdb_banner: https://artworks.thetvdb.com/banners/v4/series/364093/posters/61e846a7440f8.jpg
+              notify:
+                  entries:
+                    via:
+                      - slack:
+                          web_hook_url: "https://hooks.slack.com/services/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"
+                          blocks:
+                            - section:
+                                text: '<{{ tvdb_url }}|{{ series_name }} ({{ series_id }})>'
+                            - section:
+                                text: '{{ tvdb_ep_overview }}'
+                                image:
+                                  url: "https://api.slack.com/img/blocks/bkb_template_images/plants.png"
+                                  alt_text: 'plants'
+                                fields:
+                                  - '*Score*'
+                                  - '*Genres*'
+                                  - '{{ imdb_score }}'
+                                  - "{{ imdb_genres | join(', ') | title }}"
+                                  - '*Rating*'
+                                  - '*Cast*'
+                                  - '{{ imdb_mpaa_rating }}'
+                                  - >
+                                    {% for key, value in imdb_actors.items() %}{{ value }}{% if not loop.last %}, {% endif %}
+                                    {% endfor %}
+                            - image:
+                                url: "{{ tvdb_banner }}"
+                                alt_text: "{{ series_name }} Banner"
+                            - divider: True
+                            - context:
+                                - image:
+                                    url: 'https://image.freepik.com/free-photo/red-drawing-pin_1156-445.jpg'
+                                    alt_text: 'red pin'
+                                - text: ':round_pushpin:'
+                                - text: 'Task: {{ task }}'
+        """  # noqa: RUF001
+
+    def test_slack(self, execute_task):
+        execute_task('slack', options={'test': True})


### PR DESCRIPTION
Supersedes #2601

### Motivation for changes:
The current slack notifier uses webhook formatting which is considered legacy/deprecated. Adding a new notifier allows for an upgrade without breaking changes to the existing plugin. The two plugins can run concurrently.

The Block Kit format is wildly flexible, allowing for blocks of text, images, dividers, and context lines to appear in any order. Up to 50 blocks are supported.

### Config usage:
```yaml
tasks:
  slack:
    mock:
      - { ... }
    accept_all: yes
    notify:
      entries:
        via:
          - slack:
              web_hook_url: "https://hooks.slack.com/services/T0F1*****/B099*******/OOPTXTzIJfMyaHWG********"
              blocks:
                - section:
                    text: '<{{ tvdb_url }}|{{ series_name }} ({{ series_id }})>'
                - section:
                    text: '{{ tvdb_ep_overview }}'
                    image:
                      url: "https://api.slack.com/img/blocks/bkb_template_images/plants.png"
                      alt_text: 'plants'
                    fields:
                      - '*Score*'
                      - '*Genres*'
                      - '{{ imdb_score }}'
                      - "{{ imdb_genres | join(', ') | title }}"
                      - '*Rating*'
                      - '*Cast*'
                      - '{{ imdb_mpaa_rating }}'
                      - >
                        {% for key, value in imdb_actors.items() %}{{ value }}{% if not loop.last %}, {% endif %}
                        {% endfor %}
                - image:
                    url: "{{ tvdb_banner }}"
                    alt_text: "{{ series_name }} Banner"
                - divider: True
                - context:
                    - image:
                        url: 'https://image.freepik.com/free-photo/red-drawing-pin_1156-445.jpg'
                        alt_text: 'red pin'
                    - text: ':round_pushpin:'
                    - text: 'Task: {{ task }}'
```

### Example output
![image](https://user-images.githubusercontent.com/249456/74075454-4b5e1d00-49c7-11ea-9e58-438a90942812.png)

### Useful resources
[Sending messages using incoming webhooks](https://api.slack.com/messaging/webhooks)
[Legacy custom integrations incoming webhooks](https://api.slack.com/legacy/custom-integrations/messaging/webhooks)
