### PR TITLE
added Botarr XDCC integration plugins

### DIFF
--- a/flexget/plugins/input/botarr_history.py
+++ b/flexget/plugins/input/botarr_history.py
@@ -1,0 +1,138 @@
+from loguru import logger
+from requests import RequestException
+
+from flexget import plugin
+from flexget.entry import Entry
+from flexget.event import event
+
+logger = logger.bind(name='botarr_history')
+
+
+class BotarrHistory:
+    """Produce entries from the `Botarr <https://github.com/ddonindia/Botarr>`_ download history.
+
+    Useful for monitoring completed or failed downloads, triggering post-processing
+    tasks, or building an audit trail of what Botarr has downloaded.
+
+    Each produced entry contains the following fields:
+
+    - ``botarr_transfer_id`` -- unique Botarr transfer UUID
+    - ``botarr_status`` -- transfer status (e.g. ``Completed``, ``Failed``, ``Downloading``)
+    - ``botarr_network`` -- IRC network
+    - ``botarr_channel`` -- IRC channel
+    - ``botarr_bot`` -- XDCC bot name
+    - ``botarr_slot`` -- XDCC pack slot number
+    - ``botarr_size`` -- file size in bytes
+    - ``botarr_created_at`` -- ISO 8601 timestamp when the transfer was created
+    - ``botarr_completed_at`` -- ISO 8601 timestamp when the transfer finished
+    - ``botarr_error`` -- error message (only present when the transfer failed)
+
+    When ``only_new`` is enabled (the default), the plugin tracks which transfer IDs
+    it has already produced and skips them on subsequent runs, so post-processing
+    tasks only fire once per download.
+
+    Example::
+
+      botarr_history:
+        url: http://localhost:3001
+
+    Full configuration::
+
+      botarr_history:
+        url: http://localhost:3001
+        status: completed
+        limit: 50
+        only_new: yes
+    """
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'url': {'type': 'string', 'format': 'url'},
+            'status': {
+                'type': 'string',
+                'enum': ['Completed', 'Failed', 'Downloading', 'all'],
+                'default': 'all',
+            },
+            'limit': {'type': 'integer', 'minimum': 1, 'default': 50},
+            'only_new': {'type': 'boolean', 'default': True},
+        },
+        'required': ['url'],
+        'additionalProperties': False,
+    }
+
+    def on_task_input(self, task, config):
+        """Fetch Botarr history and return one entry per transfer."""
+        base_url = config['url'].rstrip('/')
+        history_url = f'{base_url}/api/history'
+
+        params = {'limit': config['limit']}
+
+        try:
+            logger.debug('Fetching Botarr history from {}', history_url)
+            response = task.requests.get(history_url, params=params)
+            response.raise_for_status()
+        except RequestException as e:
+            raise plugin.PluginError(f'Failed to fetch Botarr history: {e}')
+
+        data = response.json()
+        items = data.get('items', [])
+
+        logger.debug('Botarr history returned {} items (total: {})', len(items), data.get('total', '?'))
+
+        # Load previously seen transfer IDs for only_new filtering
+        only_new = config.get('only_new', True)
+        seen_ids = set()
+        if only_new:
+            seen_ids = set(task.simple_persistence.get('botarr_seen_ids', []))
+
+        entries = []
+        new_ids = []
+        for item in items:
+            status = item.get('status', '')
+            if config['status'] != 'all' and status != config['status']:
+                continue
+
+            transfer_id = item.get('id')
+
+            if only_new and transfer_id in seen_ids:
+                logger.debug('Skipping already-seen transfer: {}', transfer_id)
+                continue
+
+            filename = item.get('file_name') or transfer_id
+            network = item.get('network', '')
+            channel = item.get('channel', '')
+            bot = item.get('bot', '')
+            slot = item.get('slot', '')
+
+            irc_url = f'irc://{network}/{channel}/{bot}/{slot}'
+
+            entry = Entry(title=filename, url=irc_url)
+            entry['botarr_transfer_id'] = transfer_id
+            entry['botarr_status'] = status
+            entry['botarr_network'] = network
+            entry['botarr_channel'] = channel
+            entry['botarr_bot'] = bot
+            entry['botarr_slot'] = slot
+            entry['botarr_size'] = item.get('size')
+            entry['botarr_created_at'] = item.get('created_at')
+            entry['botarr_completed_at'] = item.get('completed_at')
+            if item.get('error'):
+                entry['botarr_error'] = item['error']
+
+            entries.append(entry)
+            if transfer_id:
+                new_ids.append(transfer_id)
+
+        # Persist newly seen IDs (keep last 500 to avoid unbounded growth)
+        if only_new and new_ids:
+            all_seen = list(seen_ids) + new_ids
+            task.simple_persistence['botarr_seen_ids'] = all_seen[-500:]
+
+        logger.verbose('Produced {} entries from Botarr history', len(entries))
+        return entries
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(BotarrHistory, 'botarr_history', api_ver=2)

--- a/flexget/plugins/input/botarr_history.py
+++ b/flexget/plugins/input/botarr_history.py
@@ -78,7 +78,9 @@ class BotarrHistory:
         data = response.json()
         items = data.get('items', [])
 
-        logger.debug('Botarr history returned {} items (total: {})', len(items), data.get('total', '?'))
+        logger.debug(
+            'Botarr history returned {} items (total: {})', len(items), data.get('total', '?')
+        )
 
         # Load previously seen transfer IDs for only_new filtering
         only_new = config.get('only_new', True)

