### PR TITLE
chore: use `codecov/codecov-action` instead of `codecov/test-results-action`

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,6 +2,9 @@ codecov:
   notify:
     after_n_builds: 13
 
+comment:
+  require_changes: 'coverage_drop OR uncovered_patch'
+
 coverage:
   status:
     patch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,10 @@ jobs:
         run: uv run --group all pytest -m 'require_optional_deps' -n logical --allow-hosts 127.0.0.1 --cov --cov-append --cov-branch --cov-report=xml --dist loadgroup --junit-xml optional_test_results.xml
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
         with:
           files: core_test_results.xml,optional_test_results.xml
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,6 @@ repos:
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.34.1
     hooks:
-      - id: check-codecov
       - id: check-github-issue-config
       - id: check-github-issue-forms
       - id: check-readthedocs


### PR DESCRIPTION
Since `codecov/test-results-action` has been deprecated https://github.com/codecov/test-results-action?tab=readme-ov-file#%EF%B8%8F-deprecation-warning-%EF%B8%8F), we should migrate to `codecov/codecov-action`.
