### PR TITLE
chore: make Renovate read the correct Read the Docs Python version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,11 +30,20 @@
     {
       customType: 'regex',
       managerFilePatterns: ['/^\\.readthedocs\\.yaml$/'],
-      matchStrings: [
-        'python:\\s*["\']?(?<currentValue>.+?)["\']?\\s*# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)\\s',
-      ],
+      matchStrings: ['python:\\s*["\']?(?<currentValue>.+?)["\']?\\s+'],
+      depNameTemplate: 'python',
+      versioningTemplate: 'semver-coerced',
+      datasourceTemplate: 'custom.readthedocsPython',
     },
   ],
+  customDatasources: {
+    readthedocsPython: {
+      defaultRegistryUrlTemplate: 'https://raw.githubusercontent.com/readthedocs/readthedocs.org/master/readthedocs/rtd_tests/fixtures/spec/v2/schema.json',
+      transformTemplates: [
+        '{"releases":properties.build.properties.tools.properties.python.enum[$match($,/^\\d+\\.\\d+$/)].{"version":$}}',
+      ],
+    },
+  },
   npm: {
     enabled: false,
   },

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-lts-latest
   tools:
-    python: '3.13' # renovate: datasource=python-version depName=python
+    python: '3.13'
   apt_packages:
     - librsvg2-bin
   jobs:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
The Python used by Read the Docs for building is not updated immediately after a new CPython release.

This PR uses the correct datasource to prevent Renovate from creating incorrect PRs.
