### PR TITLE
fix(waf): stop the AWS WAF solver from wedging the daemon for hours

### DIFF
--- a/flexget/components/imdb/imdb_watchlist.py
+++ b/flexget/components/imdb/imdb_watchlist.py
@@ -144,6 +144,7 @@ class ImdbWatchlist:
         page_no = 1
 
         while len(items) < total_item_count:
+            item_count_before = len(items)
             page_no += 1
             params['page'] = page_no
             page = self.fetch_page(task, url, params, headers)
@@ -159,6 +160,16 @@ class ImdbWatchlist:
                 )
             except Exception:
                 raise plugin.PluginError('Received invalid list data')
+            if len(items) == item_count_before:
+                # IMDb caps advancedTitleSearch paging, so totalItems can exceed what it will
+                # actually serve. Without this the loop never terminates.
+                logger.warning(
+                    'imdb list page {} returned no items, stopping at {} of {} items',
+                    page_no,
+                    len(items),
+                    total_item_count,
+                )
+                break
 
         return [self.parse_entry(item['node']['title'], config) for item in items]
 

--- a/flexget/utils/waf/aws.py
+++ b/flexget/utils/waf/aws.py
@@ -20,7 +20,7 @@ class AwsWaf:
         self.domain = domain
         self.endpoint = endpoint
         self.session = requests.Session(impersonate='chrome')
