### PR TITLE
By modifying `.gitattributes` to allow more tests to pass on Windows.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,14 +1,10 @@
-# Set default behaviour, in case users don't have core.autocrlf set.
-* text=auto
-
-# Explicitly declare text files we want to always be normalized and converted
-# to native line endings on checkout.
-*.template text
-*.py text
-*.rst text
-
-# Denote all files that are truly binary and should not be modified.
-*.png binary
-*.jpg binary
+**/cassettes/** linguist-generated=true
+*.bat eol=crlf
+*.cmd eol=crlf
 *.gz binary
+*.jpg binary
+*.mkv binary
+*.png binary
 *.tar binary
+docs/requirements.txt linguist-generated=true
+requirements.txt linguist-generated=true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,11 +70,11 @@ jobs:
       - name: Run tests for scripts
         run: |
           uv export --no-hashes --output-file scripts/bundle_webui.txt --script scripts/bundle_webui.py
-          uv run --isolated --no-project --with pytest --with vcrpy --with-requirements scripts/bundle_webui.txt -m pytest scripts/tests/test_bundle_webui.py
+          uv run --isolated --no-project --with pytest --with vcrpy --with-requirements scripts/bundle_webui.txt -m pytest --override-ini filterwarnings=error scripts/tests/test_bundle_webui.py
           uv export --no-hashes --output-file scripts/dev_tools.txt --script scripts/dev_tools.py
-          uv run --isolated --no-project --with pytest --with vcrpy --with-requirements scripts/dev_tools.txt -m pytest scripts/tests/test_dev_tools.py
+          uv run --isolated --no-project --with pytest --with vcrpy --with-requirements scripts/dev_tools.txt -m pytest --override-ini filterwarnings=error scripts/tests/test_dev_tools.py
           uv export --no-hashes --output-file scripts/update_changelog.txt --script scripts/update_changelog.py
-          uv run --isolated --no-project --with pytest --with vcrpy --with-requirements scripts/update_changelog.txt -m pytest scripts/tests/test_update_changelog.py
+          uv run --isolated --no-project --with pytest --with vcrpy --with-requirements scripts/update_changelog.txt -m pytest --override-ini filterwarnings=error scripts/tests/test_update_changelog.py
 
   test-results:
     name: Test results

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,8 @@ repos:
       - id: file-contents-sorter
         files: .dockerignore
       - id: file-contents-sorter
+        files: .gitattributes
+      - id: file-contents-sorter
         files: .gitignore
       - id: fix-byte-order-marker
       - id: mixed-line-ending

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,8 @@ repos:
       - id: destroyed-symlinks
       - id: end-of-file-fixer
       - id: file-contents-sorter
+        files: .github/CODEOWNERS
+      - id: file-contents-sorter
         files: .dockerignore
       - id: file-contents-sorter
         files: .gitignore

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,6 @@ repos:
       - id: file-contents-sorter
         files: .gitignore
       - id: fix-byte-order-marker
-      - id: mixed-line-ending
-        args: [--fix=lf]
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
         exclude_types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
       - id: mixed-line-ending
         args: [--fix=lf]
       - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
         exclude_types: [python]
   - repo: https://github.com/henryiii/validate-pyproject-schema-store
     rev: 2025.08.07

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,14 +225,12 @@ max_supported_python = '3.14'
 addopts = '-p no:legacypath --strict-markers'
 filterwarnings = [
   'error',
-  "ignore:jsonschema.RefResolver is deprecated as of v4.18.0",     # triggered by `python-restx` Consider migrate to `flask-smorest` to eliminate it. See https://github.com/python-restx/flask-restx/issues/633#issuecomment-2962412240
-  "ignore:'count' is passed as positional argument",               # triggered by `feedparser`
-  'ignore:tzname PST identified but not understood.',              # triggered by `dateutil`
-  'ignore:tzname EDT identified but not understood.',              # triggered by `dateutil`
-  "ignore:unclosed file <_io.BufferedReader name='photo.png'>",    # triggered by `python-telegram-bot`
-  "ignore:unclosed file <_io.BufferedReader name='document.jpg'>", # triggered by `python-telegram-bot`
-  "ignore:unclosed file <_io.BufferedReader name='",               # needs investigation
-  'ignore:Failed to load HostKeys from',                           # needs investigation — related to `pysftp`, occurs intermittently
+  "ignore:jsonschema.RefResolver is deprecated as of v4.18.0:DeprecationWarning:flask_restx.api",                            # Can’t be fixed, consider migrating to `flask-smorest` to eliminate it. See https://github.com/python-restx/flask-restx/issues/633#issuecomment-2962412240
+  "ignore:'count' is passed as positional argument:DeprecationWarning:feedparser.html",                                      # Can’t be fixed, feedparser is no longer maintained unless we migrate to an alternative library.
+  'ignore:tzname PST identified but not understood.:dateutil.parser._parser.UnknownTimezoneWarning:dateutil.parser._parser', # needs investigation, tests/test_input_sites.py::TestInputSites::test_apple_trailers_simple  tests/test_input_sites.py::TestInputSites::test_apple_trailers
+  'ignore:tzname EDT identified but not understood.:dateutil.parser._parser.UnknownTimezoneWarning:dateutil.parser._parser', # needs investigation, tests/test_rss.py::TestRssOnline::test_rss_online
+  "ignore:unclosed file <_io.BufferedReader name=':ResourceWarning",                                                         # needs investigation, tests/api_tests/test_cached_api.py::TestCachedAPI::test_cached_api
+  'ignore:Failed to load HostKeys from:UserWarning:pysftp',                                                                  # Can’t be fixed, https://stackoverflow.com/q/56521549 It's a bug in pysftp 0.2.9, not in 0.2.8
 ]
 markers = [
   'filecopy(src, dst): mark test to copy a file from `src` to `dst` before running',

--- a/tests/test_torrent_match.py
+++ b/tests/test_torrent_match.py
@@ -1,7 +1,4 @@
-import platform
 from pathlib import Path
-
-import pytest
 
 
 class TestTorrentMatch:
@@ -76,36 +73,18 @@ class TestTorrentMatch:
 
     """
 
-    @pytest.mark.skipif(
-        platform.system() == 'Windows',
-        reason='Due to the different file size calculation methods for torrents'
-        ' created on Windows and Linux, allowing this test to pass on'
-        'Windows will inevitably cause it to fail on Linux.',
-    )
     def test_multi_torrent_empty_name(self, execute_task):
         task = execute_task('test_multi_torrent_empty_name')
 
         assert len(task.accepted) == 1, 'Should have accepted torrent1.mkv'
         assert task.accepted[0]['path'] == Path('torrent_match_test_dir/torrent1')
 
-    @pytest.mark.skipif(
-        platform.system() == 'Windows',
-        reason='Due to the different file size calculation methods for torrents'
-        ' created on Windows and Linux, allowing this test to pass on'
-        'Windows will inevitably cause it to fail on Linux.',
-    )
     def test_single_torrent(self, execute_task):
         task = execute_task('test_single_torrent')
 
         assert len(task.accepted) == 1, 'Should have accepted torrent1.mkv'
         assert task.accepted[0]['path'] == Path('torrent_match_test_dir')
 
-    @pytest.mark.skipif(
-        platform.system() == 'Windows',
-        reason='Due to the different file size calculation methods for torrents'
-        ' created on Windows and Linux, allowing this test to pass on'
-        'Windows will inevitably cause it to fail on Linux.',
-    )
     def test_single_torrent_in_other_dir(self, execute_task):
         task = execute_task('test_single_torrent_in_other_dir')
 
@@ -142,12 +121,6 @@ class TestTorrentMatch:
         )
         assert task.accepted[0]['path'] == 'torrent_match_test_dir'
 
-    @pytest.mark.skipif(
-        platform.system() == 'Windows',
-        reason='Due to the different file size calculation methods for torrents'
-        ' created on Windows and Linux, allowing this test to pass on'
-        'Windows will inevitably cause it to fail on Linux.',
-    )
     def test_with_filesystem(self, execute_task):
         task = execute_task('test_with_filesystem')
         assert len(task.all_entries) == 4, (


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
Some of the MKV files used for testing were padded with text, and when checked out on Windows, they get converted to CRLF, which changes the file size and causes tests to fail on Windows.

Previously, we marked them with `@pytest.mark.skipif()`, but now the issue has been resolved by modifying `.gitattributes`.
