### PR TITLE
chore: fix ResourceWarning "unclosed file <_io.BufferedReader name=..."

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,14 +240,14 @@ max_supported_python = '3.14'
 keep_full_version = true
 
 [tool.pytest.ini_options]
-addopts = '-p no:legacypath --strict-markers'
+addopts = '-p no:legacypath --strict-config --strict-markers'
 filterwarnings = [
   'error',
   "ignore:jsonschema.RefResolver is deprecated as of v4.18.0:DeprecationWarning:flask_restx.api",                            # Can’t be fixed, consider migrating to `flask-smorest` to eliminate it. See https://github.com/python-restx/flask-restx/issues/633#issuecomment-2962412240
   "ignore:'count' is passed as positional argument:DeprecationWarning:feedparser.html",                                      # Can’t be fixed, feedparser is no longer maintained unless we migrate to an alternative library.
   'ignore:tzname PST identified but not understood.:dateutil.parser._parser.UnknownTimezoneWarning:dateutil.parser._parser', # needs investigation, tests/test_input_sites.py::TestInputSites::test_apple_trailers_simple  tests/test_input_sites.py::TestInputSites::test_apple_trailers
   'ignore:tzname EDT identified but not understood.:dateutil.parser._parser.UnknownTimezoneWarning:dateutil.parser._parser', # needs investigation, tests/test_rss.py::TestRssOnline::test_rss_online
-  "ignore:unclosed file <_io.BufferedReader name=':ResourceWarning",                                                         # needs investigation, tests/api_tests/test_cached_api.py::TestCachedAPI::test_cached_api
+  "ignore:unclosed file <_io.BufferedReader name=':ResourceWarning:telegram._utils.files",                                   # Can be removed once `python-telegram-bot` makes a new release
   'ignore:Failed to load HostKeys from:UserWarning:pysftp',                                                                  # Can’t be fixed, https://stackoverflow.com/q/56521549 It's a bug in pysftp 0.2.9, not in 0.2.8
 ]
 markers = [

--- a/tests/api_tests/test_cached_api.py
+++ b/tests/api_tests/test_cached_api.py
@@ -18,10 +18,9 @@ class TestCachedAPI:
 
         assert response.status_code == 200
 
-        rsp = api_client.get(f'/cached/?url={image_url}')
-        assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
+        with api_client.get(f'/cached/?url={image_url}') as rsp:
+            assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
+            assert rsp.data == response.content
 
-        assert rsp.data == response.content
-
-        rsp = api_client.get(f'/cached/?url={image_url}?force=true')
-        assert rsp.status_code == 200, f'Response code is {rsp.status_code}'
+        with api_client.get(f'/cached/?url={image_url}?force=true') as rsp:
+            assert rsp.status_code == 200, f'Response code is {rsp.status_code}'


### PR DESCRIPTION
Fixed a `ResourceWarning`. The other one is caused by the **python-telegram-bot** library and I’ve already reported it to them.
