### PR TITLE
Fix flaky tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,6 @@ def scrub_txnid(request):
 
 vcr = VCR(
     cassette_library_dir=str(VCR_CASSETTE_DIR),
-    drop_unused_requests=True,
     record_mode=VCR_RECORD_MODE,
     custom_patches=(
         (client, 'HTTPSConnection', VCRHTTPSConnection),


### PR DESCRIPTION
In #4776, I used the new VCR.py v8 option `drop_unused_requests=True`, but it causes tests to fail when parameterization leads to different possible requests being made.