### PR TITLE
fix: improve arm-server usage

### DIFF
--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -284,7 +284,7 @@ def relations_lookup(entry: Entry):
     ids = {}
     try:
         response = requests.get(
-            'https://relations.yuna.moe/api/v2/ids',
+            'https://arm.haglund.dev/api/v2/ids',
             params={'anilist': entry.get('al_id', eval_lazy=False)},
         )
         ids: dict[str, str | int] = response.json()

--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -283,9 +283,9 @@ class AniList:
 def relations_lookup(entry: Entry):
     ids = {}
     try:
-        response = requests.post(
+        response = requests.get(
             'https://relations.yuna.moe/api/v2/ids',
-            json={'anilist': entry.get('al_id', eval_lazy=False)},
+            params={'anilist': entry.get('al_id', eval_lazy=False)},
         )
         ids: dict[str, str | int] = response.json()
         if ids is None:


### PR DESCRIPTION
### Motivation for changes:

i was checking the request logs for arm-server and saw a lot of POST requests from FlexGet so i went to check out how you were using it

the code is only asking for a single entry in each request, while the POST endpoint is meant for bulk requests since it takes an object or array of objects for the body.

when only requesting one entry you can use GET instead, which lets cloudflare cache the requests, speeding them up and reducing bandwidth :)

you might also want to implement some batch functionality for requests and go back to POST, maybe just something simple as batch any calls within 50ms of each other

### Detailed changes:

- replaced the POST+json request with GET+params
- replaced the domain with the new one

### Log and/or tests output (preferably both):

i have no idea if any tests cover this or how to set up the project to test it manually :(
