### PR TITLE
Update scripts/docs to support 'local' building/releasing to personal DockerHub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,41 @@
+# Copy this file to .env and set values as needed.
+# uv run will automatically load .env from the project root.
+
+# --- Build ---
+
+# Set to '1' or 'true' to bundle the WebUI into the wheel during a build.
+# BUNDLE_WEBUI=1
+
+# Override the source location for the v2 WebUI dist.zip.
+# Accepts a URL (http/https) or a local file path.
+# Defaults to the latest GitHub release when not set.
+# V2_WEBUI_LOCATION=https://github.com/Flexget/webui/releases/latest/download/dist.zip
+# V2_WEBUI_LOCATION=~/path/to/dist.zip
+
+# Set to '1' or 'true' to generate wheel extras with locked dependencies.
+# BUILD_LOCKED_EXTRAS=1
+
+# --- Server / run_server.sh ---
+
+# Path to the FlexGet config file (default: config.yml in the repo root).
+# FLEXGET_CONFIG=config.yml
+
+# --- Docker / manual_release.sh ---
+
+# Docker Hub credentials (required by manual_release.sh).
+# DH_USERNAME=myusername
+# DH_PASSWORD=mypassword-or-access-token
+
+# Full Docker Hub repository name (default: $DH_USERNAME/flexget).
+# IMAGE_NAME=myusername/flexget
+
+# Tag to apply to the built image (default: current version from flexget/_version.py).
+# IMAGE_TAG=latest
+
+# --- Testing ---
+
+# VCR cassette record mode. Options: once, new_episodes, none, all (default: once).
+# VCR_RECORD_MODE=once
+
+# Newline-separated list of cassette file paths to preserve during cassette cleanup.
+# NEW_CASSETTES=

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+!.env.example
 *.iml
 *.noseids
 *.pyc
@@ -11,6 +12,7 @@
 .coverage
 .devcontainer/
 .dmypy.json
+.env
 .idea/
 .mypy_cache/
 .project
@@ -49,3 +51,4 @@ received/
 setuptools-*.tar.gz
 share/
 tests/cover/
+webui-dist.zip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# CLAUDE.md
+
+## Architecture
+
+- REST API: Flask + flask-restx, version tracked in `flexget/api/app.py` (`__version__`)
+- All route handlers extend `APIResource` (auto-injects SQLAlchemy session, adds API-Version header)
+- Core namespaces in `flexget/api/core/`; component namespaces each in `flexget/components/*/api.py`
+- Task execution phases (in order): prepare → start → input → metainfo → filter → download → modify → output → learn → exit
+
+## Known bugs (unresolved as of this session)
+
+- `flexget/components/pending_approval/api.py`: pagination total count ignores filters (line 105); `per_page` clamped twice (lines 85/90); `PUT /` uses wrong parser (line 137)
+- `pending_approval` plugin is deprecated — prefer `pending_list`
+
+## Package manager
+
+- Project uses `uv` exclusively — no pip/poetry/hatch invocations needed for day-to-day work
+- `setup.sh` at repo root is the fast-path for environment setup: installs uv if absent, creates `.venv`, installs `dev` + `test` dependency groups
+- `.env` file at repo root is auto-loaded by `uv run`; copy from `.env.example` to configure local env vars
+
+## bundle_webui.py behaviour
+
+- `BUNDLE_WEBUI` env var only guards the hatchling build hook (used during `uv build` / PyPI release)
+- When invoked directly via `uv run scripts/bundle_webui.py` (as the Dockerfile does), the WebUI is ALWAYS bundled — `BUNDLE_WEBUI` is not checked
+- `V2_WEBUI_LOCATION` env var overrides the v2 dist.zip source; accepts HTTP/HTTPS URL or local file path; exposed as a Docker `ARG` for build-time override
+
+## run_server.sh behaviour
+
+- Takes an optional parameter: no args = start if not running; `restart` = stop then start; `stop` = stop only (no restart)
+- If `FLEXGET_CONFIG` is unset, falls back to `.venv/config.yml`, auto-creating it with a minimal example task if the file does not exist
+- Loads `.env` from repo root before starting (non-overwriting, same pattern as `manual_release.sh`)
+
+## Known pre-existing test failures
+
+- `tests/test_npo_watchlist.py` — 3 tests fail due to `chardet` 7.x emitting a `DeprecationWarning` via `html5lib`, which FlexGet promotes to a plugin abort; unrelated to application logic

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,15 @@ COPY --from=ghcr.io/astral-sh/uv:0.11.23@sha256:d0a0a753ab981624b49c97abc98821c1
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 WORKDIR /flexget
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=scripts/bundle_webui.py,target=scripts/bundle_webui.py \
-    uv run scripts/bundle_webui.py
-RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --frozen --no-dev --group=all --no-install-project
 ADD . /flexget
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --group=all
+ARG V2_WEBUI_LOCATION
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv run scripts/bundle_webui.py
 
 FROM docker.io/python:3.11-alpine@sha256:cf0253107a1e77e63c814a05428308965a47eb44a2d62fc828564c4a8c839fab
 ENV PYTHONUNBUFFERED=1

