### PR TITLE
feat: Added `scrob_list` managed list plugin

### DIFF
--- a/flexget/components/managed_lists/lists/scrob_list.py
+++ b/flexget/components/managed_lists/lists/scrob_list.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+from collections.abc import MutableSet
+
+from loguru import logger
+
+from flexget import plugin
+from flexget.entry import Entry
+from flexget.event import event
+from flexget.utils import requests
+from flexget.utils.requests import RequestException
+
+logger = logger.bind(name='scrob_list')
+
+
+class ScrobApiError(Exception):
+    """Raised when the Scrob API returns a non-2xx response."""
+
+    def __init__(self, message, status_code=None):
+        self.status_code = status_code
+        super().__init__(message)
+
+
+class ScrobAPIWrapper:
+    """Wrapper around a Scrob API's `/api/proxy/*` REST endpoints."""
+
+    def __init__(self, base_url, api_key):
+        self.base_url = base_url.rstrip('/')
+        self.api_key = api_key
+
+    def _url(self, path):
+        return f'{self.base_url}/api/proxy/{path.lstrip("/")}'
+
+    def _request(self, method, path, **kwargs):
+        headers = kwargs.pop('headers', {})
+        headers['X-Api-Key'] = self.api_key
+        try:
+            response = requests.request(
+                method, self._url(path), headers=headers, raise_status=False, **kwargs
+            )
+        except RequestException as e:
+            raise plugin.PluginError(f'Error connecting to Scrob at {self.base_url}: {e}')
+
+        try:
+            data = response.json() if response.content else {}
+        except ValueError:
+            data = {}
+
+        if not (200 <= response.status_code < 300):
+            detail = data.get('detail') if isinstance(data, dict) else None
+            raise ScrobApiError(
+                detail or f'Scrob returned HTTP {response.status_code}',
+                status_code=response.status_code,
+            )
+        return data
+
+    def get(self, path, **kwargs):
+        return self._request('get', path, **kwargs)
+
+    def post(self, path, json=None, **kwargs):
+        return self._request('post', path, json=json, **kwargs)
+
+    def delete(self, path, **kwargs):
+        return self._request('delete', path, **kwargs)
+
+
+def _entry_media_type(entry):
+    return 'series' if entry.get('series_name') else 'movie'
+
+
+def _media_title(media, strip_year=False):
+    title = media.get('title', 'Unknown')
+    if strip_year:
+        return title
+    year = (media.get('release_date') or '')[:4]
+    return f'{title} ({year})' if year else title
+
+
+def _entry_from_item(item, strip_year=False):
+    media = item['media']
+    media_type = media.get('type')
+    year = (media.get('release_date') or '')[:4]
+
+    entry = Entry()
+    entry['title'] = _media_title(media, strip_year=strip_year)
+    if media_type == 'movie':
+        entry['url'] = f'https://www.themoviedb.org/movie/{media.get("tmdb_id")}'
+        entry['movie_name'] = media.get('title')
+        if year:
+            entry['movie_year'] = int(year)
+    else:
+        entry['url'] = f'https://www.themoviedb.org/tv/{media.get("tmdb_id")}'
+        entry['series_name'] = media.get('title')
+        if year:
+            entry['series_year'] = int(year)
+
+    entry['tmdb_id'] = media.get('tmdb_id')
+    entry['scrob_list_item_id'] = item['id']
+    entry['scrob_media_type'] = media_type
+
+    return entry
+
+
+class ScrobSet(MutableSet):
+    schema = {
+        'type': 'object',
+        'properties': {
+            'base_url': {'type': 'string', 'format': 'url', 'default': 'http://localhost:7330'},
+            'api_key': {'type': 'string'},
+            'list_id': {'type': 'integer'},
+            'strip_year': {'type': 'boolean', 'default': False},
+        },
+        'required': ['api_key', 'list_id'],
+        'additionalProperties': False,
+    }
+
+    def __init__(self, config):
+        self.config = config
+        self.api = ScrobAPIWrapper(config['base_url'], config['api_key'])
+        self.list_id = config['list_id']
+        self._cached_items = None
+
+    @property
+    def immutable(self):
+        return None
+
+    def _get_items(self):
+        try:
+            result = self.api.get(f'lists/{self.list_id}')
+        except ScrobApiError as e:
+            if e.status_code == 404:
+                raise plugin.PluginError(f'Scrob list {self.list_id} does not exist.')
+            raise plugin.PluginError(f'Could not retrieve Scrob list: {e}')
+        entries = []
+        for item in result.get('items', []):
+            media = item['media']
+            if (
+                media.get('type') not in ('movie', 'series')
+                or media.get('season_number') is not None
+            ):
+                logger.debug(
+                    'Skipping list item `%s` - not a whole movie or series.', media.get("title")
+                )
+                continue
+            entry = _entry_from_item(item, strip_year=self.config.get('strip_year', False))
+            if media.get('type') == 'movie':
+                imdb_id = self._fetch_movie_imdb_id(media.get('tmdb_id'))
+                if imdb_id:
+                    entry['imdb_id'] = imdb_id
+            entries.append(entry)
+        return entries
+
+    def _fetch_movie_imdb_id(self, tmdb_id):
+        try:
+            data = self.api.get(f'media/movie/{tmdb_id}')
+        except ScrobApiError as e:
+            logger.warning('Could not fetch imdb_id for tmdb_id %s from Scrob: %s', tmdb_id, e)
+            return None
+        return data.get('imdb_id')
+
+    @property
+    def items(self):
+        if self._cached_items is None:
+            self._cached_items = self._get_items()
+        return self._cached_items
+
+    def invalidate_cache(self):
+        self._cached_items = None
+
+    def _find_entry(self, entry):
+        tmdb_id = entry.get('tmdb_id')
+        if not tmdb_id:
+            return None
+        media_type = _entry_media_type(entry)
+        for item in self.items:
+            if item.get('tmdb_id') != tmdb_id:
+                continue
+            if item.get('scrob_media_type') != media_type:
+                continue
+            return item
+        return None
+
+    def __iter__(self):
+        return iter(self.items)
+
+    def __len__(self):
+        return len(self.items)
+
+    def __contains__(self, entry):
+        return self._find_entry(entry) is not None
+
+    def get(self, entry):
+        return self._find_entry(entry)
+
+    def add(self, entry):
+        if self._find_entry(entry):
+            return
+        tmdb_id = entry.get('tmdb_id')
+        if not tmdb_id:
+            logger.warning('Not adding `%s` to Scrob list: entry has no tmdb_id.', entry["title"])
+            return
+        media_type = _entry_media_type(entry)
+        body = {'tmdb_id': tmdb_id, 'media_type': media_type}
+        try:
+            self.api.post(f'lists/{self.list_id}/items', json=body)
+        except ScrobApiError as e:
+            if e.status_code == 409:
+                logger.debug('`%s` is already in the Scrob list.', entry["title"])
+            else:
+                logger.error('Failed to add `%s` to Scrob list: %s', entry["title"], e)
+                return
+        self.invalidate_cache()
+
+    def discard(self, entry):
+        found = self._find_entry(entry)
+        if not found:
+            return
+        try:
+            self.api.delete(f'lists/{self.list_id}/items/{found["scrob_list_item_id"]}')
+        except ScrobApiError as e:
+            logger.error('Failed to remove `%s` from Scrob list: %s', entry["title"], e)
+            return
+        self.invalidate_cache()
+
+    @property
+    def online(self):
+        """Web-based service - do not attempt to modify while running with --test."""
+        return True
+
+
+class ScrobList:
+    schema = ScrobSet.schema
+
+    def get_list(self, config):
+        return ScrobSet(config)
+
+    def on_task_input(self, task, config):
+        return list(ScrobSet(config))
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(ScrobList, 'scrob_list', api_ver=2, interfaces=['task', 'list'])