--- a/flexget/plugins/input/botarr_search.py
+++ b/flexget/plugins/input/botarr_search.py
@@ -1,0 +1,136 @@
+from loguru import logger
+from requests import RequestException
+
+from flexget import plugin
+from flexget.entry import Entry
+from flexget.event import event
+from flexget.utils.template import RenderError
+
+logger = logger.bind(name='botarr_search')
+
+
+class BotarrSearch:
+    """Search XDCC providers via a `Botarr <https://github.com/ddonindia/Botarr>`_ instance.
+
+    Can be used as a standalone input plugin to list results, or as a search plugin
+    with the ``discover`` plugin to automatically find new episodes.
+
+    Each produced entry contains the following fields in addition to the standard ones:
+
+    - ``botarr_network`` -- IRC network name
+    - ``botarr_channel`` -- IRC channel name
+    - ``botarr_bot`` -- XDCC bot name
+    - ``botarr_slot`` -- XDCC pack slot number
+    - ``botarr_size`` -- file size in bytes
+    - ``botarr_size_str`` -- human-readable file size string
+
+    Example (standalone input)::
+
+      botarr_search:
+        url: http://localhost:3001
+        query: "Breaking Bad"
+
+    Example (with discover)::
+
+      discover:
+        what:
+          - next_series_episodes:
+              from_start: yes
+        from:
+          - botarr_search:
+              url: http://localhost:3001
+              query: "{{series_name}} {{series_id}}"
+              providers:
+                - Nibl
+              max_results: 20
+    """
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'url': {'type': 'string', 'format': 'url'},
+            'query': {'type': 'string'},
+            'providers': {
+                'type': 'array',
+                'items': {'type': 'string'},
+            },
+            'max_results': {'type': 'integer', 'minimum': 1, 'default': 20},
+        },
+        'required': ['url'],
+        'additionalProperties': False,
+    }
+
+    def _perform_search(self, task, config, query_string):
+        """Execute a search against the Botarr API and return a list of entries."""
+        base_url = config['url'].rstrip('/')
+        search_url = f'{base_url}/api/search'
+
+        params = {'query': query_string}
+        if config.get('providers'):
+            params['providers'] = ','.join(config['providers'])
+
+        try:
+            logger.debug('Querying Botarr search API: {}', params)
+            response = task.requests.get(search_url, params=params)
+            response.raise_for_status()
+        except RequestException as e:
+            logger.error('Failed to query Botarr search API: {}', e)
+            return []
+
+        data = response.json()
+        results = data.get('results', [])
+
+        if config.get('max_results'):
+            results = results[: config['max_results']]
+
+        entries = []
+        for res in results:
+            filename = res.get('file_name') or res.get('filename')
+            if not filename:
+                logger.debug('Skipping result with no filename: {}', res)
+                continue
+
+            url_obj = res.get('url', {})
+            network = url_obj.get('network', res.get('server', ''))
+            channel = url_obj.get('channel', res.get('channel', ''))
+            bot = url_obj.get('bot', res.get('bot', ''))
+            slot = url_obj.get('slot', res.get('pack_number', ''))
+
+            irc_url = f'irc://{network}/{channel}/{bot}/{slot}'
+
+            entry = Entry(title=filename, url=irc_url)
+            entry['botarr_network'] = network
+            entry['botarr_channel'] = channel
+            entry['botarr_bot'] = bot
+            entry['botarr_slot'] = slot
+            entry['botarr_size'] = res.get('file_size') or res.get('size')
+            entry['botarr_size_str'] = res.get('size_str')
+            entry['botarr_gets'] = res.get('downloads')
+
+            entries.append(entry)
+
+        logger.debug('Botarr returned {} results for query `{}`', len(entries), query_string)
+        return entries
+
+    def on_task_input(self, task, config):
+        """Return entries from a Botarr search query (standalone input mode)."""
+        query = config.get('query', '')
+        if not query:
+            raise plugin.PluginError('`query` is required when botarr_search is used as an input plugin.')
+        return self._perform_search(task, config, query)
+
+    def search(self, task, entry, config):
+        """Return entries matching the given task entry (search plugin mode, used with discover)."""
+        query_template = config.get('query', '{{title}}')
+        try:
+            query_string = entry.render(query_template)
+        except RenderError as e:
+            logger.error('Failed to render botarr_search query template `{}`: {}', query_template, e)
+            return []
+
+        return self._perform_search(task, config, query_string)
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(BotarrSearch, 'botarr_search', interfaces=['task', 'search'], api_ver=2)

--- a/flexget/plugins/input/botarr_search.py
+++ b/flexget/plugins/input/botarr_search.py
@@ -80,8 +80,8 @@ class BotarrSearch:
         data = response.json()
         results = data.get('results', [])
 
-        if config.get('max_results'):
-            results = results[: config['max_results']]
+        max_res = config.get('max_results', 20)
+        results = results[:max_res]
 
         entries = []
         for res in results:

--- a/flexget/plugins/input/botarr_search.py
+++ b/flexget/plugins/input/botarr_search.py
@@ -116,7 +116,9 @@ class BotarrSearch:
         """Return entries from a Botarr search query (standalone input mode)."""
         query = config.get('query', '')
         if not query:
-            raise plugin.PluginError('`query` is required when botarr_search is used as an input plugin.')
+            raise plugin.PluginError(
+                '`query` is required when botarr_search is used as an input plugin.'
+            )
         return self._perform_search(task, config, query)
 
     def search(self, task, entry, config):
@@ -125,7 +127,9 @@ class BotarrSearch:
         try:
             query_string = entry.render(query_template)
         except RenderError as e:
-            logger.error('Failed to render botarr_search query template `{}`: {}', query_template, e)
+            logger.error(
+                'Failed to render botarr_search query template `{}`: {}', query_template, e
+            )
             return []
 
         return self._perform_search(task, config, query_string)

--- a/flexget/plugins/output/botarr.py
+++ b/flexget/plugins/output/botarr.py
@@ -71,7 +71,9 @@ class Botarr:
                 continue
 
             if not irc_url.startswith('irc://'):
