### PR TITLE
fix: anilist plugin no longer crashes when API returns None

### DIFF
--- a/flexget/entry.py
+++ b/flexget/entry.py
@@ -296,6 +296,9 @@ class Entry(LazyDict, Serializer):
         :param ignore_none:
           Ignore any None values, do not record it to the Entry
         """
+        if source_item is None:
+            logger.debug('source_item is None, skipping update_using_map')
+            return
         func = dict.get if isinstance(source_item, dict) else getattr
         for field, value in field_map.items():
             if isinstance(value, str):

--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -283,10 +283,17 @@ class AniList:
 def relations_lookup(entry: Entry):
     ids = {}
     try:
-        ids: dict[str, str | int] = requests.post(
+        response = requests.post(
             'https://relations.yuna.moe/api/v2/ids',
             json={'anilist': entry.get('al_id', eval_lazy=False)},
-        ).json()
+        )
+        ids: dict[str, str | int] = response.json()
+        if ids is None:
+            logger.warning(
+                'Relations API returned None for AniList ID {}',
+                entry.get('al_id', eval_lazy=False),
+            )
+            ids = {}
         logger.debug('Additional IDs: {}', ids)
     except RequestException as e:
         logger.warning('Error fetching additional IDs: {}', e)


### PR DESCRIPTION
Vibe-fixes for #4702 
