### PR TITLE
add(plugin): Drop "input did not return anything" warning to verbose …

### DIFF
--- a/flexget/components/series/configure_series.py
+++ b/flexget/components/series/configure_series.py
@@ -54,7 +54,11 @@ class ConfigureSeries(plugin_series.FilterSeriesBase):
                 logger.warning('Error during input plugin {}: {}', input_name, e)
                 continue
             if not result:
-                logger.warning('Input {} did not return anything', input_name)
+                msg = f'Input {input_name} did not return anything'
+                if getattr(task, 'no_entries_ok', False):
+                    logger.verbose(msg)
+                else:
+                    logger.warning(msg)
                 continue
 
             for entry in result:

--- a/flexget/utils/tools.py
+++ b/flexget/utils/tools.py
@@ -501,7 +501,11 @@ def aggregate_inputs(task: Task, inputs: list[dict]) -> list[Entry]:
                 continue
 
             if not result:
-                logger.warning('Input {} did not return anything', input_name)
+                msg = f'Input {input_name} did not return anything'
+                if getattr(task, 'no_entries_ok', False):
+                    logger.verbose(msg)
+                else:
+                    logger.warning(msg)
                 continue
 
             for entry in result:


### PR DESCRIPTION
The change was seemingly made years ago to [plugins/input/inputs.py](https://github.com/Flexget/Flexget/blob/f7fba3f29412118e34ffd14a72d320616bdb0313/flexget/plugins/input/inputs.py#L47), but I'm getting warnings from utils.

For example, I'm getting it when a movie list from Trakt is currently empty, which is quite normal.