### PR TITLE
ci: move `pyproject-fmt` in CI from `pre-commit.ci` to `GitHub Actions`

### DIFF
--- a/.github/workflows/autofix-pyproject-fmt.yml
+++ b/.github/workflows/autofix-pyproject-fmt.yml
@@ -1,0 +1,37 @@
+name: autofix.ci
+on:
+  push:
+    branches: [develop]
+    paths:
+      - .github/workflows/autofix-pyproject-fmt.yml
+      - pyproject.toml
+  pull_request:
+    paths:
+      - .github/workflows/autofix-pyproject-fmt.yml
+      - pyproject.toml
+permissions: {}
+concurrency:
+  group: ${{ github.workflow_ref }}-${{ github.event.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+env:
+  PYTHON_VERSION: '3.13' # renovate: datasource=python-version depName=python
+  UV_VERSION: 0.8.13 # renovate: datasource=pypi depName=uv
+jobs:
+  uv-lock:
+    name: run pyproject-fmt
+    if: github.event.pull_request.user.login != 'renovate[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b # v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          version: ${{ env.UV_VERSION }}
+      - name: Run pyproject-fmt
+        run: uvx pyproject-fmt pyproject.toml
+      - name: Autofix
+        uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27 # v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
   autoupdate_schedule: quarterly
-  skip: [check-jsonschema, uv-lock]
+  skip: [check-jsonschema, pyproject-fmt, uv-lock]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0


### PR DESCRIPTION
Because `pyproject-fmt` conflicts with Renovate, move `pyproject-fmt` in CI from `pre-commit.ci` to GitHub Actions. In GitHub Actions, we can run `pyproject-fmt` only when `github.event.pull_request.user.login != 'renovate[bot]'`.