### PR TITLE
Normalize LostFilm download page URLs

### DIFF
--- a/flexget/components/sites/sites/lostfilm.py
+++ b/flexget/components/sites/sites/lostfilm.py
@@ -363,7 +363,9 @@ class LostFilm:
                     if found_item is not None:
                         if found_item.has_attr('content'):
                             if found_item['content'].startswith('0; url=/'):
-                                download_page_url = site_urls[0].rstrip('/') + found_item['content'][7:]
+                                download_page_url = (
+                                    site_urls[0].rstrip('/') + found_item['content'][7:]
+                                )
                             elif found_item['content'].startswith('0; url=https://') or found_item[
                                 'content'
                             ].startswith('0; url=http://'):

--- a/flexget/components/sites/sites/lostfilm.py
+++ b/flexget/components/sites/sites/lostfilm.py
@@ -363,7 +363,7 @@ class LostFilm:
                     if found_item is not None:
                         if found_item.has_attr('content'):
                             if found_item['content'].startswith('0; url=/'):
-                                download_page_url = site_urls[0] + found_item['content'][7:]
+                                download_page_url = site_urls[0].rstrip('/') + found_item['content'][7:]
                             elif found_item['content'].startswith('0; url=https://') or found_item[
                                 'content'
                             ].startswith('0; url=http://'):


### PR DESCRIPTION
### Motivation for changes:

LostFilm download page URLs may be constructed with a duplicate slash in the path, for example:

```text
https://www.lostfilm.tv//V/?...
```

This can cause LostFilm to reject the request with `403 Forbidden`, likely because the signed download URL expects the canonical `/V/` path.

### Detailed changes:

- Normalize the configured LostFilm site URL before appending the download page path.
- Prevent duplicate slashes when the meta refresh URL starts with `/V/`.
- Keep existing behavior for configured `site_urls`, RSS URLs, and search redirect URLs.

### Log output:

Before:

```text
ERROR lostfilm lostfilm Failed to get the download page https://www.lostfilm.tv//V/?c=... Error: 403 Client Error: Forbidden for url: https://www.lostfilm.tv//V/?c=...
```

After the change, the URL is constructed without the duplicate slash:

```text
https://www.lostfilm.tv/V/?c=...
```

Manual verification was performed against a local FlexGet installation by confirming the generated LostFilm download page URL no longer contains `//V/`.
