### PR TITLE
chore: fix typos reported by `codespell`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,10 @@ repos:
     rev: v1.33.1
     hooks:
       - id: typos
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
   - repo: https://github.com/henryiii/validate-pyproject-schema-store
     rev: 2025.08.07
     hooks:

--- a/docs/contributor/Topic guides/Plugin schemas.rst
+++ b/docs/contributor/Topic guides/Plugin schemas.rst
@@ -19,9 +19,9 @@ The following list of keywords is not exhaustive, just a general primer, as
 well as some FlexGet specific notes. The JSON schema spec should be referred to
 for more details, or if a keyword is not covered here. Take not that our
 schemas will be defined as python objects equivalent to parsed JSON. The full
-list of valid keywords can be found in the `validaton spec`_.
+list of valid keywords can be found in the `validation spec`_.
 
-.. _validaton spec: https://json-schema.org/latest/json-schema-validation
+.. _validation spec: https://json-schema.org/latest/json-schema-validation
 
 Keywords
 --------
@@ -167,7 +167,7 @@ plugin or component of FlexGet::
 ^^^^^^^^^^^^^^^
 
 This keyword does not affect validation, it is merely used to define parts of
-your schema that may get re-used in more than one place. It should be in the
+your schema that may get reused in more than one place. It should be in the
 form of a dictionary mapping arbitrary names to a schema.
 
 The following schema defines a definition called posNumber, and references it

--- a/docs/contributor/Topic guides/Running and writing tests.rst
+++ b/docs/contributor/Topic guides/Running and writing tests.rst
@@ -350,7 +350,7 @@ Example:
   $ flexget inject "another test title"
 
 The ``inject`` will disable any other inputs in the task. It is possible to set
-arbitrary fields trough inject much like with mock. See
+arbitrary fields through inject much like with mock. See
 `full documentation <https://flexget.com/en/CLI/inject>`__.
 
 Commandline values

--- a/flexget/components/emby/api_emby.py
+++ b/flexget/components/emby/api_emby.py
@@ -1623,8 +1623,8 @@ class EmbyApiMedia(EmbyApiBase):
                 args['Years'] = year
 
         logger.debug('Search media with: {}', args)
-        medias = EmbyApi.request_emby(EMBY_ENDPOINT_SEARCH, auth, 'GET', **args)
-        if not medias or 'Items' not in medias or not medias['Items']:
+        media_results = EmbyApi.request_emby(EMBY_ENDPOINT_SEARCH, auth, 'GET', **args)
+        if not media_results or 'Items' not in media_results or not media_results['Items']:
             if EmbyApi.has_providers_search_arg(**parameters):
                 EmbyApi.remove_providers_search(parameters)
                 return EmbyApiMedia.search(**parameters)
@@ -1632,7 +1632,7 @@ class EmbyApiMedia(EmbyApiBase):
             logger.warning('No media found')
             return None
 
-        media = medias['Items'][0]
+        media = media_results['Items'][0]
 
         media_api = EmbyApiMedia(auth=auth, **media)
 

--- a/flexget/components/emby/emby_lookup.py
+++ b/flexget/components/emby/emby_lookup.py
@@ -10,7 +10,7 @@ logger = logger.bind(name='emby_lookup')
 
 
 class EmbyLookup:
-    """Preforms Emby Lookup.
+    """Performs Emby Lookup.
 
     Example:
         emby_lookup:

