### PR TITLE
ci: remove redundant release check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,6 @@ jobs:
           token: ${{ secrets.flexgetbot_pat }}
           persist-credentials: true
           fetch-depth: 0
-      - name: Check Commit Status # Currently, the GitHub frontend private API is being used, which may change at any time. Using the public API, however, is quite complex, as it requires querying both "Get the combined status for a specific reference" and "List check runs for a Git reference", and ensuring that both are 'success'.
-        run: |
-          commit_state=$(curl -sf -H 'Accept: application/json' 'https://github.com/${{ github.repository }}/commits/deferred_commit_data/${{ github.ref_name }}' | jq -r --arg commit_id "$(git rev-parse HEAD)" '.deferredCommits[] | select(.oid == $commit_id) | .statusCheckStatus.state // "not_found"')
-          if [[ "$commit_state" != "success" ]]; then
-            echo "::error::Status is '$commit_state'."
-            exit 1
-          fi
       - name: Install uv and Python
         uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7
         with:


### PR DESCRIPTION


### Motivation for changes:
I’ve been reconsidering the necessity of the commit status check in our release workflow. Since all changes are integrated via pull requests and **managed through a merge queue**, this additional verification feels redundant.

The merge queue already ensures that every PR is tested against the latest base branch before merging, effectively guaranteeing a green build on the main branch. Most established projects don't verify commit statuses again at the release stage, and our current implementation relies on _private_ GitHub APIs, which poses a long-term maintenance risk.

As long as contributors with write access continue to use the queue **rather than pushing directly to the repository**, we can safely remove this check without compromising release quality.