-                entry.fail(f"Entry url '{irc_url}' is not an IRC XDCC url (must start with irc://).")
+                entry.fail(
+                    f"Entry url '{irc_url}' is not an IRC XDCC url (must start with irc://)."
+                )
                 continue
 
             payload = {
@@ -94,11 +96,13 @@ class Botarr:
                         error_msg = e.response.json().get('error', e.response.text)
                     except Exception:
                         error_msg = e.response.text
-                    
+
                     if 'Duplicate release' in error_msg or 'Transfer already exists' in error_msg:
                         logger.info('Botarr already has `{}`: {}', entry['title'], error_msg)
                     else:
-                        logger.error('Botarr rejected submission for `{}`: {}', entry['title'], error_msg)
+                        logger.error(
+                            'Botarr rejected submission for `{}`: {}', entry['title'], error_msg
+                        )
                         entry.fail(f'Botarr rejected submission: {error_msg}')
                 else:
                     logger.error('Failed to connect to Botarr at `{}`: {}', base_url, e)
@@ -109,7 +113,9 @@ class Botarr:
             transfer_id = result.get('transfer_id')
 
             if not transfer_id:
-                logger.warning('Botarr returned success but no transfer_id for `{}`', entry['title'])
+                logger.warning(
+                    'Botarr returned success but no transfer_id for `{}`', entry['title']
+                )
                 continue
 
             entry['botarr_transfer_id'] = transfer_id
@@ -150,7 +156,7 @@ class Botarr:
                         entry['botarr_size'] = transfer.get('size')
                         logger.info('Botarr download completed: {}', transfer.get('filename'))
                         return
-                    elif status in ('failed', 'cancelled'):
+                    if status in ('failed', 'cancelled'):
                         error_msg = transfer.get('error') or status
                         entry['botarr_status'] = status
                         logger.error('Botarr download {}: {}', status, error_msg)

--- a/flexget/plugins/output/botarr.py
+++ b/flexget/plugins/output/botarr.py
@@ -1,0 +1,181 @@
+import time
+
+from loguru import logger
+from requests import RequestException
+
+from flexget import plugin
+from flexget.event import event
+
+logger = logger.bind(name='botarr')
+
+
+class Botarr:
+    """Submit XDCC download requests to a `Botarr <https://github.com/ddonindia/Botarr>`_ instance.
+
+    Botarr is an XDCC download manager. This plugin submits the IRC XDCC URL from each
+    accepted entry to Botarr's REST API to start the download.
+
+    The entry ``url`` field must be an XDCC IRC URL in the format::
+
+      irc://<network>/<channel>/<bot>/<slot>
+
+    This is automatically provided when used together with the ``botarr_search`` plugin.
+
+    Example::
+
+      botarr:
+        url: http://localhost:3001
+
+    Full configuration::
+
+      botarr:
+        url: http://localhost:3001
+        priority: normal
+        poll_for_result: no
+        poll_interval: 15
+        poll_timeout: 3600
+    """
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'url': {'type': 'string', 'format': 'url'},
+            'priority': {
+                'type': 'string',
+                'enum': ['low', 'normal', 'high', 'urgent'],
+                'default': 'normal',
+            },
+            'poll_for_result': {'type': 'boolean', 'default': False},
+            'poll_interval': {'type': 'integer', 'minimum': 5, 'default': 15},
+            'poll_timeout': {'type': 'integer', 'minimum': 60, 'default': 3600},
+        },
+        'required': ['url'],
+        'additionalProperties': False,
+    }
+
+    def on_task_output(self, task, config):
+        """Submit accepted entries to Botarr."""
+        if not task.accepted:
+            return
+        if task.options.learn:
+            return
+
+        base_url = config['url'].rstrip('/')
+        download_url = f'{base_url}/api/download'
+
+        for entry in task.accepted:
+            irc_url = entry.get('url')
+
+            if not irc_url:
+                entry.fail('Entry has no url field for Botarr submission.')
+                continue
+
+            if not irc_url.startswith('irc://'):
+                entry.fail(f"Entry url '{irc_url}' is not an IRC XDCC url (must start with irc://).")
+                continue
+
+            payload = {
+                'url': irc_url,
+                'priority': config['priority'],
+                'filename': entry.get('title'),
+            }
+
+            if task.options.test:
+                logger.info('Would submit to Botarr: {}', irc_url)
+                continue
+
+            try:
+                logger.debug('Submitting to Botarr: {}', download_url)
+                response = task.requests.post(download_url, json=payload)
+                response.raise_for_status()
+            except RequestException as e:
+                if getattr(e, 'response', None) is not None:
+                    try:
+                        error_msg = e.response.json().get('error', e.response.text)
+                    except Exception:
+                        error_msg = e.response.text
+                    
+                    if 'Duplicate release' in error_msg or 'Transfer already exists' in error_msg:
+                        logger.info('Botarr already has `{}`: {}', entry['title'], error_msg)
+                    else:
+                        logger.error('Botarr rejected submission for `{}`: {}', entry['title'], error_msg)
+                        entry.fail(f'Botarr rejected submission: {error_msg}')
+                else:
+                    logger.error('Failed to connect to Botarr at `{}`: {}', base_url, e)
+                    entry.fail(f'Failed to connect to Botarr: {e}')
+                continue
+
+            result = response.json()
+            transfer_id = result.get('transfer_id')
+
+            if not transfer_id:
+                logger.warning('Botarr returned success but no transfer_id for `{}`', entry['title'])
+                continue
+
+            entry['botarr_transfer_id'] = transfer_id
+            logger.info(
+                'Successfully submitted `{}` to Botarr (Transfer ID: {})',
+                entry['title'],
+                transfer_id,
+            )
+
+            if config['poll_for_result']:
+                self._poll_transfer(task, entry, transfer_id, base_url, config)
+
+    def _poll_transfer(self, task, entry, transfer_id, base_url, config):
+        """Poll Botarr until a transfer completes, fails, or the timeout is reached.
+
+        .. note::
+            This blocks the FlexGet process for up to ``poll_timeout`` seconds.
+            Only enable this if you need synchronous completion feedback.
+        """
+        poll_url = f'{base_url}/api/transfers/{transfer_id}'
+        interval = config['poll_interval']
+        timeout = config['poll_timeout']
+
+        logger.info('Polling Botarr for transfer completion (timeout: {}s)', timeout)
+
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            try:
+                response = task.requests.get(poll_url)
+                if response.status_code == 200:
+                    data = response.json()
+                    transfer = data.get('transfer', {})
+                    status = transfer.get('status')
+
+                    if status == 'completed':
+                        entry['botarr_status'] = status
+                        entry['botarr_filename'] = transfer.get('filename')
+                        entry['botarr_size'] = transfer.get('size')
+                        logger.info('Botarr download completed: {}', transfer.get('filename'))
+                        return
+                    elif status in ('failed', 'cancelled'):
+                        error_msg = transfer.get('error') or status
+                        entry['botarr_status'] = status
+                        logger.error('Botarr download {}: {}', status, error_msg)
+                        entry.fail(f'Botarr download {status}: {error_msg}')
+                        return
+
+                    logger.verbose(
+                        'Botarr transfer status: {} (progress: {:.1f}%)',
+                        status,
+                        transfer.get('progress', 0.0),
+                    )
+                elif response.status_code == 404:
+                    logger.warning('Botarr transfer {} not found during polling', transfer_id)
+                    entry.fail('Transfer not found in Botarr during polling')
+                    return
+                else:
+                    logger.debug('Botarr poll returned unexpected status {}', response.status_code)
+            except RequestException as e:
+                logger.debug('Botarr poll request failed: {}', e)
+
+            time.sleep(interval)
+
+        logger.warning('Botarr polling timed out after {}s for transfer {}', timeout, transfer_id)
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(Botarr, 'botarr', api_ver=2)

--- a/tests/test_botarr.py
+++ b/tests/test_botarr.py
@@ -1,6 +1,5 @@
 from unittest import mock
 
-import pytest
 from requests import RequestException
 
 from flexget.plugins.output.botarr import Botarr
@@ -169,8 +168,9 @@ class TestBotarr:
         task = execute_task('test_botarr_success')
         mock_post.reset_mock()
         task.options.learn = True
-        from flexget.plugins.output.botarr import Botarr
-        Botarr().on_task_output(task, {'url': 'http://localhost:3001', 'priority': 'normal', 'poll_for_result': False})
+        Botarr().on_task_output(
+            task, {'url': 'http://localhost:3001', 'priority': 'normal', 'poll_for_result': False}
+        )
         mock_post.assert_not_called()
 
     @mock.patch('flexget.utils.requests.Session.post')
@@ -183,10 +183,12 @@ class TestBotarr:
     @mock.patch('flexget.utils.requests.Session.post')
     def test_botarr_duplicate(self, mock_post, execute_task):
         mock_response = mock.Mock()
-        mock_response.raise_for_status.side_effect = RequestException(response=mock.Mock(
-            json=lambda: {'error': 'Duplicate release detected'},
-            text='Duplicate release detected'
-        ))
+        mock_response.raise_for_status.side_effect = RequestException(
+            response=mock.Mock(
+                json=lambda: {'error': 'Duplicate release detected'},
+                text='Duplicate release detected',
+            )
+        )
         mock_post.return_value = mock_response
 
         task = execute_task('test_botarr_duplicate')
@@ -197,10 +199,11 @@ class TestBotarr:
     @mock.patch('flexget.utils.requests.Session.post')
     def test_botarr_http_error(self, mock_post, execute_task):
         mock_response = mock.Mock()
-        mock_response.raise_for_status.side_effect = RequestException(response=mock.Mock(
-            json=mock.Mock(side_effect=ValueError("Invalid JSON")),
-            text='Some other error'
-        ))
+        mock_response.raise_for_status.side_effect = RequestException(
+            response=mock.Mock(
+                json=mock.Mock(side_effect=ValueError('Invalid JSON')), text='Some other error'
+            )
+        )
         mock_post.return_value = mock_response
 
         task = execute_task('test_botarr_http_error')
@@ -332,7 +335,7 @@ class TestBotarr:
         mock_post_resp.raise_for_status.return_value = None
         mock_post.return_value = mock_post_resp
 
