### PR TITLE
Update API request parameters in anilist.py

### DIFF
--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -285,7 +285,10 @@ def relations_lookup(entry: Entry):
     try:
         response = requests.get(
             'https://arm.haglund.dev/api/v2/ids',
-            params={'anilist': entry.get('al_id', eval_lazy=False)},
+            params={
+                "source": "anilist",
+                "id": entry.get("al_id", eval_lazy=False),
+            },
         )
         ids: dict[str, str | int] = response.json()
         if ids is None:

--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -286,8 +286,8 @@ def relations_lookup(entry: Entry):
         response = requests.get(
             'https://arm.haglund.dev/api/v2/ids',
             params={
-                "source": "anilist",
-                "id": entry.get("al_id", eval_lazy=False),
+                'source': 'anilist',
+                'id': entry.get('al_id', eval_lazy=False),
             },
         )
         ids: dict[str, str | int] = response.json()


### PR DESCRIPTION
### Motivation for changes:

Currently the API request requests
https://arm.haglund.dev/api/v2/ids?anilist={id}
which returns 400 bad request.


### Detailed changes:

Fixed to be https://arm.haglund.dev/api/v2/ids?source=anilist&id={id}