--- a/flexget/components/emby/emby_util.py
+++ b/flexget/components/emby/emby_util.py
@@ -124,7 +124,7 @@ field_map = {
 
 
 def simplify_text(text: str) -> str:
-    """Siplify text."""
+    """Simplify text."""
     if not isinstance(text, str):
         return text
 

--- a/flexget/components/imdb/imdb.py
+++ b/flexget/components/imdb/imdb.py
@@ -106,14 +106,14 @@ class FilterImdb:
     def on_task_filter(self, task, config):
         lookup = plugin.get('imdb_lookup', self).lookup
 
-        # since the plugin does not reject anything, no sense going trough accepted
+        # since the plugin does not reject anything, no sense going through accepted
         for entry in task.undecided:
             force_accept = False
 
             try:
                 lookup(entry)
             except plugin.PluginError as e:
-                # logs skip message once trough log_once (info) and then only when ran from cmd line (w/o --cron)
+                # logs skip message once through log_once (info) and then only when ran from cmd line (w/o --cron)
                 log_once(
                     'Skipping {} because of an error: {}'.format(entry['title'], e.value),
                     logger=logger,

--- a/flexget/components/managed_lists/lists/radarr_list.py
+++ b/flexget/components/managed_lists/lists/radarr_list.py
@@ -78,7 +78,7 @@ def request_post_json(url, headers, data):
             if len(json_response) > 0 and 'errorMessage' in json_response[0]:
                 error_message = json_response[0]['errorMessage']
         except ValueError:
-            # Raised by response.json() if JSON couln't be decoded
+            # Raised by response.json() if JSON couldn't be decoded
             logger.error('Radarr returned non-JSON error result: {}', response.content)
 
         raise RadarrRequestError(
@@ -409,7 +409,7 @@ class RadarrSet(MutableSet):
         # The following implementation is what's done in every other
         # list plugin. Does not makes sense.
         # As I understand it, it aims to be an override to base class Set._from_iterable.
-        # However, thats a classmethod and this does not even match its signature
+        # However, that's a classmethod and this does not even match its signature
         # https://blog.devzero.com/2013/01/28/how-to-override-a-class-method-in-python/
         return set(it)
 

--- a/flexget/components/sites/sites/allyoulike.py
+++ b/flexget/components/sites/sites/allyoulike.py
@@ -95,7 +95,7 @@ class UrlRewriteAllyoulike:
             for link in link_list:
                 urls.append(normalize_unicode(link['href']))
         else:
-            raise UrlRewritingError('No useable links found at {}'.format(entry['url']))
+            raise UrlRewritingError('No usable links found at {}'.format(entry['url']))
 
         num_links = len(urls)
         logger.verbose('Found {} links at {}.', num_links, entry['url'])
@@ -103,7 +103,7 @@ class UrlRewriteAllyoulike:
             entry['urls'] = urls
             entry['url'] = urls[0]
         else:
-            raise UrlRewritingError('No useable links found at {}'.format(entry['url']))
+            raise UrlRewritingError('No usable links found at {}'.format(entry['url']))
 
 
 @event('plugin.register')

--- a/flexget/components/sites/sites/rlsbb.py
+++ b/flexget/components/sites/sites/rlsbb.py
@@ -172,7 +172,7 @@ class UrlRewriteRlsbb:
             entry['urls'] = urls
             entry['url'] = urls[0]
         else:
-            raise UrlRewritingError('No useable links found at {}'.format(entry['url']))
+            raise UrlRewritingError('No usable links found at {}'.format(entry['url']))
 
 
 @event('plugin.register')

--- a/flexget/plugins/daemon/web_server.py
+++ b/flexget/plugins/daemon/web_server.py
@@ -81,7 +81,7 @@ def register_web_server(manager):
 
     config = manager.config.get('web_server')
     if get_config_hash(config) == config_hash:
-        logger.debug("web server config has'nt changed")
+        logger.debug("web server config hasn't changed")
         return
 
     config_hash = get_config_hash(config)

--- a/flexget/plugins/filter/limit_new.py
+++ b/flexget/plugins/filter/limit_new.py
@@ -13,7 +13,7 @@ class FilterLimitNew:
 
       limit_new: 1
 
-    This would allow only one new item to pass trough per execution.
+    This would allow only one new item to pass through per execution.
     Useful for passing torrents slowly into download.
 
     Note that since this is per execution, actual rate depends how often

--- a/flexget/plugins/filter/rottentomatoes.py
+++ b/flexget/plugins/filter/rottentomatoes.py
@@ -87,7 +87,7 @@ class FilterRottenTomatoes:
     def on_task_filter(self, task, config):
         lookup = plugin.get('rottentomatoes_lookup', self).lookup
 
-        # since the plugin does not reject anything, no sense going trough accepted
+        # since the plugin does not reject anything, no sense going through accepted
         for entry in task.undecided:
             force_accept = False
 

--- a/flexget/plugins/input/text.py
+++ b/flexget/plugins/input/text.py
@@ -24,7 +24,7 @@ class Text:
       format:
         <field>: <python string formatting>
 
-    Note: each entry must have atleast two fields, title and url
+    Note: each entry must have at least two fields, title and url
 
     Example::
 
@@ -120,7 +120,7 @@ class Text:
 
                 # if all fields have been found
                 if len(used) == len(entry_config):
-                    # check that entry has atleast title and url
+                    # check that entry has at least title and url
                     if not entry.isvalid():
                         logger.info(
                             'Invalid data, constructed entry is missing mandatory fields (title or url)'

--- a/flexget/plugins/input/torznab.py
+++ b/flexget/plugins/input/torznab.py
@@ -169,7 +169,7 @@ class Torznab:
             enclosure = item.find("enclosure[@type='application/x-bittorrent']")
             if enclosure is None:
                 logger.warning(
-                    "Item '{}' does not contain a bittorent enclosure.", item.title.string
+                    "Item '{}' does not contain a bittorrent enclosure.", item.title.string
                 )
                 continue
             entry['url'] = enclosure.attrib['url']

--- a/flexget/ui/v1/src/components/sidenav/sidenav.service.spec.js
+++ b/flexget/ui/v1/src/components/sidenav/sidenav.service.spec.js
@@ -16,7 +16,7 @@ describe('Sidenav Service:', function () {
       expect(sideNavService.toggle).to.exist;
     });
 
-    //TODO: test funcionalities, check how to mock $mdMedia and $mdSidenav etc
+    //TODO: test functionalities, check how to mock $mdMedia and $mdSidenav etc
   });
 
   describe('close()', function () {
@@ -24,6 +24,6 @@ describe('Sidenav Service:', function () {
       expect(sideNavService.close).to.exist;
     });
 
-    //TODO: test funcionalities, check how to mock $mdMedia and $mdSidenav etc
+    //TODO: test functionalities, check how to mock $mdMedia and $mdSidenav etc
   });
 });

