### PR TITLE
test: fix warning "Implicitly cleaning up <addinfourl at..." and "unclosed file <_io.TextIOWrapper name='..."

### DIFF
--- a/flexget/api/core/server.py
+++ b/flexget/api/core/server.py
@@ -566,9 +566,8 @@ class ServerCrashLogAPI(APIResource):
     def get(self, session: Session):
         """Get Crash logs."""
         path = self.manager.config_base
-        crashes = [
-            {'name': file.name, 'content': file.open().readlines()}
-            for file in path.iterdir()
-            if file.match('crash_report*.log')
-        ]
+        crashes = []
+        for file in path.glob('crash_report*.log'):
+            with file.open() as f:
+                crashes.append({'name': file.name, 'content': f.readlines()})
         return jsonify(crashes)

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import logging
 import time
+import types
 
 # Allow some request objects to be imported from here instead of requests
 import warnings
@@ -165,6 +166,12 @@ def _wrap_urlopen(url: str, timeout: int | None = None) -> requests.Response:
     resp.raw.read = lambda size, **kwargs: orig_read(size)
     resp.status_code = raw.code or 200
     resp.headers = requests.structures.CaseInsensitiveDict(raw.headers)
+    if url.startswith('file://'):
+
+        def close(self):
+            self.raw.close()
+
+        resp.close = types.MethodType(close, resp)
     return resp
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,8 +215,7 @@ filterwarnings = [
   "ignore:unclosed file <_io.BufferedReader name='document.jpg'>", # triggered by `python-telegram-bot`
   "ignore:unclosed file <_io.BufferedReader name='",               # needs investigation
   "ignore:unclosed file <_io.TextIOWrapper name='",                # needs investigation
-  "ignore:Implicitly cleaning up <addinfourl at ",                 # needs investigation
-  'ignore:Failed to load HostKeys from',                           # triggered by `pysftp` intermittently
+  'ignore:Failed to load HostKeys from',                           # needs investigation — related to `pysftp`, occurs intermittently
 ]
 markers = [
   'filecopy(src, dst): mark test to copy a file from `src` to `dst` before running',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,6 @@ filterwarnings = [
   "ignore:unclosed file <_io.BufferedReader name='photo.png'>",    # triggered by `python-telegram-bot`
   "ignore:unclosed file <_io.BufferedReader name='document.jpg'>", # triggered by `python-telegram-bot`
   "ignore:unclosed file <_io.BufferedReader name='",               # needs investigation
-  "ignore:unclosed file <_io.TextIOWrapper name='",                # needs investigation
   'ignore:Failed to load HostKeys from',                           # needs investigation — related to `pysftp`, occurs intermittently
 ]
 markers = [


### PR DESCRIPTION
### Summary
This PR resolves the ignored warning "Implicitly cleaning up <addinfourl at..." and "unclosed file <_io.TextIOWrapper name='...".

###  Warning "Implicitly cleaning up <addinfourl at..."

The issue lies in that `raw` is never closed:

https://github.com/Flexget/Flexget/blob/a3e983d627b571dc31e28eece5615c0e5f557482/flexget/utils/requests.py#L148-L168

When `url` starts with `file:`, it is not closed properly:

https://github.com/Flexget/Flexget/blob/a56c7331b3c798aca85c48376ef31c199ea53a4a/flexget/plugins/output/download.py#L284-L286

`requests` does not close `raw` when `self._content_consumed` is `True`, but for local files, `raw` should be closed even if it is `True`. See https://github.com/psf/requests/blob/46e939b5525d9c72b677340985582b04b128478a/src/requests/models.py#L1028-L1039

### Log for warning "Implicitly cleaning up <addinfourl at..."

```
=================================== FAILURES ===================================
______________________ TestRTorrentOutputPlugin.test_add _______________________
[gw3] linux -- Python 3.14.0 /home/runner/work/Flexget/Flexget/.venv/bin/python

self = <tempfile._TemporaryFileCloser object at 0x7f43e654be00>

    def __del__(self):
        close_called = self.close_called
        self.cleanup()
        if not close_called:
>           _warnings.warn(self.warn_message, ResourceWarning)
E           ResourceWarning: Implicitly cleaning up <addinfourl at 139929603835952 whose fp = <_io.BufferedReader name='//home/runner/work/Flexget/Flexget/tests/private.torrent'>>

/home/runner/.local/share/uv/python/cpython-3.14.0rc1-linux-x86_64-gnu/lib/python3.14/tempfile.py:484: ResourceWarning

The above exception was the direct cause of the following exception:

cls = <class '_pytest.runner.CallInfo'>
func = <function call_and_report.<locals>.<lambda> at 0x7f43e12b7ab0>
when = 'call'
reraise = (<class '_pytest.outcomes.Exit'>, <class 'KeyboardInterrupt'>)

    @classmethod
    def from_call(
        cls,
        func: Callable[[], TResult],
        when: Literal["collect", "setup", "call", "teardown"],
        reraise: type[BaseException] | tuple[type[BaseException], ...] | None = None,
    ) -> CallInfo[TResult]:
        """Call func, wrapping the result in a CallInfo.
    
        :param func:
            The function to call. Called without arguments.
        :type func: Callable[[], _pytest.runner.TResult]
        :param when:
            The phase in which the function is called.
        :param reraise:
            Exception or exceptions that shall propagate if raised by the
            function, instead of being wrapped in the CallInfo.
        """
        excinfo = None
        instant = timing.Instant()
        try:
>           result: TResult | None = func()
                                     ^^^^^^

/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/runner.py:344: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/runner.py:246: in <lambda>
    lambda: runtest_hook(item=item, **kwds), when=when, reraise=reraise
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_hooks.py:512: in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_manager.py:120: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/logging.py:850: in pytest_runtest_call
    yield
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_callers.py:53: in run_old_style_hookwrapper
    return result.get_result()
           ^^^^^^^^^^^^^^^^^^^
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_callers.py:38: in run_old_style_hookwrapper
    res = yield
          ^^^^^
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/capture.py:900: in pytest_runtest_call
    return (yield)
            ^^^^^
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/skipping.py:263: in pytest_runtest_call
    return (yield)
            ^^^^^
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/unraisableexception.py:158: in pytest_runtest_call
    collect_unraisable(item.config)
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/unraisableexception.py:79: in collect_unraisable
    raise errors[0]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

config = <_pytest.config.Config object at 0x7f43f1ac9a90>

    def collect_unraisable(config: Config) -> None:
        pop_unraisable = config.stash[unraisable_exceptions].pop
        errors: list[pytest.PytestUnraisableExceptionWarning | RuntimeError] = []
        meta = None
        hook_error = None
        try:
            while True:
                try:
                    meta = pop_unraisable()
                except IndexError:
                    break
    
                if isinstance(meta, BaseException):
                    hook_error = RuntimeError("Failed to process unraisable exception")
                    hook_error.__cause__ = meta
                    errors.append(hook_error)
                    continue
    
                msg = meta.msg
                try:
>                   warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
E                   pytest.PytestUnraisableExceptionWarning: Exception ignored while calling deallocator <function _TemporaryFileCloser.__del__ at 0x7f43f1d3eb90>: None

/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/unraisableexception.py:67: PytestUnraisableExceptionWarning
------------------------------ Captured log setup ------------------------------
DEBUG    manager:manager.py:161 sys.defaultencoding: utf-8
DEBUG    manager:manager.py:162 sys.getfilesystemencoding: utf-8
DEBUG    manager:manager.py:163 flexget detected io encoding: utf-8
DEBUG    manager:manager.py:164 os.path.supports_unicode_filenames: False
DEBUG    tests:conftest.py:325 database_uri: sqlite:///:memory:
DEBUG    plugin:plugin.py:447 Trying to load plugins from: [PosixPath('/tmp/pytest-of-runner/pytest-0/popen-gw3/manager208/plugins'), PosixPath('/home/runner/work/Flexget/Flexget/flexget/plugins')]
DEBUG    plugin:plugin.py:428 Plugin `memusage` requires plugin `guppy3` to load.
DEBUG    plugin:plugin.py:467 Trying to load components from: [PosixPath('/tmp/pytest-of-runner/pytest-0/popen-gw3/manager208/components'), PosixPath('/home/runner/work/Flexget/Flexget/flexget/components')]
DEBUG    plugin:plugin.py:553 Plugins took 0.03 seconds to load. 330 plugins in registry.
DEBUG    manager:manager.py:785 Connecting to: sqlite:///:memory:
DEBUG    schema:db_schema.py:103 Initializing plugin simple_persistence schema version to 4
DEBUG    schema:db_schema.py:103 Initializing plugin feed schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin entry_list schema version to 2
DEBUG    schema:db_schema.py:103 Initializing plugin movie_list schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin failed schema version to 3
DEBUG    schema:db_schema.py:103 Initializing plugin pending_list schema version to 1
DEBUG    schema:db_schema.py:103 Initializing plugin remember_rejected schema version to 3
DEBUG    schema:db_schema.py:103 Initializing plugin seen schema version to 4
DEBUG    schema:db_schema.py:103 Initializing plugin series schema version to 14
DEBUG    schema:db_schema.py:103 Initializing plugin api_tvdb schema version to 7
DEBUG    schema:db_schema.py:103 Initializing plugin tvmaze schema version to 7
DEBUG    schema:db_schema.py:103 Initializing plugin status schema version to 3
DEBUG    schema:db_schema.py:103 Initializing plugin trakt_auth schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin api_trakt schema version to 7
DEBUG    schema:db_schema.py:103 Initializing plugin variables schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin input_cache schema version to 2
DEBUG    schema:db_schema.py:103 Initializing plugin delay schema version to 3
DEBUG    schema:db_schema.py:103 Initializing plugin imdb_list schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin log_once schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin pending_approval schema version to 1
DEBUG    schema:db_schema.py:103 Initializing plugin subtitle_list schema version to 1
DEBUG    schema:db_schema.py:103 Initializing plugin upgrade schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin api_tmdb schema version to 6
DEBUG    schema:db_schema.py:103 Initializing plugin version_checker schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin digest schema version to 2
DEBUG    schema:db_schema.py:103 Initializing plugin api_rottentomatoes schema version to 2
DEBUG    schema:db_schema.py:103 Initializing plugin api_bluray schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin make_rss schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin myepisodes schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin pogcal_acquired schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin tail schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin gazelle_session schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin discover schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin archive schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin imdb_lookup schema version to 10
DEBUG    schema:db_schema.py:103 Initializing plugin backlog schema version to 3
DEBUG    schema:db_schema.py:103 Initializing plugin rutracker_auth schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin morethantv schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin alpharatio schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin filelist schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin telegram_chat_ids schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin regexp_list schema version to 1
DEBUG    variables:variables.py:80 loading variables from config
DEBUG    manager:manager.py:706 New config data loaded.
DEBUG    schema:db_schema.py:46 entering flexget version 3.17.7.dev to db
DEBUG    parsing:plugin_parsing.py:30 setting default movie parser to internal. (options: {'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x7f43e6a95a90>, 'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x7f43e6a95be0>})
DEBUG    parsing:plugin_parsing.py:30 setting default series parser to internal. (options: {'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x7f43e6a95a90>, 'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x7f43e6a95be0>})
------------------------------ Captured log call -------------------------------
INFO     tests:conftest.py:96 ********** Running task: test_add_torrent ********** 
DEBUG    task:task.py:635 executing test_add_torrent
DEBUG    status:status.py:26 Adding new task test_add_torrent
DEBUG    backlog:backlog.py:108 0 entries purged from backlog
VERBOSE  details:verbose_details.py:25 Produced 1 entries.
VERBOSE  task:verbose.py:30 ACCEPTED: `test` by accept_all plugin
DEBUG    urlrewriter:urlrewriting.py:24 Checking 1 entries
DEBUG    download:download.py:240 Downloading url 'file:////home/runner/work/Flexget/Flexget/tests/private.torrent'
DEBUG    utils.requests:requests.py:262 No adaptor, passing off to urllib
DEBUG    download:download.py:320 test field file set to: /tmp/tmpso48x1x5/7bfc848fd5bd05380f9059e1729e970d
DEBUG    download:download.py:368 Mimetype guess for application/x-bittorrent is ['.torrent'] 
DEBUG    download:download.py:342 No filename - setting from url: private.torrent
DEBUG    download:download.py:344 Finishing download_entry() with filename private.torrent
DEBUG    download:download.py:147 Successfully retrieved test from file:////home/runner/work/Flexget/Flexget/tests/private.torrent
VERBOSE  details:verbose_details.py:31 Summary - Accepted: 1 (Rejected: 0 Undecided: 0 Failed: 0)
DEBUG    modif_torrent:torrent.py:36 test seems to be a torrent
DEBUG    torrent_files:torrent_files.py:23 test files: ['ubuntu-9.04-desktop-amd64.iso']
DEBUG    torrent_size:torrent_size.py:18 test size: 696.71 MiB
INFO     rtorrent:rtorrent.py:753 test added to rtorrent
DEBUG    download:download.py:528 removing temp file /tmp/tmpso48x1x5/7bfc848fd5bd05380f9059e1729e970d from test
DEBUG    seen:seen.py:137 Learned 'test' (field: title, local: False)
DEBUG    seen:seen.py:137 Learned 'file:////home/runner/work/Flexget/Flexget/tests/private.torrent' (field: url, local: False)
DEBUG    seen:seen.py:137 Learned '09977FE761B8D293AD8A929CCAF2E9322D525A6C' (field: torrent_info_hash, local: False)
DEBUG    util.simple_persistence:simple_persistence.py:175 Flushing simple persistence for task test_add_torrent to db.
---------------------------- Captured log teardown -----------------------------
DEBUG    task_queue:task_queue.py:87 task queue shutdown requested
DEBUG    util.simple_persistence:simple_persistence.py:175 Flushing simple persistence for task None to db.
____________________ TestRTorrentOutputPlugin.test_add_set _____________________
[gw2] linux -- Python 3.14.0 /home/runner/work/Flexget/Flexget/.venv/bin/python

self = <tempfile._TemporaryFileCloser object at 0x7f72d7f18d70>

    def __del__(self):
        close_called = self.close_called
        self.cleanup()
        if not close_called:
>           _warnings.warn(self.warn_message, ResourceWarning)
E           ResourceWarning: Implicitly cleaning up <addinfourl at 140131225930784 whose fp = <_io.BufferedReader name='//home/runner/work/Flexget/Flexget/tests/private.torrent'>>

/home/runner/.local/share/uv/python/cpython-3.14.0rc1-linux-x86_64-gnu/lib/python3.14/tempfile.py:484: ResourceWarning

The above exception was the direct cause of the following exception:

cls = <class '_pytest.runner.CallInfo'>
func = <function call_and_report.<locals>.<lambda> at 0x7f72db1d4670>
when = 'call'
reraise = (<class '_pytest.outcomes.Exit'>, <class 'KeyboardInterrupt'>)

    @classmethod
    def from_call(
        cls,
        func: Callable[[], TResult],
        when: Literal["collect", "setup", "call", "teardown"],
        reraise: type[BaseException] | tuple[type[BaseException], ...] | None = None,
    ) -> CallInfo[TResult]:
        """Call func, wrapping the result in a CallInfo.
    
        :param func:
            The function to call. Called without arguments.
        :type func: Callable[[], _pytest.runner.TResult]
        :param when:
            The phase in which the function is called.
        :param reraise:
            Exception or exceptions that shall propagate if raised by the
            function, instead of being wrapped in the CallInfo.
        """
        excinfo = None
        instant = timing.Instant()
        try:
>           result: TResult | None = func()
                                     ^^^^^^

/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/runner.py:344: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/runner.py:246: in <lambda>
    lambda: runtest_hook(item=item, **kwds), when=when, reraise=reraise
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_hooks.py:512: in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_manager.py:120: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/logging.py:850: in pytest_runtest_call
    yield
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_callers.py:53: in run_old_style_hookwrapper
    return result.get_result()
           ^^^^^^^^^^^^^^^^^^^
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_callers.py:38: in run_old_style_hookwrapper
    res = yield
          ^^^^^
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/capture.py:900: in pytest_runtest_call
    return (yield)
            ^^^^^
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/skipping.py:263: in pytest_runtest_call
    return (yield)
            ^^^^^
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/unraisableexception.py:158: in pytest_runtest_call
    collect_unraisable(item.config)
/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/unraisableexception.py:79: in collect_unraisable
    raise errors[0]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

config = <_pytest.config.Config object at 0x7f72ea159a90>

    def collect_unraisable(config: Config) -> None:
        pop_unraisable = config.stash[unraisable_exceptions].pop
        errors: list[pytest.PytestUnraisableExceptionWarning | RuntimeError] = []
        meta = None
        hook_error = None
        try:
            while True:
                try:
                    meta = pop_unraisable()
                except IndexError:
                    break
    
                if isinstance(meta, BaseException):
                    hook_error = RuntimeError("Failed to process unraisable exception")
                    hook_error.__cause__ = meta
                    errors.append(hook_error)
                    continue
    
                msg = meta.msg
                try:
>                   warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
E                   pytest.PytestUnraisableExceptionWarning: Exception ignored while calling deallocator <function _TemporaryFileCloser.__del__ at 0x7f72ea3ceb90>: None

/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/unraisableexception.py:67: PytestUnraisableExceptionWarning
------------------------------ Captured log setup ------------------------------
DEBUG    manager:manager.py:161 sys.defaultencoding: utf-8
DEBUG    manager:manager.py:162 sys.getfilesystemencoding: utf-8
DEBUG    manager:manager.py:163 flexget detected io encoding: utf-8
DEBUG    manager:manager.py:164 os.path.supports_unicode_filenames: False
DEBUG    tests:conftest.py:325 database_uri: sqlite:///:memory:
DEBUG    plugin:plugin.py:447 Trying to load plugins from: [PosixPath('/tmp/pytest-of-runner/pytest-0/popen-gw2/manager196/plugins'), PosixPath('/home/runner/work/Flexget/Flexget/flexget/plugins')]
DEBUG    plugin:plugin.py:428 Plugin `memusage` requires plugin `guppy3` to load.
DEBUG    plugin:plugin.py:467 Trying to load components from: [PosixPath('/tmp/pytest-of-runner/pytest-0/popen-gw2/manager196/components'), PosixPath('/home/runner/work/Flexget/Flexget/flexget/components')]
DEBUG    plugin:plugin.py:553 Plugins took 0.03 seconds to load. 333 plugins in registry.
DEBUG    manager:manager.py:785 Connecting to: sqlite:///:memory:
DEBUG    schema:db_schema.py:103 Initializing plugin simple_persistence schema version to 4
DEBUG    schema:db_schema.py:103 Initializing plugin feed schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin entry_list schema version to 2
DEBUG    schema:db_schema.py:103 Initializing plugin movie_list schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin failed schema version to 3
DEBUG    schema:db_schema.py:103 Initializing plugin pending_list schema version to 1
DEBUG    schema:db_schema.py:103 Initializing plugin remember_rejected schema version to 3
DEBUG    schema:db_schema.py:103 Initializing plugin seen schema version to 4
DEBUG    schema:db_schema.py:103 Initializing plugin series schema version to 14
DEBUG    schema:db_schema.py:103 Initializing plugin api_tvdb schema version to 7
DEBUG    schema:db_schema.py:103 Initializing plugin tvmaze schema version to 7
DEBUG    schema:db_schema.py:103 Initializing plugin status schema version to 3
DEBUG    schema:db_schema.py:103 Initializing plugin trakt_auth schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin api_trakt schema version to 7
DEBUG    schema:db_schema.py:103 Initializing plugin variables schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin input_cache schema version to 2
DEBUG    schema:db_schema.py:103 Initializing plugin delay schema version to 3
DEBUG    schema:db_schema.py:103 Initializing plugin imdb_list schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin log_once schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin pending_approval schema version to 1
DEBUG    schema:db_schema.py:103 Initializing plugin subtitle_list schema version to 1
DEBUG    schema:db_schema.py:103 Initializing plugin upgrade schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin api_tmdb schema version to 6
DEBUG    schema:db_schema.py:103 Initializing plugin version_checker schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin digest schema version to 2
DEBUG    schema:db_schema.py:103 Initializing plugin api_rottentomatoes schema version to 2
DEBUG    schema:db_schema.py:103 Initializing plugin api_bluray schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin make_rss schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin myepisodes schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin pogcal_acquired schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin tail schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin gazelle_session schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin discover schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin archive schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin imdb_lookup schema version to 10
DEBUG    schema:db_schema.py:103 Initializing plugin backlog schema version to 3
DEBUG    schema:db_schema.py:103 Initializing plugin rutracker_auth schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin morethantv schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin alpharatio schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin filelist schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin telegram_chat_ids schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin regexp_list schema version to 1
DEBUG    variables:variables.py:80 loading variables from config
DEBUG    manager:manager.py:706 New config data loaded.
DEBUG    schema:db_schema.py:46 entering flexget version 3.17.7.dev to db
DEBUG    parsing:plugin_parsing.py:30 setting default movie parser to internal. (options: {'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x7f72df33f230>, 'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x7f72df33f380>})
DEBUG    parsing:plugin_parsing.py:30 setting default series parser to internal. (options: {'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x7f72df33f230>, 'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x7f72df33f380>})
------------------------------ Captured log call -------------------------------
INFO     tests:conftest.py:96 ********** Running task: test_add_torrent_set ********** 
DEBUG    task:task.py:635 executing test_add_torrent_set
DEBUG    status:status.py:26 Adding new task test_add_torrent_set
DEBUG    backlog:backlog.py:108 0 entries purged from backlog
VERBOSE  details:verbose_details.py:25 Produced 1 entries.
VERBOSE  task:verbose.py:30 ACCEPTED: `test` by accept_all plugin
DEBUG    urlrewriter:urlrewriting.py:24 Checking 1 entries
DEBUG    download:download.py:240 Downloading url 'file:////home/runner/work/Flexget/Flexget/tests/private.torrent'
DEBUG    utils.requests:requests.py:262 No adaptor, passing off to urllib
DEBUG    download:download.py:320 test field file set to: /tmp/tmpggl67xfj/7bfc848fd5bd05380f9059e1729e970d
DEBUG    download:download.py:368 Mimetype guess for application/x-bittorrent is ['.torrent'] 
DEBUG    download:download.py:342 No filename - setting from url: private.torrent
DEBUG    download:download.py:344 Finishing download_entry() with filename private.torrent
DEBUG    download:download.py:147 Successfully retrieved test from file:////home/runner/work/Flexget/Flexget/tests/private.torrent
VERBOSE  details:verbose_details.py:31 Summary - Accepted: 1 (Rejected: 0 Undecided: 0 Failed: 0)
DEBUG    modif_torrent:torrent.py:36 test seems to be a torrent
DEBUG    torrent_files:torrent_files.py:23 test files: ['ubuntu-9.04-desktop-amd64.iso']
DEBUG    torrent_size:torrent_size.py:18 test size: 696.71 MiB
INFO     rtorrent:rtorrent.py:753 test added to rtorrent
DEBUG    download:download.py:528 removing temp file /tmp/tmpggl67xfj/7bfc848fd5bd05380f9059e1729e970d from test
DEBUG    seen:seen.py:137 Learned 'test' (field: title, local: False)
DEBUG    seen:seen.py:137 Learned 'file:////home/runner/work/Flexget/Flexget/tests/private.torrent' (field: url, local: False)
DEBUG    seen:seen.py:137 Learned '09977FE761B8D293AD8A929CCAF2E9322D525A6C' (field: torrent_info_hash, local: False)
DEBUG    util.simple_persistence:simple_persistence.py:175 Flushing simple persistence for task test_add_torrent_set to db.
---------------------------- Captured log teardown -----------------------------
DEBUG    task_queue:task_queue.py:87 task queue shutdown requested
DEBUG    util.simple_persistence:simple_persistence.py:175 Flushing simple persistence for task None to db.
____________________ TestTorrentMatch.test_with_filesystem _____________________
[gw1] linux -- Python 3.14.0 /home/runner/work/Flexget/Flexget/.venv/bin/python
  + Exception Group Traceback (most recent call last):
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/runner.py", line 344, in from_call
  |     result: TResult | None = func()
  |                              ~~~~^^
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/runner.py", line 246, in <lambda>
  |     lambda: runtest_hook(item=item, **kwds), when=when, reraise=reraise
  |             ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
  |     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  |            ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
  |     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  |            ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 167, in _multicall
  |     raise exception
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
  |     teardown.throw(exception)
  |     ~~~~~~~~~~~~~~^^^^^^^^^^^
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/logging.py", line 850, in pytest_runtest_call
  |     yield
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
  |     teardown.throw(exception)
  |     ~~~~~~~~~~~~~~^^^^^^^^^^^
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 53, in run_old_style_hookwrapper
  |     return result.get_result()
  |            ~~~~~~~~~~~~~~~~~^^
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_result.py", line 103, in get_result
  |     raise exc.with_traceback(tb)
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 38, in run_old_style_hookwrapper
  |     res = yield
  |           ^^^^^
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
  |     teardown.throw(exception)
  |     ~~~~~~~~~~~~~~^^^^^^^^^^^
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/capture.py", line 900, in pytest_runtest_call
  |     return (yield)
  |             ^^^^^
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
  |     teardown.throw(exception)
  |     ~~~~~~~~~~~~~~^^^^^^^^^^^
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/skipping.py", line 263, in pytest_runtest_call
  |     return (yield)
  |             ^^^^^
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 121, in _multicall
  |     res = hook_impl.function(*args)
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/unraisableexception.py", line 158, in pytest_runtest_call
  |     collect_unraisable(item.config)
  |     ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/unraisableexception.py", line 81, in collect_unraisable
  |     raise ExceptionGroup("multiple unraisable exception warnings", errors)
  | ExceptionGroup: multiple unraisable exception warnings (4 sub-exceptions)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/home/runner/.local/share/uv/python/cpython-3.14.0rc1-linux-x86_64-gnu/lib/python3.14/tempfile.py", line 484, in __del__
    |     _warnings.warn(self.warn_message, ResourceWarning)
    |     ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | ResourceWarning: Implicitly cleaning up <addinfourl at 140341751196128 whose fp = <_io.BufferedReader name='/home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/multi_file_with_diff.torrent'>>
    | 
    | The above exception was the direct cause of the following exception:
    | 
    | Traceback (most recent call last):
    |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/unraisableexception.py", line 67, in collect_unraisable
    |     warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
    |     ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | pytest.PytestUnraisableExceptionWarning: Exception ignored while calling deallocator <function _TemporaryFileCloser.__del__ at 0x7fa3ee39eb90>: None
    | 
    +---------------- 2 ----------------
    | Traceback (most recent call last):
    |   File "/home/runner/.local/share/uv/python/cpython-3.14.0rc1-linux-x86_64-gnu/lib/python3.14/tempfile.py", line 484, in __del__
    |     _warnings.warn(self.warn_message, ResourceWarning)
    |     ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | ResourceWarning: Implicitly cleaning up <addinfourl at 140341766582224 whose fp = <_io.BufferedReader name='/home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/torrent1.mkv.torrent'>>
    | 
    | The above exception was the direct cause of the following exception:
    | 
    | Traceback (most recent call last):
    |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/unraisableexception.py", line 67, in collect_unraisable
    |     warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
    |     ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | pytest.PytestUnraisableExceptionWarning: Exception ignored while calling deallocator <function _TemporaryFileCloser.__del__ at 0x7fa3ee39eb90>: None
    | 
    +---------------- 3 ----------------
    | Traceback (most recent call last):
    |   File "/home/runner/.local/share/uv/python/cpython-3.14.0rc1-linux-x86_64-gnu/lib/python3.14/tempfile.py", line 484, in __del__
    |     _warnings.warn(self.warn_message, ResourceWarning)
    |     ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | ResourceWarning: Implicitly cleaning up <addinfourl at 140341766586064 whose fp = <_io.BufferedReader name='/home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/torrent2.torrent'>>
    | 
    | The above exception was the direct cause of the following exception:
    | 
    | Traceback (most recent call last):
    |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/unraisableexception.py", line 67, in collect_unraisable
    |     warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
    |     ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | pytest.PytestUnraisableExceptionWarning: Exception ignored while calling deallocator <function _TemporaryFileCloser.__del__ at 0x7fa3ee39eb90>: None
    | 
    +---------------- 4 ----------------
    | Traceback (most recent call last):
    |   File "/home/runner/.local/share/uv/python/cpython-3.14.0rc1-linux-x86_64-gnu/lib/python3.14/tempfile.py", line 484, in __del__
    |     _warnings.warn(self.warn_message, ResourceWarning)
    |     ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | ResourceWarning: Implicitly cleaning up <addinfourl at 140341789750816 whose fp = <_io.BufferedReader name='/home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/torrent1_empty_name.torrent'>>
    | 
    | The above exception was the direct cause of the following exception:
    | 
    | Traceback (most recent call last):
    |   File "/home/runner/work/Flexget/Flexget/.venv/lib/python3.14/site-packages/_pytest/unraisableexception.py", line 67, in collect_unraisable
    |     warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
    |     ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | pytest.PytestUnraisableExceptionWarning: Exception ignored while calling deallocator <function _TemporaryFileCloser.__del__ at 0x7fa3ee39eb90>: None
    | 
    +------------------------------------
------------------------------ Captured log setup ------------------------------
DEBUG    manager:manager.py:161 sys.defaultencoding: utf-8
DEBUG    manager:manager.py:162 sys.getfilesystemencoding: utf-8
DEBUG    manager:manager.py:163 flexget detected io encoding: utf-8
DEBUG    manager:manager.py:164 os.path.supports_unicode_filenames: False
DEBUG    tests:conftest.py:325 database_uri: sqlite:///:memory:
DEBUG    plugin:plugin.py:447 Trying to load plugins from: [PosixPath('/tmp/pytest-of-runner/pytest-0/popen-gw1/manager199/plugins'), PosixPath('/home/runner/work/Flexget/Flexget/flexget/plugins')]
DEBUG    plugin:plugin.py:428 Plugin `memusage` requires plugin `guppy3` to load.
DEBUG    plugin:plugin.py:467 Trying to load components from: [PosixPath('/tmp/pytest-of-runner/pytest-0/popen-gw1/manager199/components'), PosixPath('/home/runner/work/Flexget/Flexget/flexget/components')]
DEBUG    plugin:plugin.py:553 Plugins took 0.03 seconds to load. 331 plugins in registry.
DEBUG    manager:manager.py:785 Connecting to: sqlite:///:memory:
DEBUG    schema:db_schema.py:103 Initializing plugin simple_persistence schema version to 4
DEBUG    schema:db_schema.py:103 Initializing plugin feed schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin entry_list schema version to 2
DEBUG    schema:db_schema.py:103 Initializing plugin movie_list schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin failed schema version to 3
DEBUG    schema:db_schema.py:103 Initializing plugin pending_list schema version to 1
DEBUG    schema:db_schema.py:103 Initializing plugin remember_rejected schema version to 3
DEBUG    schema:db_schema.py:103 Initializing plugin seen schema version to 4
DEBUG    schema:db_schema.py:103 Initializing plugin series schema version to 14
DEBUG    schema:db_schema.py:103 Initializing plugin api_tvdb schema version to 7
DEBUG    schema:db_schema.py:103 Initializing plugin tvmaze schema version to 7
DEBUG    schema:db_schema.py:103 Initializing plugin status schema version to 3
DEBUG    schema:db_schema.py:103 Initializing plugin trakt_auth schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin api_trakt schema version to 7
DEBUG    schema:db_schema.py:103 Initializing plugin variables schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin input_cache schema version to 2
DEBUG    schema:db_schema.py:103 Initializing plugin delay schema version to 3
DEBUG    schema:db_schema.py:103 Initializing plugin imdb_list schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin log_once schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin pending_approval schema version to 1
DEBUG    schema:db_schema.py:103 Initializing plugin subtitle_list schema version to 1
DEBUG    schema:db_schema.py:103 Initializing plugin upgrade schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin api_tmdb schema version to 6
DEBUG    schema:db_schema.py:103 Initializing plugin version_checker schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin digest schema version to 2
DEBUG    schema:db_schema.py:103 Initializing plugin api_rottentomatoes schema version to 2
DEBUG    schema:db_schema.py:103 Initializing plugin api_bluray schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin make_rss schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin myepisodes schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin pogcal_acquired schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin tail schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin gazelle_session schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin discover schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin archive schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin imdb_lookup schema version to 10
DEBUG    schema:db_schema.py:103 Initializing plugin backlog schema version to 3
DEBUG    schema:db_schema.py:103 Initializing plugin rutracker_auth schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin morethantv schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin alpharatio schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin filelist schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin telegram_chat_ids schema version to 0
DEBUG    schema:db_schema.py:103 Initializing plugin regexp_list schema version to 1
DEBUG    manager:manager.py:706 New config data loaded.
DEBUG    schema:db_schema.py:46 entering flexget version 3.17.7.dev to db
DEBUG    parsing:plugin_parsing.py:30 setting default movie parser to internal. (options: {'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x7fa3e3182660>, 'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x7fa3e31827b0>})
DEBUG    parsing:plugin_parsing.py:30 setting default series parser to internal. (options: {'guessit': <flexget.components.parsing.parsers.parser_guessit.ParserGuessit object at 0x7fa3e3182660>, 'internal': <flexget.components.parsing.parsers.parser_internal.ParserInternal object at 0x7fa3e31827b0>})
------------------------------ Captured log call -------------------------------
INFO     tests:conftest.py:96 ********** Running task: test_with_filesystem ********** 
DEBUG    task:task.py:635 executing test_with_filesystem
DEBUG    status:status.py:26 Adding new task test_with_filesystem
VERBOSE  filesystem:filesystem.py:204 Starting to scan folders.
VERBOSE  filesystem:filesystem.py:154 Scanning folder torrent_match_test_torrents/. Recursion is set to False.
DEBUG    filesystem:filesystem.py:159 Scanning torrent_match_test_torrents
DEBUG    filesystem:filesystem.py:164 Checking if torrent_match_test_torrents/torrent1_empty_name.torrent qualifies to be added as an entry.
DEBUG    filesystem:filesystem.py:164 Checking if torrent_match_test_torrents/torrent2.torrent qualifies to be added as an entry.
DEBUG    filesystem:filesystem.py:164 Checking if torrent_match_test_torrents/torrent1.mkv.torrent qualifies to be added as an entry.
DEBUG    filesystem:filesystem.py:164 Checking if torrent_match_test_torrents/multi_file_with_diff.torrent qualifies to be added as an entry.
DEBUG    backlog:backlog.py:108 0 entries purged from backlog
VERBOSE  details:verbose_details.py:25 Produced 4 entries.
DEBUG    entry:entry.py:333 field location was not serializable. `PosixPath('/home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/torrent1_empty_name.torrent')` of type <class 'pathlib.PosixPath'> is not serializable
DEBUG    entry:entry.py:333 field location was not serializable. `PosixPath('/home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/torrent2.torrent')` of type <class 'pathlib.PosixPath'> is not serializable
DEBUG    entry:entry.py:333 field location was not serializable. `PosixPath('/home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/torrent1.mkv.torrent')` of type <class 'pathlib.PosixPath'> is not serializable
DEBUG    entry:entry.py:333 field location was not serializable. `PosixPath('/home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/multi_file_with_diff.torrent')` of type <class 'pathlib.PosixPath'> is not serializable
VERBOSE  task:verbose.py:30 ACCEPTED: `torrent1_empty_name` by accept_all plugin
VERBOSE  task:verbose.py:30 ACCEPTED: `torrent2` by accept_all plugin
VERBOSE  task:verbose.py:30 ACCEPTED: `torrent1.mkv` by accept_all plugin
VERBOSE  task:verbose.py:30 ACCEPTED: `multi_file_with_diff` by accept_all plugin
DEBUG    urlrewriter:urlrewriting.py:24 Checking 4 entries
DEBUG    download:download.py:240 Downloading url 'file:///home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/torrent1_empty_name.torrent'
DEBUG    utils.requests:requests.py:262 No adaptor, passing off to urllib
DEBUG    download:download.py:320 torrent1_empty_name field file set to: /tmp/tmpym0zxbio/3d6377e23a9575be76f61006ab62e4f0
DEBUG    download:download.py:368 Mimetype guess for application/x-bittorrent is ['.torrent'] 
DEBUG    download:download.py:371 Filename torrent1_empty_name.torrent extension matches to mime-type
DEBUG    download:download.py:344 Finishing download_entry() with filename torrent1_empty_name.torrent
DEBUG    download:download.py:147 Successfully retrieved torrent1_empty_name from file:///home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/torrent1_empty_name.torrent
DEBUG    download:download.py:240 Downloading url 'file:///home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/torrent2.torrent'
DEBUG    utils.requests:requests.py:262 No adaptor, passing off to urllib
DEBUG    download:download.py:320 torrent2 field file set to: /tmp/tmpt3hc_wtl/d64f2df9d5c7feb15cb56be777484e60
DEBUG    download:download.py:368 Mimetype guess for application/x-bittorrent is ['.torrent'] 
DEBUG    download:download.py:371 Filename torrent2.torrent extension matches to mime-type
DEBUG    download:download.py:344 Finishing download_entry() with filename torrent2.torrent
DEBUG    download:download.py:147 Successfully retrieved torrent2 from file:///home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/torrent2.torrent
DEBUG    download:download.py:240 Downloading url 'file:///home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/torrent1.mkv.torrent'
DEBUG    utils.requests:requests.py:262 No adaptor, passing off to urllib
DEBUG    download:download.py:320 torrent1.mkv field file set to: /tmp/tmpb8rahfux/ecb4e2b5c8719c37d4ac63f737d9216e
DEBUG    download:download.py:368 Mimetype guess for application/x-bittorrent is ['.torrent'] 
DEBUG    download:download.py:371 Filename torrent1.mkv.torrent extension matches to mime-type
DEBUG    download:download.py:344 Finishing download_entry() with filename torrent1.mkv.torrent
DEBUG    download:download.py:147 Successfully retrieved torrent1.mkv from file:///home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/torrent1.mkv.torrent
DEBUG    download:download.py:240 Downloading url 'file:///home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/multi_file_with_diff.torrent'
DEBUG    utils.requests:requests.py:262 No adaptor, passing off to urllib
DEBUG    download:download.py:320 multi_file_with_diff field file set to: /tmp/tmpqcgi3q68/e4c9723c8d6f385abc5c1e813e12503c
DEBUG    download:download.py:368 Mimetype guess for application/x-bittorrent is ['.torrent'] 
DEBUG    download:download.py:371 Filename multi_file_with_diff.torrent extension matches to mime-type
DEBUG    download:download.py:344 Finishing download_entry() with filename multi_file_with_diff.torrent
DEBUG    download:download.py:147 Successfully retrieved multi_file_with_diff from file:///home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/multi_file_with_diff.torrent
VERBOSE  details:verbose_details.py:31 Summary - Accepted: 4 (Rejected: 0 Undecided: 0 Failed: 0)
DEBUG    modif_torrent:torrent.py:36 torrent1_empty_name seems to be a torrent
DEBUG    modif_torrent:torrent.py:36 torrent2 seems to be a torrent
DEBUG    modif_torrent:torrent.py:36 torrent1.mkv seems to be a torrent
DEBUG    modif_torrent:torrent.py:36 multi_file_with_diff seems to be a torrent
DEBUG    torrent_files:torrent_files.py:23 torrent1_empty_name files: ['torrent1.mkv']
DEBUG    torrent_files:torrent_files.py:23 torrent2 files: ['sample/sample.mkv', 'torrent2.mkv']
DEBUG    torrent_files:torrent_files.py:23 torrent1.mkv files: ['torrent1.mkv']
DEBUG    torrent_files:torrent_files.py:23 multi_file_with_diff files: ['video.mkv', 'video.nfo', 'video_1mb.mkv']
DEBUG    torrent_size:torrent_size.py:18 torrent1_empty_name size: 5.0 B
DEBUG    torrent_size:torrent_size.py:18 torrent2 size: 26.0 B
DEBUG    torrent_size:torrent_size.py:18 torrent1.mkv size: 5.0 B
DEBUG    torrent_size:torrent_size.py:18 multi_file_with_diff size: 1.0 MiB
VERBOSE  filesystem:filesystem.py:204 Starting to scan folders.
VERBOSE  filesystem:filesystem.py:154 Scanning folder torrent_match_test_dir/. Recursion is set to False.
DEBUG    filesystem:filesystem.py:159 Scanning torrent_match_test_dir
DEBUG    filesystem:filesystem.py:164 Checking if torrent_match_test_dir/torrent2 qualifies to be added as an entry.
DEBUG    filesystem:filesystem.py:164 Checking if torrent_match_test_dir/torrent1.mkv qualifies to be added as an entry.
DEBUG    filesystem:filesystem.py:164 Checking if torrent_match_test_dir/torrent1 qualifies to be added as an entry.
DEBUG    filesystem:filesystem.py:164 Checking if torrent_match_test_dir/multi_file_with_diff qualifies to be added as an entry.
DEBUG    filesystem:filesystem.py:164 Checking if torrent_match_test_dir/torrent1_wrong_size qualifies to be added as an entry.
DEBUG    utils:tools.py:515 Ignored duplicate title `torrent1`
DEBUG    torrent_match:torrent_match.py:119 Checking local entry torrent2 against torrent1_empty_name
DEBUG    torrent_match:torrent_match.py:119 Checking local entry torrent1 against torrent1_empty_name
DEBUG    torrent_match:torrent_match.py:140 Path for torrent1_empty_name set to /home/runner/work/Flexget/Flexget/tests/torrent_match_test_dir
DEBUG    torrent_match:torrent_match.py:119 Checking local entry multi_file_with_diff against torrent1_empty_name
DEBUG    torrent_match:torrent_match.py:119 Checking local entry torrent1_wrong_size against torrent1_empty_name
DEBUG    torrent_match:torrent_match.py:119 Checking local entry torrent2 against torrent2
DEBUG    torrent_match:torrent_match.py:163 Path for torrent2 will be set to /home/runner/work/Flexget/Flexget/tests/torrent_match_test_dir
DEBUG    torrent_match:torrent_match.py:171 Path torrent2/sample/sample.mkv matched local file path /home/runner/work/Flexget/Flexget/tests/torrent_match_test_dir/torrent2/sample/sample.mkv
DEBUG    torrent_match:torrent_match.py:171 Path torrent2/torrent2.mkv matched local file path /home/runner/work/Flexget/Flexget/tests/torrent_match_test_dir/torrent2/torrent2.mkv
DEBUG    torrent_match:torrent_match.py:190 Torrent torrent2 matched path /home/runner/work/Flexget/Flexget/tests/torrent_match_test_dir
DEBUG    torrent_match:torrent_match.py:119 Checking local entry torrent2 against torrent1.mkv
DEBUG    torrent_match:torrent_match.py:119 Checking local entry torrent1 against torrent1.mkv
DEBUG    torrent_match:torrent_match.py:140 Path for torrent1.mkv set to /home/runner/work/Flexget/Flexget/tests/torrent_match_test_dir
DEBUG    torrent_match:torrent_match.py:119 Checking local entry multi_file_with_diff against torrent1.mkv
DEBUG    torrent_match:torrent_match.py:119 Checking local entry torrent1_wrong_size against torrent1.mkv
DEBUG    torrent_match:torrent_match.py:119 Checking local entry torrent2 against multi_file_with_diff
DEBUG    torrent_match:torrent_match.py:163 Path for multi_file_with_diff will be set to 
DEBUG    torrent_match:torrent_match.py:179 No local paths matched multi_file_with_diff/video.mkv
DEBUG    torrent_match:torrent_match.py:179 No local paths matched multi_file_with_diff/video.nfo
DEBUG    torrent_match:torrent_match.py:179 No local paths matched multi_file_with_diff/video_1mb.mkv
DEBUG    torrent_match:torrent_match.py:119 Checking local entry torrent1 against multi_file_with_diff
DEBUG    torrent_match:torrent_match.py:163 Path for multi_file_with_diff will be set to 
DEBUG    torrent_match:torrent_match.py:179 No local paths matched multi_file_with_diff/video.mkv
DEBUG    torrent_match:torrent_match.py:179 No local paths matched multi_file_with_diff/video.nfo
DEBUG    torrent_match:torrent_match.py:179 No local paths matched multi_file_with_diff/video_1mb.mkv
DEBUG    torrent_match:torrent_match.py:119 Checking local entry multi_file_with_diff against multi_file_with_diff
DEBUG    torrent_match:torrent_match.py:163 Path for multi_file_with_diff will be set to /home/runner/work/Flexget/Flexget/tests/torrent_match_test_dir
DEBUG    torrent_match:torrent_match.py:171 Path multi_file_with_diff/video.mkv matched local file path /home/runner/work/Flexget/Flexget/tests/torrent_match_test_dir/multi_file_with_diff/video.mkv
DEBUG    torrent_match:torrent_match.py:179 No local paths matched multi_file_with_diff/video.nfo
DEBUG    torrent_match:torrent_match.py:171 Path multi_file_with_diff/video_1mb.mkv matched local file path /home/runner/work/Flexget/Flexget/tests/torrent_match_test_dir/multi_file_with_diff/video_1mb.mkv
DEBUG    torrent_match:torrent_match.py:190 Torrent multi_file_with_diff matched path /home/runner/work/Flexget/Flexget/tests/torrent_match_test_dir
DEBUG    seen:seen.py:137 Learned 'torrent1_empty_name' (field: title, local: False)
DEBUG    seen:seen.py:137 Learned 'file:///home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/torrent1_empty_name.torrent' (field: url, local: False)
DEBUG    seen:seen.py:137 Learned 'torrent2' (field: title, local: False)
DEBUG    seen:seen.py:137 Learned 'file:///home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/torrent2.torrent' (field: url, local: False)
DEBUG    seen:seen.py:137 Learned 'torrent1.mkv' (field: title, local: False)
DEBUG    seen:seen.py:137 Learned 'file:///home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/torrent1.mkv.torrent' (field: url, local: False)
DEBUG    seen:seen.py:137 Learned 'multi_file_with_diff' (field: title, local: False)
DEBUG    seen:seen.py:137 Learned 'file:///home/runner/work/Flexget/Flexget/tests/torrent_match_test_torrents/multi_file_with_diff.torrent' (field: url, local: False)
DEBUG    seen:seen.py:137 Learned 'A50F34BF7AC54102815CA92670575CA530074414' (field: torrent_info_hash, local: False)
DEBUG    seen:seen.py:137 Learned 'D6C67E3A8DE413EE357E56F9222ED9EA98AE5C64' (field: torrent_info_hash, local: False)
DEBUG    seen:seen.py:137 Learned '22DA37C9FA29EDE8AE7D372F505DEE40D26BBBF9' (field: torrent_info_hash, local: False)
DEBUG    seen:seen.py:137 Learned 'F4F30DF23E8E7BDD850C7551AC7AC5420BEF4228' (field: torrent_info_hash, local: False)
DEBUG    util.simple_persistence:simple_persistence.py:175 Flushing simple persistence for task test_with_filesystem to db.
---------------------------- Captured log teardown -----------------------------
DEBUG    task_queue:task_queue.py:87 task queue shutdown requested
DEBUG    util.simple_persistence:simple_persistence.py:175 Flushing simple persistence for task None to db.
- generated xml file: /home/runner/work/Flexget/Flexget/core_test_results.xml --
================================ tests coverage ================================
_____________ coverage: platform linux, python 3.14.0-candidate-1 ______________

Coverage XML written to file coverage.xml
=========================== short test summary info ============================
FAILED tests/test_rtorrent.py::TestRTorrentOutputPlugin::test_add - pytest.PytestUnraisableExceptionWarning: Exception ignored while calling deallocator <function _TemporaryFileCloser.__del__ at 0x7f43f1d3eb90>: None
FAILED tests/test_rtorrent.py::TestRTorrentOutputPlugin::test_add_set - pytest.PytestUnraisableExceptionWarning: Exception ignored while calling deallocator <function _TemporaryFileCloser.__del__ at 0x7f72ea3ceb90>: None
FAILED tests/test_torrent_match.py::TestTorrentMatch::test_with_filesystem - ExceptionGroup: multiple unraisable exception warnings (4 sub-exceptions)
============ 3 failed, 1375 passed, 24 skipped in 127.74s (0:02:07) ============
Error: Process completed with exit code 1.
```
