### PR TITLE
chore: disable automatic corrections by the spell checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
     rev: v1.33.1
     hooks:
       - id: typos
+        args: [--force-exclude]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:


### PR DESCRIPTION
The decision to initially enable the spell-checker's auto-correct feature was based on its successful implementation in prominent repositories such as uv, ruff, and pytest.

However, following concerns raised by @gazpachoking, a re-evaluation was undertaken.

In light of the risk of erroneous auto-corrections and considering the relatively minor effort required for manual fixes, we will be moving forward without this feature enabled. This change is to mitigate the risk of introducing errors into the codebase.

The spell-checker will continue to identify and flag potential typos, but the final decision to implement a correction will remain with the author to ensure accuracy.

<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