-        mock_get.side_effect = RequestException("Poll error")
+        mock_get.side_effect = RequestException('Poll error')
 
         with mock.patch('time.time', side_effect=[0, 0, 70, 80]):
             execute_task('test_botarr_poll_404')

--- a/tests/test_botarr.py
+++ b/tests/test_botarr.py
@@ -161,7 +161,7 @@ class TestBotarr:
 
     @mock.patch('flexget.utils.requests.Session.post')
     def test_botarr_learn(self, mock_post, execute_task):
-        task = execute_task('test_botarr_learn', options=dict(learn=True))
+        execute_task('test_botarr_learn', options={'learn': True})
         mock_post.assert_not_called()
 
     @mock.patch('flexget.utils.requests.Session.post')

--- a/tests/test_botarr.py
+++ b/tests/test_botarr.py
@@ -1,5 +1,5 @@
-from unittest import mock
 import itertools
+from unittest import mock
 
 from requests import RequestException
 

--- a/tests/test_botarr.py
+++ b/tests/test_botarr.py
@@ -1,4 +1,5 @@
 from unittest import mock
+import itertools
 
 from requests import RequestException
 
@@ -288,7 +289,7 @@ class TestBotarr:
         mock_get.return_value = mock_get_resp
 
         # Mock time.time to simulate timeout immediately
-        with mock.patch('time.time', side_effect=[0, 0, 70, 80]):
+        with mock.patch('time.time', side_effect=itertools.count(0, 30)):
             task = execute_task('test_botarr_poll_timeout')
 
         assert len(task.accepted) == 1
@@ -323,7 +324,7 @@ class TestBotarr:
         mock_get_resp.status_code = 500
         mock_get.return_value = mock_get_resp
 
-        with mock.patch('time.time', side_effect=[0, 0, 70, 80]):
+        with mock.patch('time.time', side_effect=itertools.count(0, 30)):
             execute_task('test_botarr_poll_404')
 
     @mock.patch('time.sleep')
@@ -337,5 +338,5 @@ class TestBotarr:
 
         mock_get.side_effect = RequestException('Poll error')
 
-        with mock.patch('time.time', side_effect=[0, 0, 70, 80]):
+        with mock.patch('time.time', side_effect=itertools.count(0, 30)):
             execute_task('test_botarr_poll_404')