--- a/flexget/components/managed_lists/lists/scrob_list.py
+++ b/flexget/components/managed_lists/lists/scrob_list.py
@@ -139,7 +139,7 @@ class ScrobSet(MutableSet):
                 or media.get('season_number') is not None
             ):
                 logger.debug(
-                    'Skipping list item `%s` - not a whole movie or series.', media.get("title")
+                    'Skipping list item `%s` - not a whole movie or series.', media.get('title')
                 )
                 continue
             entry = _entry_from_item(item, strip_year=self.config.get('strip_year', False))
@@ -197,7 +197,7 @@ class ScrobSet(MutableSet):
             return
         tmdb_id = entry.get('tmdb_id')
         if not tmdb_id:
-            logger.warning('Not adding `%s` to Scrob list: entry has no tmdb_id.', entry["title"])
+            logger.warning('Not adding `%s` to Scrob list: entry has no tmdb_id.', entry['title'])
             return
         media_type = _entry_media_type(entry)
         body = {'tmdb_id': tmdb_id, 'media_type': media_type}
@@ -205,9 +205,9 @@ class ScrobSet(MutableSet):
             self.api.post(f'lists/{self.list_id}/items', json=body)
         except ScrobApiError as e:
             if e.status_code == 409:
-                logger.debug('`%s` is already in the Scrob list.', entry["title"])
+                logger.debug('`%s` is already in the Scrob list.', entry['title'])
             else:
