### PR TITLE
fix: show help message when no config file is found

### DIFF
--- a/flexget/__init__.py
+++ b/flexget/__init__.py
@@ -26,7 +26,8 @@ def main(args: Sequence[str] | None = None):
         try:
             manager = Manager(args)
         except (OSError, ValueError):
-            options = Manager.parse_initial_options(args)
+            # A `--help` request must show the help message, not the config-loading failure.
+            options = Manager.parse_initial_options(args, do_help=True)
             log.start(level=options.loglevel, to_file=False)
             if _is_debug():
                 import traceback

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -190,15 +190,19 @@ class Manager:
         tray_icon.add_menu_separator(index=4)
 
     @staticmethod
-    def parse_initial_options(args: list[str]) -> argparse.Namespace:
-        """Parse what we can from cli args before plugins are loaded."""
+    def parse_initial_options(args: list[str], do_help: bool = False) -> argparse.Namespace:
+        """Parse what we can from cli args before plugins are loaded.
+
+        :param do_help: If True, a ``--help`` argument prints the help message and exits, rather
+            than being ignored. Used when there is no manager left to hand the request off to.
+        """
         try:
-            options = CoreArgumentParser().parse_known_args(args, do_help=False)[0]
+            options = CoreArgumentParser().parse_known_args(args, do_help=do_help)[0]
         except ParserError as exc:
             try:
                 # If a non-built-in command was used, we need to parse with a parser that
                 # doesn't define the subparsers
-                options = manager_parser.parse_known_args(args, do_help=False)[0]
+                options = manager_parser.parse_known_args(args, do_help=do_help)[0]
             except ParserError:
                 manager_parser.print_help()
                 logger.critical('Error: {}', exc.message)

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -1,5 +1,7 @@
 from argparse import Action
 
+import pytest
+
 from flexget.options import ArgumentParser
 
 
@@ -59,3 +61,13 @@ def test_post_defaults():
     # Custom action should be allowed to set default
     result = p.parse_args(['--custom'])
     assert result.post_set == 'custom'
+
+
+def test_help_when_config_is_missing(capsys):
+    """`flexget --help` must print the help message, not fail to load a config (#4924)."""
+    import flexget
+
+    with pytest.raises(SystemExit) as exc_info:
+        flexget.main(['-c', '/nonexistent/flexget-test-config.yml', '--help'])
+    assert exc_info.value.code == 0
+    assert 'usage: flexget' in capsys.readouterr().out

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -63,10 +63,14 @@ def test_post_defaults():
     assert result.post_set == 'custom'
 
 
-def test_help_when_config_is_missing(capsys):
+def test_help_when_config_is_missing(capsys, monkeypatch):
     """`flexget --help` must print the help message, not fail to load a config (#4924)."""
     import flexget
 
+    # main() re-initializes logging, which would remove the pytest log
+    # capture handler set up by conftest; stub it out, it plays no part in
+    # the --help path (HelpAction exits before log.start is reached).
+    monkeypatch.setattr(flexget.log, 'initialize', lambda *args, **kwargs: None)
     with pytest.raises(SystemExit) as exc_info:
         flexget.main(['-c', '/nonexistent/flexget-test-config.yml', '--help'])
     assert exc_info.value.code == 0


### PR DESCRIPTION
### Motivation for changes:

`flexget --help` fails with `Could not instantiate manager: OSError: No configuration file found.` when no config exists, so a new user has no way to discover how to pass one.

### Detailed changes:

- `Manager.__init__` loads the config before any argument action runs, and `main()` catches the resulting `OSError`. That recovery path called `parse_initial_options()` with `do_help=False`, which suppresses `HelpAction`, so the help request was silently discarded and the manager error was reported instead.
- `parse_initial_options()` now takes a `do_help` flag, and `main()` passes `True` on the config-failure path — there is no manager left to hand the request to, so the parser should print help. Non-help invocations are unaffected and still report the config error.
- Added a regression test.

### Addressed issues/feature requests:

- Fixes #4924

### Config usage if relevant (new plugin or updated schema):

N/A

### Log and/or tests output (preferably both):

```
$ flexget --help          # before
CRITICAL manager   Failed to find configuration file config.yml
CRITICAL flexget   Could not instantiate manager:
OSError: No configuration file found.

$ flexget --help          # after
usage: flexget [-V] [--test] [-c CONFIG] [--logfile LOGFILE] ...

$ pytest tests/test_argparse.py
4 passed
```
