### PR TITLE
Disable network calls during tests to enhance stability and prevent unintended network access

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         operating-system: [windows-latest, macos-latest, ubuntu-latest]
       fail-fast: false
+    env:
+      VCR_RECORD_MODE: none
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
@@ -34,10 +36,10 @@ jobs:
           version: ${{ env.UV_VERSION }}
       - name: Run tests not requiring optional dependencies
         id: core-tests
-        run: uv run pytest -m 'not require_optional_deps' -n logical --cov --cov-branch --cov-report=xml --dist loadgroup --junit-xml core_test_results.xml
+        run: uv run pytest -m 'not require_optional_deps' -n logical --allow-hosts 127.0.0.1 --cov --cov-branch --cov-report=xml --dist loadgroup --junit-xml core_test_results.xml
       - name: Run tests requiring optional dependencies
         if: ${{!cancelled() && steps.core-tests.outcome != 'skipped'}}
-        run: uv run --group all pytest -m 'require_optional_deps' -n logical --cov --cov-append --cov-branch --cov-report=xml --dist loadgroup --junit-xml optional_test_results.xml
+        run: uv run --group all pytest -m 'require_optional_deps' -n logical --allow-hosts 127.0.0.1 --cov --cov-append --cov-branch --cov-report=xml --dist loadgroup --junit-xml optional_test_results.xml
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dev = [
   "pre-commit~=4.0",
   "pytest~=8.3",
   "pytest-cov~=6.1",
+  "pytest-socket~=0.7.0",
   "pytest-xdist~=3.6",
   "ruff==0.12.9",
   "vcrpy~=7.0",

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ name = "brotlicffi"
 version = "1.1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
+    { name = "cffi", marker = "platform_python_implementation == 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/9d/70caa61192f570fcf0352766331b735afa931b4c6bc9a348a0925cc13288/brotlicffi-1.1.0.0.tar.gz", hash = "sha256:b77827a689905143f87915310b93b273ab17888fd43ef350d4832c4a71083c13", size = 465192, upload-time = "2023-09-14T14:22:40.707Z" }
 wheels = [
@@ -722,7 +722,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -894,6 +894,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-socket" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "vcrpy" },
@@ -986,6 +987,7 @@ dev = [
     { name = "pre-commit", specifier = "~=4.0" },
     { name = "pytest", specifier = "~=8.3" },
     { name = "pytest-cov", specifier = "~=6.1" },
+    { name = "pytest-socket", specifier = "~=0.7.0" },
     { name = "pytest-xdist", specifier = "~=3.6" },
     { name = "ruff", specifier = "==0.12.9" },
     { name = "vcrpy", specifier = "~=7.0" },
@@ -2035,6 +2037,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432, upload-time = "2025-06-12T10:47:47.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644, upload-time = "2025-06-12T10:47:45.932Z" },
+]
+
+[[package]]
+name = "pytest-socket"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/ff/90c7e1e746baf3d62ce864c479fd53410b534818b9437413903596f81580/pytest_socket-0.7.0.tar.gz", hash = "sha256:71ab048cbbcb085c15a4423b73b619a8b35d6a307f46f78ea46be51b1b7e11b3", size = 12389, upload-time = "2024-01-28T20:17:23.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/58/5d14cb5cb59409e491ebe816c47bf81423cd03098ea92281336320ae5681/pytest_socket-0.7.0-py3-none-any.whl", hash = "sha256:7e0f4642177d55d317bbd58fc68c6bd9048d6eadb2d46a89307fa9221336ce45", size = 6754, upload-time = "2024-01-28T20:17:22.105Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Problem:**

The current `no_requests` fixture is limited to intercepting network requests made by the `requests` and `http` libraries. This leaves a significant gap, as it doesn't prevent tests from making network calls using other popular libraries such as `httpx`, `aiohttp`, or others. This oversight can lead to the inadvertent addition of tests that rely on network access.

These network-dependent tests introduce several critical issues:
*   **Increased test execution time:** Waiting for network responses slows down the entire test suite.
*   **Test instability:** Network failures or timeouts can cause tests to fail intermittently, leading to flaky test runs.
*   **Inaccurate test coverage:** As seen in #4426, a test requiring network access for a `subliminal`-related feature caused significant fluctuations in the project's test coverage metrics.

**Solution:**

This pull request resolves these issues by completely disabling socket calls during the test suite. By blocking network access at the socket level, we ensure that no test can inadvertently make external network requests, regardless of the HTTP library used. This guarantees a more stable, reliable, and faster testing environment.

To achieve this, we have integrated the `pytest-socket` library, which effectively disables all network calls originating from Python's socket interface during test execution.

**CI Enhancement:**

Furthermore, the `VCR_RECORD_MODE` environment variable has been set to `none` in the CI environment. This will cause any test that attempts to make a network request without a pre-existing cassette to fail, thereby ensuring that all cassettes are intentionally and explicitly added to the repository using `git add`.

<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