-                logger.error('Failed to add `%s` to Scrob list: %s', entry["title"], e)
+                logger.error('Failed to add `%s` to Scrob list: %s', entry['title'], e)
                 return
         self.invalidate_cache()
 
@@ -218,7 +218,7 @@ class ScrobSet(MutableSet):
         try:
             self.api.delete(f'lists/{self.list_id}/items/{found["scrob_list_item_id"]}')
         except ScrobApiError as e:
-            logger.error('Failed to remove `%s` from Scrob list: %s', entry["title"], e)
+            logger.error('Failed to remove `%s` from Scrob list: %s', entry['title'], e)
             return
         self.invalidate_cache()
 

--- a/tests/test_scrob_list.py
+++ b/tests/test_scrob_list.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import jsonschema
+import pytest
+
+from flexget import plugin
+from flexget.components.managed_lists.lists.scrob_list import (
+    ScrobApiError,
+    ScrobAPIWrapper,
+    ScrobSet,
+)
+from flexget.entry import Entry
+
+
+def _mock_media(tmdb_id, media_type, title, release_date=None, season_number=None):
+    return {
+        'id': tmdb_id * 10,
+        'tmdb_id': tmdb_id,
+        'type': media_type,
+        'title': title,
+        'poster_path': None,
+        'backdrop_path': None,
+        'release_date': release_date,
+        'tmdb_rating': 7.5,
+        'season_number': season_number,
+        'episode_number': None,
+    }
+
+
+def _mock_item(item_id, media):
+    return {
+        'id': item_id,
+        'list_id': 1,
+        'added_at': '2026-01-01T00:00:00',
+        'sort_order': 0,
+        'notes': None,
+        'media': media,
+    }
+
+
+class MockedScrobBackend:
+    def __init__(self):
+        self.next_item_id = 100
+        self.lists = {
+            1: {
+                'id': 1,
+                'name': 'Watchlist',
+                'items': [
+                    _mock_item(1, _mock_media(603692, 'movie', 'Deadpool', release_date='2016-02-12')),  # movie
+                    _mock_item(2, _mock_media(1399, 'series', 'Game of Thrones', release_date='2011-04-17')),  # series
+                    # season
+                    _mock_item(
+                        3,
+                        _mock_media(
+                            1399,
+                            'series',
+                            'Game of Thrones',
+                            release_date='2011-04-17',
+                            season_number=1,
+                        ),
+                    ),
+                    _mock_item(4, _mock_media(1399, 'episode', 'Winter Is Coming')),  # episode
+                    _mock_item(5, _mock_media(9999999, 'movie', 'No Imdb Movie', release_date=None)),  # broken movie
+                ],
+            }
+        }
+        self.movie_details = {
+            603692: {'tmdb_id': 603692, 'imdb_id': 'tt1431045'},
+        }
+        self.posts = []
+        self.deletes = []
+
+    def __call__(self, method, path, **kwargs):
+        if method == 'get' and path.startswith('lists/') and '/' not in path[len('lists/'):]:
+            list_id = int(path.split('/')[1])
+            lst = self.lists.get(list_id)
+            if lst is None:
+                raise ScrobApiError('List not found', status_code=404)
+            return dict(lst)
+        if method == 'get' and path.startswith('media/movie/'):
+            tmdb_id = int(path.rsplit('/', 1)[-1])
+            detail = self.movie_details.get(tmdb_id)
+            if not detail:
+                raise ScrobApiError('TMDB Media not found', status_code=404)
+            return detail
+        if method == 'post' and path.endswith('/items'):
+            list_id = int(path.split('/')[1])
+            body = kwargs.get('json') or {}
+            self.posts.append((list_id, body))
+            existing = [
+                i
+                for i in self.lists[list_id]['items']
+                if i['media']['tmdb_id'] == body['tmdb_id']
+                and i['media']['type'] == body['media_type']
+            ]
+            if existing:
+                raise ScrobApiError('Already in list', status_code=409)
+            self.next_item_id += 1
+            item = _mock_item(
+                self.next_item_id, _mock_media(body['tmdb_id'], body['media_type'], 'Added Title')
+            )
+            self.lists[list_id]['items'].append(item)
+            return item
+        if method == 'delete' and '/items/' in path:
+            list_id = int(path.split('/')[1])
+            item_id = int(path.rsplit('/', 1)[-1])
+            self.deletes.append((list_id, item_id))
+            before = len(self.lists[list_id]['items'])
+            self.lists[list_id]['items'] = [
+                i for i in self.lists[list_id]['items'] if i['id'] != item_id
+            ]
+            if len(self.lists[list_id]['items']) == before:
+                raise ScrobApiError('Item not found', status_code=404)
+            return {'message': 'Item removed'}
+        raise AssertionError(f'Unexpected request: {method} {path}')
+
+
+@pytest.fixture
+def backend():
+    return MockedScrobBackend()
+
+
+@pytest.fixture(autouse=True)
+def patched_request(backend):
+    with mock.patch.object(ScrobAPIWrapper, '_request', side_effect=backend):
+        yield backend
+
+
+def _config(list_id=1, strip_year=False):
+    return {
+        'base_url': 'http://scrob.test',
+        'api_key': 'testkey',
+        'list_id': list_id,
+        'strip_year': strip_year
+    }
+
+
+class TestScrobSetRead:
+    def test_filters_seasons_and_episodes(self, backend):
+        scrob_set = ScrobSet(_config())
+        titles = {e['title'] for e in scrob_set}
+        assert titles == {'Deadpool (2016)', 'Game of Thrones (2011)', 'No Imdb Movie'}
+
+    def test_len_and_iter(self, backend):
+        scrob_set = ScrobSet(_config())
+        assert len(scrob_set) == 3
+        assert len(list(scrob_set)) == 3
+
+    def test_movie_fields(self, backend):
+        scrob_set = ScrobSet(_config())
+        entry = next(e for e in scrob_set if e['tmdb_id'] == 603692)
+        assert entry['movie_name'] == 'Deadpool'
+        assert entry['movie_year'] == 2016
+        assert isinstance(entry['movie_year'], int)
+        assert entry['imdb_id'] == 'tt1431045'
+        assert entry['url'] == 'https://www.themoviedb.org/movie/603692'
+        assert entry['scrob_media_type'] == 'movie'
+
+    def test_series_fields(self, backend):
+        scrob_set = ScrobSet(_config())
+        entry = next(e for e in scrob_set if e['tmdb_id'] == 1399)
+        assert entry['series_name'] == 'Game of Thrones'
+        assert entry['series_year'] == 2011
+        assert isinstance(entry['series_year'], int)
+        assert entry['url'] == 'https://www.themoviedb.org/tv/1399'
+        assert 'imdb_id' not in entry
+
+    def test_broken_movie(self, backend):
+        scrob_set = ScrobSet(_config())
+        entry = next(e for e in scrob_set if e['tmdb_id'] == 9999999)
+        assert entry['title'] == 'No Imdb Movie'
+        assert 'movie_year' not in entry
+        assert 'imdb_id' not in entry
+
+    def test_strip_year(self, backend):
+        scrob_set = ScrobSet(_config(strip_year=True))
+        entry = next(e for e in scrob_set if e['tmdb_id'] == 603692)
+        assert entry['title'] == 'Deadpool'
+        assert entry['movie_year'] == 2016
+
+    def test_missing_list_error(self, backend):
+        scrob_set = ScrobSet(_config(list_id=999))
+        with pytest.raises(plugin.PluginError):
+            list(scrob_set)
+
+
+class TestScrobSetMembership:
+    def test_contains(self, backend):
+        scrob_set = ScrobSet(_config())
+        movie_entry = Entry(title='x', tmdb_id=603692)
+        series_entry = Entry(title='x', series_name='Game of Thrones', tmdb_id=1399)
+        wrong_type_entry = Entry(title='x', series_name='Foo', tmdb_id=603692)
+
+        assert movie_entry in scrob_set
+        assert series_entry in scrob_set
+        assert wrong_type_entry not in scrob_set
+
+    def test_entry_media_type(self, backend):
+        scrob_set = ScrobSet(_config())
+        entry = Entry(title='x', tmdb_id=603692, series_name='Foo')
+        assert entry not in scrob_set
+
+    def test_entry_media_type_default(self, backend):
+        scrob_set = ScrobSet(_config())
+        entry = Entry(title='x', tmdb_id=603692)
+        assert entry in scrob_set
+
+    def test_get(self, backend):
+        scrob_set = ScrobSet(_config())
+        found = scrob_set.get(Entry(title='x', tmdb_id=603692))
+        assert found is not None
+        assert found['tmdb_id'] == 603692
+        assert scrob_set.get(Entry(title='x', tmdb_id=42)) is None
+
+
+class TestScrobSetAdd:
+    def test_add_new_movie(self, backend):
+        scrob_set = ScrobSet(_config())
+        entry = Entry(title='Inception', tmdb_id=27205)
+        assert entry not in scrob_set
+
+        scrob_set.add(entry)
+
+        assert backend.posts == [(1, {'tmdb_id': 27205, 'media_type': 'movie'})]
+        assert entry in scrob_set
+
+    def test_add_new_series(self, backend):
+        scrob_set = ScrobSet(_config())
+        entry = Entry(title='Severance', series_name='Severance', tmdb_id=95396)
+
+        scrob_set.add(entry)
+
+        assert backend.posts == [(1, {'tmdb_id': 95396, 'media_type': 'series'})]
+        assert entry in scrob_set
+
+    def test_add_already_present_skips(self, backend):
+        scrob_set = ScrobSet(_config())
+        entry = Entry(title='Deadpool', tmdb_id=603692)
+
+        scrob_set.add(entry)
+
+        assert backend.posts == []
+
+    def test_add_without_tmdb_id_skips(self, backend):
+        scrob_set = ScrobSet(_config())
+        entry = Entry(title='No Tmdb Id')
+
+        scrob_set.add(entry)
+
+        assert backend.posts == []
+
+
+class TestScrobSetDiscard:
+    def test_discard(self, backend):
+        scrob_set = ScrobSet(_config())
+        entry = Entry(title='Deadpool', tmdb_id=603692)
+        assert entry in scrob_set
+
+        scrob_set.discard(entry)
+
+        assert backend.deletes == [(1, 1)]
+        assert entry not in scrob_set
+
+    def test_discard_noop(self, backend):
+        scrob_set = ScrobSet(_config())
+        entry = Entry(title='Not In List', tmdb_id=123456)
+
+        scrob_set.discard(entry)
+
+        assert backend.deletes == []
+
+
+class TestScrobListSchema:
+    def test_invalid_property(self):
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(
+                {'api_key': 'x', 'list_name': 'Watchlist'},
+                ScrobSet.schema,
+            )
+
+    def test_required_properties(self):
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate({'api_key': 'x'}, ScrobSet.schema)
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate({'list_id': 1}, ScrobSet.schema)
+        jsonschema.validate({'api_key': 'x', 'list_id': 1}, ScrobSet.schema)
+
+    def test_default_properties(self):
+        assert ScrobSet.schema['properties']['base_url']['default'] == 'http://localhost:7330'
+        assert not ScrobSet.schema['properties']['strip_year']['default']
+
+
+class TestScrobListTask:
+    config = """
+        tasks:
+          add_movie:
+            mock:
+              - {title: 'Inception', tmdb_id: 27205}
+            accept_all: yes
+            list_add:
+              - scrob_list:
+                  base_url: http://scrob.test
+                  api_key: testkey
+                  list_id: 1
+
+          remove_movie:
+            mock:
+              - {title: 'Deadpool', tmdb_id: 603692}
+            accept_all: yes
+            list_remove:
+              - scrob_list:
+                  base_url: http://scrob.test
+                  api_key: testkey
+                  list_id: 1
+
+          read_list:
+            scrob_list:
+              base_url: http://scrob.test
+              api_key: testkey
+              list_id: 1
+
+          missing_list:
+            scrob_list:
+              base_url: http://scrob.test
+              api_key: testkey
+              list_id: 999
+    """
+
+    def test_read_list(self, execute_task, backend):
+        task = execute_task('read_list')
+        assert len(task.entries) == 3
+        titles = {e['title'] for e in task.entries}
+        assert titles == {'Deadpool (2016)', 'Game of Thrones (2011)', 'No Imdb Movie'}
+
+    def test_list_add(self, execute_task, backend):
+        execute_task('add_movie')
+        assert backend.posts == [(1, {'tmdb_id': 27205, 'media_type': 'movie'})]
+
+    def test_list_remove(self, execute_task, backend):
+        execute_task('remove_movie')
+        assert backend.deletes == [(1, 1)]
+
+    def test_missing_list_aborts(self, execute_task, backend):
+        execute_task('missing_list', abort=True)