--- a/tests/test_botarr.py
+++ b/tests/test_botarr.py
@@ -1,0 +1,338 @@
+from unittest import mock
+
+import pytest
+from requests import RequestException
+
+from flexget.plugins.output.botarr import Botarr
+
+
+class TestBotarr:
+    config = """
+        templates:
+          global:
+            disable: [retry_failed, urlrewriting]
+        tasks:
+          test_botarr_success:
+            mock:
+              - {title: 'TestFile.mkv', url: 'irc://Rizon/#channel/Bot/#1'}
+            accept_all: yes
+            botarr:
+              url: http://localhost:3001
+              priority: high
+
+          test_botarr_empty:
+            mock:
+              - {title: 'Empty.mkv', url: 'irc://Rizon'}
+            botarr:
+              url: http://localhost:3001
+
+          test_botarr_no_url:
+            mock:
+              - {title: 'NoUrl.mkv'}
+            accept_all: yes
+            set:
+              url: ''
+            botarr:
+              url: http://localhost:3001
+
+          test_botarr_invalid_url:
+            mock:
+              - {title: 'Invalid.mkv', url: 'http://example.com/file'}
+            accept_all: yes
+            botarr:
+              url: http://localhost:3001
+
+          test_botarr_learn:
+            mock:
+              - {title: 'Learn.mkv', url: 'irc://Rizon/#channel/Bot/#1'}
+            accept_all: yes
+            botarr:
+              url: http://localhost:3001
+
+          test_botarr_test_mode:
+            mock:
+              - {title: 'TestMode.mkv', url: 'irc://Rizon/#channel/Bot/#1'}
+            accept_all: yes
+            botarr:
+              url: http://localhost:3001
+
+          test_botarr_duplicate:
+            mock:
+              - {title: 'Dup.mkv', url: 'irc://Rizon/#channel/Bot/#1'}
+            accept_all: yes
+            botarr:
+              url: http://localhost:3001
+
+          test_botarr_http_error:
+            mock:
+              - {title: 'Error.mkv', url: 'irc://Rizon/#channel/Bot/#1'}
+            accept_all: yes
+            botarr:
+              url: http://localhost:3001
+
+          test_botarr_connection_error:
+            mock:
+              - {title: 'ConnError.mkv', url: 'irc://Rizon/#channel/Bot/#1'}
+            accept_all: yes
+            botarr:
+              url: http://localhost:3001
+
+          test_botarr_no_transfer_id:
+            mock:
+              - {title: 'NoId.mkv', url: 'irc://Rizon/#channel/Bot/#1'}
+            accept_all: yes
+            botarr:
+              url: http://localhost:3001
+
+          test_botarr_poll_completed:
+            mock:
+              - {title: 'PollComp.mkv', url: 'irc://Rizon/#channel/Bot/#1'}
+            accept_all: yes
+            botarr:
+              url: http://localhost:3001
+              poll_for_result: yes
+              poll_interval: 5
+              poll_timeout: 60
+
+          test_botarr_poll_failed:
+            mock:
+              - {title: 'PollFail.mkv', url: 'irc://Rizon/#channel/Bot/#1'}
+            accept_all: yes
+            botarr:
+              url: http://localhost:3001
+              poll_for_result: yes
+              poll_interval: 5
+              poll_timeout: 60
+
+          test_botarr_poll_timeout:
+            mock:
+              - {title: 'PollTimeout.mkv', url: 'irc://Rizon/#channel/Bot/#1'}
+            accept_all: yes
+            botarr:
+              url: http://localhost:3001
+              poll_for_result: yes
+              poll_interval: 5
+              poll_timeout: 60
+
+          test_botarr_poll_404:
+            mock:
+              - {title: 'Poll404.mkv', url: 'irc://Rizon/#channel/Bot/#1'}
+            accept_all: yes
+            botarr:
+              url: http://localhost:3001
+              poll_for_result: yes
+              poll_interval: 5
+              poll_timeout: 60
+    """
+
+    @mock.patch('flexget.utils.requests.Session.post')
+    def test_botarr_submit(self, mock_post, execute_task):
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {'transfer_id': 'test-uuid-1234'}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        task = execute_task('test_botarr_success')
+        assert len(task.accepted) == 1
+        entry = task.accepted[0]
+
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        assert args[0] == 'http://localhost:3001/api/download'
+        assert kwargs['json']['url'] == 'irc://Rizon/#channel/Bot/#1'
+        assert kwargs['json']['priority'] == 'high'
+        assert kwargs['json']['filename'] == 'TestFile.mkv'
+        assert entry.get('botarr_transfer_id') == 'test-uuid-1234'
+        assert not entry.failed
+
+    def test_botarr_no_url(self, execute_task):
+        task = execute_task('test_botarr_no_url')
+        assert len(task.all_entries) == 1
+        assert task.all_entries[0].failed
+
+    def test_botarr_empty(self, execute_task):
+        task = execute_task('test_botarr_empty')
+        assert len(task.accepted) == 0
+
+    def test_botarr_invalid_url(self, execute_task):
+        task = execute_task('test_botarr_invalid_url')
+        assert len(task.all_entries) == 1
+        assert task.all_entries[0].failed
+
+    @mock.patch('flexget.utils.requests.Session.post')
+    def test_botarr_learn(self, mock_post, execute_task):
+        task = execute_task('test_botarr_learn', options=dict(learn=True))
+        mock_post.assert_not_called()
+
+    @mock.patch('flexget.utils.requests.Session.post')
+    def test_botarr_learn_manual(self, mock_post, execute_task):
+        task = execute_task('test_botarr_success')
+        mock_post.reset_mock()
+        task.options.learn = True
+        from flexget.plugins.output.botarr import Botarr
+        Botarr().on_task_output(task, {'url': 'http://localhost:3001', 'priority': 'normal', 'poll_for_result': False})
+        mock_post.assert_not_called()
+
+    @mock.patch('flexget.utils.requests.Session.post')
+    def test_botarr_test_mode(self, mock_post, execute_task):
+        task = execute_task('test_botarr_test_mode', options={'test': True})
+        assert len(task.accepted) == 1
+        assert not task.accepted[0].failed
+        mock_post.assert_not_called()
+
+    @mock.patch('flexget.utils.requests.Session.post')
+    def test_botarr_duplicate(self, mock_post, execute_task):
+        mock_response = mock.Mock()
+        mock_response.raise_for_status.side_effect = RequestException(response=mock.Mock(
+            json=lambda: {'error': 'Duplicate release detected'},
+            text='Duplicate release detected'
+        ))
+        mock_post.return_value = mock_response
+
+        task = execute_task('test_botarr_duplicate')
+        assert len(task.accepted) == 1
+        # Duplicate shouldn't fail the entry, just logs info
+        assert not task.accepted[0].failed
+
+    @mock.patch('flexget.utils.requests.Session.post')
+    def test_botarr_http_error(self, mock_post, execute_task):
+        mock_response = mock.Mock()
+        mock_response.raise_for_status.side_effect = RequestException(response=mock.Mock(
+            json=mock.Mock(side_effect=ValueError("Invalid JSON")),
+            text='Some other error'
+        ))
+        mock_post.return_value = mock_response
+
+        task = execute_task('test_botarr_http_error')
+        assert len(task.all_entries) == 1
+        assert task.all_entries[0].failed
+
+    @mock.patch('flexget.utils.requests.Session.post')
+    def test_botarr_connection_error(self, mock_post, execute_task):
+        mock_post.side_effect = RequestException('Connection timeout')
+        task = execute_task('test_botarr_connection_error')
+        assert len(task.all_entries) == 1
+        assert task.all_entries[0].failed
+
+    @mock.patch('flexget.utils.requests.Session.post')
+    def test_botarr_no_transfer_id(self, mock_post, execute_task):
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {}  # No transfer_id
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        task = execute_task('test_botarr_no_transfer_id')
+        assert len(task.accepted) == 1
+        assert not task.accepted[0].failed
+        assert 'botarr_transfer_id' not in task.accepted[0]
+
+    @mock.patch('flexget.utils.requests.Session.get')
+    @mock.patch('flexget.utils.requests.Session.post')
+    def test_botarr_poll_completed(self, mock_post, mock_get, execute_task):
+        mock_post_resp = mock.Mock()
+        mock_post_resp.json.return_value = {'transfer_id': 'poll-1'}
+        mock_post_resp.raise_for_status.return_value = None
+        mock_post.return_value = mock_post_resp
+
+        mock_get_resp = mock.Mock()
+        mock_get_resp.status_code = 200
+        mock_get_resp.json.return_value = {
+            'transfer': {'status': 'completed', 'filename': 'PollComp.mkv', 'size': 12345}
+        }
+        mock_get.return_value = mock_get_resp
+
+        task = execute_task('test_botarr_poll_completed')
+        assert len(task.accepted) == 1
+        entry = task.accepted[0]
+        assert entry.get('botarr_status') == 'completed'
+        assert entry.get('botarr_filename') == 'PollComp.mkv'
+        assert entry.get('botarr_size') == 12345
+        assert not entry.failed
+
+    @mock.patch('flexget.utils.requests.Session.get')
+    @mock.patch('flexget.utils.requests.Session.post')
+    def test_botarr_poll_failed(self, mock_post, mock_get, execute_task):
+        mock_post_resp = mock.Mock()
+        mock_post_resp.json.return_value = {'transfer_id': 'poll-2'}
+        mock_post_resp.raise_for_status.return_value = None
+        mock_post.return_value = mock_post_resp
+
+        mock_get_resp = mock.Mock()
+        mock_get_resp.status_code = 200
+        mock_get_resp.json.return_value = {
+            'transfer': {'status': 'failed', 'error': 'CRC mismatch'}
+        }
+        mock_get.return_value = mock_get_resp
+
+        task = execute_task('test_botarr_poll_failed')
+        assert len(task.all_entries) == 1
+        entry = task.all_entries[0]
+        assert entry.get('botarr_status') == 'failed'
+        assert entry.failed
+
+    @mock.patch('time.sleep')
+    @mock.patch('flexget.utils.requests.Session.get')
+    @mock.patch('flexget.utils.requests.Session.post')
+    def test_botarr_poll_timeout(self, mock_post, mock_get, mock_sleep, execute_task):
+        mock_post_resp = mock.Mock()
+        mock_post_resp.json.return_value = {'transfer_id': 'poll-3'}
+        mock_post_resp.raise_for_status.return_value = None
+        mock_post.return_value = mock_post_resp
+
+        mock_get_resp = mock.Mock()
+        mock_get_resp.status_code = 200
+        mock_get_resp.json.return_value = {'transfer': {'status': 'downloading', 'progress': 50.0}}
+        mock_get.return_value = mock_get_resp
+
+        # Mock time.time to simulate timeout immediately
+        with mock.patch('time.time', side_effect=[0, 0, 70, 80]):
+            task = execute_task('test_botarr_poll_timeout')
+
+        assert len(task.accepted) == 1
+        assert not task.accepted[0].failed
+
+    @mock.patch('flexget.utils.requests.Session.get')
+    @mock.patch('flexget.utils.requests.Session.post')
+    def test_botarr_poll_404(self, mock_post, mock_get, execute_task):
+        mock_post_resp = mock.Mock()
+        mock_post_resp.json.return_value = {'transfer_id': 'poll-4'}
+        mock_post_resp.raise_for_status.return_value = None
+        mock_post.return_value = mock_post_resp
+
+        mock_get_resp = mock.Mock()
+        mock_get_resp.status_code = 404
+        mock_get.return_value = mock_get_resp
+
+        task = execute_task('test_botarr_poll_404')
+        assert len(task.all_entries) == 1
+        assert task.all_entries[0].failed
+
+    @mock.patch('time.sleep')
+    @mock.patch('flexget.utils.requests.Session.get')
+    @mock.patch('flexget.utils.requests.Session.post')
+    def test_botarr_poll_500(self, mock_post, mock_get, mock_sleep, execute_task):
+        mock_post_resp = mock.Mock()
+        mock_post_resp.json.return_value = {'transfer_id': 'poll-500'}
+        mock_post_resp.raise_for_status.return_value = None
+        mock_post.return_value = mock_post_resp
+
+        mock_get_resp = mock.Mock()
+        mock_get_resp.status_code = 500
+        mock_get.return_value = mock_get_resp
+
+        with mock.patch('time.time', side_effect=[0, 0, 70, 80]):
+            execute_task('test_botarr_poll_404')
+
+    @mock.patch('time.sleep')
+    @mock.patch('flexget.utils.requests.Session.get')
+    @mock.patch('flexget.utils.requests.Session.post')
+    def test_botarr_poll_exception(self, mock_post, mock_get, mock_sleep, execute_task):
+        mock_post_resp = mock.Mock()
+        mock_post_resp.json.return_value = {'transfer_id': 'poll-exc'}
+        mock_post_resp.raise_for_status.return_value = None
+        mock_post.return_value = mock_post_resp
+
+        mock_get.side_effect = RequestException("Poll error")
+
+        with mock.patch('time.time', side_effect=[0, 0, 70, 80]):
+            execute_task('test_botarr_poll_404')

