### PR TITLE
chore(ruff): let Ruff format Python code inside docstrings.

### DIFF
--- a/flexget/components/notify/notification_framework.py
+++ b/flexget/components/notify/notification_framework.py
@@ -7,7 +7,9 @@ A plugin who wishes to send messages using this notification framework should im
 
     from flexget import plugin
 
-    send_notification = plugin.get_plugin_by_name('notification_framework').instance.send_notification
+    send_notification = plugin.get_plugin_by_name(
+        'notification_framework'
+    ).instance.send_notification
     send_notification('the title', 'the message', the_notifiers)
 
 Delivering Messages

--- a/flexget/db_schema.py
+++ b/flexget/db_schema.py
@@ -143,12 +143,14 @@ def upgrade(plugin: str) -> Callable:
     Example::
 
       from flexget import schema
+
+
       @schema.upgrade('your_plugin')
       def upgrade(ver, session):
-           if ver == 2:
-               # upgrade
-               ver = 3
-           return ver
+          if ver == 2:
+              # upgrade
+              ver = 3
+          return ver
     """
 
     def upgrade_decorator(upgrade_func):

--- a/flexget/plugins/input/plex.py
+++ b/flexget/plugins/input/plex.py
@@ -58,16 +58,16 @@ class InputPlex:
 
     Default parameters::
 
-      server           : localhost
-      port             : 32400
-      selection        : all
-      lowercase_title  : no
-      strip_non_alpha  : yes
-      strip_year       : yes
-      strip_parens     : no
+      server: localhost
+      port: 32400
+      selection: all
+      lowercase_title: no
+      strip_non_alpha: yes
+      strip_year: yes
+      strip_parens: no
       original_filename: no
-      unwatched_only   : no
-      fetch            : file
+      unwatched_only: no
+      fetch: file
 
     Example::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ line-length = 99
 extend-exclude = [ "flexget/ui" ]
 preview = true
 format.quote-style = "single"
+format.docstring-code-format = true # Ruff’s documentation claims that this will become the default behavior in the future, so we won’t need to specify it explicitly.
 lint.select = [ "ALL" ]
 lint.ignore = [
   "A",       # flake8-builtins


### PR DESCRIPTION
Currently, the Python code in docstrings is not formatted—some lines are too long, and some have indentation errors. This PR fixes those issues.