### PR TITLE
fix: correctly handle ETag formatting for compressed responses

### DIFF
--- a/flexget/api/app.py
+++ b/flexget/api/app.py
@@ -16,7 +16,7 @@ from flask_restx import Resource
 from loguru import logger
 from referencing.exceptions import Unresolvable
 from requests import HTTPError
-from werkzeug.http import generate_etag
+from werkzeug.http import generate_etag, quote_etag
 
 from flexget import manager
 from flexget.config_schema import format_checker, process_config
@@ -407,7 +407,7 @@ def etag(method: Callable | None = None, cache_age: int = 0):
             + rv.headers.get('total-count', '')
         )
         data = (rv.get_data().decode() + content_headers).encode()
-        etag = generate_etag(data)
+        etag = quote_etag(generate_etag(data))
         rv.headers['Cache-Control'] = f'max-age={cache_age}'
         rv.headers['ETag'] = etag
         if_match = request.headers.get('If-Match')


### PR DESCRIPTION
Close #4282.

This PR addresses an issue where the API returns a malformed ETag for compressed responses, preventing the proper use of `If-None-Match` headers and `304 Not Modified` status codes.

**Problem:**

When a client requests a compressed response (e.g., via `Accept-Encoding: gzip`), the server generates an ETag with a `:gzip` suffix. However, this ETag is malformed in two ways:
1.  It is missing the final character of the hash.
2.  It includes an extraneous closing double-quotation mark.

This results in the client receiving an invalid ETag. When the client sends this exact ETag back in an `If-None-Match` header, the server fails to recognize it and incorrectly returns a `200 OK` with the full response body instead of the expected `304 Not Modified`.

**Solution:**

This fix ensures that the ETag is correctly formatted *before* the compression suffix is applied. The logic has been adjusted to properly append the `:gzip` suffix to the complete and correctly quoted ETag hash.

**Verification:**

The following cURL commands can be used to reproduce the original issue and verify the fix.

***

### Original Incorrect Behavior

**1. Requesting a compressed resource:**
```bash
curl -X 'GET' 'http://127.0.0.1:5050/api/server/config/' -H 'Authorization: Token <TOKEN>' --compressed -v
```

**Response Headers:**
```
< HTTP/1.1 200 OK
< ETag: fece0505feaaa7e0754655478ac58f664285401:gzip"
```
*Notice the malformed ETag.*

**2. Sending the malformed ETag back:**
```bash
curl -X 'GET' 'http://127.0.0.1:5050/api/server/config/' -H 'Authorization: Token <TOKEN>' -H 'If-None-Match: fece0505feaaa7e0754655478ac58f664285401:gzip"' --compressed -v
```

**Result:**
The server returns `200 OK` instead of `304 Not Modified`.

***

### Expected Behavior After Fix

**1. Requesting a compressed resource:**
The server will now return a correctly formatted ETag.

**Response Headers (Example):**
```
< HTTP/1.1 200 OK
< ETag: "fece0505feaaa7e0754655478ac58f664285401f:gzip"
```

**2. Sending the correct ETag back:**
```bash
curl -X 'GET' 'http://127.0.0.1:5050/api/server/config/' -H 'Authorization: Token <TOKEN>' -H 'If-None-Match: "fece0505feaaa7e0754655478ac58f664285401f:gzip"' --compressed -v
```

**Result:**
The server correctly returns `HTTP/1.1 304 Not Modified`.

<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