-        self.session.headers = self._headers()
+        self.session.headers.update(self._headers())
 
     def _headers(self, content_type: str | None = None) -> dict:
         headers = {
@@ -50,7 +50,12 @@ class AwsWaf:
         return self.session.get(f'https://{self.endpoint}/inputs?client=browser').json()
 
     def build_payload(self, inputs: dict):
-        verify = CHALLENGE_TYPES[inputs['challenge_type']]
+        challenge_type = inputs['challenge_type']
+        verify = CHALLENGE_TYPES.get(challenge_type)
+        if not callable(verify):
+            raise NotImplementedError(
+                f'No solver implemented for challenge type: {verify or challenge_type}'
+            )
         checksum, fp = get_fp(self.user_agent)
         return {
             'challenge': inputs['challenge'],
@@ -89,11 +94,15 @@ class AwsWaf:
         }
 
     def verify(self, payload):
-        self.session.headers = self._headers(content_type='text/plain;charset=UTF-8')
+        self.session.headers.update(self._headers(content_type='text/plain;charset=UTF-8'))
         res = self.session.post(f'https://{self.endpoint}/verify', json=payload).json()
         return res['token']
 
     def __call__(self):
-        inputs = self.get_inputs()
-        payload = self.build_payload(inputs)
-        return self.verify(payload)
+        try:
+            inputs = self.get_inputs()
+            payload = self.build_payload(inputs)
+            return self.verify(payload)
+        finally:
+            # A fresh session (and curl handle) is created per solve; don't leak it.
+            self.session.close()

--- a/flexget/utils/waf/verify.py
+++ b/flexget/utils/waf/verify.py
@@ -3,12 +3,20 @@ from __future__ import annotations
 import binascii
 import hashlib
 import itertools
+import time
 from typing import TYPE_CHECKING, Any
-
-import pyscrypt
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+# The nonce search below is a brute force loop whose length is dictated by the server supplied
+# difficulty. A single task blocks the whole daemon task queue, so give up rather than wedge it.
+# ponytail: fixed budget, make it a config option if anyone actually needs a longer one.
+SOLVE_TIMEOUT = 60.0
+
+# How often to check the deadline. Checking every nonce would cost more than the hash itself
+# for the sha256 solver.
+_DEADLINE_CHECK_INTERVAL = 256
 
 
 def _check(digest: bytes, difficulty: int) -> bool:
@@ -18,9 +26,19 @@ def _check(digest: bytes, difficulty: int) -> bool:
     return not (rem and digest[full] >> (8 - rem))
 
 
+def _check_deadline(deadline: float, difficulty: int) -> None:
+    if time.monotonic() > deadline:
+        raise TimeoutError(
+            f'AWS WAF challenge (difficulty {difficulty}) not solved in {SOLVE_TIMEOUT} seconds'
+        )
+
+
 def hash_pow(challenge_input, checksum, difficulty):
+    deadline = time.monotonic() + SOLVE_TIMEOUT
     combined_bytes = (challenge_input + checksum).encode('utf-8')
     for nonce in itertools.count(0):
+        if nonce % _DEADLINE_CHECK_INTERVAL == 0:
+            _check_deadline(deadline, difficulty)
         data = combined_bytes + str(nonce).encode()
         digest = hashlib.sha256(data).digest()
         if _check(digest, difficulty):
@@ -30,17 +48,20 @@ def hash_pow(challenge_input, checksum, difficulty):
 
 def scrypt_func(input_str, salt_str, memory_cost):
     return binascii.hexlify(
-        pyscrypt.hash(
-            password=input_str.encode(), salt=salt_str.encode(), N=memory_cost, r=8, p=1, dkLen=16
+        hashlib.scrypt(
+            input_str.encode(), salt=salt_str.encode(), n=memory_cost, r=8, p=1, dklen=16
         )
     ).decode()
 
 
 def compute_scrypt_nonce(challenge_input, checksum, difficulty):
+    deadline = time.monotonic() + SOLVE_TIMEOUT
     combined = challenge_input + checksum
     salt = checksum
     memory = 128
     for nonce in itertools.count(0):
+        if nonce % _DEADLINE_CHECK_INTERVAL == 0:
+            _check_deadline(deadline, difficulty)
         result = scrypt_func(f'{combined}{nonce}', salt, memory)
         if _check(binascii.unhexlify(result), difficulty):
             return str(nonce)
@@ -48,7 +69,7 @@ def compute_scrypt_nonce(challenge_input, checksum, difficulty):
 
 
 # typos:off
-CHALLENGE_TYPES: dict[str, Callable[[Any, Any, Any], str] | str] = {
+CHALLENGE_TYPES: dict[str, Callable[[Any, Any, Any], str | None] | str] = {
     'h72f957df656e80ba55f5d8ce2e8c7ccb59687dba3bfb273d54b08a261b2f3002': compute_scrypt_nonce,
     'h7b0c470f0cfe3a80a9e26526ad185f484f6817d0832712a4a37a908786a6a67f': hash_pow,
     'ha9faaffd31b4d5ede2a2e19d2d7fd525f66fee61911511960dcbb52d3c48ce25': 'mp_verify',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
   "pynzb~=0.1.0",
   "pyparsing~=3.2",
   "pyrss2gen~=1.1",
-  "pyscrypt~=1.6",
   "python-dateutil~=2.9",
   "pyyaml~=6.0",
   "rebulk~=6.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -142,8 +142,6 @@ pyparsing==3.3.2
     # via flexget
 pyrss2gen==1.1
     # via flexget
-pyscrypt==1.6.2
-    # via flexget
 python-dateutil==2.9.0.post0
     # via
     #   flexget

--- a/tests/test_waf.py
+++ b/tests/test_waf.py
@@ -1,4 +1,9 @@
-from flexget.utils.waf import is_waf_challenge
+import hashlib
+import time
+
+import pytest
+
+from flexget.utils.waf import is_waf_challenge, verify
 
 
 class FakeResponse:
@@ -22,3 +27,28 @@ def test_is_waf_challenge_goku_props():
 
 def test_is_not_waf_challenge():
     assert not is_waf_challenge(FakeResponse(200, text='<html>normal page</html>'))
+
+
+# Reference vector produced by pyscrypt 1.6.2, which `hashlib.scrypt` replaced. This is the
+# check that fails if the swap ever stops being bit-identical.
+def test_scrypt_func_matches_reference_vector():
+    assert (
+        verify.scrypt_func('challengeinput123', 'saltysalt', 128)
+        == '1896b519cc5906810cf9b33112ba13f5'
+    )
+
+
+def test_hash_pow_solves_low_difficulty():
+    nonce = verify.hash_pow('abc', 'def', 8)
+    digest = hashlib.sha256(f'abcdef{nonce}'.encode()).digest()
+    assert verify._check(digest, 8)
+
+
+@pytest.mark.parametrize('solver', [verify.hash_pow, verify.compute_scrypt_nonce])
+def test_solvers_give_up_instead_of_hanging(solver, monkeypatch):
+    """A server-supplied difficulty must never wedge the single-threaded task queue."""
+    monkeypatch.setattr(verify, 'SOLVE_TIMEOUT', 0.1)
+    started = time.monotonic()
+    with pytest.raises(TimeoutError):
+        solver('a', 'b', 64)  # unsatisfiable
+    assert time.monotonic() - started < 30

--- a/uv.lock
+++ b/uv.lock
@@ -1417,7 +1417,6 @@ dependencies = [
     { name = "pynzb" },
     { name = "pyparsing" },
     { name = "pyrss2gen" },
-    { name = "pyscrypt" },
     { name = "python-dateutil" },
     { name = "pyyaml" },
     { name = "rebulk" },
@@ -1536,7 +1535,6 @@ requires-dist = [
     { name = "pynzb", specifier = "~=0.1.0" },
     { name = "pyparsing", specifier = "~=3.2" },
     { name = "pyrss2gen", specifier = "~=1.1" },
-    { name = "pyscrypt", specifier = "~=1.6" },
     { name = "python-dateutil", specifier = "~=2.9" },
     { name = "pyyaml", specifier = "~=6.0" },
     { name = "rebulk", specifier = "~=6.0" },
@@ -2967,12 +2965,6 @@ name = "pyrss2gen"
 version = "1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6d/01/fd610d5fc86f7dbdbefc4baa8f7fe15a2e5484244c41dcf363ca7e89f60c/PyRSS2Gen-1.1.tar.gz", hash = "sha256:7960aed7e998d2482bf58716c316509786f596426f879b05f8d84e98b82c6ee7", size = 6854, upload-time = "2013-02-21T03:23:02.807Z" }
-
-[[package]]
-name = "pyscrypt"
-version = "1.6.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c6/56/51603b5714d221b784e4cbc2790b1215b3fb108e4d308a0bd52e4c3ce532/pyscrypt-1.6.2.tar.gz", hash = "sha256:bafdd195f10f7c7395f0133bad09746a68e0e6b66da202c9bdb6b1eb4abba5e9", size = 36555, upload-time = "2015-02-03T21:44:52.793Z" }
 
 [[package]]
 name = "pysftp"


### PR DESCRIPTION
## Problem

The daemon stops making progress and apscheduler logs, for *every* job:

```
Execution of job "notify-*" skipped: maximum number of running instances reached (1)
```

`TaskQueue` runs one task at a time by design, so one wedged task starves the whole daemon — which is why unrelated `notify-*` jobs pile up too.

The wedged thread is the AWS WAF proof-of-work solver. `compute_scrypt_nonce` brute-forces a nonce with an unbounded `itertools.count()`, running a full `pyscrypt.hash()` per iteration. **pyscrypt is pure Python: 409 ms per hash**, so the server-supplied difficulty translates directly into wall time:

| difficulty | expected tries | wall time |
|---|---|---|
| 8  | 256       | 1.7 min |
| 12 | 4 096     | 28 min |
| 16 | 65 536    | 7.5 h |
| 20 | 1 048 576 | 5 days |

Nothing can interrupt it — it is CPU-bound Python, outside every HTTP timeout.

## Changes

- **`pyscrypt` → stdlib `hashlib.scrypt`.** Output is bit-identical (the new test pins the old pyscrypt vector) and it is ~1700× faster. A difficulty-12 challenge now solves in **0.8 s instead of ~28 minutes**. Drops a dependency whose last release was 2015.
- **`SOLVE_TIMEOUT` deadline in both solvers.** Speed alone is not a bound — difficulty 24 would still take an hour. On expiry they raise `TimeoutError`, which `fetch_page` already converts to `PluginError` and `input_cache` already handles by falling back to cache. A failed IMDb input is a non-event; a wedged daemon is not.
- **`AwsWaf` session leak.** A fresh `curl_cffi` session (and curl handle) was created per solve and never closed. Closed in a `finally`.
- **`'mp_verify'` challenge type.** `CHALLENGE_TYPES` maps it to a string rather than a solver, so that challenge died with `TypeError: 'str' object is not callable`. Now guarded with `callable()` and raises `NotImplementedError` naming the type.
- **Second unbounded loop in `imdb_watchlist`.** `while len(items) < total_item_count` has no progress guarantee, and IMDb caps `advancedTitleSearch` paging below the `totalItems` it reports. A page with empty `edges` looped forever at one throttled request per pass.

## Testing

`tests/test_waf.py` — 8 pass. The pyscrypt reference vector `1896b519…` is the equivalence gate for the `hashlib` swap; both solvers are asserted to raise `TimeoutError` under a patched `SOLVE_TIMEOUT`; `hash_pow` still solves a low difficulty.

Not verified end-to-end against a live WAF challenge — that needs a list that actually trips it. `tests/test_imdb.py` is entirely `@pytest.mark.online`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCxquqbSKmxn7gtAEY6qvC