### PR TITLE
fix: add recursive option to exists_series for nested season folders

### DIFF
--- a/flexget/plugins/filter/exists_series.py
+++ b/flexget/plugins/filter/exists_series.py
@@ -36,6 +36,7 @@ class FilterExistsSeries:
                         'enum': ['better', True, False],
                         'default': False,
                     },
+                    'recursive': {'type': 'boolean', 'default': False},
                 },
                 'required': ['path'],
                 'additionalProperties': False,
@@ -88,7 +89,7 @@ class FilterExistsSeries:
                     logger.warning('Directory {} does not exist', folder)
                     continue
 
-                for filename in folder.iterdir():
+                for filename in folder.rglob('*') if config.get('recursive') else folder.iterdir():
                     # run parser on filename data
                     try:
                         disk_parser = plugin.get('parsing', self).parse_series(


### PR DESCRIPTION
## Problem

`exists_series` uses `folder.iterdir()` which only lists direct children. This fails to find episodes in typical media library structures organized by season:

```
/storage/series/Show Name/
├── Season 1/
│   └── Show.Name.S01E01.1080p.mkv   ← never found
├── Season 2/
│   └── Show.Name.S02E01.1080p.mkv   ← never found
```

Fixes #4941.

## Fix

Add a `recursive` config option (default: `false`) that uses `rglob('*')` when enabled. This matches the existing implementation in `exists_movie` (line 113).

### Usage

```yaml
exists_series:
  path: /storage/series/
  recursive: yes
```