### PR TITLE
Add season roman numeral check for custom ep_regexp

### DIFF
--- a/flexget/utils/parsers/series.py
+++ b/flexget/utils/parsers/series.py
@@ -577,7 +577,11 @@ class SeriesParser(TitleParser):
                     return False
                 # Convert season and episode to integers
                 try:
-                    season = int(season)
+                    try:
+                        season = int(season)
+                    except ValueError:
+                        # in case user's custom ep_regex tries to match roman numerals
+                        season = self.roman_to_int(season)
                     if not episode.isdigit():
                         try:
                             idx = self.english_numbers.index(str(episode).lower())


### PR DESCRIPTION
### Motivation for changes:

### Detailed changes:

- Additional check for roman numerals in the series plugin.
- This is a minimal change, and should affect the rest of the project

### Config usage if relevant (new plugin or updated schema):

```yml
variables:
  roman: 'X{0,3}(?:IX|XI{0,4}|VI{0,4}|IV|V|I{1,4})'

tasks:
  erai-raws:
    discover:
      what:
        - next_series_episodes:
            from_start: yes
      from:
        - search_rss:
            url: 'https://nyaa.si/?page=rss&u=Erai-raws&q={{search_term|replace("%20","+")|re_replace("\+S\d+E\d+|\+\d+x\d+","")}}'
            all_entries: no
    series:
      default:
        - dungeon ni deai:
            ep_regexp: '\b({? roman ?})\b.*?(\d{1,3})\b'
      settings:
        default:
          identified_by: ep
```

### Log and/or tests output (preferably both):

```
DEBUG    parser_internal erai-raws       Parsing series: `[Erai-raws] Dungeon ni Deai wo Motomeru no wa Machigatteiru Darou ka: Familia Myth V - 11 (ITA) [720p]` kwargs: {'name': 'dungeon ni deai', 'identified_by': 'ep', 'alternate_names': [], 'name_regexps': [], 'strict_name': False, 'allow_groups': [], 'date_yearfirst': None, 'date_dayfirst': None, 'special_ids': [], 'prefer_specials': None, 'assume_special': None, 'ep_regexps': ['\\b(X{0,3}(?:IX|XI{0,4}|VI{0,4}|IV|V|I{1,4}))\\b.*?(\\d{1,3})\\b'], 'date_regexps': [], 'sequence_regexps': [], 'id_regexps': []} 
TRACE    seriesparser  erai-raws       name: dungeon ni deai data: [Erai-raws] Dungeon ni Deai wo Motomeru no wa Machigatteiru Darou ka: Familia Myth V - 11 (ITA) [720p]                                                                                                                                                                                                                                                                                                                                                                                                              
TRACE    seriesparser  erai-raws       NAME SUCCESS: ^(?:(?:\[[^\[\]]*\])|(?:HD.720p?:)|(?:HD.1080p?:)|(?:HD.2160p?:))?(?:[^\w&]|_)*(dungeon(?:[^\w&]|_)*ni(?:[^\w&]|_)*deai)(?:\b|_)(?:[^\w&]|_)* matched to [Erai-raws] Dungeon ni Deai wo Motomeru no wa Machigatteiru Darou ka: Familia Myth V - 11 (ITA) [720p]                                                                                                                                                                                                                                                                   
TRACE    seriesparser  erai-raws       data stripped:  wo motomeru no wa machigatteiru darou ka: familia myth v - 11 (ita) [720p] [erai-raws]                                                                                                                                                                                                                                                                                                                                                                                                                                          
TRACE    seriesparser  erai-raws       quality detected, using remaining data ` wo motomeru no wa machigatteiru darou ka: familia myth v - 11 (ita) [] [erai-raws] `                                                                                                                                                                                                                                                                                                                                                                                                                   
TRACE    seriesparser  erai-raws       data for date/ep/id parsing 'wo motomeru no wa machigatteiru darou ka familia myth v 11 ita erai raws'                                                                                                                                                                                                                                                                                                                                                                                                                                          
TRACE    seriesparser  erai-raws       found episode number with regexp \b(X{0,3}(?:IX|XI{0,4}|VI{0,4}|IV|V|I{1,4}))\b.*?(\d{1,3})\b (('v', '11'))                                                                                                                                                                                                                                                                                                                                                                                                                                     
DEBUG    parser_internal erai-raws       Parsing result: <SeriesParser(data=[Erai-raws] Dungeon ni Deai wo Motomeru no wa Machigatteiru Darou ka: Familia Myth V - 11 (ITA) [720p],name=dungeon ni deai,id=(5, 11),id_type=ep,identified_by=ep,season=5,season_pack=None,episode=11,quality=720p,proper=0,status=OK)> (in 0.5574449999998787 ms)                                                                                                                                                                                                                                       
DEBUG    series        erai-raws       `[Erai-raws] Dungeon ni Deai wo Motomeru no wa Machigatteiru Darou ka: Familia Myth V - 11 (ITA) [720p]` detected as `<SeriesParseResult(data=[Erai-raws] Dungeon ni Deai wo Motomeru no wa Machigatteiru Darou ka: Familia Myth V - 11 (ITA) [720p],name=dungeon ni deai,id=(5, 11),season=5,season_pack=None,episode=11,quality=720p,proper=0,special=False,status=OK)>`, field: `title`                                                                                                                                                      
TRACE    entry         erai-raws       ENTRY SET: series_parser = <flexget.components.parsing.parsers.parser_common.SeriesParseResult object at 0x7fa33010c890>                                                                                                                                                                                                                                                                                                                                                                                                                        
TRACE    entry         erai-raws       ENTRY SET: quality = <Quality(resolution=720p,source=unknown,codec=unknown,color_range=unknown,audio=unknown)>                                                                                                                                                                                                                                                                                                                                                                                                                                  
TRACE    metainfo_quality erai-raws       Found quality 720p for [Erai-raws] Dungeon ni Deai wo Motomeru no wa Machigatteiru Darou ka: Familia Myth V - 11 (ITA) [720p]                                                                                                                                                                                                                                                                                                                                                                                                                
TRACE    entry         erai-raws       ENTRY SET: series_episode = 11                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
TRACE    entry         erai-raws       ENTRY SET: series_id = 'S05E11'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
```

---

I know that this setup is unpopular. A more common config would be to hard-code the season number.

```yml
    series:
      default:
        - "dungeon ni deai wo motomeru no wa machigatteiru darou ka: familia myth v"
      settings:
        default:
          identified_by: sequence
```

But my setup has a benefit of keeping track of the season number in the database, and it's been working fine for years.