### PR TITLE
feat: Manipulate allows easier regex removals with erase

### DIFF
--- a/flexget/plugins/modify/manipulate.py
+++ b/flexget/plugins/modify/manipulate.py
@@ -24,11 +24,16 @@ class Manipulate:
               regexp: <regexp>
               format: <regexp>
             [remove]: <boolean>
+            [erase]: <list of regexps>
 
     Example::
       manipulate:
         - title:
             extract: \[\d\d\d\d\](.*)
+        - title:
+            erase:
+              - "^unwanted.noise."
+              - "^more.advertisement."
     """
 
     schema = {
@@ -43,6 +48,11 @@ class Manipulate:
                     'extract': {'type': 'string', 'format': 'regex'},
                     'separator': {'type': 'string'},
                     'remove': {'type': 'boolean'},
+                    'erase': {
+                        'type': 'array',
+                        'items': {'type': 'string', 'format': 'regex'},
+                        'minItems': 1,
+                    },
                     'find_all': {'type': 'boolean'},
                     'replace': {
                         'type': 'object',
@@ -116,10 +126,29 @@ class Manipulate:
                     field_value,
                 )
                 if config.get('remove'):
+                    # Eemove entire field
                     if field in entry:
                         del entry[field]
                         modified = True
                     continue
+                if config.get('erase'):
+                    # Erase text matching regex patterns
+                    if not field_value:
+                        logger.warning(
+                            'Cannot erase patterns, field `{}` is not present', from_field
+                        )
+                        continue
+                    original_value = field_value
+                    for pattern in config['erase']:
+                        field_value = re.sub(
+                            pattern, '', field_value, flags=re.IGNORECASE | re.UNICODE
+                        )
+                    field_value = field_value.strip()
+                    if original_value != field_value:
+                        logger.debug('field `{}` after erase patterns: `{}`', field, field_value)
+                    # Fail entry if title field becomes empty after erase
+                    if field == 'title' and not field_value:
+                        entry.fail('Title became empty after erase operation')
                 if 'extract' in config:
                     if not field_value:
                         logger.warning('Cannot extract, field `{}` is not present', from_field)

--- a/flexget/plugins/modify/manipulate.py
+++ b/flexget/plugins/modify/manipulate.py
@@ -51,7 +51,6 @@ class Manipulate:
                     'erase': {
                         'type': 'array',
                         'items': {'type': 'string', 'format': 'regex'},
-                        'minItems': 1,
                     },
                     'find_all': {'type': 'boolean'},
                     'replace': {
@@ -126,7 +125,7 @@ class Manipulate:
                     field_value,
                 )
                 if config.get('remove'):
-                    # Eemove entire field
+                    # Remove entire field
                     if field in entry:
                         del entry[field]
                         modified = True

--- a/tests/test_manipulate.py
+++ b/tests/test_manipulate.py
@@ -51,6 +51,70 @@ class TestManipulate:
                   replace:
                     regexp: (1234)\-(7890)
                     format: 'e\2'
+
+          test_erase_regex_single:
+            mock:
+              - {title: 'Some crap foo'}
+            manipulate:
+              - title:
+                  erase:
+                    - "^some.crap."
+
+          test_erase_regex_multiple:
+            mock:
+              - {title: 'Some crap more junk foo bar'}
+            manipulate:
+              - title:
+                  erase:
+                    - "^some.crap."
+                    - "more.junk."
+
+          test_erase_regex_case_insensitive:
+            mock:
+              - {title: 'PREFIX: SOME CRAP the title'}
+            manipulate:
+              - title:
+                  erase:
+                    - "^prefix:"
+                    - "some.crap."
+
+          test_erase_regex_no_match:
+            mock:
+              - {title: 'Clean title'}
+            manipulate:
+              - title:
+                  erase:
+                    - "^notfound"
+                    - "alsomissing"
+
+          test_erase_regex_empty_result:
+            mock:
+              - {title: 'completely removed text'}
+            manipulate:
+              - title:
+                  erase:
+                    - ".*"
+
+          test_erase_regex_with_other_operations:
+            mock:
+              - {title: 'PREFIX: some crap GOOD TITLE suffix'}
+            manipulate:
+              - title:
+                  erase:
+                    - "^prefix:"
+                    - "some.crap."
+              - title:
+                  replace:
+                    regexp: "suffix$"
+                    format: ""
+
+          test_erase_title_failure:
+            mock:
+              - {title: 'temp title'}
+            manipulate:
+              - title:
+                  erase:
+                    - ".*"
     """
 
     def test_replace(self, execute_task):
@@ -80,3 +144,40 @@ class TestManipulate:
     def test_remove(self, execute_task):
         task = execute_task('test_remove')
         assert 'description' not in task.find_entry('entries', title='abc'), 'remove failed'
+
+    def test_erase_regex_single(self, execute_task):
+        task = execute_task('test_erase_regex_single')
+        assert task.find_entry('entries', title='foo'), 'single regex erase failed'
+
+    def test_erase_regex_multiple(self, execute_task):
+        task = execute_task('test_erase_regex_multiple')
+        assert task.find_entry('entries', title='foo bar'), 'multiple regex erase failed'
+
+    def test_erase_regex_case_insensitive(self, execute_task):
+        task = execute_task('test_erase_regex_case_insensitive')
+        assert task.find_entry('entries', title='the title'), 'case insensitive regex erase failed'
+
+    def test_erase_regex_no_match(self, execute_task):
+        task = execute_task('test_erase_regex_no_match')
+        assert task.find_entry('entries', title='Clean title'), (
+            'no match regex erase changed title when it should not have'
+        )
+
+    def test_erase_regex_empty_result(self, execute_task):
+        task = execute_task('test_erase_regex_empty_result')
+        # Entry should be failed when title becomes empty
+        assert len(task.failed) == 1, 'entry should have been failed when title became empty'
+        assert 'Title became empty after erase operation' in task.failed[0]['reason']
+
+    def test_erase_regex_with_other_operations(self, execute_task):
+        task = execute_task('test_erase_regex_with_other_operations')
+        assert task.find_entry('entries', title='GOOD TITLE'), (
+            'regex erase combined with replace failed'
+        )
+
+    def test_erase_title_failure(self, execute_task):
+        task = execute_task('test_erase_title_failure')
+        # Entry should be failed when title becomes empty
+        assert len(task.failed) == 1, 'entry should have been failed when title became empty'
+        assert 'Title became empty after erase operation' in task.failed[0]['reason']
+        assert len(task.entries) == 0, 'no entries should remain when title is completely erased'


### PR DESCRIPTION
More vibing. Reduce redundant configuration when stripping away unwanted texts.

```
manipulate:
  - title:
      replace:
        regexp: '^advertisement.'
        format: ''
  - title:
      replace:
        regexp: '^more.ads.'
        format: ''
```

to

```
manipulate:
  - title:
      erase:
        - '^advertisement.'
        - '^more.ads.'
```
