### PR TITLE
Use PEP 702 @deprecated for deprecated APIs

### DIFF
--- a/docs/contributor/Topic guides/Maintainer guide/Python version bump checklist.rst
+++ b/docs/contributor/Topic guides/Maintainer guide/Python version bump checklist.rst
@@ -27,7 +27,7 @@ Codebase verification
 
 - Search for obsolete version mentions:
 
-  - Perform a batch search for the Python version being removed and the next subsequent version to identify any related TODOs or version-specific logic that needs to be updated. For example, search for ``python 3.10``, ``python3.10``, ``python 3.11``, and ``python3.11``.
+  - Perform a batch search for the Python version being removed and the next subsequent version to identify any related TODOs or version-specific logic that needs to be updated. For example, search for ``[pP]ython.*3\.10``, ``[pP]ython.*3\.11``.
 
 - Review ``sys.version_info`` usage:
 

--- a/flexget/components/managed_lists/lists/ombi_list.py
+++ b/flexget/components/managed_lists/lists/ombi_list.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import MutableSet
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 from loguru import logger
 from requests import HTTPError
-from typing_extensions import TypedDict  # for Python <3.11 with (Not)Required
 
 from flexget import plugin
 from flexget.entry import Entry
@@ -16,7 +15,10 @@ from flexget.utils import requests
 from flexget.utils.requests import RequestException
 
 if TYPE_CHECKING:
-    from typing_extensions import NotRequired
+    try:
+        from typing import NotRequired
+    except ImportError:
+        from typing_extensions import NotRequired  # for python<=3.10
 
 log = logger.bind(name='ombi_list')
 

--- a/flexget/components/series/db.py
+++ b/flexget/components/series/db.py
@@ -433,6 +433,14 @@ class EpisodeRelease(Base):
     @property
     @deprecated('accessing deprecated release.proper, use release.proper_count instead')
     def proper(self):
+        """Number of PROPER/REPACK revisions for the release.
+
+        A value of 0 indicates the original release.
+        Higher values indicate newer corrected releases (e.g. PROPER2).
+
+        .. deprecated:: 2.19.2
+           Use :attr:`proper_count` instead.
+        """
         return self.proper_count > 0
 
     def __str__(self):
@@ -472,6 +480,14 @@ class SeasonRelease(Base):
     @property
     @deprecated('accessing deprecated release.proper, use release.proper_count instead')
     def proper(self):
+        """Number of PROPER/REPACK revisions for the release.
+
+        A value of 0 indicates the original release.
+        Higher values indicate newer corrected releases (e.g. PROPER2).
+
+        .. deprecated:: 2.19.2
+           Use :attr:`proper_count` instead.
+        """
         return self.proper_count > 0
 
     def __str__(self):

--- a/flexget/components/series/db.py
+++ b/flexget/components/series/db.py
@@ -42,6 +42,11 @@ from flexget.utils.sqlalchemy_utils import (
 )
 from flexget.utils.tools import parse_episode_identifier
 
+try:
+    from warnings import deprecated
+except ImportError:
+    from typing_extensions import deprecated  # for python<=3.12
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
@@ -426,13 +431,8 @@ class EpisodeRelease(Base):
         self.first_seen = datetime.now()
 
     @property
+    @deprecated('accessing deprecated release.proper, use release.proper_count instead')
     def proper(self):
-        # TODO: TEMP
-        import warnings
-
-        warnings.warn(
-            'accessing deprecated release.proper, use release.proper_count instead', stacklevel=2
-        )
         return self.proper_count > 0
 
     def __str__(self):
@@ -470,13 +470,8 @@ class SeasonRelease(Base):
         self.first_seen = datetime.now()
 
     @property
+    @deprecated('accessing deprecated release.proper, use release.proper_count instead')
     def proper(self):
-        # TODO: TEMP
-        import warnings
-
-        warnings.warn(
-            'accessing deprecated release.proper, use release.proper_count instead', stacklevel=2
-        )
         return self.proper_count > 0
 
     def __str__(self):

--- a/flexget/entry.py
+++ b/flexget/entry.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import functools
 import types
