### PR TITLE
chore(docs): format the Python code in docs with blacken-docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,14 @@ repos:
       - id: prettier
         args: [--single-quote]
         exclude: .*tests/cassettes/.*
+  - repo: https://github.com/adamchainz/blacken-docs
+    rev: 1.19.1
+    hooks:
+      - id: blacken-docs
+        args: [--line-length, '98', --pyi]
+        language: python
+        additional_dependencies:
+          - black==25.1.0
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.11
     hooks:

--- a/docs/contributor/Topic guides/Running and writing tests.rst
+++ b/docs/contributor/Topic guides/Running and writing tests.rst
@@ -71,13 +71,12 @@ Within this file we will add our plugin.
    from flexget import plugin
    from flexget.event import event
 
-
    class Hello:
        pass
 
-   @event('plugin.register')
+   @event("plugin.register")
    def register_plugin():
-       plugin.register(Hello, 'hello', api_ver=2)
+       plugin.register(Hello, "hello", api_ver=2)
 
 Creating a test for it
 ----------------------
@@ -98,8 +97,8 @@ Write a new test case called ``tests/test_hello.py``.
 
        # The flexget test framework provides the execute_task fixture, which is a function to run tasks
        def test_feature(self, execute_task):
-         # run the task
-         execute_task('test')
+           # run the task
+           execute_task("test")
 
 Try running the test with pytest:
 
@@ -118,15 +117,14 @@ new field to each entry called ``hello`` with value ``True``.
    from flexget import plugin
    from flexget.event import event
 
-
    class Hello:
        def on_task_filter(self, task, config):
            for entry in task.entries:
-               entry['hello'] = True
+               entry["hello"] = True
 
-   @event('plugin.register')
+   @event("plugin.register")
    def register_plugin():
-       plugin.register(Hello, 'hello', api_ver=2)
+       plugin.register(Hello, "hello", api_ver=2)
 
 Adding more tests
 -----------------
@@ -146,10 +144,10 @@ Let's supplement the testsuite with the test:
        """
 
        def test_feature(self, execute_task):
-         # run the task
-         task = execute_task('test')
-         for entry in task.entries:
-             assert entry.get('hello') == True
+           # run the task
+           task = execute_task("test")
+           for entry in task.entries:
+               assert entry.get("hello") == True
 
 Testing network-dependent code
 ==============================


### PR DESCRIPTION
Currently, the Python code blocks in our documentation are not formatted. Even the Ruff repository uses `blacken-docs` to format their docs. Therefore, I believe using `blacken-docs` to format our documentation is a wise decision.

See https://github.com/astral-sh/ruff/blob/5d52902e186cea6fa73dac1ceebf53208f6e08ba/.pre-commit-config.yaml#L56-L58