--- a/docs/contributor/Getting started/Development environment setup.rst
+++ b/docs/contributor/Getting started/Development environment setup.rst
@@ -4,6 +4,19 @@
 Development environment setup
 =============================
 
+Quick setup
+===========
+
+For most contributors, the fastest way to get started is to run the provided setup
+script from the repo root::
+
+   $ ./setup.sh
+
+This installs ``uv`` if it is not already available, then creates a ``.venv`` virtual
+environment and installs all project dependencies — including the ``dev`` and ``test``
+groups. The remaining sections on this page describe the individual steps the script
+performs, which is useful if you need a customised setup.
+
 Cloning the repository
 ======================
 
@@ -140,6 +153,42 @@ rule—you'll need to run it on all files manually instead::
             $ .venv\Scripts\activate.ps1
 
 .. _linking to upstream:
+
+Environment variables
+=====================
+
+Several scripts and build processes are controlled by environment variables.
+A reference file listing all supported variables with descriptions is provided at the
+repo root. Copy it to create your own local configuration::
+
+   $ cp .env.example .env
+
+Edit ``.env`` to suit your workflow. The file is git-ignored so your local values will
+never be committed. When running commands via ``uv run``, variables in ``.env`` are
+loaded automatically.
+
+Running the development server
+==============================
+
+A helper script is provided to start, stop, and restart the FlexGet daemon
+during local development::
+
+   $ ./run_server.sh           # start the daemon if it is not already running
+   $ ./run_server.sh restart   # stop then restart (picks up code changes)
+   $ ./run_server.sh stop      # stop the running daemon
+
+The script reads ``.env`` from the repo root before starting, so any
+environment variables you have configured there are available to the daemon
+without needing to export them manually.
+
+**Config file**
+
+By default the script looks for a ``FLEXGET_CONFIG`` environment variable. If
+it is not set, it falls back to ``.venv/config.yml``, creating that file with a
+minimal example task if it does not already exist. You can point the server at
+a different config by setting the variable in your ``.env`` file::
+
+   FLEXGET_CONFIG=/path/to/your/config.yml
 
 Linking your repository to the upstream repo
 ============================================

--- a/docs/contributor/Topic guides/Maintainer guide/Triggering a manual release.rst
+++ b/docs/contributor/Topic guides/Maintainer guide/Triggering a manual release.rst
@@ -11,3 +11,31 @@ Triggering a manual release
 
 You may monitor the progress and outcome of the deployment on the
 `Deployments Page <https://github.com/Flexget/Flexget/deployments/production>`_.