--- a/flexget/ui/v1/src/plugins/movies/movies.tmpl.scss
+++ b/flexget/ui/v1/src/plugins/movies/movies.tmpl.scss
@@ -43,7 +43,7 @@ md-tabs.movie-tabs md-tabs-wrapper {
   display: none !important;
 }
 
-//nth-last-child(2), because 1 doesnt work
+//nth-last-child(2), because 1 doesn't work
 .movie-tabs .md-tab:nth-last-child(2) {
   padding: 0px;
 

--- a/flexget/ui/v1/src/plugins/seen/components/seen-field/seen-field.component.js
+++ b/flexget/ui/v1/src/plugins/seen/components/seen-field/seen-field.component.js
@@ -3,7 +3,7 @@
   'use strict';
 
   angular.module('flexget.plugins.seen').component('seenFields', {
-    templateUrl: 'plugins/seen/compnents/seen-fields/seen-fields.tmpl.html',
+    templateUrl: 'plugins/seen/components/seen-fields/seen-fields.tmpl.html',
     controllerAs: 'vm',
     controller: seenFieldsController,
     bindings: {

--- a/flexget/utils/qualities.py
+++ b/flexget/utils/qualities.py
@@ -51,7 +51,7 @@ class QualityComponent:
     def matches(self, text: str) -> tuple[bool, str]:
         """Test if quality matches to text.
 
-        :param string text: data te be tested against
+        :param string text: data to be tested against
         :returns: tuple (matches, remaining text without quality data)
         """
         qual_removed = self.regexp.sub('', text)

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -244,7 +244,7 @@ filter_d = filter_default
 
 
 def filter_asciify(text: str) -> str:
-    """Siplify text."""
+    """Simplify text."""
     if not isinstance(text, str):
         return text
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,19 @@ lint.flake8-type-checking.quote-annotations = true
 lint.isort.known-first-party = [ 'flexget' ]
 lint.future-annotations = true
 
+[tool.codespell]
+skip = [
+  "**/cassettes/*",
+  "flexget/api/templates/api_response.html",
+  "flexget/api/templates/swagger-ui.html",
+  'flexget/utils/bittorrent.py',
+  'flexget/utils/parsers/series.py',
+  'tests/couchpotato_movie_list_test_response.json',
+  'tests/LICENSE.torrent',
+  'tests/test_thetvdb.py',
+  'pyproject.toml',
+]
+
 [tool.pyproject-fmt]
 max_supported_python = '3.14'
 

--- a/tests/sftp/test_sftp_list.py
+++ b/tests/sftp/test_sftp_list.py
@@ -287,7 +287,7 @@ def assert_entries(
     :param entry_matcher: Dict continain the expected entry values, must have at least a 'title'
                           set.
     :param allow_unexpected_entries: bool to assert if there are any additional entries generated
-                                     that matchers arn't specified for.
+                                     that matchers aren't specified for.
     """
     expected = [m['title'] for m in [entry_matcher, *argv]]
     found = [m['title'] for m in task.all_entries]

--- a/tests/sftp/test_sftp_server.py
+++ b/tests/sftp/test_sftp_server.py
@@ -127,7 +127,7 @@ else:
 
             :param path: The path of the file to create absolute or relative
             :param size: The size in bytes of the file to create, defaults to 0
-            :raises ValueError: if it's not possible to canoncalize the path
+            :raises ValueError: if it's not possible to canonicalize the path
             :return: An :class: `pathlib.Path` of file created.
 
             """
@@ -143,7 +143,7 @@ else:
             If the path is relative it will be created in relation to the users home directory
 
             :param path: The path of the dir to create absolute or relative.
-            :raises ValueError: if it's not possible to canoncalize the path
+            :raises ValueError: if it's not possible to canonicalize the path
             :returns: An :class:`pathlib.Path` of file created.
             """
             canonicalized: Path = self.canonicalize(path)
@@ -158,7 +158,7 @@ else:
 
             :param path: The path of the symlink to create absolute or relative
             :param target:  The path of the target of the symlink, either absolute or relative
-            :raises ValueError: if it's not possible to canoncalize the path or target
+            :raises ValueError: if it's not possible to canonicalize the path or target
             :return: An :class:`pathlib.Path` of the symlink created.
             """
             canonicalized: Path = self.canonicalize(path)
@@ -185,7 +185,7 @@ else:
 
             if self.__root == canonicalized or self.__root in canonicalized.parents:
                 return canonicalized.resolve() if resolve else canonicalized
-            raise ValueError(f'Unable to canoicalize {path}')
+            raise ValueError(f'Unable to canonicalize {path}')
 
         def root(self) -> Path:
             return self.__root

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -29,7 +29,7 @@ class TestExec:
                 for_entries: """
         + sys.executable
         + """ exec.py "{{temp_dir}}" "{{title}}" "{{location}}" """
-        + """"/the/final destinaton/" "a {{quotefield}}" "/a hybrid{{location}}"
+        + """"/the/final destination/" "a {{quotefield}}" "/a hybrid{{location}}"
           test_auto_escape:
             mock:
               - {title: entry2, quotes: single ' double", otherchars: '% a $a! ` *'}
@@ -57,7 +57,7 @@ class TestExec:
                 line = infile.readline().rstrip('\n')
                 assert Path(line) == Path('/path/with spaces'), f'{line} != /path/with spaces'
                 line = infile.readline().rstrip('\n')
-                assert line == '/the/final destinaton/', f'{line} != /the/final destinaton/'
+                assert line == '/the/final destination/', f'{line} != /the/final destination/'
                 line = infile.readline().rstrip('\n')
                 assert line == "a with'quote", f"{line} != a with'quote"
                 line = infile.readline().rstrip('\n')

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1578,7 +1578,7 @@ class TestImportSeries:
     def test_timeframe_max(self, execute_task):
         """Tests configure_series as well as timeframe with max_quality."""
         task = execute_task('timeframe_max')
-        assert not task.accepted, 'Entry shouldnt have been accepted on first run.'
+        assert not task.accepted, "Entry shouldn't have been accepted on first run."
         age_series(minutes=6)
         task = execute_task('timeframe_max')
         assert task.find_entry('accepted', title='the show s03e02 hdtv'), (


### PR DESCRIPTION
We had previously addressed several typos using the `typos` tool, but in #4595 @kianmeng identified additional ones with `codespell`. This PR rebases the changes from #4595 and incorporates them here.

<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
