### PR TITLE
fix(scheduler): don't let a dead task queue wedge the daemon permanently

### DIFF
--- a/flexget/components/scheduler/scheduler.py
+++ b/flexget/components/scheduler/scheduler.py
@@ -90,6 +90,9 @@ main_schema = {
 scheduler = None
 scheduler_job_map = {}
 
+# How often a scheduled run checks that the task queue is still alive while waiting for a task.
+QUEUE_LIVENESS_INTERVAL = 60
+
 
 def job_id(conf):
     """Create a unique id for a schedule item in config."""
@@ -103,8 +106,17 @@ def run_job(tasks):
         options={'tasks': tasks, 'cron': True, 'allow_manual': False}, priority=5
     )
     for _, task_name, event_ in finished_events:
+        # A slow task is fine and keeps waiting, but if the queue thread dies its finished_event
+        # is never set. An unbounded wait there pins this job instance forever, and apscheduler
+        # then skips every later run with 'maximum number of running instances reached'.
+        while not event_.wait(timeout=QUEUE_LIVENESS_INTERVAL):
+            if manager.task_queue.has_died():
+                logger.error(
+                    'Task queue died while waiting for task {} to finish, abandoning this run.',
+                    task_name,
+                )
+                return
         logger.debug('task finished executing: {}', task_name)
-        event_.wait()
     logger.debug('all tasks in schedule finished executing')
 
 

--- a/flexget/manager.py
+++ b/flexget/manager.py
@@ -281,6 +281,16 @@ class Manager:
         :returns: a list of :class:`threading.Event` instances which will be
             set when each respective task has finished running
         """
+        # A dead task queue silently swallows anything queued to it: the tasks never run and
+        # their finished_events are never set. Recover here, at the funnel every caller
+        # (scheduler, api, irc, cli) routes through, rather than only in execute_command.
+        if self.task_queue.has_died():
+            logger.error(
+                'Task queue has died unexpectedly. Restarting it. Please open an issue on Github and include'
+                ' any previous error logs.'
+            )
+            self.task_queue = TaskQueue()
+            self.task_queue.start()
         if options is None:
             options = copy.copy(self.options.execute)
         elif isinstance(options, dict):
@@ -425,13 +435,6 @@ class Manager:
         """
         fire_event('manager.execute.started', self, options)
         if self.task_queue.is_alive() or self.is_daemon:
-            if not self.task_queue.is_alive():
-                logger.error(
-                    'Task queue has died unexpectedly. Restarting it. Please open an issue on Github and include'
-                    ' any previous error logs.'
-                )
-                self.task_queue = TaskQueue()
-                self.task_queue.start()
             if len(self.task_queue):
                 logger.verbose('There is a task already running, execution queued.')
             finished_events = self.execute(options)

--- a/flexget/task_queue.py
+++ b/flexget/task_queue.py
@@ -72,6 +72,13 @@ class TaskQueue:
     def is_alive(self) -> bool:
         return self._thread and self._thread.is_alive()
 
+    def has_died(self) -> bool:
+        """Return True if the queue thread was started and is no longer running.
+
+        Distinct from ``not is_alive()``, which is also true for a queue that was never started.
+        """
+        return self._thread is not None and not self._thread.is_alive()
+
     def put(self, task: Task):
         """Add a task to be executed to the queue."""
         self.run_queue.put(task)

--- a/tests/test_task_queue.py
+++ b/tests/test_task_queue.py
@@ -1,0 +1,42 @@
+import threading
+import time
+
+from flexget.components.scheduler import scheduler
+from flexget.task_queue import TaskQueue
+
+
+def test_has_died_is_false_before_the_queue_is_started():
+    # Distinct from `not is_alive()`, which is also true here.
+    assert TaskQueue().has_died() is False
+
+
+def test_has_died_tracks_the_thread():
+    queue = TaskQueue()
+    queue.start()
+    assert queue.has_died() is False
+    queue.shutdown(finish_queue=True)
+    queue._thread.join(timeout=10)
+    assert queue.has_died() is True
+
+
+class _DeadQueue:
+    def has_died(self):
+        return True
+
+
+class _FakeManager:
+    """A manager whose queue thread died mid-task, so finished_event is never set."""
+
+    task_queue = _DeadQueue()
+
+    def execute(self, options=None, priority=1, suppress_warnings=None):
+        return [('some-id', 'sometask', threading.Event())]
+
+
+def test_run_job_gives_up_when_the_task_queue_dies(monkeypatch):
+    """An unbounded wait here pins the apscheduler job instance forever."""
+    monkeypatch.setattr(scheduler, 'manager', _FakeManager())
+    monkeypatch.setattr(scheduler, 'QUEUE_LIVENESS_INTERVAL', 0.01)
+    started = time.monotonic()
+    scheduler.run_job(['sometask'])
+    assert time.monotonic() - started < 10


### PR DESCRIPTION
## Problem

If the `task_queue` thread ever dies, the daemon becomes silently and permanently useless — no scheduled task runs again, with no way back short of a restart.

The thread *can* die: `TaskQueue.run()` calls `manager.crash_report()` from its `except` handlers, and `crash_report()` opens and writes a file. If that raises, the exception escapes `run()` and the thread is gone.

Two gaps then combine:

1. **`scheduler.run_job()` waited on each task's `finished_event` with no timeout.** A dead queue never sets that event, so the wait never returned and the apscheduler job instance was pinned forever. With `max_instances=1`, every later fire of every schedule is dropped with `maximum number of running instances reached (1)` — permanently.
2. **Only `execute_command()` recovered a dead queue.** Everything else — the scheduler, the API, IRC, `run_task` — goes through `Manager.execute()` and queued into the void.

## Changes

- `run_job()` waits in `QUEUE_LIVENESS_INTERVAL` slices and abandons the run if the queue has died. A task that is merely *slow* is unaffected and keeps waiting, which is the intended behaviour — this deliberately does not add a task timeout.
- Recovery moved into `Manager.execute()`, the funnel all callers route through, and the now-redundant copy in `execute_command()` dropped.
- Adds `TaskQueue.has_died()`, deliberately *not* `not is_alive()`: the latter is also true for a queue that was never started, and treating that as a crash would restart a queue the caller is about to start itself.

## Testing

New `tests/test_task_queue.py` — 3 pass, covering the `has_died()` distinction (never started / alive / died) and `run_job` returning instead of hanging when the queue dies.

Verified the regression is real: with the old unbounded `event_.wait()`, the same scenario still hangs after 10 s (`timeout` exit 124); with the fix it returns in 0.01 s.

Found while investigating #5191 — that PR fixes the specific hang; this one fixes the fact that *any* stuck-or-dead queue takes the whole daemon down with it. Independent of it, and touches disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCxquqbSKmxn7gtAEY6qvC