--- a/tests/test_botarr_history.py
+++ b/tests/test_botarr_history.py
@@ -3,8 +3,6 @@ from unittest import mock
 import pytest
 from requests import RequestException
 
-from flexget.plugins.input.botarr_history import BotarrHistory
-
 
 class TestBotarrHistory:
     config = """
@@ -54,16 +52,16 @@ class TestBotarrHistory:
                 {
                     'status': 'Completed',
                     'file_name': 'File3.mkv',
-                }
+                },
             ],
-            'total': 3
+            'total': 3,
         }
         mock_resp.raise_for_status.return_value = None
         mock_get.return_value = mock_resp
 
         task = execute_task('test_history')
         assert len(task.entries) == 3
-        
+
         e1, e2, e3 = task.entries
         assert e1['title'] == 'File1.mkv'
         assert e1['url'] == 'irc://Rizon/#channel1/Bot1/100'
@@ -82,7 +80,7 @@ class TestBotarrHistory:
         mock_resp.json.return_value = {
             'items': [
                 {'id': 'uuid-1', 'status': 'Completed', 'file_name': 'File1.mkv'},
-                {'id': 'uuid-2', 'status': 'Failed', 'file_name': 'File2.mkv'}
+                {'id': 'uuid-2', 'status': 'Failed', 'file_name': 'File2.mkv'},
             ]
         }
         mock_resp.raise_for_status.return_value = None
@@ -125,8 +123,8 @@ class TestBotarrHistory:
     @mock.patch('flexget.utils.requests.Session.get')
     def test_botarr_history_error(self, mock_get, execute_task):
         mock_get.side_effect = RequestException('Connection error')
-        
+
         with pytest.raises(Exception) as excinfo:
             execute_task('test_history_error')
-            
+
         assert 'Failed to fetch Botarr history' in str(excinfo.value)

--- a/tests/test_botarr_history.py
+++ b/tests/test_botarr_history.py
@@ -11,7 +11,7 @@ class TestBotarrHistory:
             botarr_history:
               url: http://localhost:3001
               only_new: no
-              
+
           test_history_status:
             botarr_history:
               url: http://localhost:3001
@@ -62,7 +62,7 @@ class TestBotarrHistory:
         task = execute_task('test_history')
         assert len(task.entries) == 3
 
-        e1, e2, e3 = task.entries
+        e1, e2, _e3 = task.entries
         assert e1['title'] == 'File1.mkv'
         assert e1['url'] == 'irc://Rizon/#channel1/Bot1/100'
         assert e1['botarr_transfer_id'] == 'uuid-1'
@@ -124,7 +124,5 @@ class TestBotarrHistory:
     def test_botarr_history_error(self, mock_get, execute_task):
         mock_get.side_effect = RequestException('Connection error')
 
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception, match='Failed to fetch Botarr history'):
             execute_task('test_history_error')
-
-        assert 'Failed to fetch Botarr history' in str(excinfo.value)

--- a/tests/test_botarr_history.py
+++ b/tests/test_botarr_history.py
@@ -1,0 +1,132 @@
+from unittest import mock
+
+import pytest
+from requests import RequestException
+
+from flexget.plugins.input.botarr_history import BotarrHistory
+
+
+class TestBotarrHistory:
+    config = """
+        tasks:
+          test_history:
+            botarr_history:
+              url: http://localhost:3001
+              only_new: no
+              
+          test_history_status:
+            botarr_history:
+              url: http://localhost:3001
+              status: Completed
+              only_new: no
+
+          test_history_only_new:
+            botarr_history:
+              url: http://localhost:3001
+              only_new: yes
+
+          test_history_error:
+            botarr_history:
+              url: http://localhost:3001
+    """
+
+    @mock.patch('flexget.utils.requests.Session.get')
+    def test_botarr_history(self, mock_get, execute_task):
+        mock_resp = mock.Mock()
+        mock_resp.json.return_value = {
+            'items': [
+                {
+                    'id': 'uuid-1',
+                    'status': 'Completed',
+                    'file_name': 'File1.mkv',
+                    'network': 'Rizon',
+                    'channel': '#channel1',
+                    'bot': 'Bot1',
+                    'slot': 100,
+                    'size': 1024,
+                },
+                {
+                    'id': 'uuid-2',
+                    'status': 'Failed',
+                    'file_name': 'File2.mkv',
+                    'error': 'CRC mismatch',
+                },
+                {
+                    'status': 'Completed',
+                    'file_name': 'File3.mkv',
+                }
+            ],
+            'total': 3
+        }
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        task = execute_task('test_history')
+        assert len(task.entries) == 3
+        
+        e1, e2, e3 = task.entries
+        assert e1['title'] == 'File1.mkv'
+        assert e1['url'] == 'irc://Rizon/#channel1/Bot1/100'
+        assert e1['botarr_transfer_id'] == 'uuid-1'
+        assert e1['botarr_status'] == 'Completed'
+        assert e1['botarr_size'] == 1024
+
+        assert e2['title'] == 'File2.mkv'
+        assert e2['botarr_transfer_id'] == 'uuid-2'
+        assert e2['botarr_status'] == 'Failed'
+        assert e2['botarr_error'] == 'CRC mismatch'
+
+    @mock.patch('flexget.utils.requests.Session.get')
+    def test_botarr_history_status(self, mock_get, execute_task):
+        mock_resp = mock.Mock()
+        mock_resp.json.return_value = {
+            'items': [
+                {'id': 'uuid-1', 'status': 'Completed', 'file_name': 'File1.mkv'},
+                {'id': 'uuid-2', 'status': 'Failed', 'file_name': 'File2.mkv'}
+            ]
+        }
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        task = execute_task('test_history_status')
+        assert len(task.entries) == 1
+        assert task.entries[0]['title'] == 'File1.mkv'
+
+    @mock.patch('flexget.utils.requests.Session.get')
+    def test_botarr_history_only_new(self, mock_get, execute_task):
+        mock_resp = mock.Mock()
+        mock_resp.json.return_value = {
+            'items': [
+                {'id': 'uuid-1', 'status': 'Completed', 'file_name': 'File1.mkv'},
+            ]
+        }
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        # First run should produce the entry
+        task1 = execute_task('test_history_only_new')
+        assert len(task1.entries) == 1
+
+        # Second run with same data should produce 0 entries due to only_new
+        task2 = execute_task('test_history_only_new')
+        assert len(task2.entries) == 0
+
+        # Now add a new item
+        mock_resp.json.return_value = {
+            'items': [
+                {'id': 'uuid-1', 'status': 'Completed', 'file_name': 'File1.mkv'},
+                {'id': 'uuid-2', 'status': 'Completed', 'file_name': 'File2.mkv'},
+            ]
+        }
+        task3 = execute_task('test_history_only_new')
+        assert len(task3.entries) == 1
+        assert task3.entries[0]['title'] == 'File2.mkv'
+
+    @mock.patch('flexget.utils.requests.Session.get')
+    def test_botarr_history_error(self, mock_get, execute_task):
+        mock_get.side_effect = RequestException('Connection error')
+        
+        with pytest.raises(Exception) as excinfo:
+            execute_task('test_history_error')
+            
+        assert 'Failed to fetch Botarr history' in str(excinfo.value)

--- a/tests/test_botarr_search.py
+++ b/tests/test_botarr_search.py
@@ -3,8 +3,6 @@ from unittest import mock
 import pytest
 from requests import RequestException
 
-from flexget.plugins.input.botarr_search import BotarrSearch
-
 
 class TestBotarrSearch:
     config = """
