### PR TITLE
Fix daemon's parse_args ANSI colors

### DIFF
--- a/flexget/ipc.py
+++ b/flexget/ipc.py
@@ -8,6 +8,7 @@ import threading
 import unittest.mock
 from typing import TYPE_CHECKING
 
+import rich.text
 import rpyc
 from loguru import logger
 from rpyc.utils.server import ThreadedServer
@@ -99,7 +100,7 @@ class DaemonService(rpyc.Service):
 
     @property
     def client_out_stream(self):
-        return RemoteStream(self._conn.root.console)
+        return RemoteStream(self._conn.root.write)
 
     def client_log_sink(self, message):
         return self._conn.root.log_sink(message)
@@ -120,6 +121,11 @@ class ClientService(rpyc.Service):
 
     def exposed_console(self, text, *args, **kwargs):
         text = rpyc.classic.obtain(text)
+        terminal.console(text, *args, **kwargs)
+
+    def exposed_write(self, text, *args, **kwargs):
+        text = rpyc.classic.obtain(text)
+        text = rich.text.Text.from_ansi(text)
         terminal.console(text, *args, **kwargs)
 
     def exposed_log_sink(self, message):

--- a/flexget/ipc.py
+++ b/flexget/ipc.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 import random
 import string
 import threading
@@ -74,14 +75,15 @@ class DaemonService(rpyc.Service):
     def exposed_handle_cli(self, args):
         args = rpyc.utils.classic.obtain(args)
         logger.verbose('Running command `{}` for client.', ' '.join(args))
-        parser = get_parser()
-        try:
-            options = parser.parse_args(args, file=self.client_out_stream)
-        except SystemExit as e:
-            if e.code:
-                # TODO: Not sure how to properly propagate the exit code back to client
-                logger.debug('Parsing cli args caused system exit with status {}.', e.code)
-            return
+        with unittest.mock.patch.dict(os.environ, {'FORCE_COLOR': '1'}):
+            parser = get_parser()
+            try:
+                options = parser.parse_args(args, file=self.client_out_stream)
+            except SystemExit as e:
+                if e.code:
+                    # TODO: Not sure how to properly propagate the exit code back to client
+                    logger.debug('Parsing cli args caused system exit with status {}.', e.code)
+                return
         context_managers = []
         # Don't capture any output when used with --cron
         if not options.cron:


### PR DESCRIPTION
### Motivation for changes:

Double ANSI escaped output from `--help` string, when daemon is running.

### Detailed changes:

- Add a separate rpyc exposed method to handle parse_args, which expects the obtained text to be ANSI pre-rendered.

### Addressed issues/feature requests:

- Fixes #4953

### Config usage if relevant (new plugin or updated schema):

```yml
schedules:
  - tasks: '*'
    interval:
      hours: 24

tasks:
  test-task:
    manual: yes
    mock:
      - {title: 'Test', url: 'http://example.com/test.torrent'}
    accept_all: yes
```

### Log and/or tests output (preferably both):

