### PR TITLE
fix(exec): make auto_escape actually escape shell metacharacters

### DIFF
--- a/flexget/plugins/output/exec.py
+++ b/flexget/plugins/output/exec.py
@@ -1,3 +1,4 @@
+import shlex
 import subprocess
 
 from loguru import logger
@@ -13,23 +14,28 @@ logger = logger.bind(name='exec')
 
 
 class EscapingEntry(Entry):
-    """Helper class, same as a Entry, but returns all string value with quotes escaped."""
+    """Copy of an Entry whose string field values are pre-quoted for safe use in a shell command line.
 
-    def __init__(self, entry):
-        super().__init__(entry)
+    Used by the `auto_escape` option. The store is populated directly
+    (bypassing Entry's normal per-field __setitem__ coercion, e.g.
+    `location` -> `Path`) so the quoting survives untouched. Disposable,
+    one-shot rendering context only -- not a real Entry (no accept/reject/fail
+    state).
+    """
 
-    def __getitem__(self, key):
-        value = super().__getitem__(key)
-        # TODO: May need to be different depending on OS
-        if isinstance(value, str):
-            value = value.replace('"', '\\"')
-        return value
+    def __init__(self, entry: Entry) -> None:
+        super().__init__()
+        self.store = {
+            key: shlex.quote(value) if isinstance(value, str) else value
+            for key, value in entry.store.items()
+        }
+        self.task = entry.task
 
 
 class PluginExec:
     """Execute commands.
 
-    Simple example, xecute command for entries that reach output::
+    Simple example, execute command for entries that reach output::
 
       exec: echo 'found {{title}} at {{url}}' > file
 
@@ -44,6 +50,44 @@ class PluginExec:
           for_accepted: echo 'accepted {{title}} - {{url}} > file
 
     You can use all (available) entry fields in the command.
+
+    Security
+    --------
+    Commands run in a real shell (``shell=True``). Entry fields (``title``,
+    ``url``, and anything else that came from a feed/site) are
+    attacker-controlled: a malicious feed can put shell metacharacters
+    (backticks, ``$()``, ``;``, ``|``, quotes, newlines, ...) in a field and
+    have them run as part of your command. This does not apply to the
+    ``phase`` key, which templates from the task rather than an entry.
+
+    To safely substitute untrusted entry fields, either:
+
+    - Set ``auto_escape: yes`` to shell-quote every substituted entry field
+      automatically::
+
+        exec:
+          auto_escape: yes
+          on_output:
+            for_accepted: echo 'accepted {{title}}' >> log.txt
+
+    - Or apply the ``shell_quote`` filter to individual fields (works
+      everywhere, including ``phase:``)::
+
+        exec:
+          on_output:
+            for_accepted: echo {{title|shell_quote}} >> log.txt
+
+    Important: do not wrap an escaped field in your own quotes
+    (``"{{title}}"`` or ``'{{title}}'``). That is not just redundant, it can
+    reopen the hole: a backtick is still expanded by the shell inside double
+    quotes, and an embedded quote from the escaping can break out of your own
+    single quotes. Leave the field bare (or adjacent to plain unquoted text,
+    e.g. ``/path/{{title|shell_quote}}``).
+
+    Neither option protects shell syntax *you* write literally: ``;``,
+    ``|``, ``>``, backticks etc. that you type yourself in the command are
+    still your responsibility. They only ensure a substituted value can't
+    break out of its own token to run something else.
     """
 
     NAME = 'exec'

--- a/flexget/plugins/output/exec.py
+++ b/flexget/plugins/output/exec.py
@@ -1,4 +1,3 @@
-import shlex
 import subprocess
 
 from loguru import logger
@@ -7,7 +6,12 @@ from flexget import plugin
 from flexget.config_schema import one_or_more
 from flexget.entry import Entry
 from flexget.event import event
-from flexget.utils.template import RenderError, render_from_entry, render_from_task
+from flexget.utils.template import (
+    RenderError,
+    filter_shell_quote,
+    render_from_entry,
+    render_from_task,
+)
 from flexget.utils.tools import io_encoding
 
 logger = logger.bind(name='exec')
