### PR TITLE
test: only add `@pytest.mark.online` to tests that actually use a cassette

### DIFF
--- a/tests/api_tests/test_tvdb_lookup_api.py
+++ b/tests/api_tests/test_tvdb_lookup_api.py
@@ -212,7 +212,6 @@ class TestTVDSearchZAP2ITLookupAPI:
             assert data[0].get(field) == value
 
 
-@pytest.mark.online
 class TestTVDSearchAPIErrors:
     config = 'tasks: {}'
 
@@ -224,6 +223,7 @@ class TestTVDSearchAPIErrors:
         errors = schema_match(base_message, data)
         assert not errors
 
+    @pytest.mark.online
     def test_tvdb_search_lookup_error(self, api_client, schema_match):
         rsp = api_client.get('/tvdb/search/?search_name=sdfgsdfgsdfgsdfg')
         assert rsp.status_code == 404, f'Response code is {rsp.status_code}'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,10 @@ def use_vcr(request, monkeypatch):
             monkeypatch.setattr('flexget.utils.requests.limit_domains', mock.Mock())
         with vcr.use_cassette(path=str(cassette_path)) as cassette:
             yield cassette
+        if not cassette_path.exists():
+            raise RuntimeError(
+                'No cassette found or generated. Hint: If the test does not require network access, `@pytest.mark.online` should be removed.'
+            )
 
 
 @pytest.fixture

--- a/tests/test_nfo_lookup.py
+++ b/tests/test_nfo_lookup.py
@@ -1,7 +1,6 @@
 import pytest
 
 
-@pytest.mark.online
 class TestNfoLookupWithMovies:
     base = 'nfo_lookup_test_dir/'
     config = f"""
@@ -74,6 +73,7 @@ class TestNfoLookupWithMovies:
             nfo_lookup: yes
     """
 
+    @pytest.mark.online
     def test_nfo_with_only_id(self, execute_task):
         task = execute_task('test_1')
         for entry in task.entries:
@@ -156,6 +156,7 @@ class TestNfoLookupWithMovies:
             assert entry['nfo_genre'] == ['Fantasia', 'Romance']
             assert entry['imdb_id'] == 'tt2316801'
 
+    @pytest.mark.online
     def test_nfo_with_no_nfo_file(self, execute_task):
         task = execute_task('test_6')
         for entry in task.entries:
@@ -172,6 +173,7 @@ class TestNfoLookupWithMovies:
             # IMDB is able to find the movie from the Portuguese title, although it is not the correct one
             assert entry['imdb_name'] == 'Beauty and the Beast'
 
+    @pytest.mark.online
     def test_nfo_lookup_without_filesystem(self, execute_task):
         task = execute_task('test_7')
         # This is the same as not having an nfo file


### PR DESCRIPTION
Currently, some tests that do not actually require `@pytest.mark.online` are still marked with it; this PR removes those cases. To make it clearer which tests truly need network access, and to avoid the unnecessary overhead of loading vcrpy-related fixtures, `@pytest.mark.online` should be applied only to tests that use a cassette.

<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
