### PR TITLE
build(docker): fix Docker build failure by updating apk cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/python:3.11-alpine@sha256:8d8c6d3808243160605925c2a7ab2dc5c72d0e7
 ENV PYTHONUNBUFFERED=1
 
 RUN --mount=type=cache,target=/var/cache/apk \
-    apk add --upgrade \
+    apk update && apk add --upgrade \
         ca-certificates \
         nodejs \
         build-base \


### PR DESCRIPTION
### Failed workflow runs
https://github.com/Flexget/Flexget/actions/runs/17042553607
https://github.com/Flexget/Flexget/actions/runs/17042361279
https://github.com/Flexget/Flexget/actions/runs/17024362247

### Description

This PR addresses a critical failure in the Docker build process observed for `linux/amd64` and `linux/arm64` platforms. The build fails during the setup of the build environment within the `Dockerfile`.

### The Problem

The build process aborts with an `exit code: 14` when trying to install several essential packages using Alpine's package manager, `apk`. The build log clearly indicates that multiple packages cannot be found:

```
ERROR: unable to select packages:
  build-base (no such package):
    required by: world[build-base]
  libffi-dev (no such package):
    required by: world[libffi-dev]
  openssl-dev (no such package):
    required by: world[openssl-dev]
  unzip (no such package):
    required by: world[unzip]
...
ERROR: failed to build: failed to solve: process "/bin/sh -c apk add --upgrade ..." did not complete successfully: exit code: 14
```

### Root Cause

The root cause of this failure is that the `apk add` command is being executed without first updating the local package index. The `apk` utility relies on a local cache of the package repository index to know which packages are available for installation. Without running `apk update`, this cache is either empty or stale, leading `apk` to report that the packages do not exist.

### Solution

The fix is straightforward: prepend `apk update` to the `apk add` command within the same `RUN` instruction. By chaining these commands with `&&`, we ensure that the package index is successfully updated before the installation is attempted. This is a standard practice for `apk`-based Dockerfiles to ensure build reliability.

**Change in `Dockerfile`:**

**Before:**
```dockerfile
RUN --mount=type=cache,target=/var/cache/apk \
    apk add --upgrade \
        ca-certificates \
        nodejs \
        build-base \
        libffi-dev \
        openssl-dev \
        unzip
```

**After:**
```dockerfile
RUN --mount=type=cache,target=/var/cache/apk \
    apk update && apk add --upgrade \
        ca-certificates \
        nodejs \
        build-base \
        libffi-dev \
        openssl-dev \
        unzip
```

This change ensures the package manager has the latest information from the repositories and allows it to successfully locate and install the required dependencies, thus fixing the build.

<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
