### PR TITLE
ci: do not let Codecov errors cause the test CI to fail

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   notify:
-    after_n_builds: 15
+    after_n_builds: 13
 
 coverage:
   status:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,9 +47,8 @@ jobs:
           files: core_test_results.xml,optional_test_results.xml
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
         with:
-          fail_ci_if_error: true
           name: ${{ matrix.operating-system }}-${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Since the Codecov report upload process occasionally fails, it should not cause the entire CI to fail.