### PR TITLE
fix: exists_series should only match video files, not subtitles/metadata

### DIFF
--- a/flexget/plugins/filter/exists_series.py
+++ b/flexget/plugins/filter/exists_series.py
@@ -25,6 +25,8 @@ class FilterExistsSeries:
       exists_series: /storage/series/
     """
 
+    VIDEO_EXTENSIONS = {'.avi', '.mkv', '.mp4', '.mpg', '.m4v', '.ts', '.wmv', '.webm'}
+
     schema = {
         'anyOf': [
             one_or_more({'type': 'string', 'format': 'path'}),
@@ -90,6 +92,8 @@ class FilterExistsSeries:
                     continue
 
                 for filename in folder.rglob('*') if config.get('recursive') else folder.iterdir():
+                    if filename.is_file() and filename.suffix.lower() not in self.VIDEO_EXTENSIONS:
+                        continue
                     # run parser on filename data
                     try:
                         disk_parser = plugin.get('parsing', self).parse_series(

--- a/tests/test_exists_series.py
+++ b/tests/test_exists_series.py
@@ -84,6 +84,13 @@ class TestExistsSeries:
             - title: jinja2 s01e01
             accept_all: yes
             exists_series: __tmp__
+
+          test_non_video_skipped:
+            mock:
+              - {title: 'Foo.Bar.S01E02.XViD'}
+            series:
+              - foo bar
+            exists_series: __tmp__/nonvideo
     """
 
     test_dirs = [
@@ -102,6 +109,11 @@ class TestExistsSeries:
         """Override and parametrize default config fixture for all series tests."""
         for test_dir in self.test_dirs:
             (tmp_path / test_dir).mkdir(parents=True)
+        # Create non-video directory with subtitle/nfo files matching a series
+        nonvideo = tmp_path / 'nonvideo'
+        nonvideo.mkdir(exist_ok=True)
+        (nonvideo / 'Foo.Bar.S01E02.XViD.srt').touch()
+        (nonvideo / 'Foo.Bar.S01E02.XViD.nfo').touch()
         return self._config.replace('__parser__', request.param).replace('__tmp__', str(tmp_path))
 
     def test_existing(self, execute_task):
@@ -176,4 +188,11 @@ class TestExistsSeries:
         )
         assert task.find_entry('accepted', title='jinja s01e02'), (
             'jinja s01e02 should have been accepted'
+        )
+
+    def test_non_video_skipped(self, execute_task):
+        """Non-video files (srt, nfo) should be ignored by exists_series."""
+        task = execute_task('test_non_video_skipped')
+        assert task.find_entry('accepted', title='Foo.Bar.S01E02.XViD'), (
+            'Foo.Bar.S01E02.XViD should have been accepted (only non-video files on disk)'
         )


### PR DESCRIPTION
## Problem

`exists_series` parses every file in the configured directory, including subtitle files (`.srt`), metadata (`.nfo`), and images (`.jpg`, `.png`). Any file whose name contains a valid series pattern (e.g., `Show.S01E01.720p.eng.srt`) is treated as an existing episode and triggers a false rejection.

Fixes #4942.

## Fix

Add a `VIDEO_EXTENSIONS` set (matching the extensions used by `exists_movie`'s `file_pattern`, plus common formats like `.m4v`, `.ts`, `.wmv`) and skip non-video files during the directory scan.

Directories are still traversed (they might be season folders), only regular files with non-video extensions are skipped.