@@ -70,18 +68,23 @@ class TestBotarrSearch:
                 },
                 {
                     'filename': 'Breaking Bad S01E02.mkv',
-                    'url': {'network': 'Rizon', 'channel': '#channel1', 'bot': 'Bot1', 'slot': 101},
+                    'url': {
+                        'network': 'Rizon',
+                        'channel': '#channel1',
+                        'bot': 'Bot1',
+                        'slot': 101,
+                    },
                 },
                 {
-                    'url': {'network': 'Rizon'}, # missing filename
-                }
+                    'url': {'network': 'Rizon'},  # missing filename
+                },
             ]
         }
         mock_resp.raise_for_status.return_value = None
         mock_get.return_value = mock_resp
 
         task = execute_task('test_search_input')
-        
+
         # max_results was 1, so only 1 entry should be produced
         assert len(task.entries) == 1
         entry = task.entries[0]
@@ -109,8 +112,8 @@ class TestBotarrSearch:
                     'server': 'Rizon',
                 },
                 {
-                    'url': {'network': 'Rizon'}, # missing filename
-                }
+                    'url': {'network': 'Rizon'},  # missing filename
+                },
             ]
         }
         mock_resp.raise_for_status.return_value = None
@@ -131,7 +134,12 @@ class TestBotarrSearch:
             'results': [
                 {
                     'filename': "Frieren Beyond Journey's End S01E01.mkv",
-                    'url': {'network': 'Rizon', 'channel': '#channel1', 'bot': 'Bot1', 'slot': 101},
+                    'url': {
+                        'network': 'Rizon',
+                        'channel': '#channel1',
+                        'bot': 'Bot1',
+                        'slot': 101,
+                    },
                 }
             ]
         }
@@ -139,12 +147,12 @@ class TestBotarrSearch:
         mock_get.return_value = mock_resp
 
         task = execute_task('test_search_plugin')
-        
+
         # Discover will produce the entry from the search plugin
         assert len(task.entries) == 1
         entry = task.entries[0]
         assert entry['title'] == "Frieren Beyond Journey's End S01E01.mkv"
-        
+
         mock_get.assert_called_once()
         args, kwargs = mock_get.call_args
         assert kwargs['params']['query'] == "Frieren Beyond Journey's End S01E01"

--- a/tests/test_botarr_search.py
+++ b/tests/test_botarr_search.py
@@ -13,12 +13,12 @@ class TestBotarrSearch:
               query: "Breaking Bad"
               providers: [Nibl, SubsPlease]
               max_results: 1
-              
+
           test_search_input_no_max:
             botarr_search:
               url: http://localhost:3001
               query: "Breaking Bad"
-              
+
           test_search_input_no_query:
             botarr_search:
               url: http://localhost:3001
@@ -123,9 +123,8 @@ class TestBotarrSearch:
         assert len(task.entries) == 1
 
     def test_botarr_search_input_no_query(self, execute_task):
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception, match='`query` is required'):
             execute_task('test_search_input_no_query')
-        assert '`query` is required' in str(excinfo.value)
 
     @mock.patch('flexget.utils.requests.Session.get')
     def test_botarr_search_plugin(self, mock_get, execute_task):
@@ -154,7 +153,7 @@ class TestBotarrSearch:
         assert entry['title'] == "Frieren Beyond Journey's End S01E01.mkv"
 
         mock_get.assert_called_once()
-        args, kwargs = mock_get.call_args
+        _args, kwargs = mock_get.call_args
         assert kwargs['params']['query'] == "Frieren Beyond Journey's End S01E01"
 
     @mock.patch('flexget.utils.requests.Session.get')

