### PR TITLE
Next series include qualities for search

### DIFF
--- a/flexget/components/series/next_series_episodes.py
+++ b/flexget/components/series/next_series_episodes.py
@@ -58,8 +58,9 @@ class NextSeriesEpisodes:
         finite set of literal values.
 
         :return: [] if unconstrained (contributes nothing to the search term), None if
-            the requirement is an open-ended comparator (e.g. "<720p", "1080p+") or a
-            "!" exclusion, neither of which can be written as a literal search term.
+            the requirement is an open-ended upper-bound comparator (e.g. "<720p") or a
+            "!" exclusion, neither of which can be written as a literal search term. A
+            lower-bound-only comparator (e.g. "720p+") falls back to its floor value.
         """
         if req_component.acceptable:
             candidates = req_component.acceptable
@@ -70,7 +71,9 @@ class NextSeriesEpisodes:
                 if comp.type == req_component.type
                 and req_component.min.value <= comp.value <= req_component.max.value
             ]
-        elif req_component.min or req_component.max or req_component.none_of:
+        elif req_component.min:
+            candidates = [req_component.min]
+        elif req_component.max or req_component.none_of:
             return None
         else:
             return []

--- a/flexget/components/series/next_series_episodes.py
+++ b/flexget/components/series/next_series_episodes.py
@@ -1,4 +1,5 @@
 import contextlib
+import itertools
 import re
 
 from loguru import logger
@@ -8,6 +9,7 @@ from flexget import plugin
 from flexget.entry import Entry
 from flexget.event import event
 from flexget.manager import Session
+from flexget.utils.qualities import Quality, Requirements, _registry
 
 from . import db
 
@@ -37,6 +39,7 @@ class NextSeriesEpisodes:
                         'they will not be emitted.',
                     },
                     'only_same_season': {'type': 'boolean', 'default': False},
+                    'include_quality': {'type': 'boolean', 'default': True},
                 },
                 'additionalProperties': False,
             },
@@ -45,6 +48,78 @@ class NextSeriesEpisodes:
 
     def __init__(self):
         self.rerun_entries = []
+        self.series_settings = {}
+
+    def _component_candidates(self, req_component) -> list[str] | None:
+        """Return the concrete values a single requirement component allows, highest first.
+
+        Handles bare values ("bluray"), pipe alternatives ("720p|1080p"), and
+        min-max ranges ("720p-2160p") uniformly since all three enumerate to a
+        finite set of literal values.
+
+        :return: [] if unconstrained (contributes nothing to the search term), None if
+            the requirement is an open-ended comparator (e.g. "<720p", "1080p+") or a
+            "!" exclusion, neither of which can be written as a literal search term.
+        """
+        if req_component.acceptable:
+            candidates = req_component.acceptable
+        elif req_component.min and req_component.max:
+            candidates = [
+                comp
+                for comp in _registry.values()
+                if comp.type == req_component.type
+                and req_component.min.value <= comp.value <= req_component.max.value
+            ]
+        elif req_component.min or req_component.max or req_component.none_of:
+            return None
+        else:
+            return []
+        return [comp.name for comp in sorted(candidates, key=lambda c: c.value, reverse=True)]
+
+    def _extract_quality_strings(self, series_config: dict) -> list[str]:
+        """Extract quality strings from series configuration for use in search queries.
+
+        Resolution ranges ("720p-2160p") and alternatives on any component
+        ("720p|1080p", "bluray|webdl") are expanded into every combination.
+        Requirements that can't be expressed as literal search terms (e.g. "<=1080p",
+        "!hdr") are skipped.
+
+        :param series_config: Series configuration dict
+        :return: List of quality strings, sorted highest first
+        """
+        quality_strings = []
+        for key in ('qualities', 'target', 'quality'):
+            value = series_config.get(key)
+            if isinstance(value, list):
+                quality_strings.extend(value)
+            elif value:
+                quality_strings.append(value)
+
+        expanded_strings = []
+        for q_str in quality_strings:
+            try:
+                req = Requirements(q_str)
+            except ValueError:
+                logger.debug('Invalid quality requirement string: {}', q_str)
+                continue
+
+            per_component_candidates = []
+            for req_component in req.components:
+                candidates = self._component_candidates(req_component)
+                if candidates is None:
+                    logger.debug(
+                        'Skipping quality requirement not usable as search text: {}', q_str
+                    )
+                    break
+                if candidates:
+                    per_component_candidates.append(candidates)
+            else:
+                expanded_strings.extend(
+                    ' '.join(combo) for combo in itertools.product(*per_component_candidates)
+                )
+
+        # Quality is directly sortable (highest first); dedupe while we're at it.
+        return sorted(dict.fromkeys(expanded_strings), key=Quality, reverse=True)
 
     def ep_identifiers(self, season, episode):
         return [f'S{season:02d}E{episode:02d}', f'{season}x{episode:02d}']
@@ -72,6 +147,20 @@ class NextSeriesEpisodes:
             series_id = episode
             for alt in alts:
                 search_strings.extend([f'{alt} {id}' for id in self.sequence_identifiers(episode)])
+
+        # Append quality strings if include_quality option is enabled
+        if self.config.get('include_quality'):
+            series_config = self.series_settings.get(series.name)
+            if series_config:
+                quality_strings = self._extract_quality_strings(series_config)
+                if quality_strings:
+                    # For each quality (highest first), append all episode identifier variations
+                    search_strings = [
+                        f'{search_str} {quality_str}'
+                        for quality_str in quality_strings
+                        for search_str in search_strings
+                    ]
+
         entry = Entry(
             title=search_strings[0],
             url='',
@@ -96,6 +185,7 @@ class NextSeriesEpisodes:
         if isinstance(config, bool):
             config = {}
         config.setdefault('backfill_limit', BACKFILL_LIMIT_DEFAULT)
+        config.setdefault('include_quality', True)
         self.config = config
         if task.is_rerun:
             # Just return calculated next eps on reruns
@@ -103,6 +193,13 @@ class NextSeriesEpisodes:
             self.rerun_entries = []
             return entries
         self.rerun_entries = []
+
+        self.series_settings = {}
+        if config.get('include_quality'):
+            series_plugin = plugin.get('series', self)
+            for series_item in series_plugin.prepare_config(task.config.get('series', {})):
+                series_name, series_config = next(iter(series_item.items()))
+                self.series_settings[series_name] = series_config
 
         entries = []
         impossible = {}

--- a/tests/test_next_series_episodes.py
+++ b/tests/test_next_series_episodes.py
@@ -680,6 +680,8 @@ class TestNextSeriesEpisodesQuality:
                   identified_by: ep
               - Test Series 8:
                   identified_by: ep
+              - Test Series 9:
+                  identified_by: ep
           test_quality_target:
             next_series_episodes:
               include_quality: yes
@@ -759,6 +761,14 @@ class TestNextSeriesEpisodesQuality:
             - Test Series 8:
                 identified_by: ep
                 target: "1080p bluray|webdl hdr|dolbyvision"
+            max_reruns: 0
+          test_quality_min_only:
+            next_series_episodes:
+              include_quality: yes
+            series:
+            - Test Series 9:
+                identified_by: ep
+                target: "720p+"
             max_reruns: 0
     """
 
