### PR TITLE
chore: configure Renovate to reduce unnecessary CI runs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,6 @@
     ':prConcurrentLimitNone',
     ':prHourlyLimitNone',
     ':preserveSemverRanges',
-    ':rebaseStalePrs',
   ],
   schedule: ['* 16-23 * * 0', '* 0-12 * * 1'],
   lockFileMaintenance: {
@@ -19,6 +18,7 @@
     'github-actions[bot]@users.noreply.github.com',
     '66853113+pre-commit-ci[bot]@users.noreply.github.com',
   ],
+  addLabels: ['dependencies'],
   customManagers: [
     {
       customType: 'regex',

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,3 +29,4 @@ jobs:
           days-before-pr-close: ${{ env.DAYS_BEFORE_PR_CLOSE }}
           operations-per-run: 100
           ascending: true
+          exempt-pr-labels: dependencies


### PR DESCRIPTION
**Description**

Currently, our Renovate configuration triggers a rebase for its open pull requests whenever they fall behind the `develop` branch. This is causing a significant number of unnecessary GitHub Actions workflow runs.

For example, we often have several Renovate PRs that cannot be merged immediately (e.g., #4547, #4429, #4066). Each time a new commit is pushed to `develop`, all of these PRs are rebased. Each rebase triggers its full suite of checks (around 20 workflow runs per PR). With just these three PRs, this results in approximately 60 workflow runs for a single commit to `develop`.

These CI runs are redundant because we are aware these PRs cannot be merged, and the constant rebasing provides no value.

**Proposed Solution**

I propose we modify our Renovate configuration to only rebase pull requests when they have a merge conflict with the base branch or when automerge is enabled.

This change is safe for our workflow. We have the GitHub Merge Queue enabled, which automatically runs checks on the latest version of the base branch before any PR is merged. This practice already protects the `develop` branch from failures that might otherwise be missed, making the pre-emptive rebases unnecessary.

**Expected Outcome**

*   A significant reduction in GitHub Actions minutes and associated costs.
*   Less CI noise and faster queue times for legitimate development workflows.
*   No degradation in the stability of our `develop` branch.

<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
