### PR TITLE
Update pre-commit hook abravalheri/validate-pyproject to v0.26

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.25
+    rev: '0.26'
     hooks:
       - id: validate-pyproject
   - repo: https://github.com/tox-dev/pyproject-fmt


### PR DESCRIPTION
Supersedes #5167
