### PR TITLE
Added queue_to_top before magnetization in deluge

### DIFF
--- a/flexget/plugins/clients/deluge.py
+++ b/flexget/plugins/clients/deluge.py
@@ -445,6 +445,11 @@ class OutputDeluge(DelugePlugin):
                         logger.opt(exception=True).debug('Error adding magnet:')
                         entry.fail('Could not be added to deluge')
                     else:
+                        # Queue to top before the magnetization wait, so the torrent is
+                        # eligible for an active slot while waiting for its metadata
+                        if modify_opts.get('queue_to_top'):
+                            client.call('core.queue_top', [added_torrent])
+                            logger.debug('{} moved to top of queue', entry['title'])
                         if config.get('magnetization_timeout'):
                             timeout = config['magnetization_timeout']
                             logger.verbose(


### PR DESCRIPTION
Fixes #5093

`core.queue_top` was only called from `_set_torrent_options()`, which runs after the `magnetization_timeout` wait loop. When a magnet is added while Deluge's download queue is full (all `max_active_downloading` slots in use), it sits at the bottom of the queue for the entire wait and fails to magnetize.

This change calls `core.queue_top` immediately after `core.add_torrent_magnet` succeeds (if `queue_to_top` is true), before the wait, so the torrent can claim an active slot while FlexGet waits for its metadata.

The existing `queue_to_top` handling in `_set_torrent_options()` is left in place: it also serves already-existing torrents and `.torrent`-file adds (which have no magnetization wait), plus the `queue_to_top: false` → `queue_bottom` case. The repeated `queue_top` call on the magnet path is idempotent.

#### Motivation for changes

With `queue_to_top: true` and multiple magnet entries per task run, everything past the first `max_active_downloading` entries hits the magnetization timeout, and the task stalls `magnetization_timeout` seconds per entry.