--- a/tests/test_scrob_list.py
+++ b/tests/test_scrob_list.py
@@ -48,8 +48,13 @@ class MockedScrobBackend:
                 'id': 1,
                 'name': 'Watchlist',
                 'items': [
-                    _mock_item(1, _mock_media(603692, 'movie', 'Deadpool', release_date='2016-02-12')),  # movie
-                    _mock_item(2, _mock_media(1399, 'series', 'Game of Thrones', release_date='2011-04-17')),  # series
+                    _mock_item(
+                        1, _mock_media(603692, 'movie', 'Deadpool', release_date='2016-02-12')
+                    ),  # movie
+                    _mock_item(
+                        2,
+                        _mock_media(1399, 'series', 'Game of Thrones', release_date='2011-04-17'),
+                    ),  # series
                     # season
                     _mock_item(
                         3,
@@ -62,7 +67,9 @@ class MockedScrobBackend:
                         ),
                     ),
                     _mock_item(4, _mock_media(1399, 'episode', 'Winter Is Coming')),  # episode
-                    _mock_item(5, _mock_media(9999999, 'movie', 'No Imdb Movie', release_date=None)),  # broken movie
+                    _mock_item(
+                        5, _mock_media(9999999, 'movie', 'No Imdb Movie', release_date=None)
+                    ),  # broken movie
                 ],
             }
         }
@@ -73,7 +80,7 @@ class MockedScrobBackend:
         self.deletes = []
 
     def __call__(self, method, path, **kwargs):
-        if method == 'get' and path.startswith('lists/') and '/' not in path[len('lists/'):]:
+        if method == 'get' and path.startswith('lists/') and '/' not in path[len('lists/') :]:
             list_id = int(path.split('/')[1])
             lst = self.lists.get(list_id)
             if lst is None:
@@ -133,7 +140,7 @@ def _config(list_id=1, strip_year=False):
         'base_url': 'http://scrob.test',
         'api_key': 'testkey',
         'list_id': list_id,
-        'strip_year': strip_year
+        'strip_year': strip_year,
     }
 
 


### PR DESCRIPTION
### Motivation for changes:

Scrob is a self-hosted media tracker similar to Trakt (see https://github.com/ellite/scrob).
It provides an API so I figured I could make a plugin out of that.

### Detailed changes:

- Adds managed list plugin `scrob_list`

### Config usage if relevant (new plugin or updated schema):

```
scrob_list:
  base_url: https://foo.bar
  api_key: 1234567890
  list_id: 123
  strip_year: yes
```