+
+Manual Docker release from a local machine
+==========================================
+
+To build and push a Docker image to Docker Hub directly from your local machine,
+use the provided release script::
+
+   $ ./scripts/manual_release.sh
+
+The script requires Docker Hub credentials. The easiest way to provide them is via a
+``.env`` file in the repo root (see :ref:`Environment variables`):
+
+.. code-block:: text
+
+   DH_USERNAME=myusername
+   DH_PASSWORD=mypassword-or-access-token
+
+Optional variables:
+
+- ``IMAGE_NAME`` — full repository name (default: ``$DH_USERNAME/flexget``)
+- ``IMAGE_TAG`` — tag to apply (default: current version from ``flexget/_version.py``)
+- ``V2_WEBUI_LOCATION`` — URL or local path to the v2 WebUI ``dist.zip``
+
+The script will:
+
+#. Build the Python distribution with ``uv build``
+#. Build the Docker image from the ``Dockerfile``
+#. Log in to Docker Hub, push both the versioned tag and ``latest``, then log out

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Start (or restart) the FlexGet daemon.
+#
+# Usage:
+#   ./run_server.sh           — start the daemon if it is not already running
+#   ./run_server.sh restart   — stop the running daemon (if any), then restart it (to pick up any code changes)
+#   ./run_server.sh stop      — stop the running daemon (if any)
+#
+# Optional environment variables:
+#   FLEXGET_CONFIG   Path to the FlexGet config file (default: config.yml)
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# --- Load .env if present (does not overwrite variables already set in the environment) ---
+if [[ -f .env ]]; then
+    while IFS='=' read -r key value; do
+        [[ -z "$key" || "$key" =~ ^# ]] && continue
+        [[ -v "$key" ]] && continue
+        export "$key=$value"
+    done < .env
+fi
+
+# --- Validate arguments ---
+MODE="${1:-}"
+if [[ -n "$MODE" && "$MODE" != "restart" && "$MODE" != "stop" ]]; then
+    echo "Usage: $0 [restart|stop]" >&2
+    exit 1
+fi
+
+if [[ -z "${FLEXGET_CONFIG:-}" ]]; then
+    if [[ ! -f .venv/config.yml ]]; then
+        echo "==> No config found — creating default .venv/config.yml"
+        cat > .venv/config.yml <<'EOF'
+tasks:
+  test-task:
+    rss: http://mysite.com/myfeed.rss
+    series:
+      - My Favorite Show
+      - Another Good Show:
+          quality: 720p
+    download: /home/me/watchdir/
+web_server: true
+EOF
+    fi
+    FLEXGET_CONFIG=./.venv/config.yml
+fi
+FLEXGET=(uv run flexget -c "${FLEXGET_CONFIG}")
+
+# --- Helpers ---
+is_running() {
+    local output
+    output=$("${FLEXGET[@]}" daemon status 2>/dev/null) || true
+    echo "$output" | grep -q "Daemon running"
+}
+
+start_daemon() {
+    echo "==> Starting FlexGet daemon..."
+    "${FLEXGET[@]}" daemon start -d
+    echo "==> FlexGet daemon started."
+}
+
+stop_daemon() {
+    echo "==> Stopping FlexGet daemon..."
+    "${FLEXGET[@]}" daemon stop
+    local attempts=0
+    while is_running; do
+        if (( ++attempts >= 30 )); then
+            echo "Error: daemon did not stop within 30 seconds." >&2
+            exit 1
+        fi
+        sleep 1
+    done
+    echo "==> FlexGet daemon stopped."
+}
+
+# --- Main ---
+if [[ "$MODE" == "stop" ]]; then
+    if is_running; then
+        stop_daemon
+    else
+        echo "==> No daemon currently running."
+    fi
+elif [[ "$MODE" == "restart" ]]; then
+    if is_running; then stop_daemon; else echo "==> No daemon currently running."; fi
+    start_daemon
+else
+    if is_running; then
+        echo "==> FlexGet daemon is already running."
+    else
+        start_daemon
+    fi
+fi

--- a/scripts/bundle_webui.py
+++ b/scripts/bundle_webui.py
@@ -54,11 +54,16 @@ def bundle_webui(ui_version: str | None = None):
 
     def download_extract(url, dest_path):
         print(dest_path)
-        r = requests.get(url)
-        if r.status_code != 200:
-            raise RuntimeError(f'Unable to retrieve {dest_path}')
-        z = zipfile.ZipFile(io.BytesIO(r.content))
-        z.extractall(dest_path)
+        if url.startswith(('http://', 'https://')):
+            r = requests.get(url)
+            if r.status_code != 200:
+                raise RuntimeError(f'Unable to retrieve {dest_path}')
+            data = io.BytesIO(r.content)
+        else:
+            with Path(url).expanduser().open('rb') as f:
+                data = io.BytesIO(f.read())
+
+        zipfile.ZipFile(data).extractall(dest_path)
 
     if not ui_version or ui_version == 'v1':
         # WebUI V1
@@ -87,7 +92,10 @@ def bundle_webui(ui_version: str | None = None):
             if app_path.exists():
                 shutil.rmtree(app_path)
             download_extract(
-                'https://github.com/Flexget/webui/releases/latest/download/dist.zip',
+                os.environ.get(
+                    'V2_WEBUI_LOCATION',
+                    'https://github.com/Flexget/webui/releases/latest/download/dist.zip',
+                ),
                 ui_path / 'v2',
             )
         except (OSError, ValueError) as e:

--- a/scripts/manual_release.sh
+++ b/scripts/manual_release.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Build the application, build and tag a Docker image, and push it to Docker Hub.
+#
+# Required environment variables:
+#   DH_USERNAME   Docker Hub username (also used to form the default image name)
+#   DH_PASSWORD   Docker Hub password or access token
+#
+# Optional environment variables:
+#   IMAGE_NAME          Full image repository name (default: $DH_USERNAME/flexget)
+#   IMAGE_TAG           Primary tag to apply (default: current version from flexget/_version.py)
+#   V2_WEBUI_LOCATION   URL or local file path for the v2 WebUI dist.zip (default: latest GitHub release)
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# --- Load .env if present (does not overwrite variables already set in the environment) ---
+if [[ -f .env ]]; then
+    while IFS='=' read -r key value; do
+        [[ -z "$key" || "$key" =~ ^# ]] && continue
+        [[ -v "$key" ]] && continue
+        export "$key=$value"
+    done < .env
+fi
+
+# --- Validate required variables ---
+: "${DH_USERNAME:?DH_USERNAME is required}"
+: "${DH_PASSWORD:?DH_PASSWORD is required}"
+
+# --- Resolve defaults ---
+IMAGE_NAME="${IMAGE_NAME:-${DH_USERNAME}/flexget}"
+IMAGE_TAG="${IMAGE_TAG:-$(uv run scripts/dev_tools.py version)}"
+
+echo "==> Image:  ${IMAGE_NAME}:${IMAGE_TAG}"
+
+# --- Step 1: Build the application ---
+echo "==> Building application..."
+uv build
+
+# --- Step 2: Build the Docker image ---
+
+# If V2_WEBUI_LOCATION is a local path, copy it into the build context so that
+# Docker's ADD picks it up at /flexget/webui-dist.zip during the bundle step.
+DOCKER_V2_WEBUI_LOCATION="${V2_WEBUI_LOCATION:-}"
+WEBUI_DIST_COPIED=false
+
+if [[ -n "${V2_WEBUI_LOCATION:-}" && ! "$V2_WEBUI_LOCATION" =~ ^https?:// ]]; then
+    EXPANDED_PATH="${V2_WEBUI_LOCATION/#\~/$HOME}"
+    cp "$EXPANDED_PATH" ./webui-dist.zip
+    WEBUI_DIST_COPIED=true
+    DOCKER_V2_WEBUI_LOCATION=/flexget/webui-dist.zip
+fi
+
+cleanup() {
+    [[ "$WEBUI_DIST_COPIED" == true ]] && rm -f ./webui-dist.zip
+}
+trap cleanup EXIT
+
+echo "==> Building Docker image..."
+docker build \
+    ${DOCKER_V2_WEBUI_LOCATION:+--build-arg "V2_WEBUI_LOCATION=${DOCKER_V2_WEBUI_LOCATION}"} \
+    -t "${IMAGE_NAME}:${IMAGE_TAG}" \
+    -t "${IMAGE_NAME}:latest" \
+    .
+
+# --- Step 3: Push to Docker Hub ---
+echo "==> Logging in to Docker Hub..."
+echo "${DH_PASSWORD}" | docker login -u "${DH_USERNAME}" --password-stdin
+
+echo "==> Pushing ${IMAGE_NAME}:${IMAGE_TAG}..."
+docker push "${IMAGE_NAME}:${IMAGE_TAG}"
+docker push "${IMAGE_NAME}:latest"
+
+docker logout
+
+echo ""
+echo "Done. Pushed ${IMAGE_NAME}:${IMAGE_TAG} and ${IMAGE_NAME}:latest"

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# Install uv if not present
+if ! command -v uv &>/dev/null; then
+    echo "==> uv not found — installing..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    # uv installer puts the binary in ~/.local/bin by default
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
+echo "==> uv $(uv --version)"
+
+# Sync the project with all groups needed to run, test, and develop:
+#   (default)  — core runtime dependencies from [project.dependencies]
+#   --group dev  — pytest, ruff, prek, pytest-cov, pytest-xdist, vcrpy
+#   --group test — pillow, pytest-ftpserver, plus all optional plugin deps
+#                  (boto3, deluge, ftp, matrix, plexapi, qbittorrent, rarfile,
+#                   sftp, subliminal, telegram, transmission)
+echo "==> Syncing dependencies (dev + test groups)..."
+uv sync --group dev --group test
+
+echo ""
+echo "Done. Virtual environment created at .venv/"
+echo ""
+echo "  Activate:    source .venv/bin/activate"
+echo "  Run tests:   uv run pytest"
+echo "  Start app:   uv run flexget"


### PR DESCRIPTION
### Motivation for changes:

Make it easier / more consistent to release personal builds to a personal Dockerhub, and engage in development of new features that span across both 'Flexget' and the 'WebUI'

### Detailed changes:

- Added a 'setup' script to easy installation of tooling and dependencies (plus 'contributor' documentation)
- Added a 'manual_release' script to easily build the application, package into a Docker container, and push to a personal Docker Hub repo (pls 'contributor' documentation)
- Added a preliminary 'CLAUDE.md' file to the repo, to support AI-assisted development
- Added support for a '.env' file to set personal Environment Variables (plus 'contributor' documentation)
- Updated 'Dockerfile' (and 'build_webui.py' script) to allow the location of the V2 Web UI to be overridden (for building a 'test' container using a local webui build, or from a forked repository)
- Added a 'run_server' script that can start / restart / stop a local 'Flexget instance


### Addressed issues/feature requests:

NA

### Config usage if relevant (new plugin or updated schema):

NA

### Log and/or tests output (preferably both):

NA