--- a/tests/test_botarr_search.py
+++ b/tests/test_botarr_search.py
@@ -1,0 +1,164 @@
+from unittest import mock
+
+import pytest
+from requests import RequestException
+
+from flexget.plugins.input.botarr_search import BotarrSearch
+
+
+class TestBotarrSearch:
+    config = """
+        tasks:
+          test_search_input:
+            botarr_search:
+              url: http://localhost:3001
+              query: "Breaking Bad"
+              providers: [Nibl, SubsPlease]
+              max_results: 1
+              
+          test_search_input_no_max:
+            botarr_search:
+              url: http://localhost:3001
+              query: "Breaking Bad"
+              
+          test_search_input_no_query:
+            botarr_search:
+              url: http://localhost:3001
+
+          test_search_plugin:
+            accept_all: yes
+            discover:
+              release_estimations: ignore
+              what:
+                - mock:
+                    - {"title": "Frieren Beyond Journey's End S01E01"}
+              from:
+                - botarr_search:
+                    url: http://localhost:3001
+                    query: "{{title}}"
+
+          test_search_render_error:
+            accept_all: yes
+            discover:
+              release_estimations: ignore
+              what:
+                - mock:
+                    - {title: 'Frieren'}
+              from:
+                - botarr_search:
+                    url: http://localhost:3001
+                    query: "{{missing_field}}"
+
+          test_search_http_error:
+            botarr_search:
+              url: http://localhost:3001
+              query: "Breaking Bad"
+    """
+
+    @mock.patch('flexget.utils.requests.Session.get')
+    def test_botarr_search_input(self, mock_get, execute_task):
+        mock_resp = mock.Mock()
+        mock_resp.json.return_value = {
+            'results': [
+                {
+                    'filename': 'Breaking Bad S01E01.mkv',
+                    'server': 'Rizon',
+                    'channel': '#channel1',
+                    'bot': 'Bot1',
+                    'pack_number': 100,
+                    'size': 1024,
+                },
+                {
+                    'filename': 'Breaking Bad S01E02.mkv',
+                    'url': {'network': 'Rizon', 'channel': '#channel1', 'bot': 'Bot1', 'slot': 101},
+                },
+                {
+                    'url': {'network': 'Rizon'}, # missing filename
+                }
+            ]
+        }
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        task = execute_task('test_search_input')
+        
+        # max_results was 1, so only 1 entry should be produced
+        assert len(task.entries) == 1
+        entry = task.entries[0]
+        assert entry['title'] == 'Breaking Bad S01E01.mkv'
+        assert entry['url'] == 'irc://Rizon/#channel1/Bot1/100'
+        assert entry['botarr_network'] == 'Rizon'
+        assert entry['botarr_channel'] == '#channel1'
+        assert entry['botarr_bot'] == 'Bot1'
+        assert entry['botarr_slot'] == 100
+        assert entry['botarr_size'] == 1024
+
+        mock_get.assert_called_once()
+        args, kwargs = mock_get.call_args
+        assert args[0] == 'http://localhost:3001/api/search'
+        assert kwargs['params']['query'] == 'Breaking Bad'
+        assert kwargs['params']['providers'] == 'Nibl,SubsPlease'
+
+    @mock.patch('flexget.utils.requests.Session.get')
+    def test_botarr_search_input_no_max(self, mock_get, execute_task):
+        mock_resp = mock.Mock()
+        mock_resp.json.return_value = {
+            'results': [
+                {
+                    'filename': 'File.mkv',
+                    'server': 'Rizon',
+                },
+                {
+                    'url': {'network': 'Rizon'}, # missing filename
+                }
+            ]
+        }
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        task = execute_task('test_search_input_no_max')
+        assert len(task.entries) == 1
+
+    def test_botarr_search_input_no_query(self, execute_task):
+        with pytest.raises(Exception) as excinfo:
+            execute_task('test_search_input_no_query')
+        assert '`query` is required' in str(excinfo.value)
+
+    @mock.patch('flexget.utils.requests.Session.get')
+    def test_botarr_search_plugin(self, mock_get, execute_task):
+        mock_resp = mock.Mock()
+        mock_resp.json.return_value = {
+            'results': [
+                {
+                    'filename': "Frieren Beyond Journey's End S01E01.mkv",
+                    'url': {'network': 'Rizon', 'channel': '#channel1', 'bot': 'Bot1', 'slot': 101},
+                }
+            ]
+        }
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        task = execute_task('test_search_plugin')
+        
+        # Discover will produce the entry from the search plugin
+        assert len(task.entries) == 1
+        entry = task.entries[0]
+        assert entry['title'] == "Frieren Beyond Journey's End S01E01.mkv"
+        
+        mock_get.assert_called_once()
+        args, kwargs = mock_get.call_args
+        assert kwargs['params']['query'] == "Frieren Beyond Journey's End S01E01"
+
+    @mock.patch('flexget.utils.requests.Session.get')
+    def test_botarr_search_render_error(self, mock_get, execute_task):
+        task = execute_task('test_search_render_error')
+        # Render error should mean 0 results are returned and plugin skips gracefully
+        assert len(task.entries) == 0
+        mock_get.assert_not_called()
+
+    @mock.patch('flexget.utils.requests.Session.get')
+    def test_botarr_search_http_error(self, mock_get, execute_task):
+        mock_get.side_effect = RequestException('Connection timeout')
+        task = execute_task('test_search_http_error')
+        # Should catch error and return [] gracefully
+        assert len(task.entries) == 0

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1982,6 +1982,7 @@ class TestCLI:
         execute_task('learn_series')
         import os
         from unittest import mock
+
         options = get_parser().parse_args(['series', 'list', '--porcelain'])
         buffer = StringIO()
         with mock.patch.dict(os.environ, {'COLUMNS': '120'}), capture_console(buffer):

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1980,9 +1980,11 @@ class TestCLI:
     def test_series_list(self, manager, execute_task):
         """Very rudimentary test, mostly makes sure this doesn't crash."""
         execute_task('learn_series')
+        import os
+        from unittest import mock
         options = get_parser().parse_args(['series', 'list', '--porcelain'])
         buffer = StringIO()
-        with capture_console(buffer):
+        with mock.patch.dict(os.environ, {'COLUMNS': '120'}), capture_console(buffer):
             manager.handle_cli(options=options)
         lines = buffer.getvalue().split('\n')
         assert all(


### PR DESCRIPTION
# Added Botarr XDCC download manager integration plugins

Added three new plugins for integrating FlexGet with [Botarr](https://github.com/ddonindia/Botarr) XDCC download manager:

- **botarr** (output): Submits accepted entries to Botarr's REST API for XDCC downloading. Supports priority levels, optional polling for transfer completion, duplicate detection, and test mode.

- **botarr_history** (input): Produces entries from Botarr's download history. Supports status filtering and `only_new` tracking via `simple_persistence` to avoid re-processing.

- **botarr_search** (input): Searches Botarr's aggregated XDCC providers. Works as both standalone input and as a search plugin with `discover`.

## Motivation for changes:

[Botarr](https://github.com/ddonindia/Botarr) is a modern, high-performance, self-hosted XDCC manager. It features aggregated multi-provider search, an async IRC client, SSL/TLS support, SOCKS5 proxy, queue management with retries, and a Lua plugin system — all exposed via a REST API.

The workflow: FlexGet queries Botarr's search API for XDCC packs --> Botarr aggregates results from multiple providers and returns them --> FlexGet applies its filtering (series, quality, regex, seen) --> FlexGet submits accepted entries back to Botarr for the actual XDCC download. This lets FlexGet's powerful automation drive Botarr's download engine.

## Detailed changes:

| File | Type | Description |
|------|------|-------------|
| `flexget/plugins/output/botarr.py` | New | Output plugin — POSTs accepted entries to Botarr's `/api/download` endpoint |
| `flexget/plugins/input/botarr_history.py` | New | Input plugin — fetches completed/failed transfers from `/api/history` |
| `flexget/plugins/input/botarr_search.py` | New | Input+Search plugin — queries `/api/search` for XDCC packs |

## Addressed issues/feature requests:

N/A — new feature, no existing issue.

## Config usage if relevant (new plugin or updated schema):

```yaml
# Submit to Botarr (output)
tasks:
  anime-xdcc:
    botarr_search:
      url: http://localhost:3001
      query: "Frieren 1080p"
      providers:
        - Nibl
      max_results: 20
    series:
      - "Frieren Beyond Journey's End"
    botarr:
      url: http://localhost:3001
      priority: high
      poll_for_result: no

  # Post-process completed downloads (input)
  xdcc-post-process:
    botarr_history:
      url: http://localhost:3001
      status: Completed
      limit: 20
      only_new: yes
    accept_all: yes
    exec:
      on_output:
        for_accepted:
          - echo "Completed: {{botarr_filename}}"

```

## Log and/or tests output (preferably both):

```
# Test mode (no HTTP calls made)
$ flexget execute --tasks test-botarr --test

2026-07-05 22:00:00 INFO     botarr         Would submit to Botarr: irc://Rizon/#xdcc-test/TestBot/#1

# Submission
$ flexget execute --tasks test-botarr

2026-07-05 22:01:00 INFO     botarr         Successfully submitted `TestFile.mkv` to Botarr (Transfer ID: e4f2-abc1)

# History input
$ flexget execute --tasks xdcc-post-process

2026-07-05 22:02:00 VERBOSE  botarr_history Produced 3 entries from Botarr history

# Search
$ flexget execute --tasks auto-find

2026-07-05 22:03:00 DEBUG    botarr_search  Botarr returned 5 results for query `Frieren S01E05`
```
