### PR TITLE
fix(tests): stub curl_cffi so IMDb WAF requests don't bypass vcrpy

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,6 +218,28 @@ def caplog(pytestconfig, _caplog):  # noqa: F811
     logger.remove(handler_id)
 
 
+@pytest.fixture(autouse=True)
+def _stub_curl_cffi_session(monkeypatch):
+    """Curl_cffi bypasses vcrpy; give it a plain requests.Session so tests can see it.
+
+    curl_cffi (used by the AWS WAF / IMDb solver) talks to libcurl directly
+    and never touches http.client, so it bypasses both vcrpy cassette replay
+    (use_vcr) and the no_requests network guard. Give it a plain
+    requests.Session instead, which both already know how to handle.
+
+    ponytail: unconditional swap, so re-recording one of the IMDb cassettes
+    from scratch needs a manual workaround (real WAF-solving needs the real
+    curl_cffi session) -- upgrade to a conditional stub if that's needed often.
+    """
+
+    def fake_session(*args, **kwargs):
+        kwargs.pop('impersonate', None)
+        return requests.Session()
+
+    monkeypatch.setattr('curl_cffi.requests.Session', fake_session)
+    monkeypatch.setattr('flexget.components.imdb.waf._session', None)
+
+
 # --- End Public Fixtures ---
 
 

--- a/tests/test_imdb_parser.py
+++ b/tests/test_imdb_parser.py
@@ -47,9 +47,8 @@ class TestImdbParser:
         assert parser.name == 'The Usual Suspects', 'Name not parsed correctly'
         assert parser.photo, 'Photo not parsed correctly'
         assert parser.plot_outline == (
-            'The sole survivor of a pier shoot-out tells the story of how a notorious criminal '
-            'influenced the events that began with five criminals meeting in a seemingly random '
-            'police lineup.'
+            'A sole survivor tells of the twisty events leading up to a horrific gun battle on '
+            'a boat, which began when five criminals met at a seemingly random police lineup.'
         ), 'Plot outline not parsed correctly'
         assert 8.0 < parser.score < 9.0, 'Score not parsed correctly'
         assert parser.url == 'https://www.imdb.com/title/tt0114814/', 'URL not parsed correctly'


### PR DESCRIPTION
## Summary

Fixes #5182.

- `curl_cffi` (used by the AWS WAF / IMDb solver added in #5134) talks to libcurl directly and never touches `http.client`, so it bypasses both the `use_vcr` cassette-replay fixture and the `no_requests` network guard that everything else in the suite relies on. Tests exercising IMDb parsing were silently making real network calls every run regardless of `VCR_RECORD_MODE` or cassette state — the CI flakiness reported in #5182.
- Added one autouse fixture (`_stub_curl_cffi_session` in `tests/conftest.py`) that swaps `curl_cffi.requests.Session` for a plain `requests.Session()` during tests. `waf_get()` only needs `.headers`/`.get()`/`.cookies.set()`, all of which `requests.Session` already provides, so **no production code changes** are needed.
  - Online tests: the resulting `requests` calls route through `http.client` like any other request, so the already-active `use_vcr` cassette replays them from the existing cassette files.
  - Non-online tests: `no_requests` already patches `requests.sessions.Session.request` to raise, so any accidental IMDb network call now fails loudly instead of silently going out to the network.
- Known limitation (documented inline): the stub is unconditional, so re-recording one of these IMDb cassettes from scratch needs a temporary manual workaround, since real WAF-solving needs the real curl_cffi session with TLS fingerprint spoofing.
- Also fixed a stale assertion in `tests/test_imdb_parser.py::TestImdbParser::test_parsed_data`, unmasked by the above fix: `ImdbParser.parse()` tries an IMDb GraphQL POST first and falls back to HTML-scraping on failure; that cassette only has the GET HTML interaction recorded, so it deterministically falls back to HTML-scraping, but the `plot_outline` assertion expected GraphQL-sourced wording. Updated the assertion to match the plot text the existing cassette actually produces via the (deterministic, offline) HTML fallback.

## Test plan

- [x] `VCR_RECORD_MODE=none uv run pytest tests/test_imdb.py tests/test_imdb_parser.py tests/test_exists_movie.py tests/test_nfo_lookup.py -v` — all pass (down from the issue's reported 20 failures)
- [x] `task test` (full suite, offline) — 1484 passed, 26 skipped, 0 failed
- [x] `ruff check` / `ruff format --diff` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFyPLqvyvSrb4qtSLaYTMu