### PR TITLE
feat: make automatic configuration reloading the default behavior

### DIFF
--- a/flexget/_version.py
+++ b/flexget/_version.py
@@ -10,4 +10,4 @@ and update the version again for continued development.
 NOTE: Should always have all three parts of the version, even on major and minor bumps. i.e. 4.0.0.dev, not 4.0.dev
 """
 
-__version__ = '3.18.55.dev'
+__version__ = '3.19.0.dev'

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -129,7 +129,7 @@ class Manager:
             logger.info('last manager was not torn down correctly')
 
         self.args = args
-        self.autoreload_config = False
+        self.autoreload_config = True
         self.config_file_hash: str | None = None
         self._config_path: Path | None = None
         self.log_filename: str = ''
@@ -469,8 +469,8 @@ class Manager:
                 return
             if options.daemonize:
                 self.daemonize()
-            if options.autoreload_config:
-                self.autoreload_config = True
+            if options.no_autoreload_config:
+                self.autoreload_config = False
             try:
                 signal.signal(signal.SIGTERM, self._handle_sigterm)
             except ValueError as e:

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -469,6 +469,10 @@ class Manager:
                 return
             if options.daemonize:
                 self.daemonize()
+            if options.autoreload_config:
+                logger.warning(
+                    'The "--autoreload-config" flag is now default and deprecated. It is slated for removal in a future version, after which its use will cause an error. Please remove it from your command.'
+                )
             if options.no_autoreload_config:
                 self.autoreload_config = False
             try:

--- a/flexget/options.py
+++ b/flexget/options.py
@@ -546,6 +546,11 @@ class CoreArgumentParser(ArgumentParser):
         start_parser = daemon_parser.add_subparser('start', help='start the daemon')
         start_parser.add_argument('-d', '--daemonize', action='store_true', help=daemonize_help)
         start_parser.add_argument(
+            '--autoreload-config',
+            action='store_true',
+            help='This option is already the default behavior. It is retained only for compatibility and will be removed in a future version. Please stop using this option.',
+        )
+        start_parser.add_argument(
             '--no-autoreload-config',
             action='store_true',
             help='do not automatically reload the config from disk if the daemon detects any changes',

--- a/flexget/options.py
+++ b/flexget/options.py
@@ -546,9 +546,9 @@ class CoreArgumentParser(ArgumentParser):
         start_parser = daemon_parser.add_subparser('start', help='start the daemon')
         start_parser.add_argument('-d', '--daemonize', action='store_true', help=daemonize_help)
         start_parser.add_argument(
-            '--autoreload-config',
+            '--no-autoreload-config',
             action='store_true',
-            help='automatically reload the config from disk if the daemon detects any changes',
+            help='do not automatically reload the config from disk if the daemon detects any changes',
         )
         start_parser.add_argument(
             '--enable-tray-icon',


### PR DESCRIPTION
### Motivation for changes:
Paranoidi pointed out in [#4860](https://github.com/Flexget/Flexget/discussions/4860#discussioncomment-15962259) that we should make `--autoreload-config` the default behavior and add `--no-autoreload-config` to disable it.
### Detailed changes:
Make `--autoreload-config` the default behavior and add `--no-autoreload-config` to disable it.

### Addressed issues/feature requests:

- Fixes #4860
