### PR TITLE
Add a new (optional) parameter the '/tasks/execute/' API endpoint

### DIFF
--- a/flexget/api/core/tasks.py
+++ b/flexget/api/core/tasks.py
@@ -25,6 +25,7 @@ from flexget.entry import Entry
 from flexget.event import event
 from flexget.log import capture_logs
 from flexget.options import get_parser
+from flexget.plugin import get as get_plugin
 from flexget.task import task_phases
 from flexget.terminal import capture_console
 from flexget.utils import json, requests
@@ -156,6 +157,11 @@ class ObjectsContainer:
                 'type': 'boolean',
                 'default': True,
                 'description': 'Include dump of entries including fields',
+            },
+            'second_guess_metadata': {
+                'type': 'boolean',
+                'default': False,
+                'description': "After execution, rerun metadata 'guess' functionality for each entry in 'entry_dump', 'to maximise likelihood of returning entry metadata",
             },
             'inject': {
                 'type': 'array',
@@ -598,6 +604,23 @@ def update_stream(task, status: str = 'pending') -> None:
     task.stream['queue'].put(json.dumps({'progress': progress, 'task_id': task.id}))
 
 
+def _apply_second_guess_metadata(entries):
+    """Re-run series and movie metadata guessing against entries in their final state.
+
+    Called when both entry_dump and second_guess_metadata are requested. Mutates entries
+    in-place by populating series_* and movie_* fields where they were not already set
+    during the normal metainfo phase (e.g. because title reformatting occurred after that
+    phase ran).
+    """
+    metainfo_series = get_plugin('metainfo_series', 'tasks')
+    metainfo_movie = get_plugin('metainfo_movie', 'tasks')
+    for entry in entries:
+        if not entry.get('series_name'):
+            metainfo_series.guess_entry(entry)
+        if not entry.get('movie_name'):
+            metainfo_movie.guess_entry(entry)
+
+
 @event('task.execute.started')
 def start_task(task):
     task.stream = _streams.get(task.id)
@@ -613,9 +636,14 @@ def finish_task(task):
             update_stream(task, status='complete')
 
         if task.stream['args'].get('entry_dump'):
-            entries = [entry.store for entry in task.entries]
+            entries_to_dump = list(task.entries)
+            if task.stream['args'].get('second_guess_metadata'):
+                _apply_second_guess_metadata(entries_to_dump)
             task.stream['queue'].put(
-                EntryDecoder().encode({'entry_dump': entries, 'task_id': task.id})
+                EntryDecoder().encode({
+                    'entry_dump': [e.store for e in entries_to_dump],
+                    'task_id': task.id,
+                })
             )
 
         if task.stream['args'].get('summary'):

--- a/tests/api_tests/test_execute_api.py
+++ b/tests/api_tests/test_execute_api.py
@@ -2,6 +2,8 @@ import json
 
 from flexget.api.app import base_message
 from flexget.api.core.tasks import ObjectsContainer as OC
+from flexget.api.core.tasks import _apply_second_guess_metadata
+from flexget.entry import Entry
 
 
 class TestExecuteAPI:
@@ -222,3 +224,122 @@ class TestExecuteMultipleTasks:
 
         errors = schema_match(OC.task_execution_results_schema, data)
         assert not errors
+
+
+class TestSecondGuessMetadata:
+    config = """
+        tasks:
+          test_task:
+            mock:
+              - title: 'TestShow - 12'
+                url: 'http://test.com/show.torrent'
+              - title: 'Some Movie 2024'
+                url: 'http://test.com/movie.torrent'
+            manipulate:
+              - title:
+                  replace:
+                    regexp: ' - (\\d+)$'
+                    format: ' S01E\\1'
+            accept_all: yes
+        """
+
+    @staticmethod
+    def get_task_queue(manager):
+        assert len(manager.task_queue) == 1
+        task = manager.task_queue.run_queue.get(timeout=0.5)
+        assert task
+        return task
+
+    def test_params_contains_second_guess_metadata(self, api_client):
+        rsp = api_client.get('/tasks/execute/params/')
+        assert rsp.status_code == 200
+        data = json.loads(rsp.get_data(as_text=True))
+        assert 'second_guess_metadata' in data['properties']
+        param = data['properties']['second_guess_metadata']
+        assert param['type'] == 'boolean'
+        assert 'description' in param
+
+    def test_second_guess_metadata_accepted_by_schema(self, api_client, manager):
+        payload = {
+            'tasks': ['test_task'],
+            'entry_dump': False,
+            'second_guess_metadata': True,
+        }
+        rsp = api_client.json_post('/tasks/execute/', data=json.dumps(payload))
+        assert rsp.status_code == 200
+
+    def test_second_guess_metadata_unit(self, manager):
+        series_entry = Entry(title='TestShow S01E12', url='http://test.com/1.torrent')
+        movie_entry = Entry(title='Some Movie 2024', url='http://test.com/2.torrent')
+
+        _apply_second_guess_metadata([series_entry, movie_entry])
+
+        assert series_entry.get('series_name') is not None
+        assert series_entry.get('series_season') == 1
+        assert series_entry.get('series_episode') == 12
+        assert series_entry.get('series_guessed') is True
+
+        assert movie_entry.get('movie_name') is not None
+        assert movie_entry.get('movie_year') == 2024
+
+    def test_second_guess_metadata_does_not_overwrite_existing_series(self, manager):
+        entry = Entry(title='TestShow S01E12', url='http://test.com/1.torrent')
+        entry['series_name'] = 'Explicitly Set Name'
+        entry['series_season'] = 5
+        entry['series_episode'] = 99
+
+        _apply_second_guess_metadata([entry])
+
+        assert entry['series_name'] == 'Explicitly Set Name'
+        assert entry['series_season'] == 5
+        assert entry['series_episode'] == 99
+
+    def test_second_guess_metadata_does_not_overwrite_existing_movie(self, manager):
+        entry = Entry(title='Some Movie 2024', url='http://test.com/2.torrent')
+        entry['movie_name'] = 'Explicit Movie'
+        entry['movie_year'] = 1999
+
+        _apply_second_guess_metadata([entry])
+
+        assert entry['movie_name'] == 'Explicit Movie'
+        assert entry['movie_year'] == 1999
+
+    def test_second_guess_metadata_ignored_without_entry_dump(self, api_client, manager):
+        payload = {
+            'tasks': ['test_task'],
+            'second_guess_metadata': True,
+        }
+        rsp = api_client.json_post('/tasks/execute/', data=json.dumps(payload))
+        assert rsp.status_code == 200
+
+        task = self.get_task_queue(manager)
+        task.execute()
+        assert len(task.all_entries) > 0
+
+    def test_entry_dump_second_guesses_metadata_when_enabled(self, api_client, manager):
+        payload = {'tasks': ['test_task'], 'entry_dump': True, 'second_guess_metadata': True}
+        rsp = api_client.json_post('/tasks/execute/', data=json.dumps(payload))
+        assert rsp.status_code == 200
+
+        task = self.get_task_queue(manager)
+        task.execute()
+
+        message = json.loads(task.stream['queue'].get(timeout=1))
+        dumped = {e['title']: e for e in message['entry_dump']}
+        assert dumped['TestShow S01E12'].get('series_name') is not None
+        assert dumped['TestShow S01E12'].get('series_season') == 1
+        assert dumped['TestShow S01E12'].get('series_episode') == 12
+        assert dumped['Some Movie 2024'].get('movie_name') is not None
+
+    def test_entry_dump_skips_second_guess_by_default(self, api_client, manager):
+        payload = {'tasks': ['test_task'], 'entry_dump': True}
+        rsp = api_client.json_post('/tasks/execute/', data=json.dumps(payload))
+        assert rsp.status_code == 200
+
+        task = self.get_task_queue(manager)
+        task.execute()
+
+        message = json.loads(task.stream['queue'].get(timeout=1))
+        dumped = {e['title']: e for e in message['entry_dump']}
+        assert dumped['TestShow S01E12'].get('series_name') is None
+        assert dumped['Some Movie 2024'].get('movie_name') is None


### PR DESCRIPTION
### Motivation for changes:

A number of the series I watch (from a group I like) don't match nicely with the default guess-series logic... so when I call the Execute Task API, with 'entry_dump=true', the returned Entry list has no series data.

By default, the metadata 'guess' functionality is applied once, *before* the title manipulations are performed.

The added flag tells the Execute Task endpoint to re-do the Series / Movie 'guessing' process after the Tasks have run, in case the Tasks contain Title manipulations (or similar) that make the title more procesable.

Note: if the 'series_name' (and/or 'movie_name') is populated, the Entry is skipped and no 'second guess' attempt is made, for the respective plugin.

(This solution was chosen instead of reordering plugin execution order, to minimise the risk of changing existing behaviour/functionality).

### Detailed changes:

- Add a new 'second_guess_metadata' boolean flag (default: False) to the /api/core/tasks endpoint
- New parameter appears in the API documentation
- If the flag is set, then `finish_task` will call the 'apply_second_guess_metadata' function
  - loads the 'metainfo_series plugin, and the 'metainfo_movie' plugin
  - for each Entry
    - if series_name is not populated, re-run the series 'guess_entry' function against the Entry
    - if move_name is not populated, re-run the movie 'guess_entry' function against the Entry
- Added covering unit tests

### Addressed issues/feature requests:

- NA

### Config usage if relevant (new plugin or updated schema):

NA

### Log and/or tests output (preferably both):

NA