@@ -26,7 +30,7 @@ class EscapingEntry(Entry):
     def __init__(self, entry: Entry) -> None:
         super().__init__()
         self.store = {
-            key: shlex.quote(value) if isinstance(value, str) else value
+            key: filter_shell_quote(value) if isinstance(value, str) else value
             for key, value in entry.store.items()
         }
         self.task = entry.task

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import locale
 import re
+import shlex
 from contextlib import suppress
 from copy import copy
 from datetime import date, datetime, time
@@ -172,6 +173,11 @@ def filter_pathscrub(val: str, os_mode: str | None = None) -> str:
     if not isinstance(val, str):
         return val
     return pathscrub(val, os_mode)
+
+
+def filter_shell_quote(val) -> str:
+    """Quote a value so it is safe to use as a single token in a shell command line."""
+    return shlex.quote(str(val))
 
 
 def filter_re_replace(val: AnyStr, pattern: str, repl: str) -> str:

--- a/flexget/utils/template.py
+++ b/flexget/utils/template.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import locale
+import os
 import re
 import shlex
 from contextlib import suppress
@@ -175,8 +176,43 @@ def filter_pathscrub(val: str, os_mode: str | None = None) -> str:
     return pathscrub(val, os_mode)
 
 
+def _quote_windows(value: str) -> str:
+    """Quote a value as a single safe argument for a command run via cmd.exe (Windows shell=True).
+
+    Unlike `subprocess.list2cmdline`, this *always* wraps in quotes (not just when the value
+    has whitespace/quotes), so cmd.exe treats characters it would otherwise parse itself
+    (`&|<>()^`) as inert content instead of command syntax.
+
+    ponytail: doesn't neutralize `%var%` expansion (cmd.exe performs it even inside quotes,
+    with no clean escape outside a batch file) or a value that mixes a literal `"` with those
+    metacharacters (the embedded-quote escape can end the quoted region early); reach for a
+    dedicated library (e.g. mslex) if either becomes a real threat.
+    """
+    out = ['"']
+    i, n = 0, len(value)
+    while i < n:
+        char = value[i]
+        if char == '\\':
+            j = i
+            while j < n and value[j] == '\\':
+                j += 1
+            run = j - i
+            out.append('\\' * (run * 2 if j == n or value[j] == '"' else run))
+            i = j
+        elif char == '"':
+            out.append('\\"')
+            i += 1
+        else:
+            out.append(char)
+            i += 1
+    out.append('"')
+    return ''.join(out)
+
+
 def filter_shell_quote(val) -> str:
     """Quote a value so it is safe to use as a single token in a shell command line."""
+    if os.name == 'nt':
+        return _quote_windows(str(val))
     return shlex.quote(str(val))
 
 

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -1,11 +1,8 @@
 import sys
 from pathlib import Path
 
-import pytest
-
 
 class TestExec:
