### PR TITLE
Avoid covert quality again when read from database

### DIFF
--- a/flexget/utils/database.py
+++ b/flexget/utils/database.py
@@ -147,7 +147,10 @@ class CaseInsensitiveWord(Comparator):
 
 def quality_property(text_attr):
     def getter(self):
-        return qualities.get(getattr(self, text_attr))
+        try:
+            return qualities.get(getattr(self, text_attr))
+        except (ValueError, AttributeError):
+            return qualities.Quality(getattr(self, text_attr))
 
     def setter(self, value):
         if isinstance(value, str):

--- a/flexget/utils/database.py
+++ b/flexget/utils/database.py
@@ -147,7 +147,7 @@ class CaseInsensitiveWord(Comparator):
 
 def quality_property(text_attr):
     def getter(self):
-        return qualities.Quality(getattr(self, text_attr))
+        return qualities.get(getattr(self, text_attr))
 
     def setter(self, value):
         if isinstance(value, str):


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please:
* Read our pull request guidelines:
  https://github.com/Flexget/Flexget/blob/develop/.github/CONTRIBUTING.md#pull-requests
* Include a description of the proposed changes and how to test them.
-->
[fix] Avoid double parsing the quality string when read from database. Which cause `hybrid_hdr` convert to `hdr`.  https://github.com/Flexget/Flexget/issues/4760

Closes #4760