### PR TITLE
Update pre-commit hook crate-ci/typos to v1.46.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         args: [--markdown-linebreak-ext=md]
         exclude_types: [python, yaml]
   - repo: https://github.com/crate-ci/typos
-    rev: v1.45.2
+    rev: v1.46.1
     hooks:
       - id: typos
         args: [--force-exclude]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,6 +252,7 @@ default.extend-ignore-identifiers-re = [
   "IST",
   "McClory",
   "[Pp]yload",
+  "Namee",
 ]
 default.extend-ignore-words-re = [
   "nd",


### PR DESCRIPTION
Supersedes #4998
