### PR TITLE
Stop filtering warnings in dev versions to avoid conflicts with pytest's `filterwarnings`

### DIFF
--- a/flexget/log.py
+++ b/flexget/log.py
@@ -7,13 +7,10 @@ import os
 import sys
 import threading
 import uuid
-import warnings
 from collections import deque
 from typing import TYPE_CHECKING
 
 from loguru import logger
-
-from flexget import __version__
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -126,10 +123,6 @@ def initialize(unit_test: bool = False) -> None:
 
     if _logging_configured:
         return
-
-    if 'dev' in __version__:
-        warnings.filterwarnings('always', category=DeprecationWarning, module='flexget.*')
-    warnings.simplefilter('once', append=True)
 
     logger.level('VERBOSE', no=VERBOSE, color='<bold>', icon='👄')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,11 +270,12 @@ files.extend-exclude = [
 addopts = [ "-p no:legacypath" ]
 filterwarnings = [
   "error",
-  "ignore:Failed to load HostKeys from:UserWarning:pysftp", # It's a bug in pysftp (unmaintained) 0.2.9, not in 0.2.8: https://stackoverflow.com/q/56521549
+  "ignore:Failed to load HostKeys from:UserWarning:pysftp",                                  # It's a bug in pysftp (unmaintained) 0.2.9, not in 0.2.8: https://stackoverflow.com/q/56521549
+  "ignore:chardet.universaldetector is deprecated:DeprecationWarning:html5lib._inputstream", # See https://github.com/html5lib/html5lib-python/pull/602
   """\
-  ignore:chardet.universaldetector is deprecated, import UniversalDetector from chardet or chardet.detector \
-  instead:DeprecationWarning:html5lib._inputstream\
-  """  # `html5lib` uses a deprecated module from `chardet`
+  ignore:In ftputil 6.0.0, the default file path encoding will change from Latin-1 to \
+  UTF-8.:DeprecationWarning:flexget.components.ftp.ftp_list\
+  """
 ]
 markers = [
   "filecopy(src, dst): mark test to copy a file from `src` to `dst` before running",


### PR DESCRIPTION
### Motivation for changes:
Currently, FlexGet filters warnings in development versions to always show `DeprecationWarning`. However, this warning filter prevents pytest from promoting them to errors. I think it's better to let pytest treat `DeprecationWarning` as errors in CI so we can catch them as soon as they're introduced. **This is better than relying on users of development versions to discover `DeprecationWarning`s by always displaying them.**

Additionally, `warnings.simplefilter("once", append=True)` is unnecessary because warnings that do not match any filter use the `default` action, which already ensures that each warning is emitted only once per source location.
