### PR TITLE
[add] qBittorrent: add option for incomplete save path

### DIFF
--- a/flexget/plugins/clients/qbittorrent.py
+++ b/flexget/plugins/clients/qbittorrent.py
@@ -27,6 +27,7 @@ class OutputQBitTorrent:
           use_ssl: <SSL> (default: False)
           verify_cert: <VERIFY> (default: True)
           path: <OUTPUT_DIR> (default: (none))
+          incomplete_path: <INCOMPLETE_OUTPUT_DIR> (default: (none))
           label: <LABEL> (default: (none))
           tags: <TAGS> (default: (none))
           maxupspeed: <torrent upload speed limit> (default: 0)
@@ -49,6 +50,7 @@ class OutputQBitTorrent:
                     'use_ssl': {'type': 'boolean'},
                     'verify_cert': {'type': 'boolean'},
                     'path': {'type': 'string'},
+                    'incomplete_path': {'type': 'string'},
                     'label': {'type': 'string'},
                     'tags': {'type': 'array', 'items': {'type': 'string'}},
                     'maxupspeed': {'type': 'integer'},
@@ -237,6 +239,15 @@ class OutputQBitTorrent:
             except RenderError as e:
                 logger.error('Error setting path for {}: {}', entry['title'], e)
 
+            try:
+                download_path = entry.render(
+                    entry.get('incomplete_path', config.get('incomplete_path', ''))
+                )
+                if download_path:
+                    form_data['downloadPath'] = download_path
+            except RenderError as e:
+                logger.error('Error setting incomplete_path for {}: {}', entry['title'], e)
+
             label = entry.render(entry.get('label', config.get('label', '')))
             if label:
                 form_data['label'] = label  # qBittorrent v3.3.3-
@@ -287,6 +298,7 @@ class OutputQBitTorrent:
                 else:
                     logger.info('Url: {}', entry.get('url'))
                 logger.info('Save path: {}', form_data.get('savepath'))
+                logger.info('Download path: {}', form_data.get('downloadPath'))
                 logger.info('Label: {}', form_data.get('label'))
                 logger.info('Tags: {}', form_data.get('tags'))
                 logger.info('Paused: {}', form_data.get('paused', 'false'))

--- a/tests/cassettes/test_qbittorrent.TestQbittorrent.test_incomplete_path.yml
+++ b/tests/cassettes/test_qbittorrent.TestQbittorrent.test_incomplete_path.yml
@@ -1,0 +1,141 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Cookie:
+      - SID=acnKad9OWbfB0a5nk8mnkbmf1/tNdis2
+      User-Agent:
+      - python-requests/2.32.5
+    method: GET
+    uri: http://localhost:8080/api/v2/app/webapiVersion
+  response:
+    body:
+      string: 2.11.4
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '6'
+      content-security-policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;
+        script-src 'self' 'unsafe-inline'; object-src 'none'; form-action 'self';
+        frame-src 'self' blob:; frame-ancestors 'self';
+      content-type:
+      - text/plain; charset=UTF-8
+      cross-origin-opener-policy:
+      - same-origin
+      date:
+      - Wed, 22 Oct 2025 11:47:58 GMT
+      referrer-policy:
+      - same-origin
+      set-cookie:
+      - SID=qMHzQLDzjqLDMyLTqNotALIST6OWKwdn; HttpOnly; SameSite=Strict; path=/
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Cookie:
+      - SID=qMHzQLDzjqLDMyLTqNotALIST6OWKwdn
+      User-Agent:
+      - python-requests/2.32.5
+    method: GET
+    uri: http://localhost:8080/api/v2/torrents/info?hashes=2a8959bed2be495bb0e3ea96f497d873d5faed05
+  response:
+    body:
+      string: '[]'
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '2'
+      content-security-policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;
+        script-src 'self' 'unsafe-inline'; object-src 'none'; form-action 'self';
+        frame-src 'self' blob:; frame-ancestors 'self';
+      content-type:
+      - application/json
+      cross-origin-opener-policy:
+      - same-origin
+      date:
+      - Wed, 22 Oct 2025 11:47:58 GMT
+      referrer-policy:
+      - same-origin
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "--3439360f07642a151a2cfb46296563f6\r\nContent-Disposition: form-data; name=\"downloadPath\"\r\n\r\n/tmp\r\n--3439360f07642a151a2cfb46296563f6\r\nContent-Disposition:
+      form-data; name=\"urls\"\r\n\r\nmagnet:?xt=urn:btih:2a8959bed2be495bb0e3ea96f497d873d5faed05&dn=some.thing.720p\r\n--3439360f07642a151a2cfb46296563f6--\r\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '299'
+      Content-Type:
+      - multipart/form-data; boundary=3439360f07642a151a2cfb46296563f6
+      Cookie:
+      - SID=qMHzQLDzjqLDMyLTqNotALIST6OWKwdn
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: http://localhost:8080/api/v2/torrents/add
+  response:
+    body:
+      string: Ok.
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '3'
+      content-security-policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;
+        script-src 'self' 'unsafe-inline'; object-src 'none'; form-action 'self';
+        frame-src 'self' blob:; frame-ancestors 'self';
+      content-type:
+      - text/plain; charset=UTF-8
+      cross-origin-opener-policy:
+      - same-origin
+      date:
+      - Wed, 22 Oct 2025 11:47:58 GMT
+      referrer-policy:
+      - same-origin
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_qbittorrent.py
+++ b/tests/test_qbittorrent.py
@@ -17,6 +17,9 @@ class TestQbittorrent:
           ratio_limit:
             qbittorrent:
               ratio_limit: 1.65
+          incomplete_path:
+            qbittorrent:
+              incomplete_path: /tmp
         """
 
     def test_default(self, execute_task):
@@ -25,4 +28,8 @@ class TestQbittorrent:
 
     def test_ratio_limit(self, execute_task):
         task = execute_task('ratio_limit')
+        assert task.accepted
+
+    def test_incomplete_path(self, execute_task):
+        task = execute_task('incomplete_path')
         assert task.accepted


### PR DESCRIPTION
support setting the incomplete save path, where qBittorrent saves the incomplete file(s) while the torrent is still downloading

resolves https://github.com/Flexget/Flexget/discussions/4059

<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