@@ -864,4 +874,16 @@ class TestNextSeriesEpisodesQuality:
             'Test Series 8 1x02 1080p webdl dolbyvision',
             'Test Series 8 S01E02 1080p webdl hdr',
             'Test Series 8 1x02 1080p webdl hdr',
+        ]
+
+    def test_quality_min_only_uses_floor_value(self, execute_task):
+        # "720p+" is a lower-bound-only comparator; it should fall back to its floor
+        # value (720p) as the search term rather than being dropped entirely.
+        self.inject_series(execute_task, 'Test Series 9 S01E01')
+        task = execute_task('test_quality_min_only')
+        entry = task.find_entry(title='Test Series 9 S01E02 720p')
+        assert entry
+        assert entry['search_strings'] == [
+            'Test Series 9 S01E02 720p',
+            'Test Series 9 1x02 720p',
         ]

--- a/tests/test_next_series_episodes.py
+++ b/tests/test_next_series_episodes.py
@@ -653,3 +653,215 @@ class TestNextSeriesEpisodesSeasonPack:
             for result_title in this_test[2]:
                 assert task.find_entry(title=result_title)
             assert len(task.all_entries) == len(this_test[2])
+
+
+class TestNextSeriesEpisodesQuality:
+    config = """
+        templates:
+          global:
+            parsing:
+              series: internal
+        tasks:
+          inject_series:
+            series:
+              - Test Series 1:
+                  identified_by: ep
+              - Test Series 2:
+                  identified_by: ep
+              - Test Series 3:
+                  identified_by: ep
+              - Test Series 4:
+                  identified_by: ep
+              - Test Series 5:
+                  identified_by: ep
+              - Test Series 6:
+                  identified_by: ep
+              - Test Series 7:
+                  identified_by: ep
+              - Test Series 8:
+                  identified_by: ep
+          test_quality_target:
+            next_series_episodes:
+              include_quality: yes
+            series:
+            - Test Series 2:
+                identified_by: ep
+                target: 1080p
+            max_reruns: 0
+          test_quality_qualities_list:
+            next_series_episodes:
+              include_quality: yes
+            series:
+            - Test Series 3:
+                identified_by: ep
+                qualities:
+                  - 720p
+                  - 1080p
+            max_reruns: 0
+          test_quality_range:
+            next_series_episodes:
+              include_quality: yes
+            series:
+            - Test Series 4:
+                identified_by: ep
+                target: 720p-1080p
+            max_reruns: 0
+          test_quality_disabled:
+            next_series_episodes:
+              include_quality: no
+            series:
+            - Test Series 5:
+                identified_by: ep
+            max_reruns: 0
+          test_quality_bool_shorthand_default:
+            next_series_episodes: yes
+            series:
+            - Test Series 5:
+                identified_by: ep
+                target: 1080p
+            max_reruns: 0
+          test_quality_no_series_settings:
+            next_series_episodes:
+              include_quality: yes
+            series:
+            - Test Series 1
+            max_reruns: 0
+          test_quality_grouped_series:
+            next_series_episodes:
+              include_quality: yes
+            series:
+              settings:
+                my_group:
+                  target: 1080p
+              my_group:
+                - Test Series 1
+            max_reruns: 0
+          test_quality_unsupported_syntax:
+            next_series_episodes:
+              include_quality: yes
+            series:
+            - Test Series 6:
+                identified_by: ep
+                target: "<=1080p"
+            max_reruns: 0
+          test_quality_pipe_alternatives:
+            next_series_episodes:
+              include_quality: yes
+            series:
+            - Test Series 7:
+                identified_by: ep
+                target: "720p|1080p"
+            max_reruns: 0
+          test_quality_multi_axis_pipe:
+            next_series_episodes:
+              include_quality: yes
+            series:
+            - Test Series 8:
+                identified_by: ep
+                target: "1080p bluray|webdl hdr|dolbyvision"
+            max_reruns: 0
+    """
+
+    def inject_series(self, execute_task, release_name):
+        execute_task(
+            'inject_series',
+            options={'inject': [Entry(title=release_name, url='')]},
+        )
+
+    def test_quality_target_appended_to_search_strings(self, execute_task):
+        self.inject_series(execute_task, 'Test Series 2 S01E01')
+        task = execute_task('test_quality_target')
+        entry = task.find_entry(title='Test Series 2 S01E02 1080p')
+        assert entry
+        assert entry['search_strings'] == [
+            'Test Series 2 S01E02 1080p',
+            'Test Series 2 1x02 1080p',
+        ]
+
+    def test_quality_qualities_list_sorted_highest_first(self, execute_task):
+        self.inject_series(execute_task, 'Test Series 3 S01E01')
+        task = execute_task('test_quality_qualities_list')
+        # Highest configured quality (1080p) is used for the entry title.
+        entry = task.find_entry(title='Test Series 3 S01E02 1080p')
+        assert entry
+        # Every base identifier is repeated once per configured quality.
+        assert len(entry['search_strings']) == 4
+        assert any(s.endswith('720p') for s in entry['search_strings'])
+        assert any(s.endswith('1080p') for s in entry['search_strings'])
+
+    def test_quality_range_expands_all_resolutions(self, execute_task):
+        self.inject_series(execute_task, 'Test Series 4 S01E01')
+        task = execute_task('test_quality_range')
+        entry = task.find_entry(title='Test Series 4 S01E02 1080p')
+        assert entry
+        assert 'Test Series 4 S01E02 720p' in entry['search_strings']
+        assert 'Test Series 4 S01E02 1080p' in entry['search_strings']
+
+    def test_quality_disabled_does_not_append_quality(self, execute_task):
+        self.inject_series(execute_task, 'Test Series 5 S01E01')
+        task = execute_task('test_quality_disabled')
+        entry = task.find_entry(title='Test Series 5 S01E02')
+        assert entry
+        assert not any('1080p' in s for s in entry['search_strings'])
+
+    def test_quality_default_enabled_with_bool_shorthand_config(self, execute_task):
+        # Regression: `next_series_episodes: yes` must still apply the include_quality
+        # default (True) from the schema, not silently disable the feature.
+        self.inject_series(execute_task, 'Test Series 5 S01E01')
+        task = execute_task('test_quality_bool_shorthand_default')
+        assert task.find_entry(title='Test Series 5 S01E02 1080p')
+
+    def test_quality_series_without_settings_does_not_crash(self, execute_task):
+        # Regression: plain string series list entries (no per-series settings dict)
+        # used to crash `_get_series_config` with AttributeError.
+        self.inject_series(execute_task, 'Test Series 1 S01E01')
+        task = execute_task('test_quality_no_series_settings')
+        assert task.find_entry(title='Test Series 1 S01E02')
+
+    def test_quality_grouped_series_settings(self, execute_task):
+        # Regression: series config in grouped/settings form used to crash, and
+        # group-level settings need to be merged in to be picked up.
+        self.inject_series(execute_task, 'Test Series 1 S01E01')
+        task = execute_task('test_quality_grouped_series')
+        assert task.find_entry(title='Test Series 1 S01E02 1080p')
+
+    def test_quality_unsupported_syntax_is_skipped(self, execute_task):
+        # Comparator syntax ("<=1080p") can't be expressed as a literal search
+        # token, it should be dropped rather than leaking into the query.
+        self.inject_series(execute_task, 'Test Series 6 S01E01')
+        task = execute_task('test_quality_unsupported_syntax')
+        entry = task.find_entry(title='Test Series 6 S01E02')
+        assert entry
+        assert not any('<' in s or '=' in s for s in entry['search_strings'])
+
+    def test_quality_pipe_alternatives_expand_highest_first(self, execute_task):
+        # "720p|1080p" enumerates both alternatives, same as a range would, with the
+        # highest quality used for the entry title/first search string.
+        self.inject_series(execute_task, 'Test Series 7 S01E01')
+        task = execute_task('test_quality_pipe_alternatives')
+        entry = task.find_entry(title='Test Series 7 S01E02 1080p')
+        assert entry
+        assert entry['search_strings'] == [
+            'Test Series 7 S01E02 1080p',
+            'Test Series 7 1x02 1080p',
+            'Test Series 7 S01E02 720p',
+            'Test Series 7 1x02 720p',
+        ]
+
+    def test_quality_multiple_pipe_axes_cross_product(self, execute_task):
+        # "bluray|webdl hdr|dolbyvision" pipes two different component types at once;
+        # every combination (2 x 2 = 4) should be enumerated, highest quality first.
+        self.inject_series(execute_task, 'Test Series 8 S01E01')
+        task = execute_task('test_quality_multi_axis_pipe')
+        entry = task.find_entry(title='Test Series 8 S01E02 1080p bluray dolbyvision')
+        assert entry
+        assert entry['search_strings'] == [
+            'Test Series 8 S01E02 1080p bluray dolbyvision',
+            'Test Series 8 1x02 1080p bluray dolbyvision',
+            'Test Series 8 S01E02 1080p bluray hdr',
+            'Test Series 8 1x02 1080p bluray hdr',
+            'Test Series 8 S01E02 1080p webdl dolbyvision',
+            'Test Series 8 1x02 1080p webdl dolbyvision',
+            'Test Series 8 S01E02 1080p webdl hdr',
+            'Test Series 8 1x02 1080p webdl hdr',
+        ]


### PR DESCRIPTION
### Motivation for changes:

Quality is needed for search to produce good results

Includes option "include_quality" to turn off this feature. Default is on.