### PR TITLE
build(docker): stop loading APK cache to try to resolve occasional `apk update` errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM docker.io/python:3.11-alpine@sha256:b8cb949a9d1d675a4f71ac10a5dead3d817ee8f2e05bb227597dc2b42b02a317 AS builder
 ENV PYTHONUNBUFFERED=1
 
-RUN --mount=type=cache,target=/var/cache/apk \
-    apk update && apk add --upgrade \
+RUN apk update && apk add --upgrade \
         ca-certificates \
         nodejs \
         build-base \


### PR DESCRIPTION


<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
I suspect that the occasional APK errors might be related to a corrupted cache.

We can try disabling the cache to see if the errors still occur in the future.
