### PR TITLE
pre-commit: migrate from unmaintained `pycontribs/mirrors-prettier` to `rbubley/mirrors-prettier`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,8 +50,8 @@ repos:
     rev: v2.26.0
     hooks:
       - id: pyproject-fmt
-  - repo: https://github.com/pycontribs/mirrors-prettier
-    rev: v3.6.2
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.9.6
     hooks:
       - id: prettier
         args: [--single-quote]


### PR DESCRIPTION
### Motivation for changes:
https://github.com/pycontribs/mirrors-prettier is no longer maintained, so we need to migrate to use https://github.com/rbubley/mirrors-prettier