### PR TITLE
[Fix] `tmdb_lookup` crashes due to new undocumented field from the API

### DIFF
--- a/flexget/components/tmdb/api_tmdb.py
+++ b/flexget/components/tmdb/api_tmdb.py
@@ -24,9 +24,10 @@ from flexget.event import event
 from flexget.manager import Session
 from flexget.utils import requests
 from flexget.utils.database import json_synonym, with_session, year_property
+from flexget.utils.sqlalchemy_utils import table_add_column
 
 logger = logger.bind(name='api_tmdb')
-Base = db_schema.versioned_base('api_tmdb', 6)
+Base = db_schema.versioned_base('api_tmdb', 7)
 
 # This is a FlexGet API key
 API_KEY = 'bdfc018dbdb7c243dc7cb1454ff74b95'
@@ -79,6 +80,10 @@ def tmdb_request(endpoint, **params):
 def upgrade(ver, session):
     if ver is None or ver <= 5:
         raise db_schema.UpgradeImpossible
+    if ver == 6:
+        logger.info('Adding `iso_3166_1` column to tmdb_images table.')
+        table_add_column('tmdb_images', 'iso_3166_1', Unicode, session)
+        ver = 7
     return ver
 
 
@@ -228,6 +233,7 @@ class TMDBImage(Base):
     vote_average = Column(Float)
     vote_count = Column(Integer)
     iso_639_1 = Column(Unicode)
+    iso_3166_1 = Column(Unicode)
     type = Column(Unicode)
     __mapper_args__ = {'polymorphic_on': type}
 


### PR DESCRIPTION
### Motivation for changes:
Hundreds of crash logs popped up after a couple or so runs of movie discover tasks with `tmdb_lookup` on them.

I narrowed it down to a new undocumented field in the response from the Images endpoint of the TMDB API.

`$ curl "https://api.themoviedb.org/3/movie/264166/images?api_key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"`
<details><summary>Response</summary>

```json
{
  "backdrops": [
    {
      "aspect_ratio": 1.777,
      "height": 844,
      "iso_3166_1": "XX",
      "iso_639_1": "xx",
      "file_path": "/sSjyXL9xngmHQXtiOO6xOS3NfGr.jpg",
      "vote_average": 0,
      "vote_count": 0,
      "width": 1500
    },
    {
      "aspect_ratio": 1.777,
      "height": 844,
      "iso_3166_1": "XX",
      "iso_639_1": "xx",
      "file_path": "/2jM3Zs7U16LTbAVsHaqzhkIS8QO.jpg",
      "vote_average": 0,
      "vote_count": 0,
      "width": 1500
    }
  ],
  "id": 264166,
  "logos": [],
  "posters": [
    {
      "aspect_ratio": 0.667,
      "height": 1500,
      "iso_3166_1": "US",
      "iso_639_1": "en",
      "file_path": "/6hUKnGZTVK8Hyx1mMluX0qMMlac.jpg",
      "vote_average": 3.334,
      "vote_count": 1,
      "width": 1000
    },
    {
      "aspect_ratio": 0.674,
      "height": 895,
      "iso_3166_1": "US",
      "iso_639_1": "en",
      "file_path": "/7cJGQPN53BV2hHvglsAVlEGbllN.jpg",
      "vote_average": 0,
      "vote_count": 0,
      "width": 603
    },
    {
      "aspect_ratio": 0.667,
      "height": 2100,
      "iso_3166_1": "US",
      "iso_639_1": "en",
      "file_path": "/tzGF9brOHiHYMMDBYfJAJegAkra.jpg",
      "vote_average": 0,
      "vote_count": 0,
      "width": 1400
    }
  ]
}
```

</details> 

### Detailed changes:
- Added `iso_3166_1` column to the `tmdb_images` table

The API (https://developer.themoviedb.org/reference/movie-images) doesn't have this field documented, only `iso_639_1`, however `iso_3166_1` was present in some responses as pointed above, breaking the serialization.
