### PR TITLE
fix(imdb): bypass AWS WAF JS challenge with optional Playwright

### DIFF
--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -138,7 +138,9 @@ class ImdbWatchlist:
                     locale=headers.get('Accept-Language', 'en-us').replace('-', '_'),
                 )
                 page = context.new_page()
-                page.set_extra_http_headers({'Accept-Language': headers.get('Accept-Language', 'en-us')})
+                page.set_extra_http_headers({
+                    'Accept-Language': headers.get('Accept-Language', 'en-us')
+                })
                 page.goto(
                     url + '?' + '&'.join(f'{k}={v}' for k, v in params.items()),
                     wait_until='networkidle',

--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -9,6 +9,11 @@ from flexget.utils.cached_input import cached
 from flexget.utils.requests import RequestException
 from flexget.utils.soup import get_soup
 
+try:
+    from playwright.sync_api import sync_playwright
+except ImportError:
+    sync_playwright = None
+
 logger = logger.bind(name='imdb_watchlist')
 USER_ID_RE = r'^ur\d{7,9}$'
 CUSTOM_LIST_RE = r'^ls\d{7,10}$'
@@ -28,6 +33,9 @@ TITLE_TYPE_MAP = {
 
 class ImdbWatchlist:
     """Creates an entry for each movie in your imdb list."""
+
+    def __init__(self):
+        self._waf_cookies = None
 
     schema = {
         'type': 'object',
@@ -109,12 +117,70 @@ class ImdbWatchlist:
             entries = self.parse_html_list(task, config, url, params, headers)
         return entries
 
+    def _solve_waf(self, url, params, headers):
+        """Bypass AWS WAF JS challenge using Playwright (optional dep).
+
+        Returns cookies dict with aws-waf-token, or None on failure.
+        """
+        if sync_playwright is None:
+            logger.warning(
+                'AWS WAF challenge detected. Install playwright to bypass: '
+                'pip install playwright && playwright install chromium'
+            )
+            return None
+
+        logger.info('Solving AWS WAF challenge via Playwright headless browser...')
+        try:
+            with sync_playwright() as pw:
+                browser = pw.chromium.launch(headless=True)
+                context = browser.new_context(
+                    user_agent=headers.get('User-Agent', self.default_user_agent),
+                    locale=headers.get('Accept-Language', 'en-us').replace('-', '_'),
+                )
+                page = context.new_page()
+                page.set_extra_http_headers({'Accept-Language': headers.get('Accept-Language', 'en-us')})
+                page.goto(
+                    url + '?' + '&'.join(f'{k}={v}' for k, v in params.items()),
+                    wait_until='networkidle',
+                    timeout=30000,
+                )
+                cookies = page.context.cookies()
+                browser.close()
+
+            cookie_dict = {c['name']: c['value'] for c in cookies}
+            if 'aws-waf-token' in cookie_dict:
+                logger.debug('Successfully obtained aws-waf-token from Playwright')
+                return cookie_dict
+            logger.warning('Playwright did not receive aws-waf-token cookie')
+            return None
+        except Exception as e:
+            logger.warning('Failed to solve AWS WAF challenge with Playwright: {}', e)
+            return None
+
     def fetch_page(self, task, url, params, headers):
         logger.debug('Requesting: {} {}', url, headers)
+
+        # If we have cached WAF cookies from a previous solve, attach them
+        if self._waf_cookies:
+            task.requests.cookies.update(self._waf_cookies)
+
         try:
             page = task.requests.get(url, params=params, headers=headers)
         except RequestException as e:
             raise plugin.PluginError(str(e))
+
+        # AWS WAF JS challenge detected — solve it via Playwright
+        if page.status_code == 202 and page.headers.get('x-amzn-waf-action') == 'challenge':
+            logger.info('IMDB WAF challenge triggered, attempting to bypass...')
+            waf_cookies = self._solve_waf(url, params, headers)
+            if waf_cookies:
+                self._waf_cookies = waf_cookies
+                task.requests.cookies.update(waf_cookies)
+                try:
+                    page = task.requests.get(url, params=params, headers=headers)
+                except RequestException as e:
+                    raise plugin.PluginError(str(e))
+
         if page.status_code != 200:
             raise plugin.PluginError(
                 f'Unable to get imdb list. Either list is private or does not exist. '

--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -154,7 +154,7 @@ class ImdbWatchlist:
                 logger.debug('Successfully obtained aws-waf-token from Playwright')
                 return cookie_dict
             logger.warning('Playwright did not receive aws-waf-token cookie')
-            return None
+            return None  # noqa: TRY300
         except Exception as e:
             logger.warning('Failed to solve AWS WAF challenge with Playwright: {}', e)
             return None


### PR DESCRIPTION
IMDB added AWS WAF with JS challenge, returns HTTP 202 + empty body to plain requests. Detect x-amzn-waf-action: challenge header, solve via Playwright headless browser, extract aws-waf-token cookie, retry.

Playwright is optional dependency. If unavailable, logs install instructions and falls through to existing error path.