-    __tmp__ = True
     config = (
         """
         templates:
@@ -38,7 +35,24 @@ class TestExec:
               on_output:
                 for_entries: """
         + sys.executable
-        + """ exec.py "{{temp_dir}}" "{{title}}" "{{quotes}}" "/start/{{quotes}}" "{{otherchars}}"
+        + """ exec.py "{{temp_dir}}" "{{title}}" {{quotes}} /start/{{quotes}} {{otherchars}}
+          test_auto_escape_injection:
+            mock:
+              - {title: 'inject `touch __tmp__/pwned_backtick` and $(touch __tmp__/pwned_subshell); echo done'}
+            exec:
+              auto_escape: yes
+              on_output:
+                for_entries: """
+        + sys.executable
+        + """ exec.py "{{temp_dir}}" result {{title}}
+          test_shell_quote_filter_injection:
+            mock:
+              - {title: 'inject `touch __tmp__/pwned_backtick2` and $(touch __tmp__/pwned_subshell2); echo done'}
+            exec:
+              on_output:
+                for_entries: """
+        + sys.executable
+        + """ exec.py "{{temp_dir}}" result {{title|shell_quote}}
     """
     )
 
@@ -65,15 +79,39 @@ class TestExec:
                     f'{line} != /a hybrid/path/with spaces'
                 )
 
-    # TODO: This doesn't work on linux.
-    @pytest.mark.skip(reason="This doesn't work on linux")
-    def test_auto_escape(self, execute_task):
+    def test_auto_escape(self, execute_task, tmp_path):
         task = execute_task('test_auto_escape')
         for entry in task.accepted:
-            with (self.__tmp__ / entry['title']).open() as infile:
-                line = infile.readline().rstrip('\n')
-                assert line == 'single \' double"', f'{line} != single \' double"'
-                line = infile.readline().rstrip('\n')
-                assert line == '/start/single \' double"', f'{line} != /start/single \' double"'
-                line = infile.readline().rstrip('\n')
-                assert line == '% a $a! ` *', f'{line} != % a $a! ` *'
+            with (tmp_path / entry['title']).open() as infile:
+                lines = infile.read().splitlines()
+            assert lines[0] == entry['quotes'], f'{lines[0]!r} != {entry["quotes"]!r}'
+            assert lines[1] == '/start/' + entry['quotes']
+            assert lines[2] == entry['otherchars']
+
+    def test_auto_escape_blocks_injection(self, execute_task, tmp_path):
+        task = execute_task('test_auto_escape_injection')
+        assert len(task.accepted) == 1
+        entry = task.accepted[0]
+        with (tmp_path / 'result').open() as infile:
+            line = infile.readline().rstrip('\n')
+        assert line == entry['title'], (
+            'malicious title was not passed through as one safe argument'
+        )
+        assert not (tmp_path / 'pwned_backtick').exists(), (
+            'backtick command substitution executed!'
+        )
+        assert not (tmp_path / 'pwned_subshell').exists(), '$() command substitution executed!'
+
+    def test_shell_quote_filter_blocks_injection(self, execute_task, tmp_path):
+        task = execute_task('test_shell_quote_filter_injection')
+        assert len(task.accepted) == 1
+        entry = task.accepted[0]
+        with (tmp_path / 'result').open() as infile:
+            line = infile.readline().rstrip('\n')
+        assert line == entry['title'], (
+            'malicious title was not passed through as one safe argument'
+        )
+        assert not (tmp_path / 'pwned_backtick2').exists(), (
+            'backtick command substitution executed!'
+        )
+        assert not (tmp_path / 'pwned_subshell2').exists(), '$() command substitution executed!'

--- a/tests/test_jinja_filters.py
+++ b/tests/test_jinja_filters.py
@@ -66,6 +66,7 @@ class TestJinjaFilters:
         'format_size',
         'asciify',
         'strip_symbols',
+        'shell_quote',
     ]
 
     def test_stripyear(self, execute_task):


### PR DESCRIPTION
## Summary

- `exec`'s `auto_escape` option was dead code: `EscapingEntry.__getitem__` was never invoked because `render_from_entry()` copies `entry.store` directly, so entry fields (e.g. RSS/torrent titles, which are attacker-controlled) were substituted into the `shell=True` command completely unescaped even with `auto_escape: yes` set (CWE-78).
- `EscapingEntry` now pre-quotes string field values with `shlex.quote()` at construction time (bypassing `Entry.__setitem__`'s per-field coercion so the quoting isn't corrupted).
- Added a `shell_quote` Jinja filter for explicit per-field quoting, usable anywhere including the `phase:` key (task-level), which `auto_escape` doesn't cover.
- Rewrote the `exec` plugin docstring with a security note covering the risk, correct usage of `auto_escape`/`shell_quote`, and why wrapping an already-escaped field in your own quotes can reopen the hole.
- `auto_escape` stays opt-in with no default change — existing configs are unaffected unless they enable it.

## Test plan

- [x] `pytest tests/test_exec.py -v` — 5 passed, including the previously `@pytest.mark.skip`'d `test_auto_escape` (now fixed) and two new tests that plant a malicious title (backticks/`$()`/`;`) and assert no side-effect command executes, one via `auto_escape`, one via `shell_quote`
- [x] `pytest tests/test_template.py -v` — 7 passed
- [x] `ruff check` / `ruff format --diff` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)