-import warnings
 from datetime import date, datetime
 from enum import Enum
 from pathlib import Path
@@ -15,6 +14,11 @@ from flexget import plugin
 from flexget.utils.lazy_dict import LazyDict, LazyLookup
 from flexget.utils.serialization import Serializer, deserialize, serialize
 from flexget.utils.template import CoercingDateTime, FlexGetTemplate, render_from_entry
+
+try:
+    from warnings import deprecated
+except ImportError:
+    from typing_extensions import deprecated  # for python<=3.12
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -381,17 +385,11 @@ class Entry(LazyDict, Serializer):
         super().register_lazy_func(func.function, fields, args, kwargs)
         self.lazy_lookups.append((lazy_func, fields, args, kwargs))
 
+    @deprecated(
+        '`register_lazy_func` is deprecated. `add_lazy_fields` should be used instead. '
+        'This plugin should be updated to work with the latest versions of FlexGet'
+    )
     def register_lazy_func(self, func, keys):
-        """Do not use this anymore as it is DEPRECATED.
-
-        Use `add_lazy_fields` instead.
-        """
-        warnings.warn(
-            '`register_lazy_func` is deprecated. `add_lazy_fields` should be used instead. '
-            'This plugin should be updated to work with the latest versions of FlexGet',
-            DeprecationWarning,
-            stacklevel=2,
-        )
         super().register_lazy_func(func, keys, [], {})
 
     def __eq__(self, other):

--- a/flexget/entry.py
+++ b/flexget/entry.py
@@ -390,6 +390,11 @@ class Entry(LazyDict, Serializer):
         'This plugin should be updated to work with the latest versions of FlexGet'
     )
     def register_lazy_func(self, func, keys):
+        """Add lazy fields to an entry.
+
+        .. deprecated:: 3.1.11
+           Use :meth:`add_lazy_fields` instead.
+        """
         super().register_lazy_func(func, keys, [], {})
 
     def __eq__(self, other):

--- a/flexget/task.py
+++ b/flexget/task.py
@@ -331,7 +331,10 @@ class Task:
 
     @property
     def undecided(self):
-        """.. deprecated:: Use API v3.
+        """Return an iterator over entries that are still in an undecided state.
+
+        .. deprecated:: 1.2.0
+           Use API v3.
 
         .. note:: We did not migrate to v3
 
@@ -349,27 +352,47 @@ class Task:
 
     @property
     def failed(self):
-        """.. deprecated:: Use API v3."""
+        """Return an iterator over entries that have failed.
+
+        .. deprecated:: 1.2.0
+           Use API v3.
+        """
         return self.all_entries.failed
 
     @property
     def rejected(self):
-        """.. deprecated:: Use API v3."""
+        """Return an iterator over entries that have been rejected.
+
+        .. deprecated:: 1.2.0
+           Use API v3.
+        """
         return self.all_entries.rejected
 
     @property
     def accepted(self):
-        """.. deprecated:: Use API v3."""
+        """Return an iterator over entries that have been accepted.
+
+        .. deprecated:: 1.2.0
+           Use API v3.
+        """
         return self.all_entries.accepted
 
     @property
     def entries(self):
-        """.. deprecated:: Use API v3."""
+        """Return an iterator over entries that are undecided or accepted.
+
+        .. deprecated:: 1.2.0
+           Use API v3.
+        """
         return self.all_entries.entries
 
     @property
     def all_entries(self):
-        """.. deprecated:: Use API v3."""
+        """Return an iterator over all entries that were processed in the task.
+
+        .. deprecated:: 1.2.0
+           Use API v3.
+        """
         return self._all_entries
 
     def __lt__(self, other):

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -226,6 +226,9 @@ class Session(requests.Session):
 
         :param domain: The domain to set the interval on
         :param delay: The amount of time between requests, can be a timedelta or string like '3 seconds'