```console
$ flexget daemon start &
$ script -c 'flexget -h'
$ cat -v typescript
Script started on 2026-03-31 09:15:20+02:00 [COMMAND="flexget -h" TERM="alacritty" TTY="/dev/pts/0" COLUMNS="-1" LINES="-1"]
There is a FlexGet process already running for this config, sending execution there.^M
^[[1;34musage: ^[[0m^[[1;35mflexget^[[0m [^[[32m-V^[[0m] [^[[36m--test^[[0m] [^[[32m-c ^[[0m^[[33mCONFIG^[[0m] [^[[36m--logfile ^[[0m^[[33mLOGFILE^[[0m] [^[[36m--loglevel ^[[0m^[[33mLEVEL^[[0m] [^[[36m--profile ^[[0m^[[33m[OUTFILE]^[[0m]^M
               [^[[36m--cron^[[0m] [^[[36m--help^[[0m] [^[[36m--debug-db-sessions^[[0m] [^[[36m--debug-warnings^[[0m]^M
               ^[[32m<command> ...^[[0m^M
^M
^[[1;34moptions:^[[0m^M
  ^[[1;32m-V^[[0m, ^[[1;36m--version^[[0m         Print FlexGet version and exit.^M
  ^[[1;36m--test^[[0m                Verbose what would happen on normal execution.^M
  ^[[1;32m-c^[[0m ^[[1;33mCONFIG^[[0m             Specify configuration file. Default: config.yml^M
  ^[[1;36m--logfile^[[0m, ^[[1;32m-l^[[0m ^[[1;33mLOGFILE^[[0m^M
                        Specify a custom logfile name/location. Default: flexget.log in the config^M
                        directory.^M
  ^[[1;36m--loglevel^[[0m, ^[[1;32m-L^[[0m ^[[1;33mLEVEL^[[0m  Set the verbosity of the logger. Levels: NONE, CRITICAL, ERROR, WARNING, INFO,^M
                        VERBOSE, DEBUG, TRACE^M
  ^[[1;36m--profile^[[0m ^[[1;33m[OUTFILE]^[[0m   Use the python profiler for this run to debug performance issues.^M
  ^[[1;36m--cron^[[0m                use when executing FlexGet non-interactively: allows background maintenance to^M
                        run, disables stdout and stderr output, reduces logging level^M
  ^[[1;36m--help^[[0m, ^[[1;32m-h^[[0m            Show this help message and exit^M
  ^[[1;36m--debug-db-sessions^[[0m   debug session starts and ends, for finding problems with db locks^M
  ^[[1;36m--debug-warnings^[[0m      elevate warnings to errors for debugging purposes, so a traceback is shown^M
^M
^[[1;34mcommands:^[[0m^M
  ^[[1;32m<command>^[[0m^M
    ^[[1;32mexecute^[[0m             execute tasks now^M
    ^[[1;32mdaemon^[[0m              run continuously, executing tasks according to schedules defined in config^M
    ^[[1;32mexport-schema^[[0m       Output the JSON schema for the config^M
    ^[[1;32mweb^[[0m                 Manage web server settings^M
    ^[[1;32mdatabase^[[0m            Utilities to manage the FlexGet database^M
    ^[[1;32mplugins^[[0m             Print registered plugin summaries^M
    ^[[1;32mcheck^[[0m               validate configuration file and print errors^M
    ^[[1;32mdebug-info^[[0m          display useful info for debugging^M
    ^[[1;32mtemplates^[[0m           View all available templates^M
    ^[[1;32mdoc^[[0m                 display plugin documentation^M
    ^[[1;32mjinja-filters^[[0m       View registered jinja2 filters and their description^M
    ^[[1;32mtorznab^[[0m             Query torznab indexer capabilities^M
    ^[[1;32mirc^[[0m                 View and manage irc connections^M
    ^[[1;32mbacklog^[[0m             View or clear entries from backlog plugin^M
    ^[[1;32mseen^[[0m                View or forget entries remembered by the seen plugin^M
    ^[[1;32mhistory^[[0m             View the history of entries that FlexGet has accepted^M
    ^[[1;32marchive^[[0m             Search and manipulate the archive database^M
    ^[[1;32mpending^[[0m             View and manage pending entries^M
    ^[[1;32mtrakt^[[0m               View and manage trakt authentication.^M
    ^[[1;32mfailed^[[0m              list or clear remembered failures^M
    ^[[1;32mrejected^[[0m            list or clear remembered rejections^M
    ^[[1;32mstatus^[[0m              View task health status^M
    ^[[1;32mseries^[[0m              View and manipulate the series plugin database^M
    ^[[1;32mregexp-list^[[0m         View and manage regexp lists^M
    ^[[1;32mmovie-list^[[0m          View and manage movie lists^M
    ^[[1;32mpending-list^[[0m        View and manage pending lists^M
    ^[[1;32mentry-list^[[0m          view and manage entry lists^M
    ^[[1;32minject^[[0m              inject an entry from command line into tasks
Script done on 2026-03-31 09:15:20+02:00 [COMMAND_EXIT_CODE="0"]
```
