### PR TITLE
ci: reuse workflow configuration with YAML anchors

### DIFF
--- a/.github/workflows/autofix-uv.lock.yml
+++ b/.github/workflows/autofix-uv.lock.yml
@@ -2,15 +2,12 @@ name: autofix.ci
 on:
   push:
     branches: [develop]
-    paths:
+    paths: &paths
       - .github/workflows/autofix-uv.lock.yml
       - pyproject.toml
       - uv.lock
   pull_request:
-    paths:
-      - .github/workflows/autofix-uv.lock.yml
-      - pyproject.toml
-      - uv.lock
+    paths: *paths
 permissions: {}
 concurrency:
   group: ${{ github.workflow_ref }}-${{ github.event.number || github.ref || github.run_id }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,9 +2,9 @@ name: GitHub Actions security analysis with zizmor
 on:
   push:
     branches: [develop]
-    paths: [.github/workflows/*]
+    paths: &paths [.github/workflows/*]
   pull_request:
-    paths: [.github/workflows/*]
+    paths: *paths
 permissions: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref || github.run_id }}


### PR DESCRIPTION
GitHub Actions now supports YAML anchors, a top request from the GitHub community. With YAML anchors, you can reuse configuration across your workflows and ensure better conformance with the YAML spec.

See https://github.blog/changelog/2025-09-18-actions-yaml-anchors-and-non-public-workflow-templates/