+
+        .. deprecated:: 1.2.460
+           Use :meth:`add_domain_limiter` instead.
         """
         self.domain_limiters[domain] = TimedLimiter(domain, delay)
 

--- a/flexget/utils/requests.py
+++ b/flexget/utils/requests.py
@@ -6,7 +6,6 @@ import time
 import types
 
 # Allow some request objects to be imported from here instead of requests
-import warnings
 from datetime import datetime, timedelta
 from email.message import EmailMessage
 from typing import TYPE_CHECKING
@@ -19,6 +18,11 @@ from requests import RequestException
 
 from flexget import __version__ as version
 from flexget.utils.tools import TimedDict, parse_timedelta
+
+try:
+    from warnings import deprecated
+except ImportError:
+    from typing_extensions import deprecated  # for python<=3.12
 
 # If we use just 'requests' here, we'll get the logger created by requests, rather than our own
 logger = logger.bind(name='utils.requests')
@@ -216,19 +220,13 @@ class Session(requests.Session):
         for cookie in cookiejar:
             self.cookies.set_cookie(cookie)
 
+    @deprecated('set_domain_delay is deprecated, use add_domain_limiter')
     def set_domain_delay(self, domain, delay):
-        """Do not use this anymore as it is DEPRECATED. Use `add_domain_limiter`.
-
-        Register a minimum interval between requests to `domain`
+        """Register a minimum interval between requests to `domain`.
 
         :param domain: The domain to set the interval on
         :param delay: The amount of time between requests, can be a timedelta or string like '3 seconds'
         """
-        warnings.warn(
-            'set_domain_delay is deprecated, use add_domain_limiter',
-            DeprecationWarning,
-            stacklevel=2,
-        )
         self.domain_limiters[domain] = TimedLimiter(domain, delay)
 
     def add_domain_limiter(self, limiter: DomainLimiter, replace: bool = True) -> None:

--- a/flexget/utils/sqlalchemy_utils.py
+++ b/flexget/utils/sqlalchemy_utils.py
@@ -12,7 +12,10 @@ from sqlalchemy.schema import MetaData, Table
 from sqlalchemy.types import TypeEngine
 
 if TYPE_CHECKING:
-    from typing_extensions import Self
+    try:
+        from typing import Self
+    except ImportError:
+        from typing_extensions import Self  # for python<=3.10
 
 logger = logger.bind(name='sql_utils')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
   "rich~=15.0",
   "rpyc~=6.0",
   "sqlalchemy~=2.0",
+  "typing-extensions>=4.16; python_version<='3.12'",
   "werkzeug~=3.1",
   "zxcvbn~=4.4",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -191,6 +191,7 @@ typing-extensions==4.16.0
     # via
     #   beautifulsoup4
     #   flask-cors
+    #   flexget
     #   plumbum
     #   referencing
     #   sqlalchemy

--- a/uv.lock
+++ b/uv.lock
@@ -1267,6 +1267,7 @@ dependencies = [
     { name = "rich" },
     { name = "rpyc" },
     { name = "sqlalchemy" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "werkzeug" },
     { name = "zxcvbn" },
 ]
@@ -1382,6 +1383,7 @@ requires-dist = [
     { name = "rich", specifier = "~=15.0" },
     { name = "rpyc", specifier = "~=6.0" },
     { name = "sqlalchemy", specifier = "~=2.0" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.16" },
     { name = "werkzeug", specifier = "~=3.1" },
     { name = "zxcvbn", specifier = "~=4.4" },
 ]


### PR DESCRIPTION
## Motivation

Using [PEP 702 `@deprecated`](https://peps.python.org/pep-0702) provides better support for static analysis tools while making deprecation metadata part of the API definition. Explicitly declaring `typing_extensions` also makes the project's dependencies accurate and more maintainable.

## Changes

* Replace `warnings.warn` calls for deprecated APIs with the PEP 702 `@deprecated` decorator.

  * This allows type checkers and IDEs to detect deprecated APIs before runtime.
  * Keep deprecation information available through the standard deprecation mechanism.

* `typing_extensions` was already used in the project but was not listed as a project requirement — it was only installed as a transitive dependency of other packages. It is now explicitly declared as a direct dependency.

  * The project already uses `typing_extensions`, but it was previously only installed as a transitive dependency of other packages.
  * Declaring it explicitly ensures the project does not rely on indirect dependencies.


