### PR TITLE
Restore logic to using naive datetimes for tvdb. fix #4541

### DIFF
--- a/flexget/components/thetvdb/api_tvdb.py
+++ b/flexget/components/thetvdb/api_tvdb.py
@@ -761,20 +761,19 @@ def mark_expired(session):
     # Only get the expired list every hour
     last_check = persist.get('last_check')
 
+    utcnow = datetime.now(timezone.utc).replace(tzinfo=None)
     if not last_check:
-        persist['last_check'] = datetime.now(timezone.utc)
+        persist['last_check'] = utcnow
         return
-    if datetime.now(timezone.utc) - last_check <= timedelta(hours=2):
+    if utcnow - last_check <= timedelta(hours=2):
         # It has been less than 2 hour, don't check again
         return
 
-    new_last_check = datetime.now(timezone.utc)
+    new_last_check = utcnow
 
     try:
         # Calculate seconds since epoch minus a minute for buffer
-        last_check_epoch = (
-            int((last_check - datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds()) - 60
-        )
+        last_check_epoch = int((last_check - datetime(1970, 1, 1)).total_seconds()) - 60
         logger.debug('Getting updates from thetvdb ({})', last_check_epoch)
         updates = TVDBRequest().get('updated/query', fromTime=last_check_epoch)
     except requests.RequestException as e:

--- a/tests/test_thetvdb.py
+++ b/tests/test_thetvdb.py
@@ -217,7 +217,9 @@ class TestTVDBExpire:
         test_run()
 
         # Should not expire as it was checked less then an hour ago
-        persist['last_check'] = datetime.now(timezone.utc) - timedelta(hours=1)
+        persist['last_check'] = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(
+            hours=1
+        )
         with (
             mock.patch(
                 'requests.sessions.Session.request',
@@ -251,7 +253,9 @@ class TestTVDBExpire:
         test_run()
 
         # Should expire
-        persist['last_check'] = datetime.now(timezone.utc) - timedelta(hours=3)
+        persist['last_check'] = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(
+            hours=3
+        )
 
         expired_data = [
             {'id': 73255, 'lastUpdated': 1458186055},


### PR DESCRIPTION
#4490 removed some deprecated uses of `utcnow` but changed the logic to use tz aware datetimes instead of naive. This was causing issues (#4541) because our simple_persistence plugin (and sqlite datetime columns) don't retain timezone information so naive datetimes come out of the db at the moment.

This just reverts to using naive datetimes for now. If/when we want to make those aware we'll need to have a solution to serialize aware datetimes to the database as well. We could also probably move to pendulum if we are going with aware datetimes.

<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
