### PR TITLE
chore: always wait until all upgrades are available

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,6 +57,7 @@
       description: 'Group all ruff updates together.',
       groupName: 'ruff',
       matchPackageNames: ['ruff', 'astral-sh/ruff-pre-commit'],
+      minimumGroupSize: 2,
       extends: [':automergeAll'],
     },
     {
@@ -67,6 +68,7 @@
         'ghcr.io/astral-sh/uv',
         'astral-sh/uv-pre-commit',
       ],
+      minimumGroupSize: 3,
       extends: [':automergeAll'],
     },
   ],


### PR DESCRIPTION
It ensures version synchronization within the group to some extent. However, desynchronization can still occur — for example, suppose all uv versions are currently 0.8.0, Renovate creates a PR that updates uv to 0.8.2, but updates ghcr.io/astral-sh/uv and astral-sh/uv-pre-commit to 0.8.1.

To achieve complete synchronization, see
- https://github.com/renovatebot/renovate/issues/9739